### PR TITLE
chore: fix TODO about libapp.txt

### DIFF
--- a/updater/library/src/network.rs
+++ b/updater/library/src/network.rs
@@ -6,6 +6,10 @@ use std::string::ToString;
 
 use serde::Deserialize;
 
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
 use crate::cache::{client_id, current_patch, UpdaterState};
 use crate::config::{current_arch, current_platform, ResolvedConfig};
 
@@ -53,4 +57,18 @@ pub fn send_patch_check_request(
         .json()?;
     info!("Patch check response: {:?}", response);
     return Ok(response);
+}
+
+pub fn download_file_to_path(url: &str, path: &PathBuf) -> anyhow::Result<()> {
+    // Download the file at the given url to the given path.
+    let client = reqwest::blocking::Client::new();
+    let response = client.get(url).send()?;
+    let mut bytes = response.bytes()?;
+
+    // Ensure the download directory exists.
+    std::fs::create_dir_all(path.parent().unwrap())?;
+
+    let mut file = File::create(path)?;
+    file.write_all(&mut bytes)?;
+    Ok(())
 }


### PR DESCRIPTION
Doesn't matter a ton what we name the download.  Giving it a generic name since we're going to change the format more over time (but it's not .txt).

Also moved more of the networking code into network.rs :)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
