### PR TITLE
refactor: Use methods instead of free functions with UpdateState

### DIFF
--- a/updater/library/src/network.rs
+++ b/updater/library/src/network.rs
@@ -1,16 +1,18 @@
 // This file's job is to deal with the update_server and network side
 // of the updater library.
 
-use std::collections::HashMap;
-use std::string::ToString;
-
 use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::string::ToString;
 
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
-use crate::cache::{client_id, current_patch, UpdaterState};
+use crate::cache::UpdaterState;
 use crate::config::{current_arch, current_platform, ResolvedConfig};
 
 fn patches_check_url(base_url: &str) -> String {
@@ -35,12 +37,12 @@ pub fn send_patch_check_request(
     config: &ResolvedConfig,
     state: &UpdaterState,
 ) -> anyhow::Result<PatchCheckResponse> {
-    let patch = current_patch(state);
+    let patch = state.current_patch();
 
     // Send the request to the server.
     let client = reqwest::blocking::Client::new();
     let mut body = HashMap::new();
-    body.insert("client_id", client_id(state));
+    body.insert("client_id", state.client_id());
     body.insert("product_id", config.product_id.clone());
     body.insert("channel", config.channel.clone());
     body.insert("base_version", config.base_version.clone());


### PR DESCRIPTION
For whatever reason when I wrote all this rust code I seem to have forgotten that methods were a thing in rust.  I think it's a lot cleaner now using methods.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
