### PR TITLE
feat: Start adding rust tests.

### DIFF
--- a/updater/cli/src/main.rs
+++ b/updater/cli/src/main.rs
@@ -30,7 +30,7 @@ app_id: demo
 channel: stable
 base_url: http://localhost:8000
 ";
-    updater::init(config, yaml_str);
+    updater::init(config, yaml_str).expect("init failed");
 
     // You can check for the existence of subcommands, and if found use their
     // matches just as you would the top level cmd

--- a/updater/library/Cargo.toml
+++ b/updater/library/Cargo.toml
@@ -30,3 +30,7 @@ uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics", "
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.13.0"
 log-panics = { version = "2", features = ["with-backtrace"]}
+
+
+[dev-dependencies]
+tempdir = "0.3.7"

--- a/updater/library/src/c_api.rs
+++ b/updater/library/src/c_api.rs
@@ -57,7 +57,13 @@ pub extern "C" fn shorebird_init(c_params: *const AppParameters, c_yaml: *const 
     let config = app_config_from_c(c_params);
 
     let yaml_string = to_rust(c_yaml);
-    updater::init(config, &yaml_string);
+    let result = updater::init(config, &yaml_string);
+    match result {
+        Ok(_) => {}
+        Err(e) => {
+            error!("Error initializing updater: {:?}", e);
+        }
+    }
 }
 
 /// Return the active version of the app, or NULL if there is no active version.

--- a/updater/library/src/lib.rs
+++ b/updater/library/src/lib.rs
@@ -19,3 +19,6 @@ pub use self::updater::*;
 // Exposes error!(), info!(), etc macros.
 #[macro_use]
 extern crate log;
+
+#[cfg(test)]
+extern crate tempdir;


### PR DESCRIPTION
We need to remove most/all of the unwrap() calls in the library since we should never crash (just fail to update and log).

Adding testing while I do this.

Updated updater::init and updater::report_failed_launch to now return Result<(), UpdaterError> instead () as before.
Added tempdir as a dev-only/test-only dependency.
Added UpdaterError so we have our own error type for our API, rather than exposing different error types for different functions.  I'm not sure if this is the right approach, but trying it.

Added two very simple tests which confirm that if you pass invalid yaml to init, or you don't have a current patch when calling report_failed_launch, we don't crash but we do return error (previously we would have crashed in both).

## Type of Change

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
