### PR TITLE
feat: Add support for diff patches

### DIFF
--- a/updater/library/Cargo.toml
+++ b/updater/library/Cargo.toml
@@ -19,17 +19,28 @@ reqwest = { version = "0.11",  default-features = false, features = ["blocking",
 # Json serialization/de-serialization.
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.93"
-# Used for error handling.
+# Used for error handling for now.
 anyhow = {version = "1.0.69", features = ["backtrace"]}
 # For error!(), info!(), etc macros. `print` will not show up on Android.
 log = "0.4.14"
+# For implementing thread-local-storage of ResolvedConfig object.
 once_cell = "1.17.1"
+# For reading shorebird.yaml
 serde_yaml = "0.9.19"
-uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics", "serde"]}
+# For validating hashes of downloaded patch files.
 sha2 = "0.10.6"
+# For inflating compressed patch files.
+bipatch = "1.0.0"
+# comde is a wrapper around several compression libraries.
+# We only use zstd and could depend on it directly instead.
+comde = {version = "0.2.3", default-features = false, features = ["zstandard"]}
+# Pipe is a simple in-memory pipe implementation, there might be a std way too?
+pipe = "0.4.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
+# For logging to Android logcat.
 android_logger = "0.13.0"
+# Send panics to log (instead of stderr), thus logcat on Android.
 log-panics = { version = "2", features = ["with-backtrace"]}
 
 

--- a/updater/library/include/updater.h
+++ b/updater/library/include/updater.h
@@ -59,13 +59,13 @@ void shorebird_init(const struct AppParameters *c_params,
                     const char *c_yaml);
 
 /**
- * Return the active version of the app, or NULL if there is no active version.
+ * Return the active patch number, or NULL if there is no active patch.
  */
 SHOREBIRD_EXPORT char *shorebird_active_patch_number(void);
 
 /**
- * Return the path to the active version of the app, or NULL if there is no
- * active version.
+ * Return the path to the active patch for the app, or NULL if there is no
+ * active patch.
  */
 SHOREBIRD_EXPORT char *shorebird_active_path(void);
 

--- a/updater/library/include/updater.h
+++ b/updater/library/include/updater.h
@@ -61,7 +61,7 @@ void shorebird_init(const struct AppParameters *c_params,
 /**
  * Return the active version of the app, or NULL if there is no active version.
  */
-SHOREBIRD_EXPORT char *shorebird_active_version(void);
+SHOREBIRD_EXPORT char *shorebird_active_patch_number(void);
 
 /**
  * Return the path to the active version of the app, or NULL if there is no
@@ -84,6 +84,11 @@ SHOREBIRD_EXPORT bool shorebird_check_for_update(void);
  */
 SHOREBIRD_EXPORT void shorebird_update(void);
 
+/**
+ * Report that the app failed to launch.  This will cause the updater to
+ * attempt to roll back to the previous version if this version has not
+ * been launched successfully before.
+ */
 SHOREBIRD_EXPORT void shorebird_report_failed_launch(void);
 
 #ifdef __cplusplus

--- a/updater/library/src/c_api.rs
+++ b/updater/library/src/c_api.rs
@@ -67,9 +67,8 @@ pub extern "C" fn shorebird_init(c_params: *const AppParameters, c_yaml: *const 
 }
 
 /// Return the active version of the app, or NULL if there is no active version.
-// TODO: This should probably be renamed to `shorebird_active_patch_number`.
 #[no_mangle]
-pub extern "C" fn shorebird_active_version() -> *mut c_char {
+pub extern "C" fn shorebird_active_patch_number() -> *mut c_char {
     let patch = updater::active_patch();
     match patch {
         Some(v) => {

--- a/updater/library/src/c_api.rs
+++ b/updater/library/src/c_api.rs
@@ -66,7 +66,7 @@ pub extern "C" fn shorebird_init(c_params: *const AppParameters, c_yaml: *const 
     }
 }
 
-/// Return the active version of the app, or NULL if there is no active version.
+/// Return the active patch number, or NULL if there is no active patch.
 #[no_mangle]
 pub extern "C" fn shorebird_active_patch_number() -> *mut c_char {
     let patch = updater::active_patch();
@@ -79,8 +79,8 @@ pub extern "C" fn shorebird_active_patch_number() -> *mut c_char {
     }
 }
 
-/// Return the path to the active version of the app, or NULL if there is no
-/// active version.
+/// Return the path to the active patch for the app, or NULL if there is no
+/// active patch.
 #[no_mangle]
 // rename to shorebird_patch_path
 pub extern "C" fn shorebird_active_path() -> *mut c_char {

--- a/updater/library/src/cache.rs
+++ b/updater/library/src/cache.rs
@@ -266,7 +266,7 @@ impl UpdaterState {
             .into());
         }
 
-        // Move the patch into the slot.
+        // Move the artifact into the slot.
         let artifact_path = slot_dir.join("dlc.vmcode");
         std::fs::rename(&patch.path, &artifact_path)?;
 
@@ -363,7 +363,7 @@ mod tests {
     }
 
     #[test]
-    fn dont_install_known_bad_patch() {
+    fn do_not_install_known_bad_patch() {
         let tmp_dir = TempDir::new("example").unwrap();
         let mut state = test_state(&tmp_dir);
         let bad_patch = fake_patch(&tmp_dir, 1);

--- a/updater/library/src/network.rs
+++ b/updater/library/src/network.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::Path;
 use std::string::ToString;
 
 use crate::cache::UpdaterState;
@@ -16,9 +16,17 @@ fn patches_check_url(base_url: &str) -> String {
 
 #[derive(Debug, Deserialize)]
 pub struct Patch {
+    /// The patch number.  Starts at 1 for each new release and increases
+    /// monotonically.
     pub number: usize,
+    /// The hash of the final uncompressed patch file.
     pub hash: String,
+    /// The URL to download the patch file from.
     pub download_url: String,
+    /// Whether the artifact is a diff (modern) or full (legacy) artifact.
+    /// Will eventually be removed once we no longer support legacy artifacts.
+    #[serde(default)]
+    pub is_diff: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -74,7 +82,7 @@ pub fn send_patch_check_request(
     return Ok(response);
 }
 
-pub fn download_to_path(url: &str, path: &PathBuf) -> anyhow::Result<()> {
+pub fn download_to_path(url: &str, path: &Path) -> anyhow::Result<()> {
     // Download the file at the given url to the given path.
     let client = reqwest::blocking::Client::new();
     let response = client.get(url).send()?;


### PR DESCRIPTION
This adds support for zstd-compressed patch files.

This reduces our update sizes by two orders of magnitude.  In testing changing the default flutter counter app from "blue" to "red' background it was a 3mb update before, now it's a 31k update.  That's still larger than needed, and I think we can go smaller, but this is good enough for now.

I ended up needing to change the engine code as well (it was sending the wrong path for the base libapp.so), so I also changed the signature of shorebird_active_version to shorebird_active_patch_number to match our modern wording.  It's still a char* for now.

The compression comes from zstd, through comde (compression/decompression) which is a simple wrapper library around a few rust compression libraries.  We could drop the intermediate layer once we're sure which compression algorithm we're using.

Fixed dont to do_not to appease cspell.

Added a new (optional) bool in the server Patch response "is_diff" which controls whether this behavior is turned on or not.

I've tested by manually submitting my own diff that this flow does work correctly, but we'll need to change the cli and server to support it by default.

Fixed a couple places we were using PathBuf instead of Path.  Turns out PathBuf is to String where Path& is to str&, so using Path& instead of PathBuf& where possible.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
