### PR TITLE
feat: Teach rust side to validate hashes when installing

### DIFF
--- a/updater/library/Cargo.toml
+++ b/updater/library/Cargo.toml
@@ -27,8 +27,6 @@ log = "0.4.14"
 once_cell = "1.17.1"
 # For reading shorebird.yaml
 serde_yaml = "0.9.19"
-# For validating hashes of downloaded patch files.
-sha2 = "0.10.6"
 # For inflating compressed patch files.
 bipatch = "1.0.0"
 # comde is a wrapper around several compression libraries.
@@ -36,6 +34,10 @@ bipatch = "1.0.0"
 comde = {version = "0.2.3", default-features = false, features = ["zstandard"]}
 # Pipe is a simple in-memory pipe implementation, there might be a std way too?
 pipe = "0.4.0"
+# For computing hashes of patch files for validation.
+sha2 = "0.10.6"
+# For decoding the hex-encoded hashes in Patch network responses.
+hex = "0.4.3"
 
 [target.'cfg(target_os = "android")'.dependencies]
 # For logging to Android logcat.

--- a/updater/library/src/cache.rs
+++ b/updater/library/src/cache.rs
@@ -70,17 +70,6 @@ impl UpdaterState {
     }
 }
 
-// fn compute_hash(path: &Path) -> anyhow::Result<String> {
-//     use sha2::{Digest, Sha256};
-//     use std::{fs, io};
-
-//     let mut file = fs::File::open(&path)?;
-//     let mut hasher = Sha256::new();
-//     let n = io::copy(&mut file, &mut hasher)?;
-//     let hash = hasher.finalize();
-//     Ok(format!("{:x}", hash))
-// }
-
 impl UpdaterState {
     pub fn is_known_good_patch(&self, patch: &PatchInfo) -> bool {
         self.successful_patches.iter().any(|v| v == &patch.number)

--- a/updater/library/src/network.rs
+++ b/updater/library/src/network.rs
@@ -19,7 +19,8 @@ pub struct Patch {
     /// The patch number.  Starts at 1 for each new release and increases
     /// monotonically.
     pub number: usize,
-    /// The hash of the final uncompressed patch file.
+    /// The hex-encoded sha256 hash of the final uncompressed patch file.
+    /// Legacy: originally "#" before we implemented hash checks (remove).
     pub hash: String,
     /// The URL to download the patch file from.
     pub download_url: String,


### PR DESCRIPTION
Patches which are sent down with a valid hash have that hash checked during install.

We could also (later) choose to check on every boot or otherwise validate the integrity of the cache.

Confirmed manually through deploys (and unittests) that both hashes are ignored when invalid (e.g. "#") and validated when valid.
