### PR TITLE
feat: Add patch command for use by cli

### DIFF
--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["cli", "library"]
+members = ["cli", "library", "patch"]

--- a/updater/library/src/config.rs
+++ b/updater/library/src/config.rs
@@ -96,6 +96,8 @@ pub fn current_arch() -> &'static str {
     static ARCH: &str = "x86_64";
     #[cfg(target_arch = "aarch64")]
     static ARCH: &str = "aarch64";
+    #[cfg(target_arch = "arm")]
+    static ARCH: &str = "arm";
     return ARCH;
 }
 

--- a/updater/patch/Cargo.toml
+++ b/updater/patch/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "patch"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# Compression and decompression of patch files.
+bidiff = "1.0.0"
+# Pipe is a simple in-memory pipe implementation, there might be a std way too?
+pipe = "0.4.0"
+# comde is a wrapper around several compression libraries.
+# We only use zstd and could depend on it directly instead.
+comde = {version = "0.2.3", default-features = false, features = ["zstandard"]}

--- a/updater/patch/README.md
+++ b/updater/patch/README.md
@@ -1,0 +1,13 @@
+# patch command line tool
+
+This is the tool used by the `shorebird` command line to compute the patch
+file for uploading to the server.
+
+This currently uses the rust `bidiff` crate to compute the patch file.
+and could just use the `bic` command line tool included in that crate. However
+we're explicitly writing our own command line to allow us to change the
+underlying compression without affecting the `shorebird` command line callers.
+
+## Usage
+
+    patch <old> <new> <patch>

--- a/updater/patch/src/main.rs
+++ b/updater/patch/src/main.rs
@@ -1,0 +1,52 @@
+use bidiff::DiffParams;
+use std::{
+    fs::{self, File},
+    io::{BufWriter, Write},
+    time::Instant,
+};
+
+use comde::com::Compressor;
+use comde::zstd::ZstdCompressor;
+
+// Originally inspired from example in:
+// https://github.com/divvun/bidiff/blob/main/crates/bic/src/main.rs
+// and then hacked down to just service our needs.
+
+// comde is just a wrapper around various compression/decompression libraries.
+// and we could just depend on the zstd crate directly if we end up using
+// zstd long term.
+
+fn main() {
+    let mut args = std::env::args();
+    args.next(); // skip program name
+    let older = args.next().expect("path to base file");
+    let newer = args.next().expect("path to new file");
+    let patch = args.next().expect("path to output file");
+
+    let start = Instant::now();
+
+    let older_contents = fs::read(older).expect("read base file");
+    let newer_contents = fs::read(newer).expect("read new file");
+
+    let (mut patch_r, mut patch_w) = pipe::pipe();
+    let diff_params = DiffParams::new(1, None).unwrap();
+    std::thread::spawn(move || {
+        bidiff::simple_diff_with_params(
+            &older_contents[..],
+            &newer_contents[..],
+            &mut patch_w,
+            &diff_params,
+        )
+        .unwrap();
+    });
+
+    let compressor = ZstdCompressor::new();
+
+    let mut compatch_w = BufWriter::new(File::create(patch).expect("create patch file"));
+    compressor
+        .compress(&mut compatch_w, &mut patch_r)
+        .expect("compress patch");
+    compatch_w.flush().expect("flush patch");
+
+    println!("Completed in {:?}", start.elapsed());
+}


### PR DESCRIPTION
I created a `patch` command that knows how to create a patch from a base and new libapp.so.  This uses the same rust crate the updater library does to minimize compatibility risk.

Also improved build_engine.sh, to also build the rust side, both the updater library and the new patch command.

build_engine.sh now errors in output is relative (previously it just dumped output in temp dir silently. :joy:)

I made the rust side build for both arm64 and arm32 even though we don't yet include the arm32 bits in the build.

I also fixed the updater build to support arm32/armv7 (currently called "arm" to the server).

Added --no-goma flag to gn to silence the later warning from ninja that goma was configured but not present.  GOMA is the (google-internal?) compile service Chrome uses.

Included the `patch` binary in the engine.zip for now.  It belongs in some separate artifact system eventually, but this is good enough for now.

Removed dart2wasm_product.snapshot for now since it's not present in our current build.

Made build_engine exit on any error with -e, previously it would just continue happily.