### PR TITLE
fix(updater): use all base library paths

### DIFF
--- a/updater/cli/src/main.rs
+++ b/updater/cli/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     let config = updater::AppConfig {
         cache_dir: "updater_cache".to_owned(),
         release_version: "0.1.0".to_owned(),
-        original_libapp_path: "libapp.so".to_owned(),
+        original_libapp_paths: vec!["libapp.so".to_owned()],
         vm_path: "libflutter.so".to_owned(),
     };
     let yaml_str = "

--- a/updater/dart_bindings/lib/src/bindings.dart
+++ b/updater/dart_bindings/lib/src/bindings.dart
@@ -16,7 +16,7 @@ class AppParameters extends ffi.Struct {
   // ignore: non_constant_identifier_names
   external ffi.Pointer<Utf8> update_url;
   // ignore: non_constant_identifier_names
-  external ffi.Pointer<ffi.Pointer<Utf8>> original_libapp_path;
+  external ffi.Pointer<ffi.Pointer<Utf8>> original_libapp_paths;
   // ignore: non_constant_identifier_names
   external ffi.Pointer<Utf8> vm_path;
   // ignore: non_constant_identifier_names
@@ -38,9 +38,9 @@ class AppParameters extends ffi.Struct {
     if (updateUrl != null) {
       config.ref.update_url = updateUrl.toNativeUtf8();
     }
-    config.ref.original_libapp_path = calloc<ffi.Pointer<Utf8>>();
+    config.ref.original_libapp_paths = calloc<ffi.Pointer<Utf8>>();
     for (var i = 0; i < libappPaths.length; i++) {
-      config.ref.original_libapp_path[i] = libappPaths[i].toNativeUtf8();
+      config.ref.original_libapp_paths[i] = libappPaths[i].toNativeUtf8();
     }
     config.ref.vm_path = libflutterPath.toNativeUtf8();
     config.ref.cache_dir = cacheDir.toNativeUtf8();
@@ -54,11 +54,11 @@ class AppParameters extends ffi.Struct {
     calloc.free(config.ref.update_url);
     // Free all paths in original_libapp_path.
     var i = 0;
-    while (config.ref.original_libapp_path[i].address != 0) {
-      calloc.free(config.ref.original_libapp_path[i]);
+    while (config.ref.original_libapp_paths[i].address != 0) {
+      calloc.free(config.ref.original_libapp_paths[i]);
       i++;
     }
-    calloc.free(config.ref.original_libapp_path);
+    calloc.free(config.ref.original_libapp_paths);
     calloc.free(config.ref.vm_path);
     calloc.free(config.ref.cache_dir);
     calloc.free(config);

--- a/updater/dart_bindings/lib/src/bindings.dart
+++ b/updater/dart_bindings/lib/src/bindings.dart
@@ -42,7 +42,7 @@ class AppParameters extends ffi.Struct {
       config.ref.update_url = updateUrl.toNativeUtf8();
     }
     config.ref.original_libapp_paths = calloc<ffi.Pointer<Utf8>>(
-      libappPaths.length + 1, // +1 for the null terminator.
+      libappPaths.length,
     );
 
     for (var i = 0; i < libappPaths.length; i++) {
@@ -59,11 +59,8 @@ class AppParameters extends ffi.Struct {
     calloc.free(config.ref.channel);
     calloc.free(config.ref.update_url);
     // Free all paths in original_libapp_path.
-    var i = 0;
-    for (var i = 0; i < config.ref.original_libapp_paths_size; i++) {}
-    while (config.ref.original_libapp_paths[i].address != 0) {
+    for (var i = 0; i < config.ref.original_libapp_paths_size; i++) {
       calloc.free(config.ref.original_libapp_paths[i]);
-      i++;
     }
     calloc.free(config.ref.original_libapp_paths);
     calloc.free(config.ref.vm_path);

--- a/updater/dart_bindings/lib/src/bindings.dart
+++ b/updater/dart_bindings/lib/src/bindings.dart
@@ -16,7 +16,7 @@ class AppParameters extends ffi.Struct {
   // ignore: non_constant_identifier_names
   external ffi.Pointer<Utf8> update_url;
   // ignore: non_constant_identifier_names
-  external ffi.Pointer<Utf8> original_libapp_path;
+  external ffi.Pointer<ffi.Pointer<Utf8>> original_libapp_path;
   // ignore: non_constant_identifier_names
   external ffi.Pointer<Utf8> vm_path;
   // ignore: non_constant_identifier_names
@@ -27,7 +27,7 @@ class AppParameters extends ffi.Struct {
     required String version,
     required String channel,
     required String? updateUrl,
-    required String libappPath,
+    required List<String> libappPaths,
     required String libflutterPath,
     required String cacheDir,
   }) {
@@ -38,7 +38,10 @@ class AppParameters extends ffi.Struct {
     if (updateUrl != null) {
       config.ref.update_url = updateUrl.toNativeUtf8();
     }
-    config.ref.original_libapp_path = libappPath.toNativeUtf8();
+    config.ref.original_libapp_path = calloc<ffi.Pointer<Utf8>>();
+    for (var i = 0; i < libappPaths.length; i++) {
+      config.ref.original_libapp_path[i] = libappPaths[i].toNativeUtf8();
+    }
     config.ref.vm_path = libflutterPath.toNativeUtf8();
     config.ref.cache_dir = cacheDir.toNativeUtf8();
     return config;
@@ -49,6 +52,12 @@ class AppParameters extends ffi.Struct {
     calloc.free(config.ref.base_version);
     calloc.free(config.ref.channel);
     calloc.free(config.ref.update_url);
+    // Free all paths in original_libapp_path.
+    var i = 0;
+    while (config.ref.original_libapp_path[i].address != 0) {
+      calloc.free(config.ref.original_libapp_path[i]);
+      i++;
+    }
     calloc.free(config.ref.original_libapp_path);
     calloc.free(config.ref.vm_path);
     calloc.free(config.ref.cache_dir);

--- a/updater/dart_bindings/lib/src/bindings.dart
+++ b/updater/dart_bindings/lib/src/bindings.dart
@@ -17,6 +17,9 @@ class AppParameters extends ffi.Struct {
   external ffi.Pointer<Utf8> update_url;
   // ignore: non_constant_identifier_names
   external ffi.Pointer<ffi.Pointer<Utf8>> original_libapp_paths;
+  @ffi.Int8()
+  // ignore: non_constant_identifier_names
+  external int original_libapp_paths_size;
   // ignore: non_constant_identifier_names
   external ffi.Pointer<Utf8> vm_path;
   // ignore: non_constant_identifier_names
@@ -38,7 +41,10 @@ class AppParameters extends ffi.Struct {
     if (updateUrl != null) {
       config.ref.update_url = updateUrl.toNativeUtf8();
     }
-    config.ref.original_libapp_paths = calloc<ffi.Pointer<Utf8>>();
+    config.ref.original_libapp_paths = calloc<ffi.Pointer<Utf8>>(
+      libappPaths.length + 1, // +1 for the null terminator.
+    );
+
     for (var i = 0; i < libappPaths.length; i++) {
       config.ref.original_libapp_paths[i] = libappPaths[i].toNativeUtf8();
     }
@@ -54,6 +60,7 @@ class AppParameters extends ffi.Struct {
     calloc.free(config.ref.update_url);
     // Free all paths in original_libapp_path.
     var i = 0;
+    for (var i = 0; i < config.ref.original_libapp_paths_size; i++) {}
     while (config.ref.original_libapp_paths[i].address != 0) {
       calloc.free(config.ref.original_libapp_paths[i]);
       i++;

--- a/updater/dart_bindings/lib/updater.dart
+++ b/updater/dart_bindings/lib/updater.dart
@@ -54,7 +54,7 @@ class Updater {
     required String version,
     required String channel,
     required String? updateUrl,
-    required String baseLibraryPath,
+    required List<String> baseLibraryPaths,
     required String vmPath,
     required String cacheDir,
   }) {
@@ -63,7 +63,7 @@ class Updater {
       version: version,
       channel: channel,
       updateUrl: updateUrl,
-      libappPath: baseLibraryPath,
+      libappPaths: baseLibraryPaths,
       libflutterPath: vmPath,
       cacheDir: cacheDir,
     );

--- a/updater/dart_cli/bin/dart_cli.dart
+++ b/updater/dart_cli/bin/dart_cli.dart
@@ -14,7 +14,7 @@ void main(List<String> args) async {
     version: '1.0.0',
     channel: 'stable',
     updateUrl: null,
-    baseLibraryPath: 'libapp.so',
+    baseLibraryPaths: ['libapp.so'],
     vmPath: Platform.executable,
     cacheDir: 'updater_cache',
   );

--- a/updater/library/include/updater.h
+++ b/updater/library/include/updater.h
@@ -74,11 +74,6 @@ SHOREBIRD_EXPORT char *shorebird_active_path(void);
 SHOREBIRD_EXPORT void shorebird_free_string(char *c_string);
 
 /**
- * Free an array returned by the updater library.
- */
-SHOREBIRD_EXPORT void shorebird_free_array(char **c_array);
-
-/**
  * Check for an update.  Returns true if an update is available.
  */
 SHOREBIRD_EXPORT bool shorebird_check_for_update(void);

--- a/updater/library/include/updater.h
+++ b/updater/library/include/updater.h
@@ -74,6 +74,11 @@ SHOREBIRD_EXPORT char *shorebird_active_path(void);
 SHOREBIRD_EXPORT void shorebird_free_string(char *c_string);
 
 /**
+ * Free an array returned by the updater library.
+ */
+SHOREBIRD_EXPORT void shorebird_free_array(char **c_array);
+
+/**
  * Check for an update.  Returns true if an update is available.
  */
 SHOREBIRD_EXPORT bool shorebird_check_for_update(void);

--- a/updater/library/include/updater.h
+++ b/updater/library/include/updater.h
@@ -26,11 +26,10 @@ typedef struct AppParameters {
    */
   const char *release_version;
   /**
-   * Path to the original aot library, required.  For Flutter apps this
-   * is the path to the bundled libapp.so.  May be used for compression
-   * downloaded artifacts.
+   * Array of paths to the original aot library, required.  For Flutter apps
+   * these are the paths to the bundled libapp.so.  May be used for compression downloaded artifacts.
    */
-  const char *original_libapp_path;
+  const char *const *original_libapp_paths;
   /**
    * Path to the app's libflutter.so, required.  May be used for ensuring
    * downloaded artifacts are compatible with the Flutter/Dart versions

--- a/updater/library/include/updater.h
+++ b/updater/library/include/updater.h
@@ -31,6 +31,10 @@ typedef struct AppParameters {
    */
   const char *const *original_libapp_paths;
   /**
+   * Length of the original_libapp_paths array.
+   */
+  int original_libapp_paths_size;
+  /**
    * Path to the app's libflutter.so, required.  May be used for ensuring
    * downloaded artifacts are compatible with the Flutter/Dart versions
    * used by the app.  For Flutter apps this should be the path to the

--- a/updater/library/src/c_api.rs
+++ b/updater/library/src/c_api.rs
@@ -18,10 +18,9 @@ pub struct AppParameters {
     /// are based.  Can be either a version number or a hash.
     pub release_version: *const libc::c_char,
 
-    /// Path to the original aot library, required.  For Flutter apps this
-    /// is the path to the bundled libapp.so.  May be used for compression
-    /// downloaded artifacts.
-    pub original_libapp_path: *const libc::c_char,
+    /// Array of paths to the original aot library, required.  For Flutter apps
+    /// these are the paths to the bundled libapp.so.  May be used for compression downloaded artifacts.
+    pub original_libapp_paths: *const *const libc::c_char,
 
     /// Path to the app's libflutter.so, required.  May be used for ensuring
     /// downloaded artifacts are compatible with the Flutter/Dart versions
@@ -38,13 +37,27 @@ fn to_rust(c_string: *const libc::c_char) -> String {
     unsafe { CStr::from_ptr(c_string).to_str().unwrap() }.to_string()
 }
 
+fn to_rust_vector(c_array: *const *const libc::c_char) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut i = 0;
+    loop {
+        let c_string = unsafe { *c_array.offset(i) };
+        if c_string.is_null() {
+            break;
+        }
+        result.push(to_rust(c_string));
+        i += 1;
+    }
+    result
+}
+
 fn app_config_from_c(c_params: *const AppParameters) -> updater::AppConfig {
     let c_params_ref = unsafe { &*c_params };
 
     updater::AppConfig {
         cache_dir: to_rust(c_params_ref.cache_dir),
         release_version: to_rust(c_params_ref.release_version),
-        original_libapp_path: to_rust(c_params_ref.original_libapp_path),
+        original_libapp_paths: to_rust_vector(c_params_ref.original_libapp_paths),
         vm_path: to_rust(c_params_ref.vm_path),
     }
 }

--- a/updater/library/src/c_api.rs
+++ b/updater/library/src/c_api.rs
@@ -118,22 +118,6 @@ pub extern "C" fn shorebird_free_string(c_string: *mut c_char) {
     }
 }
 
-/// Free an array returned by the updater library.
-#[no_mangle]
-pub extern "C" fn shorebird_free_array(c_array: *mut *mut c_char) {
-    unsafe {
-        let mut i = 0;
-        loop {
-            let c_string = *c_array.offset(i);
-            if c_string.is_null() {
-                break;
-            }
-            drop(CString::from_raw(c_string));
-            i += 1;
-        }
-    }
-}
-
 /// Check for an update.  Returns true if an update is available.
 #[no_mangle]
 pub extern "C" fn shorebird_check_for_update() -> bool {

--- a/updater/library/src/c_api.rs
+++ b/updater/library/src/c_api.rs
@@ -42,14 +42,9 @@ fn to_rust(c_string: *const libc::c_char) -> String {
 
 fn to_rust_vector(c_array: *const *const libc::c_char, size: libc::c_int) -> Vec<String> {
     let mut result = Vec::new();
-    let mut i = 0;
-    loop {
-        if i >= size {
-            break;
-        }
+    for i in 0..size {
         let c_string = unsafe { *c_array.offset(i as isize) };
         result.push(to_rust(c_string));
-        i += 1;
     }
     result
 }

--- a/updater/library/src/c_api.rs
+++ b/updater/library/src/c_api.rs
@@ -118,6 +118,22 @@ pub extern "C" fn shorebird_free_string(c_string: *mut c_char) {
     }
 }
 
+/// Free an array returned by the updater library.
+#[no_mangle]
+pub extern "C" fn shorebird_free_array(c_array: *mut *mut c_char) {
+    unsafe {
+        let mut i = 0;
+        loop {
+            let c_string = *c_array.offset(i);
+            if c_string.is_null() {
+                break;
+            }
+            drop(CString::from_raw(c_string));
+            i += 1;
+        }
+    }
+}
+
 /// Check for an update.  Returns true if an update is available.
 #[no_mangle]
 pub extern "C" fn shorebird_check_for_update() -> bool {

--- a/updater/library/src/config.rs
+++ b/updater/library/src/config.rs
@@ -40,7 +40,7 @@ pub struct ResolvedConfig {
     pub channel: String,
     pub app_id: String,
     pub release_version: String,
-    pub original_libapp_path: String,
+    pub original_libapp_paths: Vec<String>,
     pub vm_path: String,
     pub base_url: String,
 }
@@ -54,7 +54,7 @@ impl ResolvedConfig {
             channel: String::new(),
             app_id: String::new(),
             release_version: String::new(),
-            original_libapp_path: String::new(),
+            original_libapp_paths: Vec::new(),
             vm_path: String::new(),
             base_url: String::new(),
         }
@@ -83,7 +83,7 @@ pub fn set_config(config: AppConfig, yaml: YamlConfig) {
     lock.download_dir = cache_path.to_str().unwrap().to_string();
     lock.app_id = yaml.app_id.to_string();
     lock.release_version = config.release_version.to_string();
-    lock.original_libapp_path = config.original_libapp_path.to_string();
+    lock.original_libapp_paths = config.original_libapp_paths;
     lock.vm_path = config.vm_path.to_string();
     lock.is_initialized = true;
     info!("Updater configured with: {:?}", lock);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- fix(updater): use all base library paths rather than assuming the last path is the correct one

Looks like we have an issue because we're incorrectly assuming the last path in `settings.application_library_path` is the correct path when the docs say:

```
// Path to a library containing the application's compiled Dart code.
// This is a vector so that the embedder can provide fallback paths in
// case the primary path to the library can not be loaded.
```

This change passes the entire list of paths to the rust updater and the rust updater uses the first path that exists.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
