### PR TITLE
feat: Add basic `shorebird account` command

### DIFF
--- a/packages/shorebird_cli/README.md
+++ b/packages/shorebird_cli/README.md
@@ -78,6 +78,21 @@ shorebird logout
 ✓ Logging out of shorebird.dev (1ms)
 ```
 
+### Account
+
+To see information about your Shorebird account, use the `shorebird account` command.
+
+```bash
+shorebird account
+```
+
+**Sample**
+
+```
+$ shorebird account
+You are logged in as <bryan@shorebird.dev>
+```
+
 ### Doctor
 
 To check your environment for common issues, use the `shorebird doctor` command.
@@ -90,9 +105,12 @@ shorebird doctor
 
 ```
 $ shorebird doctor
-Doctor summary
 
 Shorebird v0.0.3
+
+✓ Shorebird is up-to-date (0.7s)
+✓ Flutter install is correct (0.1s)
+✓ AndroidManifest.xml files contain INTERNET permission (26ms)
 
 No issues detected!
 ```

--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -35,6 +35,7 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
         help: 'Noisy logging, including all shell commands executed.',
       );
 
+    addCommand(AccountCommand(logger: _logger));
     addCommand(AppsCommand(logger: _logger));
     addCommand(BuildCommand(logger: _logger));
     addCommand(ChannelsCommand(logger: _logger));

--- a/packages/shorebird_cli/lib/src/commands/account_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account_command.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/command.dart';
+
+class AccountCommand extends ShorebirdCommand {
+  AccountCommand({required super.logger, super.auth});
+
+  @override
+  String get name => 'account';
+
+  @override
+  String get description => 'Show information about the logged-in user';
+
+  @override
+  Future<int> run() async {
+    if (!auth.isAuthenticated) {
+      logger.info(
+        'You are not logged in.'
+        ' Run ${green.wrap('shorebird login')} to log in.',
+      );
+      return ExitCode.success.code;
+    }
+
+    logger.info('You are logged in as <${auth.user!.email}>');
+
+    return ExitCode.success.code;
+  }
+}

--- a/packages/shorebird_cli/lib/src/commands/commands.dart
+++ b/packages/shorebird_cli/lib/src/commands/commands.dart
@@ -1,3 +1,4 @@
+export 'account_command.dart';
 export 'apps/apps.dart';
 export 'build_command.dart';
 export 'channels/channels.dart';

--- a/packages/shorebird_cli/test/src/commands/account_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account_command_test.dart
@@ -1,0 +1,48 @@
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shorebird_cli/src/auth/auth.dart';
+import 'package:shorebird_cli/src/commands/account_command.dart';
+import 'package:test/test.dart';
+
+class _MockAuth extends Mock implements Auth {}
+
+class _MockLogger extends Mock implements Logger {}
+
+void main() {
+  group('AccountCommand', () {
+    const user = User(email: 'hello@shorebird.dev');
+
+    late Auth auth;
+    late Logger logger;
+    late AccountCommand accountCommand;
+
+    setUp(() {
+      auth = _MockAuth();
+      logger = _MockLogger();
+      accountCommand = AccountCommand(logger: logger, auth: auth);
+
+      when(() => auth.isAuthenticated).thenReturn(true);
+      when(() => auth.user).thenReturn(user);
+    });
+
+    test("doesn't do anything if no user is logged in", () async {
+      when(() => auth.isAuthenticated).thenReturn(false);
+
+      final result = await accountCommand.run();
+
+      expect(result, equals(ExitCode.success.code));
+      verify(
+        () => logger.info(any(that: contains('You are not logged in'))),
+      ).called(1);
+    });
+
+    test('prints the email address of the current user', () async {
+      final result = await accountCommand.run();
+
+      expect(result, equals(ExitCode.success.code));
+      verify(
+        () => logger.info('You are logged in as <hello@shorebird.dev>'),
+      ).called(1);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds a simple `shorebird account` command that prints whether you're logged in. More account info (e.g., payment status) will be added soon.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
