### PR TITLE
feat: Add FLUTTER_STORAGE_BASE_URL when using shorebird vended flutter

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -50,7 +50,8 @@ abstract class ShorebirdProcess {
 
   static String _resolveExecutable(String executable) {
     if (executable == 'flutter') {
-      return ShorebirdPaths.flutterBinaryFile.path;
+      return 'FLUTTER_STORAGE_BASE_URL="https://download.shorebird.dev/" '
+          '${ShorebirdPaths.flutterBinaryFile.path}';
     }
 
     return executable;


### PR DESCRIPTION
## Description

Sets the `FLUTTER_STORAGE_BASE_URL` to `"https://download.shorebird.dev/"` when using shorebird-vended Flutter.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
