### PR TITLE
fix(shorebird_cli): Make `shorebird release` logging clearer

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release_command.dart
@@ -155,8 +155,7 @@ Did you forget to run "shorebird init"?''',
     final arch = results['arch'] as String;
     final platform = results['platform'] as String;
 
-    logger.info(
-      '''
+    logger.info('''
 
 ${styleBold.wrap(lightGreen.wrap('🚀 Ready to create a new release!'))}
 
@@ -165,14 +164,7 @@ ${styleBold.wrap(lightGreen.wrap('🚀 Ready to create a new release!'))}
 ⚙️  Architecture: ${lightCyan.wrap(arch)}
 🕹️  Platform: ${lightCyan.wrap(platform)}
 #️⃣  Hash: ${lightCyan.wrap(hash)}
-
-Your next step is to upload the release artifact to the Play Store.
-${lightCyan.wrap("./build/app/outputs/bundle/release/app-release.aab")}
-
-See the following link for more information:    
-${link(uri: Uri.parse('https://support.google.com/googleplay/android-developer/answer/9859152?hl=en'))}
-''',
-    );
+''');
 
     final confirm = logger.confirm('Would you like to continue?');
 
@@ -221,7 +213,17 @@ ${link(uri: Uri.parse('https://support.google.com/googleplay/android-developer/a
       return ExitCode.software.code;
     }
 
-    logger.success('\n✅ Published Release!');
+    logger
+      ..success('\n✅ Published Release!')
+      ..info('''
+
+Your next step is to upload the release artifact to the Play Store.
+${lightCyan.wrap("./build/app/outputs/bundle/release/app-release.aab")}
+
+See the following link for more information:    
+${link(uri: Uri.parse('https://support.google.com/googleplay/android-developer/answer/9859152?hl=en'))}
+''');
+
     return ExitCode.success.code;
   }
 }


### PR DESCRIPTION
## Description

Updates the `shorebird release` output to make it clearer that this command is not publishing to the Play store. 

Sample output:

```
⑆ shorebird release
✓ Building release (6.0s)
✓ Fetching apps (0.2s)

What is the version of this release? (1.0.4) 1.0.4

🚀 Ready to create a new release!

📱 App: time_shift (989fac5b-578c-4fdb-b607-542da788a6c7)
📦 Release Version: 1.0.4
⚙️  Architecture: aarch64
🕹️  Platform: android
#️⃣  Hash: e3aeb495bd24483e68da49f8add9964179ed14648ec5e530b3a94b7000df1e5e

Would you like to continue? (y/N) Yes
✓ Fetching releases (86ms)
✓ Creating release (67ms)
✓ Creating artifact (0.8s)

✅ Published Release!

Your next step is to upload the release artifact to the Play Store.
./build/app/outputs/bundle/release/app-release.aab

See the following link for more information:
https://support.google.com/googleplay/android-developer/answer/9859152?hl=en
```

Fixes https://github.com/shorebirdtech/shorebird/issues/254

Also filed https://github.com/shorebirdtech/shorebird/issues/257

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
