### PR TITLE
chore(shorebird_cli): Update ShorebirdCommand to accept a list of validators instead of a single ShorebirdFlutterValidator

### DIFF
--- a/packages/shorebird_cli/lib/src/command.dart
+++ b/packages/shorebird_cli/lib/src/command.dart
@@ -33,14 +33,14 @@ abstract class ShorebirdCommand extends Command<int> {
     CodePushClientBuilder? buildCodePushClient,
     RunProcess? runProcess,
     StartProcess? startProcess,
-    ShorebirdFlutterValidator? flutterValidator,
+    List<Validator>? validators,
   })  : auth = auth ?? Auth(),
         cache = cache ?? Cache(),
         buildCodePushClient = buildCodePushClient ?? CodePushClient.new,
         runProcess = runProcess ?? ShorebirdProcess.run,
         startProcess = startProcess ?? ShorebirdProcess.start {
-    this.flutterValidator = flutterValidator ??
-        ShorebirdFlutterValidator(runProcess: this.runProcess);
+    this.validators =
+        validators ?? [ShorebirdFlutterValidator(runProcess: this.runProcess)];
   }
 
   final Auth auth;
@@ -49,7 +49,9 @@ abstract class ShorebirdCommand extends Command<int> {
   final Logger logger;
   final RunProcess runProcess;
   final StartProcess startProcess;
-  late final ShorebirdFlutterValidator flutterValidator;
+
+  /// Checks that the Shorebird install and project are in a good state.
+  late List<Validator> validators;
 
   /// [ArgResults] used for testing purposes only.
   @visibleForTesting

--- a/packages/shorebird_cli/lib/src/commands/build_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build_command.dart
@@ -19,7 +19,7 @@ class BuildCommand extends ShorebirdCommand
     super.auth,
     super.buildCodePushClient,
     super.runProcess,
-    super.flutterValidator,
+    super.validators,
   });
 
   @override
@@ -37,7 +37,7 @@ class BuildCommand extends ShorebirdCommand
       return ExitCode.noUser.code;
     }
 
-    await logFlutterValidationIssues();
+    await logValidationIssues();
 
     final buildProgress = logger.progress('Building release ');
     try {

--- a/packages/shorebird_cli/lib/src/commands/doctor_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/doctor_command.dart
@@ -77,7 +77,7 @@ Shorebird v$packageVersion
     final missingValidators = _doctorValidators
         .where(
           (doctorValidator) => baseValidators.none(
-            (baseValidator) => baseValidator.name == doctorValidator.name,
+            (baseValidator) => baseValidator.id == doctorValidator.id,
           ),
         )
         .toList();

--- a/packages/shorebird_cli/lib/src/commands/doctor_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/doctor_command.dart
@@ -76,8 +76,8 @@ Shorebird v$packageVersion
   }) {
     final missingValidators = _doctorValidators
         .where(
-          (defaultValidator) => baseValidators.none(
-            (baseValidator) => baseValidator.name == defaultValidator.name,
+          (doctorValidator) => baseValidators.none(
+            (baseValidator) => baseValidator.name == doctorValidator.name,
           ),
         )
         .toList();

--- a/packages/shorebird_cli/lib/src/commands/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch_command.dart
@@ -29,7 +29,7 @@ class PatchCommand extends ShorebirdCommand
     super.buildCodePushClient,
     super.cache,
     super.runProcess,
-    super.flutterValidator,
+    super.validators,
     HashFunction? hashFn,
     http.Client? httpClient,
   })  : _hashFn = hashFn ?? ((m) => sha256.convert(m).toString()),
@@ -108,7 +108,7 @@ class PatchCommand extends ShorebirdCommand
       return ExitCode.usage.code;
     }
 
-    await logFlutterValidationIssues();
+    await logValidationIssues();
 
     await cache.updateAll();
 

--- a/packages/shorebird_cli/lib/src/commands/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release_command.dart
@@ -27,7 +27,7 @@ class ReleaseCommand extends ShorebirdCommand
     super.auth,
     super.buildCodePushClient,
     super.runProcess,
-    super.flutterValidator,
+    super.validators,
     HashFunction? hashFn,
   }) : _hashFn = hashFn ?? ((m) => sha256.convert(m).toString()) {
     argParser
@@ -77,7 +77,7 @@ make smaller updates to your app.
       return ExitCode.noUser.code;
     }
 
-    await logFlutterValidationIssues();
+    await logValidationIssues();
 
     final buildProgress = logger.progress('Building release');
     try {

--- a/packages/shorebird_cli/lib/src/commands/run_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/run_command.dart
@@ -17,7 +17,7 @@ class RunCommand extends ShorebirdCommand
     super.auth,
     super.buildCodePushClient,
     super.startProcess,
-    super.flutterValidator,
+    super.validators,
   });
 
   @override
@@ -35,7 +35,7 @@ class RunCommand extends ShorebirdCommand
       return ExitCode.noUser.code;
     }
 
-    await logFlutterValidationIssues();
+    await logValidationIssues();
 
     logger.info('Running app...');
     final process = await startProcess(

--- a/packages/shorebird_cli/lib/src/flutter_validation_mixin.dart
+++ b/packages/shorebird_cli/lib/src/flutter_validation_mixin.dart
@@ -1,13 +1,17 @@
+import 'package:collection/collection.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/validators/shorebird_flutter_validator.dart';
 
 mixin FlutterValidationMixin on ShorebirdCommand {
   /// Runs [ShorebirdFlutterValidator.validate] and writes validation issues to
   /// stdout.
-  Future<void> logFlutterValidationIssues() async {
-    final flutterValidationIssues = await flutterValidator.validate();
-    if (flutterValidationIssues.isNotEmpty) {
-      for (final issue in flutterValidationIssues) {
+  Future<void> logValidationIssues() async {
+    final validationIssues = (await Future.wait(
+      validators.map((v) => v.validate()),
+    ))
+        .flattened;
+    if (validationIssues.isNotEmpty) {
+      for (final issue in validationIssues) {
         logger.info(issue.displayMessage);
       }
     }

--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -57,7 +57,7 @@ class ShorebirdFlutterValidator extends Validator {
       final message = """
 Shorebird Flutter and the Flutter on your path are different versions.
 \tShorebird Flutter: $shorebirdFlutterVersion
-\tSystem Flutter:    $pathFlutterVersion'''
+\tSystem Flutter:    $pathFlutterVersion
 This can cause unexpected behavior if the version gap is wide. If you're seeing this unexpectedly, please let us know on Shorebird discord!""";
 
       issues.add(

--- a/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
@@ -27,9 +27,7 @@ class ShorebirdVersionValidator extends Validator {
         const ValidationIssue(
           severity: ValidationIssueSeverity.warning,
           message: '''
-A new version of shorebird is available!
-Run `shorebird upgrade` to upgrade.
-''',
+A new version of shorebird is available! Run `shorebird upgrade` to upgrade.''',
         )
       ];
     }

--- a/packages/shorebird_cli/lib/src/validators/validators.dart
+++ b/packages/shorebird_cli/lib/src/validators/validators.dart
@@ -65,8 +65,8 @@ class ValidationIssue {
 /// Checks for a specific issue with either the Shorebird installation or the
 /// current Shorebird project.
 abstract class Validator {
-  /// The short name of this validator.
-  String get name => '$runtimeType';
+  /// A unique identifer for this class.
+  String get id => '$runtimeType';
 
   /// A one-sentence explanation of what this validator is checking.
   String get description;

--- a/packages/shorebird_cli/lib/src/validators/validators.dart
+++ b/packages/shorebird_cli/lib/src/validators/validators.dart
@@ -65,6 +65,9 @@ class ValidationIssue {
 /// Checks for a specific issue with either the Shorebird installation or the
 /// current Shorebird project.
 abstract class Validator {
+  /// The short name of this validator.
+  String get name => '$runtimeType';
+
   /// A one-sentence explanation of what this validator is checking.
   String get description;
 

--- a/packages/shorebird_cli/test/src/commands/build_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build_command_test.dart
@@ -68,7 +68,7 @@ void main() {
         }) async {
           return processResult;
         },
-        flutterValidator: flutterValidator,
+        validators: [flutterValidator],
       )..testArgResults = argResults;
       testApplicationConfigHome = (_) => applicationConfigHome.path;
 

--- a/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
@@ -38,21 +38,21 @@ void main() {
       shorebirdVersionValidator = _MockShorebirdVersionValidator();
       shorebirdFlutterValidator = _MockShorebirdFlutterValidator();
 
-      when(() => androidInternetPermissionValidator.name)
+      when(() => androidInternetPermissionValidator.id)
           .thenReturn('$AndroidInternetPermissionValidator');
       when(() => androidInternetPermissionValidator.description)
           .thenReturn('Android');
       when(() => androidInternetPermissionValidator.validate())
           .thenAnswer((_) async => []);
 
-      when(() => shorebirdVersionValidator.name)
+      when(() => shorebirdVersionValidator.id)
           .thenReturn('$ShorebirdVersionValidator');
       when(() => shorebirdVersionValidator.description)
           .thenReturn('Shorebird Version');
       when(() => shorebirdVersionValidator.validate())
           .thenAnswer((_) async => []);
 
-      when(() => shorebirdFlutterValidator.name)
+      when(() => shorebirdFlutterValidator.id)
           .thenReturn('$ShorebirdFlutterValidator');
       when(() => shorebirdFlutterValidator.description)
           .thenReturn('Shorebird Flutter');

--- a/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
@@ -10,6 +10,9 @@ class _MockShorebirdVersionValidator extends Mock
 class _MockAndroidInternetPermissionValidator extends Mock
     implements AndroidInternetPermissionValidator {}
 
+class _MockShorebirdFlutterValidator extends Mock
+    implements ShorebirdFlutterValidator {}
+
 class _MockLogger extends Mock implements Logger {}
 
 class _MockProgress extends Mock implements Progress {}
@@ -21,36 +24,49 @@ void main() {
     late DoctorCommand command;
     late AndroidInternetPermissionValidator androidInternetPermissionValidator;
     late ShorebirdVersionValidator shorebirdVersionValidator;
+    late ShorebirdFlutterValidator shorebirdFlutterValidator;
 
     setUp(() {
       logger = _MockLogger();
       progress = _MockProgress();
 
+      when(() => logger.progress(any())).thenReturn(progress);
+      when(() => logger.info(any())).thenReturn(null);
+
       androidInternetPermissionValidator =
           _MockAndroidInternetPermissionValidator();
       shorebirdVersionValidator = _MockShorebirdVersionValidator();
+      shorebirdFlutterValidator = _MockShorebirdFlutterValidator();
+
+      when(() => androidInternetPermissionValidator.name)
+          .thenReturn('$AndroidInternetPermissionValidator');
+      when(() => androidInternetPermissionValidator.description)
+          .thenReturn('Android');
+      when(() => androidInternetPermissionValidator.validate())
+          .thenAnswer((_) async => []);
+
+      when(() => shorebirdVersionValidator.name)
+          .thenReturn('$ShorebirdVersionValidator');
+      when(() => shorebirdVersionValidator.description)
+          .thenReturn('Shorebird Version');
+      when(() => shorebirdVersionValidator.validate())
+          .thenAnswer((_) async => []);
+
+      when(() => shorebirdFlutterValidator.name)
+          .thenReturn('$ShorebirdFlutterValidator');
+      when(() => shorebirdFlutterValidator.description)
+          .thenReturn('Shorebird Flutter');
+      when(() => shorebirdFlutterValidator.validate())
+          .thenAnswer((_) async => []);
 
       command = DoctorCommand(
         logger: logger,
         validators: [
           androidInternetPermissionValidator,
           shorebirdVersionValidator,
+          shorebirdFlutterValidator,
         ],
       );
-
-      when(() => logger.progress(any())).thenReturn(progress);
-
-      when(() => logger.info(any())).thenReturn(null);
-
-      when(() => androidInternetPermissionValidator.description)
-          .thenReturn('Android');
-      when(() => androidInternetPermissionValidator.validate())
-          .thenAnswer((_) async => []);
-
-      when(() => shorebirdVersionValidator.description)
-          .thenReturn('Shorebird Version');
-      when(() => shorebirdVersionValidator.validate())
-          .thenAnswer((_) async => []);
     });
 
     test('prints "no issues" when everything is OK', () async {

--- a/packages/shorebird_cli/test/src/commands/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch_command_test.dart
@@ -144,7 +144,7 @@ flutter:
         },
         logger: logger,
         httpClient: httpClient,
-        flutterValidator: flutterValidator,
+        validators: [flutterValidator],
       )..testArgResults = argResults;
       testApplicationConfigHome = (_) => applicationConfigHome.path;
 

--- a/packages/shorebird_cli/test/src/commands/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release_command_test.dart
@@ -116,7 +116,7 @@ flutter:
           return processResult;
         },
         logger: logger,
-        flutterValidator: flutterValidator,
+        validators: [flutterValidator],
       )..testArgResults = argResults;
       testApplicationConfigHome = (_) => applicationConfigHome.path;
 

--- a/packages/shorebird_cli/test/src/commands/run_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/run_command_test.dart
@@ -63,7 +63,7 @@ void main() {
         startProcess: (executable, arguments, {bool runInShell = false}) async {
           return process;
         },
-        flutterValidator: flutterValidator,
+        validators: [flutterValidator],
       )..testArgResults = argResults;
 
       testApplicationConfigHome = (_) => applicationConfigHome.path;


### PR DESCRIPTION
## Description

Replaces the `flutterValidator` constructor parameter of `ShorebirdCommand` with `validators` to facilitate more thorough validation for shorebird commands. This is pre-work for https://github.com/shorebirdtech/shorebird/issues/261.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
