### PR TITLE
fix(shorebird_cli): make android manifest and shorebird version validation more robust

### DIFF
--- a/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
@@ -18,9 +18,20 @@ class ShorebirdVersionValidator extends Validator {
   @override
   Future<List<ValidationIssue>> validate() async {
     final workingDirectory = p.dirname(Platform.script.toFilePath());
-    final isShorebirdUpToDate = await isShorebirdVersionCurrent(
-      workingDirectory: workingDirectory,
-    );
+    final bool isShorebirdUpToDate;
+
+    try {
+      isShorebirdUpToDate = await isShorebirdVersionCurrent(
+        workingDirectory: workingDirectory,
+      );
+    } on ProcessException catch (e) {
+      return [
+        ValidationIssue(
+          severity: ValidationIssueSeverity.error,
+          message: 'Failed to get shorebird version. Error: ${e.message}',
+        ),
+      ];
+    }
 
     if (!isShorebirdUpToDate) {
       return [

--- a/packages/shorebird_cli/test/src/validators/android_internet_permission_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/android_internet_permission_validator_test.dart
@@ -65,6 +65,33 @@ void main() {
       },
     );
 
+    test('returns an error if no android project is found', () async {
+      final results = await AndroidInternetPermissionValidator().validate();
+
+      expect(results, hasLength(1));
+      expect(results.first.severity, ValidationIssueSeverity.error);
+      expect(results.first.message, 'No Android project found');
+    });
+
+    test('returns an error if no AndroidManifest.xml files are found',
+        () async {
+      final tempDirectory = createTempDir();
+      Directory(p.join(tempDirectory.path, 'android', 'app', 'src', 'debug'))
+          .createSync(recursive: true);
+
+      final results = await IOOverrides.runZoned(
+        () => AndroidInternetPermissionValidator().validate(),
+        getCurrentDirectory: () => tempDirectory,
+      );
+
+      expect(results, hasLength(1));
+      expect(results.first.severity, ValidationIssueSeverity.error);
+      expect(
+        results.first.message,
+        startsWith('No AndroidManifest.xml files found in'),
+      );
+    });
+
     test(
       'returns separate errors for all AndroidManifest.xml files without the '
       'INTERNET permission',

--- a/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
@@ -87,5 +87,29 @@ void main() {
         contains('A new version of shorebird is available!'),
       );
     });
+
+    test(
+      'returns an error on failure to retrieve shorebird version',
+      () async {
+        when(
+          () => fetchLatestVersionResult.stdout,
+        ).thenThrow(
+          const ProcessException(
+            'git',
+            ['--rev'],
+            'Some error',
+          ),
+        );
+
+        final results = await validator.validate();
+
+        expect(results, hasLength(1));
+        expect(results.first.severity, ValidationIssueSeverity.error);
+        expect(
+          results.first.message,
+          'Failed to get shorebird version. Error: Some error',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

Updates AndroidInternetPermissionValidator and ShorebirdVersionValidator to handle exceptions more gracefully. Specifically:

- AndroidInternetPermissionValidator won't throw an unhandled exception if it can't find an Android project
- ShorebirdVersionValidator won't throw an unhandled exception if the shorebird repo is on a different branch.

Fixes https://github.com/shorebirdtech/shorebird/issues/272

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
