### PR TITLE
feat(shorebird_cli): Add `shorebird subscription cancel` command.

### DIFF
--- a/packages/shorebird_cli/README.md
+++ b/packages/shorebird_cli/README.md
@@ -324,6 +324,22 @@ Would you like to continue? (y/N) Yes
 ✅ New Channel Created!
 ```
 
+### Cancel Subscription
+
+Cancel your Shorebird subscription using `shorebird subscription cancel` command:
+
+```bash
+shoreburd subscription cancel
+```
+
+**Sample**
+
+```bash
+$ shorebird subscription cancel
+This will cancel your Shorebird subscription. Are you sure? (y/N) Yes
+Your subscription has been canceled.
+```
+
 ### Usage
 
 ```

--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -46,6 +46,7 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
     addCommand(PatchCommand(logger: _logger));
     addCommand(ReleaseCommand(logger: _logger));
     addCommand(RunCommand(logger: _logger));
+    addCommand(SubscriptionCommand(logger: _logger));
     addCommand(UpgradeCommand(logger: _logger));
   }
 

--- a/packages/shorebird_cli/lib/src/commands/commands.dart
+++ b/packages/shorebird_cli/lib/src/commands/commands.dart
@@ -9,4 +9,5 @@ export 'logout_command.dart';
 export 'patch_command.dart';
 export 'release_command.dart';
 export 'run_command.dart';
+export 'subscription/subscription_command.dart';
 export 'upgrade_command.dart';

--- a/packages/shorebird_cli/lib/src/commands/subscription/cancel_subscription_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/subscription/cancel_subscription_command.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:intl/intl.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -52,14 +53,25 @@ class CancelSubscriptionCommand extends ShorebirdCommand
       return ExitCode.success.code;
     }
 
+    final progress = logger.progress('Canceling your subscription...');
+
+    final DateTime cancellationDate;
     try {
-      await client.cancelSubscription();
+      cancellationDate = await client.cancelSubscription();
     } catch (error) {
-      logger.err(error.toString());
+      progress.fail('Failed to cancel subscription. Error: $error');
       return ExitCode.software.code;
     }
 
-    logger.info('Your subscription has been canceled.');
+    final formattedDate = DateFormat.yMMMMd().format(cancellationDate);
+    progress.complete(
+      '''
+Your subscription has been canceled.
+
+Note: Your access to Shorebird will continue until $formattedDate, after which all data stored with Shorebird will be deleted as per our privacy policy: https://shorebird.dev/privacy.html.
+
+Apps on devices you've built with Shorebird will continue to function normally, but will not receive further updates.''',
+    );
 
     return ExitCode.success.code;
   }

--- a/packages/shorebird_cli/lib/src/commands/subscription/cancel_subscription_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/subscription/cancel_subscription_command.dart
@@ -68,7 +68,7 @@ class CancelSubscriptionCommand extends ShorebirdCommand
       '''
 Your subscription has been canceled.
 
-Note: Your access to Shorebird will continue until $formattedDate, after which all data stored with Shorebird will be deleted as per our privacy policy: https://shorebird.dev/privacy.html.
+Note: Your access to Shorebird will continue until $formattedDate, after which all data stored by Shorebird will be deleted as per our privacy policy: https://shorebird.dev/privacy.html.
 
 Apps on devices you've built with Shorebird will continue to function normally, but will not receive further updates.''',
     );

--- a/packages/shorebird_cli/lib/src/commands/subscription/cancel_subscription_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/subscription/cancel_subscription_command.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
+import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
+
+class CancelSubscriptionCommand extends ShorebirdCommand
+    with ShorebirdConfigMixin {
+  CancelSubscriptionCommand({
+    required super.logger,
+    super.auth,
+    super.buildCodePushClient,
+  });
+
+  @override
+  String get name => 'cancel';
+
+  @override
+  String get description => 'Cancel your Shorebird subscription.';
+
+  @override
+  Future<int> run() async {
+    if (!auth.isAuthenticated) {
+      logger.err('You must be logged in to cancel your subscription.');
+      return ExitCode.noUser.code;
+    }
+
+    final client = buildCodePushClient(
+      httpClient: auth.client,
+      hostedUri: hostedUri,
+    );
+
+    final User user;
+    try {
+      user = await client.getCurrentUser();
+    } catch (error) {
+      logger.err(error.toString());
+      return ExitCode.software.code;
+    }
+
+    if (!user.hasActiveSubscription) {
+      logger.err('You do not have an active subscription.');
+      return ExitCode.software.code;
+    }
+
+    final confirm = logger.confirm(
+      red.wrap('This will cancel your Shorebird subscription. Are you sure?'),
+    );
+    if (!confirm) {
+      logger.info('Aborting.');
+      return ExitCode.success.code;
+    }
+
+    try {
+      await client.cancelSubscription();
+    } catch (error) {
+      logger.err(error.toString());
+      return ExitCode.software.code;
+    }
+
+    logger.info('Your subscription has been canceled.');
+
+    return ExitCode.success.code;
+  }
+}

--- a/packages/shorebird_cli/lib/src/commands/subscription/cancel_subscription_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/subscription/cancel_subscription_command.dart
@@ -53,7 +53,7 @@ class CancelSubscriptionCommand extends ShorebirdCommand
       return ExitCode.success.code;
     }
 
-    final progress = logger.progress('Canceling your subscription...');
+    final progress = logger.progress('Canceling your subscription');
 
     final DateTime cancellationDate;
     try {

--- a/packages/shorebird_cli/lib/src/commands/subscription/subscription.dart
+++ b/packages/shorebird_cli/lib/src/commands/subscription/subscription.dart
@@ -1,0 +1,1 @@
+export 'cancel_subscription_command.dart';

--- a/packages/shorebird_cli/lib/src/commands/subscription/subscription_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/subscription/subscription_command.dart
@@ -1,0 +1,20 @@
+import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/commands/subscription/subscription.dart';
+
+/// {@template subscription_command}
+///
+/// `shorebird subscription`
+/// Manage your Shorebird subscription.
+/// {@endtemplate}
+class SubscriptionCommand extends ShorebirdCommand {
+  /// {@macro subscription_command}
+  SubscriptionCommand({required super.logger}) {
+    addSubcommand(CancelSubscriptionCommand(logger: logger));
+  }
+
+  @override
+  String get name => 'subscription';
+
+  @override
+  String get description => 'Manage your Shorebird subscription.';
+}

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   crypto: ^3.0.2
   googleapis_auth: ^1.4.0
   http: ^0.13.5
+  intl: ^0.18.0
   json_annotation: ^4.8.0
   mason_logger: ^0.2.4
   meta: ^1.9.0

--- a/packages/shorebird_cli/test/src/commands/subscription/cancel_subscription_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/subscription/cancel_subscription_command_test.dart
@@ -1,0 +1,167 @@
+import 'package:http/http.dart' as http;
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shorebird_cli/src/auth/auth.dart';
+import 'package:shorebird_cli/src/commands/subscription/cancel_subscription_command.dart';
+import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
+import 'package:test/test.dart';
+
+class _MockAuth extends Mock implements Auth {}
+
+class _MockCodePushClient extends Mock implements CodePushClient {}
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+class _MockLogger extends Mock implements Logger {}
+
+void main() {
+  group('CancelSubscriptionCommand', () {
+    const noSubscriptionUser = User(id: 1, email: 'tester1@shorebird.dev');
+    const subscriptionUser = User(
+      id: 2,
+      email: 'tester2@shorebird.dev',
+      hasActiveSubscription: true,
+    );
+
+    late Auth auth;
+    late CodePushClient codePushClient;
+    late http.Client httpClient;
+    late Logger logger;
+
+    late CancelSubscriptionCommand command;
+
+    setUp(() {
+      auth = _MockAuth();
+      codePushClient = _MockCodePushClient();
+      httpClient = _MockHttpClient();
+      logger = _MockLogger();
+
+      command = CancelSubscriptionCommand(
+        logger: logger,
+        auth: auth,
+        buildCodePushClient: ({
+          required http.Client httpClient,
+          Uri? hostedUri,
+        }) =>
+            codePushClient,
+      );
+
+      when(() => auth.client).thenReturn(httpClient);
+    });
+
+    test('prints an error if the user is not logged in', () async {
+      when(() => auth.isAuthenticated).thenReturn(false);
+
+      final result = await command.run();
+
+      expect(result, ExitCode.noUser.code);
+      verify(
+        () => logger.err(any(that: contains('You must be logged in'))),
+      ).called(1);
+    });
+
+    test('prints an error if fetch current user fails', () async {
+      when(() => auth.isAuthenticated).thenReturn(true);
+      when(() => codePushClient.getCurrentUser()).thenThrow(
+        Exception('an error occurred'),
+      );
+
+      final result = await command.run();
+
+      expect(result, ExitCode.software.code);
+      verify(
+        () => logger.err(any(that: contains('an error occurred'))),
+      ).called(1);
+    });
+
+    test(
+      'prints an error if the user does not have an active subscription',
+      () async {
+        when(() => auth.isAuthenticated).thenReturn(true);
+        when(() => codePushClient.getCurrentUser())
+            .thenAnswer((_) async => noSubscriptionUser);
+
+        final result = await command.run();
+
+        expect(result, ExitCode.software.code);
+        verify(
+          () => logger.err(
+            any(that: contains('You do not have an active subscription')),
+          ),
+        ).called(1);
+      },
+    );
+
+    test('exits successfully if the user opts not to cancel', () async {
+      when(() => auth.isAuthenticated).thenReturn(true);
+      when(() => codePushClient.getCurrentUser())
+          .thenAnswer((_) async => subscriptionUser);
+      when(
+        () => logger.confirm(
+          any(
+            that: contains(
+              'This will cancel your Shorebird subscription. Are you sure?',
+            ),
+          ),
+        ),
+      ).thenReturn(false);
+
+      final result = await command.run();
+
+      expect(result, ExitCode.success.code);
+      verify(() => logger.info('Aborting.')).called(1);
+    });
+
+    test('prints an error if call to cancel subscription fails', () async {
+      when(() => auth.isAuthenticated).thenReturn(true);
+      when(() => codePushClient.getCurrentUser())
+          .thenAnswer((_) async => subscriptionUser);
+      when(
+        () => logger.confirm(
+          any(
+            that: contains(
+              'This will cancel your Shorebird subscription. Are you sure?',
+            ),
+          ),
+        ),
+      ).thenReturn(true);
+      when(() => codePushClient.cancelSubscription()).thenThrow(
+        Exception('an error occurred'),
+      );
+
+      final result = await command.run();
+
+      expect(result, ExitCode.software.code);
+      verify(
+        () => logger.err(
+          any(that: contains('an error occurred')),
+        ),
+      ).called(1);
+    });
+
+    test('exits successfully on subscription cancellation', () async {
+      when(() => auth.isAuthenticated).thenReturn(true);
+      when(() => codePushClient.getCurrentUser())
+          .thenAnswer((_) async => subscriptionUser);
+      when(
+        () => logger.confirm(
+          any(
+            that: contains(
+              'This will cancel your Shorebird subscription. Are you sure?',
+            ),
+          ),
+        ),
+      ).thenReturn(true);
+
+      when(() => codePushClient.cancelSubscription())
+          .thenAnswer((_) async => {});
+
+      final result = await command.run();
+
+      expect(result, ExitCode.success.code);
+      verify(
+        () => logger.info('Your subscription has been canceled.'),
+      ).called(1);
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/commands/subscription/cancel_subscription_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/subscription/cancel_subscription_command_test.dart
@@ -49,6 +49,10 @@ void main() {
       when(() => auth.client).thenReturn(httpClient);
     });
 
+    test('returns a non-empty description', () {
+      expect(command.description, isNotEmpty);
+    });
+
     test('prints an error if the user is not logged in', () async {
       when(() => auth.isAuthenticated).thenReturn(false);
 

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -278,14 +278,18 @@ class CodePushClient {
   }
 
   /// Cancels the current user's subscription.
-  Future<void> cancelSubscription() async {
+  Future<DateTime> cancelSubscription() async {
     final response = await _httpClient.delete(
       Uri.parse('$hostedUri/api/v1/subscriptions'),
     );
 
-    if (response.statusCode != HttpStatus.noContent) {
+    if (response.statusCode != HttpStatus.ok) {
       throw _parseErrorResponse(response.body);
     }
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    final timestamp = json['expiration_date'] as int;
+    return DateTime.fromMillisecondsSinceEpoch(timestamp * 1000);
   }
 
   /// Closes the client.

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -40,6 +40,19 @@ class CodePushClient {
   /// The hosted uri for the Shorebird CodePush API.
   final Uri hostedUri;
 
+  /// Fetches the currently logged-in user.
+  Future<User> getCurrentUser() async {
+    final uri = Uri.parse('$hostedUri/api/v1/users/me');
+    final response = await _httpClient.get(uri);
+
+    if (response.statusCode != HttpStatus.ok) {
+      throw _parseErrorResponse(response.body);
+    }
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    return User.fromJson(json);
+  }
+
   /// Create a new artifact for a specific [patchId].
   Future<PatchArtifact> createPatchArtifact({
     required String artifactPath,
@@ -260,6 +273,17 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.created) {
+      throw _parseErrorResponse(response.body);
+    }
+  }
+
+  /// Cancels the current user's subscription.
+  Future<void> cancelSubscription() async {
+    final response = await _httpClient.delete(
+      Uri.parse('$hostedUri/api/v1/subscriptions'),
+    );
+
+    if (response.statusCode != HttpStatus.noContent) {
       throw _parseErrorResponse(response.body);
     }
   }

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -1249,11 +1249,18 @@ void main() {
       });
 
       test('completes when request succeeds', () async {
-        when(() => httpClient.delete(uri))
-            .thenAnswer((_) async => http.Response('', HttpStatus.noContent));
+        const timestamp = 1681455600;
 
-        await codePushClient.cancelSubscription();
+        when(() => httpClient.delete(uri)).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode({'expiration_date': 1681455600}),
+            HttpStatus.ok,
+          ),
+        );
 
+        final response = await codePushClient.cancelSubscription();
+
+        expect(response.millisecondsSinceEpoch, timestamp * 1000);
         verify(() => httpClient.delete(uri)).called(1);
       });
     });


### PR DESCRIPTION
## Description

Adds `shorebird subscription cancel` as a command. If the current user has an active Stripe subscription, this command will cancel it.

Closes https://github.com/shorebirdtech/shorebird/issues/215

Example output:

```
bryanoltman@boltman ~/Shorebird/time_shift (main)
⑆ shorebird subscription cancel
This will cancel your Shorebird subscription. Are you sure? (y/N) No
Aborting.

bryanoltman@boltman ~/Shorebird/time_shift (main)
⑆ shorebird subscription cancel
This will cancel your Shorebird subscription. Are you sure? (y/N) Yes
✓ Your subscription has been canceled.

Note: Your access to Shorebird will continue until April 14, 2023, after which all data stored with Shorebird will be deleted as per our privacy policy: https://shorebird.dev/privacy.html.

Apps on devices you've built with Shorebird will continue to function normally, but will not receive further updates. (0.3s)
```

I've verified that this works locally by:

1. Setting up stripe event forwarding using their CLI (`stripe listen --forward-to localhost:8080/api/v1/webhooks/stripe`)
1. Updating our Stripe verification secret to match the secret printed by the previous command
1. Running our codepush server at localhost:8080
1. Updating the CLI to point to localhost:8080
1. Creating a subscription on the stripe console
1. Verifying that `api/v1/users/me` says I have an active subscription
1. Executing `shorebird subscription cancel`
1. Verifying that `api/v1/users/me` says I do not have an active subscription

I also verified that the subscription was being changed on the Stripe dashboard as well.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
