### PR TITLE
feat: Add a workflow for local-engine dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ packages in the repository.
 We don't yet have a script to run tests locally. For now, you can run tests
 manually by running `dart test` in a Dart package directory.
 
+### Tracking coverage
+
+The following command will generate a coverage report for the Dart packages:
+
+```bash
+dart test --coverage=coverage && dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --check-ignore
+```
+
+We don't yet have a recommended way to view the coverage report but there are
+several extensions available in VSCode.
+
 ## License
 
 Shorebird projects are licensed for use under either Apache License, Version 2.0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ https://github.com/shorebirdtech/old_repo
 
 ## Getting Started
 
-Refer to [shorebird/install](https://github.com/shorebirdtech/install) for installation instructions.
+Refer to [shorebird/install](https://github.com/shorebirdtech/install) for
+installation instructions.
 
 ## Packages
 
@@ -47,17 +48,13 @@ We currently assume the Dart from the Flutter SDK on the 'stable' channel. Due
 to the way the Dart compiler works, Shorebird requires an exact version of
 Flutter/Dart to operate correctly today.
 
-We currently assume Rust 1.67.0 or later, although the code is unlikely to be
-sensitive to the exact version of Rust.
-
-Once both are installed, `./scripts/bootstrap.sh` will run `pub get`
-and `cargo check` for all packages in the repository.
+Once both are installed, `./scripts/bootstrap.sh` will run `pub get` all
+packages in the repository.
 
 ### Running tests
 
 We don't yet have a script to run tests locally. For now, you can run tests
-manually by running `cargo test` in a Rust package directory or `dart test` in
-a Dart package directory.
+manually by running `dart test` in a Dart package directory.
 
 ## License
 

--- a/packages/shorebird_cli/lib/src/command.dart
+++ b/packages/shorebird_cli/lib/src/command.dart
@@ -31,13 +31,6 @@ List<Validator> _defaultValidators() => [
       AndroidInternetPermissionValidator(),
     ];
 
-class Context {
-  Context({
-    required this.process,
-  });
-  ShorebirdProcess process;
-}
-
 abstract class ShorebirdCommand extends Command<int> {
   ShorebirdCommand({
     required this.logger,
@@ -54,8 +47,6 @@ abstract class ShorebirdCommand extends Command<int> {
   final Cache cache;
   final CodePushClientBuilder buildCodePushClient;
   final Logger logger;
-  // Context is set by the command runner just before run() is called.
-  late final Context context;
 
   @override
   ShorebirdCliCommandRunner? get runner =>

--- a/packages/shorebird_cli/lib/src/command.dart
+++ b/packages/shorebird_cli/lib/src/command.dart
@@ -48,9 +48,13 @@ abstract class ShorebirdCommand extends Command<int> {
   final CodePushClientBuilder buildCodePushClient;
   final Logger logger;
 
+  // We don't currently have a test involving both a CommandRunner
+  // and a Command, so we can't test this getter.
+  // coverage:ignore-start
   @override
   ShorebirdCliCommandRunner? get runner =>
       super.runner as ShorebirdCliCommandRunner?;
+  // coverage:ignore-end
 
   /// [ShorebirdProcess] used for testing purposes only.
   @visibleForTesting

--- a/packages/shorebird_cli/lib/src/command.dart
+++ b/packages/shorebird_cli/lib/src/command.dart
@@ -38,24 +38,21 @@ abstract class ShorebirdCommand extends Command<int> {
     Auth? auth,
     Cache? cache,
     CodePushClientBuilder? buildCodePushClient,
-    RunProcess? runProcess,
-    StartProcess? startProcess,
     List<Validator>? validators,
+    ShorebirdProcess? process,
   })  : auth = auth ?? Auth(),
         cache = cache ?? Cache(),
         buildCodePushClient = buildCodePushClient ?? CodePushClient.new,
-        runProcess = runProcess ?? ShorebirdProcess.run,
-        startProcess = startProcess ?? ShorebirdProcess.start {
+        process = process ?? ShorebirdProcess() {
     this.validators =
-        validators ?? _defaultValidators(runProcess: this.runProcess);
+        validators ?? _defaultValidators(runProcess: this.process.run);
   }
 
   final Auth auth;
   final Cache cache;
   final CodePushClientBuilder buildCodePushClient;
   final Logger logger;
-  final RunProcess runProcess;
-  final StartProcess startProcess;
+  final ShorebirdProcess process;
 
   /// Checks that the Shorebird install and project are in a good state.
   late List<Validator> validators;

--- a/packages/shorebird_cli/lib/src/command.dart
+++ b/packages/shorebird_cli/lib/src/command.dart
@@ -57,9 +57,18 @@ abstract class ShorebirdCommand extends Command<int> {
   ShorebirdProcess? testProcess;
 
   // If you hit a late initialization error here, it's because you're either
-  // using context before runCommand has been called, or you're in a test
-  // and should mock this method instead.
+  // using process before runCommand has been called, or you're in a test
+  // and should set testProcess instead.
   ShorebirdProcess get process => testProcess ?? runner!.process;
+
+  /// [EngineConfig] used for testing purposes only.
+  @visibleForTesting
+  EngineConfig? testEngineConfig;
+
+  // If you hit a late initialization error here, it's because you're either
+  // using engineConfig before runCommand has been called, or you're in a test
+  // and should set testEngineConfig instead.
+  EngineConfig get engineConfig => testEngineConfig ?? process.engineConfig;
 
   /// Checks that the Shorebird install and project are in a good state.
   late List<Validator> validators;

--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -33,6 +33,18 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
       ..addFlag(
         'verbose',
         help: 'Noisy logging, including all shell commands executed.',
+      )
+      ..addOption(
+        'local-engine-src-path',
+        hide: true,
+        help: 'Path to your engine src directory, if you are building Flutter '
+            'locally.',
+      )
+      ..addOption(
+        'local-engine',
+        hide: true,
+        help: 'Name of a build output within the engine out directory, if you '
+            'are building Flutter locally.',
       );
 
     addCommand(AccountCommand(logger: _logger));

--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -70,6 +70,7 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
   final Logger _logger;
   // Currently using ShorebirdCliCommandRunner as our context object.
   late final ShorebirdProcess process;
+  late final EngineConfig engineConfig;
 
   @override
   Future<int> run(Iterable<String> args) async {
@@ -80,12 +81,12 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
       }
 
       // Set up our context before running the command.
+      engineConfig = EngineConfig(
+        localEngineSrcPath: topLevelResults['local-engine-src-path'] as String?,
+        localEngine: topLevelResults['local-engine'] as String?,
+      );
       process = ShorebirdProcess(
-        engineConfig: EngineConfig(
-          localEngineSrcPath:
-              topLevelResults['local-engine-src-path'] as String?,
-          localEngine: topLevelResults['local-engine'] as String?,
-        ),
+        engineConfig: engineConfig,
       );
 
       return await runCommand(topLevelResults) ?? ExitCode.success.code;

--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -4,6 +4,7 @@ import 'package:cli_completion/cli_completion.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/shorebird_environment.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/version.dart';
 
 const executableName = 'shorebird';
@@ -67,6 +68,8 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
   void printUsage() => _logger.info(usage);
 
   final Logger _logger;
+  // Currently using ShorebirdCliCommandRunner as our context object.
+  late final ShorebirdProcess process;
 
   @override
   Future<int> run(Iterable<String> args) async {
@@ -75,6 +78,15 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
       if (topLevelResults['verbose'] == true) {
         _logger.level = Level.verbose;
       }
+
+      // Set up our context before running the command.
+      process = ShorebirdProcess(
+        engineConfig: EngineConfig(
+          localEngineSrcPath:
+              topLevelResults['local-engine-src-path'] as String?,
+          localEngine: topLevelResults['local-engine'] as String?,
+        ),
+      );
 
       return await runCommand(topLevelResults) ?? ExitCode.success.code;
     } on FormatException catch (e, stackTrace) {

--- a/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
@@ -19,7 +19,6 @@ class BuildApkCommand extends ShorebirdCommand
     super.auth,
     super.buildCodePushClient,
     super.validators,
-    super.process,
   });
 
   @override

--- a/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
@@ -17,7 +17,6 @@ class BuildApkCommand extends ShorebirdCommand
   BuildApkCommand({
     required super.logger,
     super.auth,
-    super.buildCodePushClient,
     super.validators,
   });
 

--- a/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
@@ -17,8 +17,9 @@ class BuildApkCommand extends ShorebirdCommand
   BuildApkCommand({
     required super.logger,
     super.auth,
-    super.runProcess,
+    super.buildCodePushClient,
     super.validators,
+    super.process,
   });
 
   @override

--- a/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart.dart
@@ -17,7 +17,6 @@ class BuildAppBundleCommand extends ShorebirdCommand
   BuildAppBundleCommand({
     required super.logger,
     super.auth,
-    super.runProcess,
     super.validators,
   });
 

--- a/packages/shorebird_cli/lib/src/commands/build/build_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_command.dart
@@ -17,7 +17,6 @@ class BuildCommand extends ShorebirdCommand
       BuildApkCommand(
         auth: auth,
         logger: logger,
-        runProcess: runProcess,
         validators: validators,
       ),
     );
@@ -25,7 +24,6 @@ class BuildCommand extends ShorebirdCommand
       BuildAppBundleCommand(
         auth: auth,
         logger: logger,
-        runProcess: runProcess,
         validators: validators,
       ),
     );

--- a/packages/shorebird_cli/lib/src/commands/doctor_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/doctor_command.dart
@@ -17,7 +17,6 @@ class DoctorCommand extends ShorebirdCommand with ShorebirdVersionMixin {
   DoctorCommand({
     required super.logger,
     super.validators,
-    super.process,
   }) {
     validators = _allValidators(baseValidators: validators);
   }
@@ -26,7 +25,7 @@ class DoctorCommand extends ShorebirdCommand with ShorebirdVersionMixin {
     ShorebirdVersionValidator(
       isShorebirdVersionCurrent: isShorebirdVersionCurrent,
     ),
-    ShorebirdFlutterValidator(runProcess: process.run),
+    ShorebirdFlutterValidator(),
     AndroidInternetPermissionValidator(),
   ];
 
@@ -46,7 +45,7 @@ Shorebird Engine • revision ${ShorebirdEnvironment.shorebirdEngineRevision}'''
     var numIssues = 0;
     for (final validator in validators) {
       final progress = logger.progress(validator.description);
-      final issues = await validator.validate();
+      final issues = await validator.validate(process);
       numIssues += issues.length;
       if (issues.isEmpty) {
         progress.complete();

--- a/packages/shorebird_cli/lib/src/commands/doctor_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/doctor_command.dart
@@ -17,7 +17,7 @@ class DoctorCommand extends ShorebirdCommand with ShorebirdVersionMixin {
   DoctorCommand({
     required super.logger,
     super.validators,
-    super.runProcess,
+    super.process,
   }) {
     validators = _allValidators(baseValidators: validators);
   }
@@ -26,7 +26,7 @@ class DoctorCommand extends ShorebirdCommand with ShorebirdVersionMixin {
     ShorebirdVersionValidator(
       isShorebirdVersionCurrent: isShorebirdVersionCurrent,
     ),
-    ShorebirdFlutterValidator(runProcess: runProcess),
+    ShorebirdFlutterValidator(runProcess: process.run),
     AndroidInternetPermissionValidator(),
   ];
 

--- a/packages/shorebird_cli/lib/src/commands/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch_command.dart
@@ -47,7 +47,6 @@ class PatchCommand extends ShorebirdCommand
     super.buildCodePushClient,
     super.cache,
     super.validators,
-    super.process,
     HashFunction? hashFn,
     http.Client? httpClient,
   })  : _hashFn = hashFn ?? ((m) => sha256.convert(m).toString()),

--- a/packages/shorebird_cli/lib/src/commands/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch_command.dart
@@ -46,8 +46,8 @@ class PatchCommand extends ShorebirdCommand
     super.auth,
     super.buildCodePushClient,
     super.cache,
-    super.runProcess,
     super.validators,
+    super.process,
     HashFunction? hashFn,
     http.Client? httpClient,
   })  : _hashFn = hashFn ?? ((m) => sha256.convert(m).toString()),
@@ -215,7 +215,7 @@ Please create a release using "shorebird release" and try again.
     final fetchReleaseArtifactProgress = logger.progress(
       'Fetching release artifacts',
     );
-    for (final entry in ShorebirdBuildMixin.architectures.entries) {
+    for (final entry in architectures.entries) {
       try {
         final releaseArtifact = await codePushClient.getReleaseArtifact(
           releaseId: release.id,
@@ -251,8 +251,7 @@ Please create a release using "shorebird release" and try again.
     final createDiffProgress = logger.progress('Creating artifacts');
 
     for (final releaseArtifactPath in releaseArtifactPaths.entries) {
-      final archMetadata =
-          ShorebirdBuildMixin.architectures[releaseArtifactPath.key]!;
+      final archMetadata = architectures[releaseArtifactPath.key]!;
       final patchArtifactPath = p.join(
         Directory.current.path,
         'build',
@@ -413,7 +412,7 @@ ${styleBold.wrap(lightGreen.wrap('🚀 Ready to publish a new patch!'))}
       diffPath,
     ];
 
-    final result = await runProcess(
+    final result = await process.run(
       diffExecutable,
       diffArguments,
       runInShell: true,

--- a/packages/shorebird_cli/lib/src/commands/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release_command.dart
@@ -26,8 +26,8 @@ class ReleaseCommand extends ShorebirdCommand
     required super.logger,
     super.auth,
     super.buildCodePushClient,
-    super.runProcess,
     super.validators,
+    super.process,
     HashFunction? hashFn,
   }) : _hashFn = hashFn ?? ((m) => sha256.convert(m).toString()) {
     argParser
@@ -126,7 +126,7 @@ Did you forget to run "shorebird init"?''',
         );
 
     final platform = results['platform'] as String;
-    final archNames = ShorebirdBuildMixin.architectures.keys.map(
+    final archNames = architectures.keys.map(
       (arch) => arch.name,
     );
 
@@ -172,7 +172,7 @@ ${styleBold.wrap(lightGreen.wrap('🚀 Ready to create a new release!'))}
     }
 
     final createArtifactProgress = logger.progress('Creating artifacts');
-    for (final archMetadata in ShorebirdBuildMixin.architectures.values) {
+    for (final archMetadata in architectures.values) {
       final artifactPath = p.join(
         Directory.current.path,
         'build',

--- a/packages/shorebird_cli/lib/src/commands/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release_command.dart
@@ -27,7 +27,6 @@ class ReleaseCommand extends ShorebirdCommand
     super.auth,
     super.buildCodePushClient,
     super.validators,
-    super.process,
     HashFunction? hashFn,
   }) : _hashFn = hashFn ?? ((m) => sha256.convert(m).toString()) {
     argParser

--- a/packages/shorebird_cli/lib/src/commands/run_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/run_command.dart
@@ -17,7 +17,6 @@ class RunCommand extends ShorebirdCommand
     super.auth,
     super.buildCodePushClient,
     super.validators,
-    super.process,
   });
 
   @override

--- a/packages/shorebird_cli/lib/src/commands/run_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/run_command.dart
@@ -16,8 +16,8 @@ class RunCommand extends ShorebirdCommand
     required super.logger,
     super.auth,
     super.buildCodePushClient,
-    super.startProcess,
     super.validators,
+    super.process,
   });
 
   @override
@@ -38,7 +38,7 @@ class RunCommand extends ShorebirdCommand
     await logValidationIssues();
 
     logger.info('Running app...');
-    final process = await startProcess(
+    final flutter = await process.start(
       'flutter',
       [
         'run',
@@ -49,13 +49,13 @@ class RunCommand extends ShorebirdCommand
       runInShell: true,
     );
 
-    process.stdout.listen((event) {
+    flutter.stdout.listen((event) {
       logger.info(utf8.decode(event));
     });
-    process.stderr.listen((event) {
+    flutter.stderr.listen((event) {
       logger.err(utf8.decode(event));
     });
 
-    return process.exitCode;
+    return flutter.exitCode;
   }
 }

--- a/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
@@ -11,7 +11,7 @@ import 'package:shorebird_cli/src/shorebird_version_mixin.dart';
 /// {@endtemplate}
 class UpgradeCommand extends ShorebirdCommand with ShorebirdVersionMixin {
   /// {@macro upgrade_command}
-  UpgradeCommand({required super.logger, super.process});
+  UpgradeCommand({required super.logger});
 
   @override
   String get description => 'Upgrade your copy of Shorebird.';

--- a/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
@@ -11,7 +11,7 @@ import 'package:shorebird_cli/src/shorebird_version_mixin.dart';
 /// {@endtemplate}
 class UpgradeCommand extends ShorebirdCommand with ShorebirdVersionMixin {
   /// {@macro upgrade_command}
-  UpgradeCommand({required super.logger, super.runProcess});
+  UpgradeCommand({required super.logger, super.process});
 
   @override
   String get description => 'Upgrade your copy of Shorebird.';

--- a/packages/shorebird_cli/lib/src/flutter_validation_mixin.dart
+++ b/packages/shorebird_cli/lib/src/flutter_validation_mixin.dart
@@ -6,7 +6,7 @@ mixin ShorebirdValidationMixin on ShorebirdCommand {
   /// Runs [Validator.validate] on all [validators] and writes issues to stdout.
   Future<void> logValidationIssues() async {
     final validationIssues = (await Future.wait(
-      validators.map((v) => v.validate()),
+      validators.map((v) => v.validate(process)),
     ))
         .flattened;
     if (validationIssues.isNotEmpty) {

--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -1,37 +1,68 @@
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/command.dart';
 
 enum Arch {
   arm64,
   arm32,
-  x86,
+  x86_64,
 }
 
 class ArchMetadata {
-  const ArchMetadata({required this.path, required this.arch});
+  const ArchMetadata({
+    required this.path,
+    required this.arch,
+    required this.enginePath,
+  });
 
   final String path;
   final String arch;
+  final String enginePath;
 }
 
 mixin ShorebirdBuildMixin on ShorebirdCommand {
-  // TODO(felangel): extend to other platforms.
-  static const architectures = <Arch, ArchMetadata>{
+  // This exists only so tests can get the full list.
+  static const allAndroidArchitectures = <Arch, ArchMetadata>{
     Arch.arm64: ArchMetadata(
       path: 'arm64-v8a',
       arch: 'aarch64',
+      enginePath: 'android_release_arm64',
     ),
     Arch.arm32: ArchMetadata(
       path: 'armeabi-v7a',
       arch: 'arm',
+      enginePath: 'android_release',
     ),
-    Arch.x86: ArchMetadata(
+    Arch.x86_64: ArchMetadata(
       path: 'x86_64',
       arch: 'x86_64',
+      enginePath: 'android_release_x64',
     ),
   };
+
+  // TODO(felangel): extend to other platforms.
+  Map<Arch, ArchMetadata> get architectures {
+    // Flutter has a whole bunch of logic to parse the --local-engine flag.
+    // We probably need similar.
+    if (globalResults?['local-engine'] != null) {
+      final localEngineOutName = globalResults!['local-engine'] as String;
+      final metaDataEntry = allAndroidArchitectures.entries.firstWhereOrNull(
+        (entry) => localEngineOutName == entry.value.enginePath,
+      );
+      if (metaDataEntry == null) {
+        throw Exception(
+          'Unknown local engine architecture for '
+          '--local-engine=$localEngineOutName\n'
+          'Known values: '
+          '${allAndroidArchitectures.values.map((e) => e.enginePath)}',
+        );
+      }
+      return {metaDataEntry.key: metaDataEntry.value};
+    }
+    return allAndroidArchitectures;
+  }
 
   Future<void> buildAppBundle() async {
     const executable = 'flutter';
@@ -42,7 +73,7 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
       ...results.rest,
     ];
 
-    final result = await runProcess(
+    final result = await process.run(
       executable,
       arguments,
       runInShell: true,

--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -98,7 +98,7 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
       ...results.rest,
     ];
 
-    final result = await runProcess(
+    final result = await process.run(
       executable,
       arguments,
       runInShell: true,

--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/command.dart';
@@ -42,12 +43,19 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
     ),
   };
 
+  ArgResults? testGlobalResults; // for mocking.
+
+  @override
+  ArgResults? get globalResults => testGlobalResults ?? super.globalResults;
+
   // TODO(felangel): extend to other platforms.
   Map<Arch, ArchMetadata> get architectures {
     // Flutter has a whole bunch of logic to parse the --local-engine flag.
     // We probably need similar.
-    if (globalResults?['local-engine'] != null) {
-      final localEngineOutName = globalResults!['local-engine'] as String;
+    // It's a bit odd to grab off the shorebird process, but it's the easiest
+    // way to have a single source of truth for the engine config for now.
+    if (engineConfig.localEngine != null) {
+      final localEngineOutName = engineConfig.localEngine;
       final metaDataEntry = allAndroidArchitectures.entries.firstWhereOrNull(
         (entry) => localEngineOutName == entry.value.enginePath,
       );

--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/command.dart';
@@ -42,11 +41,6 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
       enginePath: 'android_release_x64',
     ),
   };
-
-  ArgResults? testGlobalResults; // for mocking.
-
-  @override
-  ArgResults? get globalResults => testGlobalResults ?? super.globalResults;
 
   // TODO(felangel): extend to other platforms.
   Map<Arch, ArchMetadata> get architectures {

--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -4,10 +4,14 @@ import 'package:meta/meta.dart';
 import 'package:shorebird_cli/src/shorebird_environment.dart';
 
 class EngineConfig {
-  EngineConfig({
+  const EngineConfig({
     required this.localEngineSrcPath,
     required this.localEngine,
   });
+
+  const EngineConfig.empty()
+      : localEngineSrcPath = null,
+        localEngine = null;
 
   final String? localEngineSrcPath;
   final String? localEngine;

--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -22,11 +22,15 @@ typedef StartProcess = Future<Process> Function(
 
 /// A wrapper around [Process] that replaces executables to Shorebird-vended
 /// versions.
-abstract class ShorebirdProcess {
-  @visibleForTesting
-  static ProcessWrapper processWrapper = ProcessWrapper();
+// This may need a better name, since it returns "Process" it's more a
+// "ProcessFactory" than a "Process".
+class ShorebirdProcess {
+  ShorebirdProcess([ProcessWrapper? processWrapper])
+      : processWrapper = processWrapper ?? ProcessWrapper();
 
-  static Future<ProcessResult> run(
+  ProcessWrapper processWrapper;
+
+  Future<ProcessResult> run(
     String executable,
     List<String> arguments, {
     bool runInShell = false,
@@ -44,16 +48,16 @@ abstract class ShorebirdProcess {
 
     return processWrapper.run(
       useVendedFlutter ? _resolveExecutable(executable) : executable,
-      arguments,
+      useVendedFlutter ? _resolveArguments(executable, arguments) : arguments,
       runInShell: runInShell,
       workingDirectory: workingDirectory,
       environment: resolvedEnvironment,
     );
   }
 
-  static Future<Process> start(
+  Future<Process> start(
     String executable,
-    List<String> argument, {
+    List<String> arguments, {
     Map<String, String>? environment,
     bool runInShell = false,
     bool useVendedFlutter = true,
@@ -68,13 +72,13 @@ abstract class ShorebirdProcess {
 
     return processWrapper.start(
       useVendedFlutter ? _resolveExecutable(executable) : executable,
-      argument,
+      useVendedFlutter ? _resolveArguments(executable, arguments) : arguments,
       runInShell: runInShell,
       environment: resolvedEnvironment,
     );
   }
 
-  static String _resolveExecutable(String executable) {
+  String _resolveExecutable(String executable) {
     if (executable == 'flutter') {
       return ShorebirdEnvironment.flutterBinaryFile.path;
     }
@@ -82,7 +86,21 @@ abstract class ShorebirdProcess {
     return executable;
   }
 
-  static Map<String, String> _environmentOverrides({
+  List<String> _resolveArguments(
+    String executable,
+    List<String> arguments,
+  ) {
+    if (executable == 'flutter') {
+      return [
+        '--local-engine-src-path=/Users/eseidel/Documents/GitHub/engine/src',
+        '--local-engine=android_release_arm64',
+        ...arguments
+      ];
+    }
+    return arguments;
+  }
+
+  Map<String, String> _environmentOverrides({
     required String executable,
   }) {
     if (executable == 'flutter') {

--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -3,32 +3,28 @@ import 'dart:io';
 import 'package:meta/meta.dart';
 import 'package:shorebird_cli/src/shorebird_environment.dart';
 
-typedef RunProcess = Future<ProcessResult> Function(
-  String executable,
-  List<String> arguments, {
-  bool runInShell,
-  Map<String, String>? environment,
-  String? workingDirectory,
-  bool useVendedFlutter,
-});
+class EngineConfig {
+  EngineConfig({
+    required this.localEngineSrcPath,
+    required this.localEngine,
+  });
 
-typedef StartProcess = Future<Process> Function(
-  String executable,
-  List<String> arguments, {
-  bool runInShell,
-  Map<String, String>? environment,
-  bool useVendedFlutter,
-});
+  final String? localEngineSrcPath;
+  final String? localEngine;
+}
 
 /// A wrapper around [Process] that replaces executables to Shorebird-vended
 /// versions.
 // This may need a better name, since it returns "Process" it's more a
 // "ProcessFactory" than a "Process".
 class ShorebirdProcess {
-  ShorebirdProcess([ProcessWrapper? processWrapper])
-      : processWrapper = processWrapper ?? ProcessWrapper();
+  ShorebirdProcess({
+    required this.engineConfig,
+    ProcessWrapper? processWrapper, // For mocking ShorebirdProcess.
+  }) : processWrapper = processWrapper ?? ProcessWrapper();
 
-  ProcessWrapper processWrapper;
+  final ProcessWrapper processWrapper;
+  final EngineConfig engineConfig;
 
   Future<ProcessResult> run(
     String executable,
@@ -90,10 +86,10 @@ class ShorebirdProcess {
     String executable,
     List<String> arguments,
   ) {
-    if (executable == 'flutter') {
+    if (executable == 'flutter' && engineConfig.localEngine != null) {
       return [
-        '--local-engine-src-path=/Users/eseidel/Documents/GitHub/engine/src',
-        '--local-engine=android_release_arm64',
+        '--local-engine-src-path=${engineConfig.localEngineSrcPath}',
+        '--local-engine=${engineConfig.localEngine}',
         ...arguments
       ];
     }

--- a/packages/shorebird_cli/lib/src/shorebird_version_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_version_mixin.dart
@@ -23,7 +23,7 @@ mixin ShorebirdVersionMixin on ShorebirdCommand {
   /// Exits if HEAD isn't pointing to a branch, or there is no upstream.
   Future<String> fetchLatestGitHash({required String workingDirectory}) async {
     // Fetch upstream branch's commits and tags
-    await runProcess(
+    await process.run(
       'git',
       ['fetch', '--tags'],
       workingDirectory: workingDirectory,
@@ -47,7 +47,7 @@ mixin ShorebirdVersionMixin on ShorebirdCommand {
     String? workingDirectory,
   }) async {
     // Get the commit revision of HEAD
-    final result = await runProcess(
+    final result = await process.run(
       'git',
       ['rev-parse', '--verify', revision],
       workingDirectory: workingDirectory,
@@ -72,7 +72,7 @@ mixin ShorebirdVersionMixin on ShorebirdCommand {
     required String newRevision,
     required String workingDirectory,
   }) async {
-    final result = await runProcess(
+    final result = await process.run(
       'git',
       ['reset', '--hard', newRevision],
       workingDirectory: workingDirectory,

--- a/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:xml/xml.dart';
 
@@ -16,7 +17,7 @@ class AndroidInternetPermissionValidator extends Validator {
   // coverage:ignore-end
 
   @override
-  Future<List<ValidationIssue>> validate() async {
+  Future<List<ValidationIssue>> validate(ShorebirdProcess process) async {
     const manifestFileName = 'AndroidManifest.xml';
     final androidSrcDir = Directory(
       p.join(

--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -44,7 +44,7 @@ class ShorebirdFlutterValidator extends Validator {
       );
     }
 
-    if (!await _flutterDirectoryTracksCorrectRevision()) {
+    if (!await _flutterDirectoryTracksCorrectRevision(process)) {
       final message =
           '''${ShorebirdEnvironment.flutterDirectory} is not on the correct revision''';
       issues.add(

--- a/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 
 /// Verifies that the currently installed version of Shorebird is the latest.
@@ -16,7 +17,7 @@ class ShorebirdVersionValidator extends Validator {
   // coverage:ignore-end
 
   @override
-  Future<List<ValidationIssue>> validate() async {
+  Future<List<ValidationIssue>> validate(ShorebirdProcess process) async {
     final workingDirectory = p.dirname(Platform.script.toFilePath());
     final bool isShorebirdUpToDate;
 

--- a/packages/shorebird_cli/lib/src/validators/validators.dart
+++ b/packages/shorebird_cli/lib/src/validators/validators.dart
@@ -1,5 +1,6 @@
 import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
 
 export 'android_internet_permission_validator.dart';
 export 'shorebird_flutter_validator.dart';
@@ -74,5 +75,6 @@ abstract class Validator {
   /// Checks for [ValidationIssue]s.
   ///
   /// Returns an empty list if no issues are found.
-  Future<List<ValidationIssue>> validate();
+  /// Not all validators use [process].
+  Future<List<ValidationIssue>> validate(ShorebirdProcess process);
 }

--- a/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
@@ -52,7 +52,8 @@ void main() {
         validators: [flutterValidator],
       )
         ..testArgResults = argResults
-        ..testProcess = shorebirdProcess;
+        ..testProcess = shorebirdProcess
+        ..testEngineConfig = const EngineConfig.empty();
       registerFallbackValue(shorebirdProcess);
 
       when(

--- a/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
@@ -60,9 +60,6 @@ void main() {
           any(),
           any(),
           runInShell: any(named: 'runInShell'),
-          environment: any(named: 'environment'),
-          workingDirectory: any(named: 'workingDirectory'),
-          useVendedFlutter: any(named: 'useVendedFlutter'),
         ),
       ).thenAnswer((_) async => processResult);
       when(() => argResults.rest).thenReturn([]);

--- a/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
@@ -54,9 +54,11 @@ void main() {
       command = BuildApkCommand(
         auth: auth,
         logger: logger,
-        process: shorebirdProcess,
         validators: [flutterValidator],
-      )..testArgResults = argResults;
+      )
+        ..testArgResults = argResults
+        ..testProcess = shorebirdProcess;
+      registerFallbackValue(shorebirdProcess);
 
       when(
         () => shorebirdProcess.run(
@@ -73,7 +75,7 @@ void main() {
       when(() => auth.client).thenReturn(httpClient);
       when(() => logger.progress(any())).thenReturn(_MockProgress());
       when(() => logger.info(any())).thenReturn(null);
-      when(() => flutterValidator.validate()).thenAnswer((_) async => []);
+      when(() => flutterValidator.validate(any())).thenAnswer((_) async => []);
     });
 
     test('has correct description', () {
@@ -121,7 +123,7 @@ void main() {
     });
 
     test('prints flutter validation warnings', () async {
-      when(() => flutterValidator.validate()).thenAnswer(
+      when(() => flutterValidator.validate(any())).thenAnswer(
         (_) async => [
           const ValidationIssue(
             severity: ValidationIssueSeverity.warning,

--- a/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
@@ -38,9 +38,6 @@ void main() {
     late ShorebirdFlutterValidator flutterValidator;
     late ShorebirdProcess shorebirdProcess;
 
-    String? processExecutable;
-    List<String>? processArguments;
-
     setUp(() {
       argResults = _MockArgResults();
       httpClient = _MockHttpClient();
@@ -49,8 +46,6 @@ void main() {
       shorebirdProcess = _MockShorebirdProcess();
       processResult = _MockProcessResult();
       flutterValidator = _MockShorebirdFlutterValidator();
-      processExecutable = null;
-      processArguments = null;
       command = BuildApkCommand(
         auth: auth,
         logger: logger,
@@ -105,8 +100,13 @@ void main() {
       );
 
       expect(result, equals(ExitCode.software.code));
-      expect(processExecutable, equals('flutter'));
-      expect(processArguments, equals(['build', 'apk', '--release']));
+      verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['build', 'apk', '--release'],
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).called(1);
     });
 
     test('exits with code 0 when building apk succeeds', () async {
@@ -118,8 +118,13 @@ void main() {
       );
 
       expect(result, equals(ExitCode.success.code));
-      expect(processExecutable, equals('flutter'));
-      expect(processArguments, equals(['build', 'apk', '--release']));
+      verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['build', 'apk', '--release'],
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).called(1);
     });
 
     test('prints flutter validation warnings', () async {

--- a/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
@@ -52,7 +52,8 @@ void main() {
         validators: [flutterValidator],
       )
         ..testArgResults = argResults
-        ..testProcess = shorebirdProcess;
+        ..testProcess = shorebirdProcess
+        ..testEngineConfig = const EngineConfig.empty();
 
       registerFallbackValue(shorebirdProcess);
 
@@ -123,6 +124,23 @@ void main() {
           runInShell: any(named: 'runInShell'),
         ),
       ).called(1);
+    });
+
+    test('local-engine and architectures', () async {
+      expect(command.architectures.length, greaterThan(1));
+
+      command.testEngineConfig = const EngineConfig(
+        localEngine: 'android_release_arm64',
+        localEngineSrcPath: 'path/to/engine/src',
+      );
+      expect(command.architectures.length, equals(1));
+
+      // We only support a few release configs for now.
+      command.testEngineConfig = const EngineConfig(
+        localEngine: 'android_debug_unopt',
+        localEngineSrcPath: 'path/to/engine/src',
+      );
+      expect(() => command.architectures, throwsException);
     });
 
     test('prints flutter validation warnings', () async {

--- a/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
@@ -49,18 +49,6 @@ void main() {
       command = BuildAppBundleCommand(
         auth: auth,
         logger: logger,
-        runProcess: (
-          executable,
-          arguments, {
-          bool runInShell = false,
-          Map<String, String>? environment,
-          String? workingDirectory,
-          bool useVendedFlutter = true,
-        }) async {
-          processExecutable = executable;
-          processArguments = arguments;
-          return processResult;
-        },
         validators: [flutterValidator],
       )..testArgResults = argResults;
 

--- a/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
@@ -61,9 +61,6 @@ void main() {
           any(),
           any(),
           runInShell: any(named: 'runInShell'),
-          environment: any(named: 'environment'),
-          workingDirectory: any(named: 'workingDirectory'),
-          useVendedFlutter: any(named: 'useVendedFlutter'),
         ),
       ).thenAnswer((_) async => processResult);
       when(() => argResults.rest).thenReturn([]);

--- a/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
@@ -75,7 +75,9 @@ void main() {
           shorebirdVersionValidator,
           shorebirdFlutterValidator,
         ],
-      )..testProcess = shorebirdProcess;
+      )
+        ..testProcess = shorebirdProcess
+        ..testEngineConfig = const EngineConfig.empty();
     });
 
     test('prints "no issues" when everything is OK', () async {

--- a/packages/shorebird_cli/test/src/commands/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch_command_test.dart
@@ -157,7 +157,8 @@ flutter:
         validators: [flutterValidator],
       )
         ..testArgResults = argResults
-        ..testProcess = shorebirdProcess;
+        ..testProcess = shorebirdProcess
+        ..testEngineConfig = const EngineConfig.empty();
 
       registerFallbackValue(shorebirdProcess);
 

--- a/packages/shorebird_cli/test/src/commands/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch_command_test.dart
@@ -152,11 +152,14 @@ flutter:
           return codePushClient;
         },
         cache: cache,
-        process: shorebirdProcess,
         logger: logger,
         httpClient: httpClient,
         validators: [flutterValidator],
-      )..testArgResults = argResults;
+      )
+        ..testArgResults = argResults
+        ..testProcess = shorebirdProcess;
+
+      registerFallbackValue(shorebirdProcess);
 
       when(
         () => shorebirdProcess.run(
@@ -165,8 +168,13 @@ flutter:
           runInShell: any(named: 'runInShell'),
         ),
       ).thenAnswer((_) async => flutterBuildProcessResult);
-      when(() => shorebirdProcess.run(any(that: endsWith('patch')), any()))
-          .thenAnswer((_) async => flutterBuildProcessResult);
+      when(
+        () => shorebirdProcess.run(
+          any(that: endsWith('patch')),
+          any(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).thenAnswer((_) async => patchProcessResult);
       when(() => argResults.rest).thenReturn([]);
       when(() => argResults['arch']).thenReturn(arch);
       when(() => argResults['platform']).thenReturn(platform);
@@ -227,7 +235,7 @@ flutter:
           channelId: any(named: 'channelId'),
         ),
       ).thenAnswer((_) async {});
-      when(() => flutterValidator.validate()).thenAnswer((_) async => []);
+      when(() => flutterValidator.validate(any())).thenAnswer((_) async => []);
       when(() => cache.updateAll()).thenAnswer((_) async => {});
       when(
         () => cache.getArtifactDirectory(any()),
@@ -584,7 +592,7 @@ base_url: $baseUrl''',
     test('prints flutter validation warnings', () async {
       final tempDir = setUpTempDir();
       setUpTempArtifacts(tempDir);
-      when(() => flutterValidator.validate()).thenAnswer(
+      when(() => flutterValidator.validate(any())).thenAnswer(
         (_) async => [
           const ValidationIssue(
             severity: ValidationIssueSeverity.warning,

--- a/packages/shorebird_cli/test/src/commands/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch_command_test.dart
@@ -9,6 +9,7 @@ import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/cache.dart' show Cache;
 import 'package:shorebird_cli/src/commands/patch_command.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
@@ -33,6 +34,8 @@ class _MockCodePushClient extends Mock implements CodePushClient {}
 
 class _MockShorebirdFlutterValidator extends Mock
     implements ShorebirdFlutterValidator {}
+
+class _MockShorebirdProcess extends Mock implements ShorebirdProcess {}
 
 void main() {
   group('patch', () {
@@ -91,6 +94,7 @@ flutter:
     late PatchCommand command;
     late Uri? capturedHostedUri;
     late ShorebirdFlutterValidator flutterValidator;
+    late ShorebirdProcess shorebirdProcess;
 
     Directory setUpTempDir() {
       final tempDir = Directory.systemTemp.createTempSync();
@@ -104,7 +108,8 @@ flutter:
     }
 
     void setUpTempArtifacts(Directory dir) {
-      for (final archMetadata in ShorebirdBuildMixin.architectures.values) {
+      for (final archMetadata
+          in ShorebirdBuildMixin.allAndroidArchitectures.values) {
         final artifactPath = p.join(
           dir.path,
           'build',
@@ -136,6 +141,7 @@ flutter:
       codePushClient = _MockCodePushClient();
       flutterValidator = _MockShorebirdFlutterValidator();
       cache = _MockCache();
+      shorebirdProcess = _MockShorebirdProcess();
       command = PatchCommand(
         auth: auth,
         buildCodePushClient: ({
@@ -146,23 +152,21 @@ flutter:
           return codePushClient;
         },
         cache: cache,
-        runProcess: (
-          executable,
-          arguments, {
-          bool runInShell = false,
-          Map<String, String>? environment,
-          String? workingDirectory,
-          bool useVendedFlutter = true,
-        }) async {
-          if (executable == 'flutter') return flutterBuildProcessResult;
-          if (executable.endsWith('patch')) return patchProcessResult;
-          return _MockProcessResult();
-        },
+        process: shorebirdProcess,
         logger: logger,
         httpClient: httpClient,
         validators: [flutterValidator],
       )..testArgResults = argResults;
 
+      when(
+        () => shorebirdProcess.run(
+          'flutter',
+          any(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).thenAnswer((_) async => flutterBuildProcessResult);
+      when(() => shorebirdProcess.run(any(that: endsWith('patch')), any()))
+          .thenAnswer((_) async => flutterBuildProcessResult);
       when(() => argResults.rest).thenReturn([]);
       when(() => argResults['arch']).thenReturn(arch);
       when(() => argResults['platform']).thenReturn(platform);

--- a/packages/shorebird_cli/test/src/commands/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release_command_test.dart
@@ -131,7 +131,8 @@ flutter:
         validators: [flutterValidator],
       )
         ..testArgResults = argResults
-        ..testProcess = shorebirdProcess;
+        ..testProcess = shorebirdProcess
+        ..testEngineConfig = const EngineConfig.empty();
 
       registerFallbackValue(shorebirdProcess);
 

--- a/packages/shorebird_cli/test/src/commands/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release_command_test.dart
@@ -127,10 +127,13 @@ flutter:
           capturedHostedUri = hostedUri;
           return codePushClient;
         },
-        process: shorebirdProcess,
         logger: logger,
         validators: [flutterValidator],
-      )..testArgResults = argResults;
+      )
+        ..testArgResults = argResults
+        ..testProcess = shorebirdProcess;
+
+      registerFallbackValue(shorebirdProcess);
 
       when(
         () => shorebirdProcess.run(
@@ -171,7 +174,7 @@ flutter:
           hash: any(named: 'hash'),
         ),
       ).thenAnswer((_) async => releaseArtifact);
-      when(() => flutterValidator.validate()).thenAnswer((_) async => []);
+      when(() => flutterValidator.validate(any())).thenAnswer((_) async => []);
     });
 
     test('throws config error when shorebird is not initialized', () async {
@@ -335,7 +338,7 @@ Did you forget to run "shorebird init"?''',
     });
 
     test('prints flutter validation warnings', () async {
-      when(() => flutterValidator.validate()).thenAnswer(
+      when(() => flutterValidator.validate(any())).thenAnswer(
         (_) async => [
           const ValidationIssue(
             severity: ValidationIssueSeverity.warning,

--- a/packages/shorebird_cli/test/src/commands/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release_command_test.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
@@ -28,6 +29,8 @@ class _MockCodePushClient extends Mock implements CodePushClient {}
 
 class _MockShorebirdFlutterValidator extends Mock
     implements ShorebirdFlutterValidator {}
+
+class _MockShorebirdProcess extends Mock implements ShorebirdProcess {}
 
 void main() {
   group('release', () {
@@ -73,6 +76,7 @@ flutter:
     late ReleaseCommand command;
     late Uri? capturedHostedUri;
     late ShorebirdFlutterValidator flutterValidator;
+    late ShorebirdProcess shorebirdProcess;
 
     Directory setUpTempDir() {
       final tempDir = Directory.systemTemp.createTempSync();
@@ -86,7 +90,8 @@ flutter:
     }
 
     void setUpTempArtifacts(Directory dir) {
-      for (final archMetadata in ShorebirdBuildMixin.architectures.values) {
+      for (final archMetadata
+          in ShorebirdBuildMixin.allAndroidArchitectures.values) {
         final artifactPath = p.join(
           dir.path,
           'build',
@@ -112,6 +117,7 @@ flutter:
       processResult = _MockProcessResult();
       codePushClient = _MockCodePushClient();
       flutterValidator = _MockShorebirdFlutterValidator();
+      shorebirdProcess = _MockShorebirdProcess();
       command = ReleaseCommand(
         auth: auth,
         buildCodePushClient: ({
@@ -121,20 +127,18 @@ flutter:
           capturedHostedUri = hostedUri;
           return codePushClient;
         },
-        runProcess: (
-          executable,
-          arguments, {
-          bool runInShell = false,
-          Map<String, String>? environment,
-          String? workingDirectory,
-          bool useVendedFlutter = true,
-        }) async {
-          return processResult;
-        },
+        process: shorebirdProcess,
         logger: logger,
         validators: [flutterValidator],
       )..testArgResults = argResults;
 
+      when(
+        () => shorebirdProcess.run(
+          any(),
+          any(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).thenAnswer((_) async => processResult);
       when(() => argResults.rest).thenReturn([]);
       when(() => argResults['arch']).thenReturn(arch);
       when(() => argResults['platform']).thenReturn(platform);

--- a/packages/shorebird_cli/test/src/commands/run_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/run_command_test.dart
@@ -8,6 +8,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/commands/run_command.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
@@ -32,6 +33,8 @@ class _MockAndroidInternetPermissionValidator extends Mock
 class _MockShorebirdFlutterValidator extends Mock
     implements ShorebirdFlutterValidator {}
 
+class _MockShorebirdProcess extends Mock implements ShorebirdProcess {}
+
 void main() {
   group('run', () {
     late ArgResults argResults;
@@ -43,6 +46,7 @@ void main() {
     late RunCommand runCommand;
     late AndroidInternetPermissionValidator androidInternetPermissionValidator;
     late ShorebirdFlutterValidator flutterValidator;
+    late ShorebirdProcess shorebirdProcess;
 
     setUp(() {
       argResults = _MockArgResults();
@@ -50,6 +54,7 @@ void main() {
       auth = _MockAuth();
       logger = _MockLogger();
       process = _MockProcess();
+      shorebirdProcess = _MockShorebirdProcess();
       codePushClient = _MockCodePushClient();
       androidInternetPermissionValidator =
           _MockAndroidInternetPermissionValidator();
@@ -63,15 +68,20 @@ void main() {
         }) {
           return codePushClient;
         },
-        startProcess: (executable, arguments, {bool runInShell = false}) async {
-          return process;
-        },
+        process: shorebirdProcess,
         validators: [
           androidInternetPermissionValidator,
           flutterValidator,
         ],
       )..testArgResults = argResults;
 
+      when(
+        () => shorebirdProcess.start(
+          any(),
+          any(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).thenAnswer((_) async => process);
       when(() => argResults.rest).thenReturn([]);
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => auth.client).thenReturn(httpClient);

--- a/packages/shorebird_cli/test/src/commands/run_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/run_command_test.dart
@@ -68,12 +68,15 @@ void main() {
         }) {
           return codePushClient;
         },
-        process: shorebirdProcess,
         validators: [
           androidInternetPermissionValidator,
           flutterValidator,
         ],
-      )..testArgResults = argResults;
+      )
+        ..testArgResults = argResults
+        ..testProcess = shorebirdProcess;
+
+      registerFallbackValue(shorebirdProcess);
 
       when(
         () => shorebirdProcess.start(
@@ -87,9 +90,9 @@ void main() {
       when(() => auth.client).thenReturn(httpClient);
       when(() => logger.progress(any())).thenReturn(_MockProgress());
       when(
-        () => androidInternetPermissionValidator.validate(),
+        () => androidInternetPermissionValidator.validate(any()),
       ).thenAnswer((_) async => []);
-      when(() => flutterValidator.validate()).thenAnswer((_) async => []);
+      when(() => flutterValidator.validate(any())).thenAnswer((_) async => []);
     });
 
     test('exits with no user when not logged in', () async {
@@ -155,7 +158,7 @@ void main() {
     });
 
     test('prints validation warnings', () async {
-      when(() => flutterValidator.validate()).thenAnswer(
+      when(() => flutterValidator.validate(any())).thenAnswer(
         (_) async => [
           const ValidationIssue(
             severity: ValidationIssueSeverity.warning,
@@ -163,7 +166,7 @@ void main() {
           ),
         ],
       );
-      when(() => androidInternetPermissionValidator.validate()).thenAnswer(
+      when(() => androidInternetPermissionValidator.validate(any())).thenAnswer(
         (_) async => [
           const ValidationIssue(
             severity: ValidationIssueSeverity.error,

--- a/packages/shorebird_cli/test/src/commands/run_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/run_command_test.dart
@@ -74,7 +74,8 @@ void main() {
         ],
       )
         ..testArgResults = argResults
-        ..testProcess = shorebirdProcess;
+        ..testProcess = shorebirdProcess
+        ..testEngineConfig = const EngineConfig.empty();
 
       registerFallbackValue(shorebirdProcess);
 

--- a/packages/shorebird_cli/test/src/commands/upgrade_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/upgrade_command_test.dart
@@ -39,7 +39,9 @@ void main() {
       shorebirdProcess = _MockShorebirdProcess();
       command = UpgradeCommand(
         logger: logger,
-      )..testProcess = shorebirdProcess;
+      )
+        ..testProcess = shorebirdProcess
+        ..testEngineConfig = const EngineConfig.empty();
 
       when(
         () => shorebirdProcess.run(

--- a/packages/shorebird_cli/test/src/commands/upgrade_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/upgrade_command_test.dart
@@ -39,8 +39,7 @@ void main() {
       shorebirdProcess = _MockShorebirdProcess();
       command = UpgradeCommand(
         logger: logger,
-        process: shorebirdProcess,
-      );
+      )..testProcess = shorebirdProcess;
 
       when(
         () => shorebirdProcess.run(

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -155,6 +155,31 @@ void main() {
       );
     });
 
+    test('adds local-engine arguments if set', () async {
+      shorebirdProcess = ShorebirdProcess(
+        processWrapper: processWrapper,
+        engineConfig: EngineConfig(
+          localEngineSrcPath: '/path/to/engine/src',
+          localEngine: 'android_release_arm64',
+        ),
+      );
+
+      await shorebirdProcess.run('flutter', []);
+
+      verify(
+        () => processWrapper.run(
+          any(),
+          [
+            '--local-engine-src-path=/path/to/engine/src',
+            '--local-engine=android_release_arm64',
+          ],
+          runInShell: any(named: 'runInShell'),
+          environment: any(named: 'environment'),
+          workingDirectory: any(named: 'workingDirectory'),
+        ),
+      ).called(1);
+    });
+
     group('start', () {
       test('forwards non-flutter executables to Process.run', () async {
         await shorebirdProcess.start('git', ['pull'], runInShell: true);

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -15,13 +15,13 @@ void main() {
     late ProcessWrapper processWrapper;
     late Process startProcess;
     late ProcessResult runProcessResult;
+    late ShorebirdProcess shorebirdProcess;
 
     setUp(() {
       processWrapper = _MockProcessWrapper();
       runProcessResult = _MockProcessResult();
       startProcess = _MockProcess();
-
-      ShorebirdProcess.processWrapper = processWrapper;
+      shorebirdProcess = ShorebirdProcess(processWrapper);
 
       when(
         () => processWrapper.run(
@@ -45,7 +45,7 @@ void main() {
 
     group('run', () {
       test('forwards non-flutter executables to Process.run', () async {
-        await ShorebirdProcess.run(
+        await shorebirdProcess.run(
           'git',
           ['pull'],
           runInShell: true,
@@ -64,7 +64,7 @@ void main() {
       });
 
       test('replaces "flutter" with our local flutter', () async {
-        await ShorebirdProcess.run(
+        await shorebirdProcess.run(
           'flutter',
           ['--version'],
           runInShell: true,
@@ -87,7 +87,7 @@ void main() {
       test(
           'does not replace flutter with our local flutter if'
           ' useVendedFlutter is false', () async {
-        await ShorebirdProcess.run(
+        await shorebirdProcess.run(
           'flutter',
           ['--version'],
           runInShell: true,
@@ -107,7 +107,7 @@ void main() {
       });
 
       test('Updates environment if useVendedFlutter is true', () async {
-        await ShorebirdProcess.run(
+        await shorebirdProcess.run(
           'flutter',
           ['--version'],
           runInShell: true,
@@ -130,7 +130,7 @@ void main() {
       test(
         'Makes no changes to environment if useVendedFlutter is false',
         () async {
-          await ShorebirdProcess.run(
+          await shorebirdProcess.run(
             'flutter',
             ['--version'],
             runInShell: true,
@@ -154,7 +154,7 @@ void main() {
 
     group('start', () {
       test('forwards non-flutter executables to Process.run', () async {
-        await ShorebirdProcess.start('git', ['pull'], runInShell: true);
+        await shorebirdProcess.start('git', ['pull'], runInShell: true);
 
         verify(
           () => processWrapper.start(
@@ -167,7 +167,7 @@ void main() {
       });
 
       test('replaces "flutter" with our local flutter', () async {
-        await ShorebirdProcess.start('flutter', ['run'], runInShell: true);
+        await shorebirdProcess.start('flutter', ['run'], runInShell: true);
 
         verify(
           () => processWrapper.start(
@@ -184,7 +184,7 @@ void main() {
       test(
           'does not replace flutter with our local flutter if'
           ' useVendedFlutter is false', () async {
-        await ShorebirdProcess.start(
+        await shorebirdProcess.start(
           'flutter',
           ['--version'],
           runInShell: true,
@@ -203,7 +203,7 @@ void main() {
     });
 
     test('Updates environment if useVendedFlutter is true', () async {
-      await ShorebirdProcess.start(
+      await shorebirdProcess.start(
         'flutter',
         ['--version'],
         runInShell: true,
@@ -226,7 +226,7 @@ void main() {
     test(
       'Makes no changes to environment if useVendedFlutter is false',
       () async {
-        await ShorebirdProcess.start(
+        await shorebirdProcess.start(
           'flutter',
           ['--version'],
           runInShell: true,

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -23,7 +23,7 @@ void main() {
       startProcess = _MockProcess();
       shorebirdProcess = ShorebirdProcess(
         processWrapper: processWrapper,
-        engineConfig: EngineConfig(localEngine: null, localEngineSrcPath: null),
+        engineConfig: const EngineConfig.empty(),
       );
 
       when(
@@ -158,7 +158,7 @@ void main() {
     test('adds local-engine arguments if set', () async {
       shorebirdProcess = ShorebirdProcess(
         processWrapper: processWrapper,
-        engineConfig: EngineConfig(
+        engineConfig: const EngineConfig(
           localEngineSrcPath: '/path/to/engine/src',
           localEngine: 'android_release_arm64',
         ),

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -21,7 +21,10 @@ void main() {
       processWrapper = _MockProcessWrapper();
       runProcessResult = _MockProcessResult();
       startProcess = _MockProcess();
-      shorebirdProcess = ShorebirdProcess(processWrapper);
+      shorebirdProcess = ShorebirdProcess(
+        processWrapper: processWrapper,
+        engineConfig: EngineConfig(localEngine: null, localEngineSrcPath: null),
+      );
 
       when(
         () => processWrapper.run(

--- a/packages/shorebird_cli/test/src/validators/android_internet_permission_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/android_internet_permission_validator_test.dart
@@ -1,9 +1,13 @@
 import 'dart:io';
 
 import 'package:collection/collection.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:test/test.dart';
+
+class _MockShorebirdProcess extends Mock implements ShorebirdProcess {}
 
 void main() {
   const manifestWithInternetPermission = '''
@@ -34,6 +38,12 @@ void main() {
 ''';
 
   group('AndroidInternetPermissionValidator', () {
+    late ShorebirdProcess shorebirdProcess;
+
+    setUp(() {
+      shorebirdProcess = _MockShorebirdProcess();
+    });
+
     Directory createTempDir() => Directory.systemTemp.createTempSync();
 
     void writeManifestToPath(String manifestContents, String path) {
@@ -57,7 +67,7 @@ void main() {
         );
 
         final results = await IOOverrides.runZoned(
-          () => AndroidInternetPermissionValidator().validate(),
+          () => AndroidInternetPermissionValidator().validate(shorebirdProcess),
           getCurrentDirectory: () => tempDirectory,
         );
 
@@ -66,7 +76,8 @@ void main() {
     );
 
     test('returns an error if no android project is found', () async {
-      final results = await AndroidInternetPermissionValidator().validate();
+      final results =
+          await AndroidInternetPermissionValidator().validate(shorebirdProcess);
 
       expect(results, hasLength(1));
       expect(results.first.severity, ValidationIssueSeverity.error);
@@ -80,7 +91,7 @@ void main() {
           .createSync(recursive: true);
 
       final results = await IOOverrides.runZoned(
-        () => AndroidInternetPermissionValidator().validate(),
+        () => AndroidInternetPermissionValidator().validate(shorebirdProcess),
         getCurrentDirectory: () => tempDirectory,
       );
 
@@ -133,7 +144,7 @@ void main() {
         );
 
         final results = await IOOverrides.runZoned(
-          () => AndroidInternetPermissionValidator().validate(),
+          () => AndroidInternetPermissionValidator().validate(shorebirdProcess),
           getCurrentDirectory: () => tempDirectory,
         );
 

--- a/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
@@ -77,10 +77,20 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
       shorebirdProcess = _MockShorebirdProcess();
 
       validator = ShorebirdFlutterValidator();
-      when(() => shorebirdProcess.run('git', ['rev-parse', 'HEAD']))
-          .thenAnswer((_) async => gitRevParseHeadProcessResult);
-      when(() => shorebirdProcess.run('git', ['status']))
-          .thenAnswer((_) async => gitStatusProcessResult);
+      when(
+        () => shorebirdProcess.run(
+          'git',
+          ['rev-parse', 'HEAD'],
+          workingDirectory: any(named: 'workingDirectory'),
+        ),
+      ).thenAnswer((_) async => gitRevParseHeadProcessResult);
+      when(
+        () => shorebirdProcess.run(
+          'git',
+          ['status'],
+          workingDirectory: any(named: 'workingDirectory'),
+        ),
+      ).thenAnswer((_) async => gitStatusProcessResult);
       when(() => shorebirdProcess.run('flutter', ['--version']))
           .thenAnswer((_) async => shorebirdFlutterVersionProcessResult);
       when(

--- a/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
@@ -158,7 +158,8 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
         expect(
           results.first.message,
           contains(
-            'The version of Flutter that Shorebird includes and the Flutter on your path are different',
+            'The version of Flutter that Shorebird includes and the Flutter on '
+            'your path are different',
           ),
         );
       },

--- a/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
@@ -33,8 +33,7 @@ void main() {
 
       command = DoctorCommand(
         logger: logger,
-        process: shorebirdProcess,
-      );
+      )..testProcess = shorebirdProcess;
 
       validator = ShorebirdVersionValidator(
         isShorebirdVersionCurrent: command.isShorebirdVersionCurrent,
@@ -77,7 +76,7 @@ void main() {
     });
 
     test('returns no issues when shorebird is up-to-date', () async {
-      final results = await validator.validate();
+      final results = await validator.validate(shorebirdProcess);
       expect(results, isEmpty);
     });
 
@@ -86,7 +85,7 @@ void main() {
         () => fetchLatestVersionResult.stdout,
       ).thenReturn(newerShorebirdRevision);
 
-      final results = await validator.validate();
+      final results = await validator.validate(shorebirdProcess);
       expect(results, hasLength(1));
       expect(results.first.severity, ValidationIssueSeverity.warning);
       expect(
@@ -108,7 +107,7 @@ void main() {
           ),
         );
 
-        final results = await validator.validate();
+        final results = await validator.validate(shorebirdProcess);
 
         expect(results, hasLength(1));
         expect(results.first.severity, ValidationIssueSeverity.error);

--- a/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
@@ -33,7 +33,9 @@ void main() {
 
       command = DoctorCommand(
         logger: logger,
-      )..testProcess = shorebirdProcess;
+      )
+        ..testProcess = shorebirdProcess
+        ..testEngineConfig = const EngineConfig.empty();
 
       validator = ShorebirdVersionValidator(
         isShorebirdVersionCurrent: command.isShorebirdVersionCurrent,


### PR DESCRIPTION
Fixes https://github.com/shorebirdtech/shorebird/issues/279

This required refactoring ShorebirdProcess to have state (e.g. whether to pass --local-engine-src-path or not), which required making it not static.  However then I realized we were setting ShorebirdProcess (or its functions) at construction time, which was too early to know the configuration.  CommandRunner only knows the top-level results during runCommand, so I refactored further to have CommandRunner vend a ShorebirdProcess for Command's to consume.

The rest was just plumbing and fixing unit tests.