### PR TITLE
fix: build and test cli and code push client packages when changes to shorebird_code_push_protocol are made

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,9 +39,11 @@ jobs:
               - ./.github/actions/dart_package
               - packages/shorebird_cli/**
               - packages/shorebird_code_push_client/**
+              - packages/shorebird_code_push_protocol/**
             shorebird_code_push_client:
               - ./.github/actions/dart_package
               - packages/shorebird_code_push_client/**
+              - packages/shorebird_code_push_protocol/**
             shorebird_code_push_protocol:
               - ./.github/actions/dart_package
               - packages/shorebird_code_push_protocol/**


### PR DESCRIPTION
## Description

Currently, making changes to the `shorebird_code_push_protocol` package does not trigger CI for packages with it as a dependency. This change fixes that.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
