### PR TITLE
chore: Update subscribe text

### DIFF
--- a/packages/artifact_proxy/lib/src/artifact_manifest_client.dart
+++ b/packages/artifact_proxy/lib/src/artifact_manifest_client.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:artifact_proxy/artifact_proxy.dart';

--- a/packages/artifact_proxy/test/src/artifact_manifest_client_test.dart
+++ b/packages/artifact_proxy/test/src/artifact_manifest_client_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:artifact_proxy/artifact_proxy.dart';
-import 'package:artifact_proxy/src/artifact_manifest_client.dart';
 import 'package:http/http.dart' as http;
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_cli/lib/src/commands/account/create_account_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/create_account_command.dart
@@ -54,9 +54,13 @@ To subscribe, run ${lightCyan.wrap('shorebird account subscribe')}.
 🎉 ${lightGreen.wrap('Welcome to Shorebird, ${newUser.displayName}!')}
 🔑 Credentials are stored in ${lightCyan.wrap(auth.credentialsFilePath)}.
 🚪 To logout, use: "${lightCyan.wrap('shorebird logout')}".
-⬆️  To upgrade your account, use: "${lightCyan.wrap('shorebird account subscribe')}".
 
-Enjoy! Please let us know via Discord if we can help.''',
+A subscription is required to use Shorebird during the Trusted Tester program.
+To subscribe, run ${lightCyan.wrap('shorebird account subscribe')}.
+
+Please let us know via Discord if we can help!
+${lightCyan.wrap('https://discord.com/invite/9hKJcWGcaB')}.
+''',
     );
     return ExitCode.success.code;
   }

--- a/packages/shorebird_cli/lib/src/commands/account/subscribe_account_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/subscribe_account_command.dart
@@ -25,9 +25,12 @@ class SubscribeAccountCommand extends ShorebirdCommand
 
   @override
   String get summary => '''
-A subscription is required to use Shorebird to create and publish apps.
-Subscriptions are currently \$20 per month and are billed through Stripe.
-Visit ${styleUnderlined.wrap(lightCyan.wrap('https://github.com/shorebirdtech/shorebird/blob/main/TRUSTED_TESTERS.md'))} to learn more.''';
+A subscription to Shorebird's Trusted Tester program is required to publish
+patches to your apps.
+
+The subscription costs \$20 USD per month per user and is billed through Stripe.
+
+Visit ${styleUnderlined.wrap(lightCyan.wrap('https://github.com/shorebirdtech/shorebird/blob/main/TRUSTED_TESTERS.md'))} for more details.''';
 
   @override
   Future<int> run() async {
@@ -88,8 +91,14 @@ ${lightCyan.wrap(paymentLink.toString())}
 
 Once Stripe has processed your payment, you will be able to use Shorebird to create and publish apps.
 
-${styleBold.wrap(red.wrap('Note: This payment link is specifically for ${styleItalic.wrap('your account')}. Do not share it with others.'))}''');
+${styleBold.wrap(red.wrap('Note: This payment link is specifically for ${styleItalic.wrap('your account')}. Do not share it with others.'))}
 
+Once you have completed your payment, please let us know on Discord or by
+replying to your invite email, so that we can add you to the Trusted Tester
+private Discord channel for live support.
+
+Thanks for you help!
+''');
     return ExitCode.success.code;
   }
 }


### PR DESCRIPTION
Update `shorebird account subscribe` text.

Removed two unnecessary imports according to the analyzer.