### PR TITLE
chore(shorebird_cli): use standardized message to tell user to login

### DIFF
--- a/packages/shorebird_cli/lib/src/auth_logger_mixin.dart
+++ b/packages/shorebird_cli/lib/src/auth_logger_mixin.dart
@@ -1,0 +1,15 @@
+import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/command.dart';
+
+mixin AuthLoggerMixin on ShorebirdCommand {
+  void printNeedsAuthInstructions() {
+    logger
+      ..err('You must be logged in to run this command.')
+      ..info(
+        '''If you already have an account, run ${lightCyan.wrap('shorebird login')} to sign in.''',
+      )
+      ..info(
+        '''If you don't have a Shorebird account, run ${lightCyan.wrap('shorebird account create')} to create one.''',
+      );
+  }
+}

--- a/packages/shorebird_cli/lib/src/commands/account/subscribe_account_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/subscribe_account_command.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -9,7 +10,7 @@ import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 /// `shorebird account subscribe`
 /// {@endtemplate}
 class SubscribeAccountCommand extends ShorebirdCommand
-    with ShorebirdConfigMixin {
+    with AuthLoggerMixin, ShorebirdConfigMixin {
   /// {@macro subscribe_account_command}
   SubscribeAccountCommand({
     required super.logger,
@@ -35,13 +36,7 @@ Visit ${styleUnderlined.wrap(lightCyan.wrap('https://github.com/shorebirdtech/sh
   @override
   Future<int> run() async {
     if (!auth.isAuthenticated) {
-      logger
-        ..err('''
-You must be logged in to subscribe.''')
-        ..info('''
-
-If you have a Shorebird account, run ${lightCyan.wrap('shorebird login')} to log in.
-If you don't have a Shorebird account, run ${lightCyan.wrap('shorebird account create')} to create one.''');
+      printNeedsAuthInstructions();
       return ExitCode.software.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/apps/create_apps_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/apps/create_apps_command.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_create_app_mixin.dart';
@@ -12,7 +13,7 @@ import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 /// Create a new app on Shorebird.
 /// {@endtemplate}
 class CreateAppCommand extends ShorebirdCommand
-    with ShorebirdConfigMixin, ShorebirdCreateAppMixin {
+    with AuthLoggerMixin, ShorebirdConfigMixin, ShorebirdCreateAppMixin {
   /// {@macro create_app_command}
   CreateAppCommand({
     required super.logger,
@@ -36,7 +37,7 @@ Defaults to the name in "pubspec.yaml".''',
   @override
   Future<int>? run() async {
     if (!auth.isAuthenticated) {
-      logger.err('You must be logged in.');
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/apps/delete_apps_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/apps/delete_apps_command.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 
@@ -9,7 +10,8 @@ import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 /// `shorebird apps delete`
 /// Delete an existing app on Shorebird.
 /// {@endtemplate}
-class DeleteAppCommand extends ShorebirdCommand with ShorebirdConfigMixin {
+class DeleteAppCommand extends ShorebirdCommand
+    with AuthLoggerMixin, ShorebirdConfigMixin {
   /// {@macro delete_app_command}
   DeleteAppCommand({
     required super.logger,
@@ -33,7 +35,7 @@ Defaults to the app_id in "shorebird.yaml".''',
   @override
   Future<int>? run() async {
     if (!auth.isAuthenticated) {
-      logger.err('You must be logged in.');
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/apps/list_apps_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/apps/list_apps_command.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:barbecue/barbecue.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -11,7 +12,8 @@ import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 /// `shorebird apps list`
 /// List all apps using Shorebird.
 /// {@endtemplate}
-class ListAppsCommand extends ShorebirdCommand with ShorebirdConfigMixin {
+class ListAppsCommand extends ShorebirdCommand
+    with AuthLoggerMixin, ShorebirdConfigMixin {
   /// {@macro list_apps_command}
   ListAppsCommand({
     required super.logger,
@@ -31,7 +33,7 @@ class ListAppsCommand extends ShorebirdCommand with ShorebirdConfigMixin {
   @override
   Future<int>? run() async {
     if (!auth.isAuthenticated) {
-      logger.err('You must be logged in.');
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/flutter_validation_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -12,7 +13,11 @@ import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 /// Build an Android APK file from your app.
 /// {@endtemplate}
 class BuildApkCommand extends ShorebirdCommand
-    with ShorebirdValidationMixin, ShorebirdConfigMixin, ShorebirdBuildMixin {
+    with
+        AuthLoggerMixin,
+        ShorebirdValidationMixin,
+        ShorebirdConfigMixin,
+        ShorebirdBuildMixin {
   /// {@macro build_apk_command}
   BuildApkCommand({
     required super.logger,
@@ -29,9 +34,7 @@ class BuildApkCommand extends ShorebirdCommand
   @override
   Future<int> run() async {
     if (!auth.isAuthenticated) {
-      logger
-        ..err('You must be logged in to build.')
-        ..err("Run 'shorebird login' to log in and try again.");
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/flutter_validation_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -12,7 +13,11 @@ import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 /// Build an Android App Bundle file from your app.
 /// {@endtemplate}
 class BuildAppBundleCommand extends ShorebirdCommand
-    with ShorebirdValidationMixin, ShorebirdConfigMixin, ShorebirdBuildMixin {
+    with
+        AuthLoggerMixin,
+        ShorebirdValidationMixin,
+        ShorebirdConfigMixin,
+        ShorebirdBuildMixin {
   /// {@macro build_app_bundle_command}
   BuildAppBundleCommand({
     required super.logger,
@@ -29,9 +34,7 @@ class BuildAppBundleCommand extends ShorebirdCommand
   @override
   Future<int> run() async {
     if (!auth.isAuthenticated) {
-      logger
-        ..err('You must be logged in to build.')
-        ..err("Run 'shorebird login' to log in and try again.");
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/channels/create_channels_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/channels/create_channels_command.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 
@@ -8,7 +9,8 @@ import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 /// `shorebird channels create`
 /// Create a new channel for a Shorebird app.
 /// {@endtemplate}
-class CreateChannelsCommand extends ShorebirdCommand with ShorebirdConfigMixin {
+class CreateChannelsCommand extends ShorebirdCommand
+    with AuthLoggerMixin, ShorebirdConfigMixin {
   /// {@macro create_channels_command}
   CreateChannelsCommand({
     required super.logger,
@@ -38,7 +40,7 @@ class CreateChannelsCommand extends ShorebirdCommand with ShorebirdConfigMixin {
   @override
   Future<int>? run() async {
     if (!auth.isAuthenticated) {
-      logger.err('You must be logged in to view channels.');
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/channels/list_channels_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/channels/list_channels_command.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:barbecue/barbecue.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -10,7 +11,8 @@ import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 /// `shorebird channels list`
 /// List all channels for a Shorebird app.
 /// {@endtemplate}
-class ListChannelsCommand extends ShorebirdCommand with ShorebirdConfigMixin {
+class ListChannelsCommand extends ShorebirdCommand
+    with AuthLoggerMixin, ShorebirdConfigMixin {
   /// {@macro list_channels_command}
   ListChannelsCommand({
     required super.logger,
@@ -37,7 +39,7 @@ class ListChannelsCommand extends ShorebirdCommand with ShorebirdConfigMixin {
   @override
   Future<int>? run() async {
     if (!auth.isAuthenticated) {
-      logger.err('You must be logged in to view channels.');
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -12,7 +13,7 @@ import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 /// Initialize Shorebird.
 /// {@endtemplate}
 class InitCommand extends ShorebirdCommand
-    with ShorebirdConfigMixin, ShorebirdCreateAppMixin {
+    with AuthLoggerMixin, ShorebirdConfigMixin, ShorebirdCreateAppMixin {
   /// {@macro init_command}
   InitCommand({required super.logger, super.auth, super.buildCodePushClient});
 
@@ -25,7 +26,7 @@ class InitCommand extends ShorebirdCommand
   @override
   Future<int> run() async {
     if (!auth.isAuthenticated) {
-      logger.err('You must be logged in.');
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch_command.dart
@@ -5,6 +5,7 @@ import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/flutter_validation_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -36,6 +37,7 @@ class PatchArtifactBundle {
 /// {@endtemplate}
 class PatchCommand extends ShorebirdCommand
     with
+        AuthLoggerMixin,
         ShorebirdValidationMixin,
         ShorebirdConfigMixin,
         ShorebirdBuildMixin,
@@ -106,7 +108,7 @@ class PatchCommand extends ShorebirdCommand
     }
 
     if (!auth.isAuthenticated) {
-      logger.err('You must be logged in to publish.');
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release_command.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/flutter_validation_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -17,6 +18,7 @@ import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 /// {@endtemplate}
 class ReleaseCommand extends ShorebirdCommand
     with
+        AuthLoggerMixin,
         ShorebirdValidationMixin,
         ShorebirdConfigMixin,
         ShorebirdBuildMixin,
@@ -65,7 +67,7 @@ make smaller updates to your app.
     }
 
     if (!auth.isAuthenticated) {
-      logger.err('You must be logged in to release.');
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/run_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/run_command.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/flutter_validation_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -10,7 +11,7 @@ import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 /// Run the Flutter application.
 /// {@endtemplate}
 class RunCommand extends ShorebirdCommand
-    with ShorebirdValidationMixin, ShorebirdConfigMixin {
+    with AuthLoggerMixin, ShorebirdValidationMixin, ShorebirdConfigMixin {
   /// {@macro run_command}
   RunCommand({
     required super.logger,
@@ -28,9 +29,7 @@ class RunCommand extends ShorebirdCommand
   @override
   Future<int> run() async {
     if (!auth.isAuthenticated) {
-      logger
-        ..err('You must be logged in to run.')
-        ..err("Run 'shorebird login' to log in and try again.");
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/subscription/cancel_subscription_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/subscription/cancel_subscription_command.dart
@@ -2,12 +2,13 @@ import 'dart:async';
 
 import 'package:intl/intl.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth_logger_mixin.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 class CancelSubscriptionCommand extends ShorebirdCommand
-    with ShorebirdConfigMixin {
+    with AuthLoggerMixin, ShorebirdConfigMixin {
   CancelSubscriptionCommand({
     required super.logger,
     super.auth,
@@ -23,7 +24,7 @@ class CancelSubscriptionCommand extends ShorebirdCommand
   @override
   Future<int> run() async {
     if (!auth.isAuthenticated) {
-      logger.err('You must be logged in to cancel your subscription.');
+      printNeedsAuthInstructions();
       return ExitCode.noUser.code;
     }
 

--- a/packages/shorebird_cli/test/src/commands/account/subscribe_account_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account/subscribe_account_command_test.dart
@@ -77,10 +77,9 @@ void main() {
       final result = await subscribeAccountCommand.run();
 
       expect(result, ExitCode.software.code);
+
       verify(
-        () => logger.err(
-          any(that: contains('You must be logged in to subscribe')),
-        ),
+        () => logger.err(any(that: contains('You must be logged in to run'))),
       ).called(1);
       verifyNever(() => codePushClient.createPaymentLink());
     });

--- a/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
@@ -81,9 +81,8 @@ void main() {
       final result = await command.run();
       expect(result, equals(ExitCode.noUser.code));
 
-      verify(() => logger.err('You must be logged in to build.')).called(1);
       verify(
-        () => logger.err("Run 'shorebird login' to log in and try again."),
+        () => logger.err(any(that: contains('You must be logged in to run'))),
       ).called(1);
     });
 

--- a/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
@@ -82,9 +82,8 @@ void main() {
       final result = await command.run();
       expect(result, equals(ExitCode.noUser.code));
 
-      verify(() => logger.err('You must be logged in to build.')).called(1);
       verify(
-        () => logger.err("Run 'shorebird login' to log in and try again."),
+        () => logger.err(any(that: contains('You must be logged in to run'))),
       ).called(1);
     });
 

--- a/packages/shorebird_cli/test/src/commands/run_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/run_command_test.dart
@@ -102,9 +102,8 @@ void main() {
       final result = await runCommand.run();
       expect(result, equals(ExitCode.noUser.code));
 
-      verify(() => logger.err('You must be logged in to run.')).called(1);
       verify(
-        () => logger.err("Run 'shorebird login' to log in and try again."),
+        () => logger.err(any(that: contains('You must be logged in to run'))),
       ).called(1);
     });
 


### PR DESCRIPTION
## Description

Each command was previously logging its own version of a "you need to be authenticated" message. This change adds a mixin to standardize the message and to clarify when the user should run `shorebird login` vs `shorebird account create`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
