### PR TITLE
fix(shorebird_cli): use path.join to construct paths

### DIFF
--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -159,6 +159,7 @@ This can cause unexpected behavior if you are switching between the tools and th
       'flutter',
       ['--version'],
       useVendedFlutter: !checkPathFlutter,
+      runInShell: true,
     );
 
     if (result.exitCode != 0) {

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:test/test.dart';
 
@@ -80,7 +81,11 @@ void main() {
 
         verify(
           () => processWrapper.run(
-            any(that: contains('bin/cache/flutter/bin/flutter')),
+            any(
+              that: contains(
+                p.join('bin', 'cache', 'flutter', 'bin', 'flutter'),
+              ),
+            ),
             ['--version'],
             runInShell: true,
             environment: flutterStorageBaseUrlEnv,
@@ -158,10 +163,11 @@ void main() {
     });
 
     test('adds local-engine arguments if set', () async {
+      final localEngineSrcPath = p.join('path', 'to', 'engine', 'src');
       shorebirdProcess = ShorebirdProcess(
         processWrapper: processWrapper,
-        engineConfig: const EngineConfig(
-          localEngineSrcPath: '/path/to/engine/src',
+        engineConfig: EngineConfig(
+          localEngineSrcPath: localEngineSrcPath,
           localEngine: 'android_release_arm64',
         ),
       );
@@ -172,7 +178,7 @@ void main() {
         () => processWrapper.run(
           any(),
           [
-            '--local-engine-src-path=/path/to/engine/src',
+            '--local-engine-src-path=$localEngineSrcPath',
             '--local-engine=android_release_arm64',
           ],
           runInShell: any(named: 'runInShell'),
@@ -201,7 +207,11 @@ void main() {
 
         verify(
           () => processWrapper.start(
-            any(that: contains('bin/cache/flutter/bin/flutter')),
+            any(
+              that: contains(
+                p.join('bin', 'cache', 'flutter', 'bin', 'flutter'),
+              ),
+            ),
             ['run'],
             runInShell: true,
             environment: flutterStorageBaseUrlEnv,
@@ -240,7 +250,11 @@ void main() {
 
       verify(
         () => processWrapper.start(
-          any(that: contains('bin/cache/flutter/bin/flutter')),
+          any(
+            that: contains(
+              p.join('bin', 'cache', 'flutter', 'bin', 'flutter'),
+            ),
+          ),
           ['--version'],
           runInShell: true,
           environment: {

--- a/packages/shorebird_cli/test/src/validators/android_internet_permission_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/android_internet_permission_validator_test.dart
@@ -59,11 +59,11 @@ void main() {
         final tempDirectory = createTempDir();
         writeManifestToPath(
           manifestWithInternetPermission,
-          p.join(tempDirectory.path, 'android/app/src/debug'),
+          p.join(tempDirectory.path, 'android', 'app', 'src', 'debug'),
         );
         writeManifestToPath(
           manifestWithInternetPermission,
-          p.join(tempDirectory.path, 'android/app/src/main'),
+          p.join(tempDirectory.path, 'android', 'app', 'src', 'main'),
         );
 
         final results = await IOOverrides.runZoned(
@@ -157,7 +157,8 @@ void main() {
               (path) => ValidationIssue(
                 severity: ValidationIssueSeverity.error,
                 message:
-                    '$path/AndroidManifest.xml is missing the INTERNET permission.',
+                    '${p.join(path, 'AndroidManifest.xml')} is missing the '
+                    'INTERNET permission.',
               ),
             ),
           ),

--- a/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
@@ -91,13 +91,19 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
           workingDirectory: any(named: 'workingDirectory'),
         ),
       ).thenAnswer((_) async => gitStatusProcessResult);
-      when(() => shorebirdProcess.run('flutter', ['--version']))
-          .thenAnswer((_) async => shorebirdFlutterVersionProcessResult);
+      when(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['--version'],
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).thenAnswer((_) async => shorebirdFlutterVersionProcessResult);
       when(
         () => shorebirdProcess.run(
           'flutter',
           ['--version'],
           useVendedFlutter: false,
+          runInShell: any(named: 'runInShell'),
         ),
       ).thenAnswer((_) async => pathFlutterVersionProcessResult);
 


### PR DESCRIPTION
## Description

Updates path construction logic to use [`path.join`](https://api.flutter.dev/flutter/package-path_path/join.html) instead of hardcoding the path separator character as `/`, which doesn't work on Windows. Also changes a few invocations of `flutter` to spawn in a shell to fix `shorebird doctor`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
