### PR TITLE
feat(shorebird_code_push_client): add deleteRelease

### DIFF
--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -195,6 +195,17 @@ class CodePushClient {
     return Release.fromJson(body);
   }
 
+  /// Delete the release with the provided [releaseId].
+  Future<void> deleteRelease({required int releaseId}) async {
+    final response = await _httpClient.delete(
+      Uri.parse('$hostedUri/api/v1/releases/$releaseId'),
+    );
+
+    if (response.statusCode != HttpStatus.noContent) {
+      throw _parseErrorResponse(response.body);
+    }
+  }
+
   /// Create a new Shorebird user with the provided [name].
   ///
   /// The email associated with the user's JWT will be used as the user's email.


### PR DESCRIPTION
## Description

Adds the ability to delete a release by `releaseId` to `CodePushClient`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
