### PR TITLE
fix(shorebird_cli): add more logging when rebuilding shorebird on Windows

### DIFF
--- a/bin/shorebird.ps1
+++ b/bin/shorebird.ps1
@@ -14,6 +14,8 @@ $shorebirdScript = [IO.Path]::Combine($shorebirdCliDir, "bin", "shorebird.dart")
 $dart = [IO.Path]::Combine($flutterPath, "bin", "cache", "dart-sdk", "bin", "dart.exe")
 
 function Update-Flutter {
+    Write-Output "Updating Flutter..."
+
     if (!(Test-Path $flutterPath)) {
         Write-Output "Cloning flutter, this may take a bit..."
         git clone --filter=tree:0 https://github.com/shorebirdtech/flutter.git --no-checkout "$flutterPath" *> $null
@@ -71,6 +73,8 @@ function Update-Shorebird {
     Write-Debug "Invalidate cache: $invalidateCache"
 
     if ($invalidateCache) {
+        Write-Output "Rebuilding shorebird..."
+
         Update-Flutter
 
         Push-Location $shorebirdCliDir


### PR DESCRIPTION
## Description

On Windows, the "update Flutter" step that happens when we detect that we need to rebuild shorebird happened silently. This made it appear as though shorebird was hanging for several seconds.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
