### PR TITLE
feat(shorebird_cli): add `--force` to `shorebird release`

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release_command.dart
@@ -53,6 +53,12 @@ class ReleaseCommand extends ShorebirdCommand
       ..addOption(
         'flavor',
         help: 'The product flavor to use when building the app.',
+      )
+      ..addFlag(
+        'force',
+        abbr: 'f',
+        help: 'Release without confirmation if there are no errors.',
+        negatable: false,
       );
   }
 
@@ -171,11 +177,15 @@ ${styleBold.wrap(lightGreen.wrap('🚀 Ready to create a new release!'))}
 ${summary.join('\n')}
 ''');
 
-    final confirm = logger.confirm('Would you like to continue?');
+    final force = results['force'] == true;
+    final needConfirmation = !force;
+    if (needConfirmation) {
+      final confirm = logger.confirm('Would you like to continue?');
 
-    if (!confirm) {
-      logger.info('Aborting.');
-      return ExitCode.success.code;
+      if (!confirm) {
+        logger.info('Aborting.');
+        return ExitCode.success.code;
+      }
     }
 
     late final List<Release> releases;

--- a/packages/shorebird_cli/test/src/commands/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release_command_test.dart
@@ -414,6 +414,25 @@ Did you forget to run "shorebird init"?''',
       expect(exitCode, ExitCode.software.code);
     });
 
+    test(
+        'does not prompt for confirmation '
+        'when --release-version and --force are used', () async {
+      when(() => argResults['force']).thenReturn(true);
+      when(() => argResults['release-version']).thenReturn(version);
+      final tempDir = setUpTempDir();
+      setUpTempArtifacts(tempDir);
+      final exitCode = await IOOverrides.runZoned(
+        command.run,
+        getCurrentDirectory: () => tempDir,
+      );
+      verify(() => logger.success('\n✅ Published Release!')).called(1);
+      expect(exitCode, ExitCode.success.code);
+      expect(capturedHostedUri, isNull);
+      verifyNever(
+        () => logger.prompt(any(), defaultValue: any(named: 'defaultValue')),
+      );
+    });
+
     test('succeeds when release is successful', () async {
       final tempDir = setUpTempDir();
       setUpTempArtifacts(tempDir);


### PR DESCRIPTION
## Description

I have added force flag in shorebird release command.
If given, it will not ask for confirmation for release.
As it's mentioned in #448 .

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
