### PR TITLE
docs: make artifact proxy `/` return an explainer

### DIFF
--- a/packages/artifact_proxy/lib/src/artifact_proxy.dart
+++ b/packages/artifact_proxy/lib/src/artifact_proxy.dart
@@ -4,10 +4,44 @@ import 'package:artifact_proxy/artifact_proxy.dart';
 import 'package:artifact_proxy/config.dart';
 import 'package:shelf/shelf.dart';
 
+const String explainerHtml = """
+<html>
+<head>
+<title>Shorebird Artifact Proxy</title>
+</head>
+<body>
+<p>
+This server proxies requests for Flutter artifacts to the correct location,
+depending on the engine revision.  Most artifacts are served from the standard
+`download.flutter.io` location, but a few artifacts are served from Shorebird's
+storage bucket to add support for code push.
+</p>
+<p>
+See <a href='https://docs.shorebird.dev/architecture'>
+https://docs.shorebird.dev/architecture</a> for more information.
+</p>
+<p>
+Source code can be found here:
+<a
+href='https://github.com/shorebirdtech/shorebird/tree/main/packages/artifact_proxy'>
+https://github.com/shorebirdtech/shorebird/tree/main/packages/artifact_proxy</a>
+</p>
+<p>
+If you're seeing problems with your Shorebird install, or are interested in
+replicating this proxy, please reach out to us over Discord.
+<a href='https://shorebird.dev/contact'>https://shorebird.dev/contact</a>
+</p>
+</body>
+</html>
+""";
+
 /// A [Handler] that proxies artifact requests to the correct location.
 Handler artifactProxyHandler({required ArtifactManifestClient client}) {
   return (Request request) async {
     final path = request.url.path;
+    if (path.isEmpty) {
+      return Response.ok(explainerHtml, headers: {'content-type': 'text/html'});
+    }
 
     RegExpMatch? engineArtifactMatch;
     for (final pattern in engineArtifactPatterns) {

--- a/packages/artifact_proxy/test/artifact_proxy_test.dart
+++ b/packages/artifact_proxy/test/artifact_proxy_test.dart
@@ -132,5 +132,15 @@ void main() {
       );
       verifyNever(() => client.getManifest(any()));
     });
+
+    test('should return explainer at /', () async {
+      const path = '/';
+      final request = buildRequest(path);
+      final response = await handler(request);
+      expect(response.statusCode, equals(HttpStatus.ok));
+      verifyNever(() => client.getManifest(any()));
+      expect(response.headers['content-type'], equals('text/html'));
+      expect(response.readAsString(), completion(contains('Shorebird')));
+    });
   });
 }


### PR DESCRIPTION
We've seen a number of requests to /, so figured might as well return an explainer there.