### PR TITLE
docs: Update forking instructions to use cutler

### DIFF
--- a/packages/cutler/FORKING_FLUTTER.md
+++ b/packages/cutler/FORKING_FLUTTER.md
@@ -5,88 +5,147 @@ These are our old docs for our manual update process.
 
 ## Keeping our fork up to date
 
-1. Pick a version of Flutter to update to (e.g. 3.7.10) new_flutter
-3.7.10 flutter = https://github.com/flutter/flutter/tree/3.7.10
-https://github.com/flutter/flutter/commit/4b12645012342076800eb701bcdfe18f87da21cf
+You need checkouts of all the various repos in the same directory.
 
-2. Find the engine version for new_flutter (e.g. 3.7.10) new_engine
-3.7.10 engine = https://github.com/flutter/flutter/blob/3.7.10/bin/internal/engine.version
-ec975089acb540fc60752606a3d3ba809dd1528b
-
-3. Find the buildroot version for new_engine (e.g. 3.7.10) new_buildroot
-https://github.com/flutter/engine/tree/3.7.10/
-3.7.10 buildroot = https://github.com/flutter/engine/blob/3.7.10/DEPS#L239
-8747bce41d0dc6d9dc45c4d1b46d2100bb9ee688
-
-4. Find the version of Flutter we're based on (currently, incorrectly 3.7.9) old_flutter
-https://github.com/shorebirdtech/flutter/tree/stable
-https://github.com/shorebirdtech/flutter/commit/62bd79521d8d007524e351747471ba66696fc2d4
-
-5. Find the engine version for old_flutter (e.g. 3.7.8) old_engine
-https://github.com/shorebirdtech/engine/tree/stable_codepush
-is based on 3.7.8 engine =
-https://github.com/flutter/engine/tree/3.7.8
-https://github.com/shorebirdtech/engine/commit/9aa7816315095c86410527932918c718cb35e7d6
-
-6. Find the buildroot version for old_engine (e.g. 3.7.8) old_buildroot
-https://github.com/shorebirdtech/buildroot/commits/stable_codepush
-is based on:
-https://github.com/shorebirdtech/buildroot/commit/8747bce41d0dc6d9dc45c4d1b46d2100bb9ee688
-
-
-7. With that data, we now just go through and move the patches we made from
-on top of old_* to be on top of new_*.  e.g.
-`git rebase --onto new_flutter old_flutter stable_codepush`
-
-In addition to doing the rebasing we also need to go through and update the version
-numbers in the various places.  We can do both in a single pass.
-
-8. buildroot: Based on the above, we don't need to do anything for buildroot this time,
-but do need to rebase the engine and flutter repos.
-
-9. engine: But we do need to move our engine fork:
-`git rebase --onto 3.7.10 3.7.8 stable_codepush`
-And save off that hash:
-`git rev-parse stable_codepush`
-978a56f2d97f9ce24a2b6bc22c9bbceaaba0343c
-
-We do not need to update our engine fork commits at this time since it already
-pointed to the (unchanged) forked buildroot in `DEPS`.
-
-Because this kind of rebase is a non-fast-forward commit, we will need to
-force push to our fork.  A better solution will be for us to tag or branch
-each of these releases instead of keeping a single release branch.
+Currently the tool assumes you're using our internal repository `_shorebird`
+to check out `shorebird`.  Example:
 ```
-git push origin --force
+cd $HOME/Documents/GitHub
+git clone https://github.com/shorebirdtech/_shorebird
+```
+To check out the engine, you should follow:
+https://github.com/shorebirdtech/updater/blob/main/BUILDING_ENGINE.md
+it will result in an `engine` directory in the same directory as `_shorebird`.
+
+Run `cutler` to get the git commands you need.
+
+For a stable update:
+```
+dart run cutler --dry-run --root=$HOME/Documents/GitHub
 ```
 
-10. flutter: Then we need to move our flutter fork.
-Our flutter fork currently uses the `stable` channel instead of stable_codepush
-we should eventually standardize on across all the repos on something.
-
-If we change this branch we also would need to change the branch in the
-shorebird cli which controls updating the flutter version.
-
-Since the only commit on our flutter
-fork is one changing engine.version, we can just replace the commit:
+For a beta update:
 ```
-git fetch upstream
-git reset --hard 3.7.10
-echo '978a56f2d97f9ce24a2b6bc22c9bbceaaba0343c' > bin/internal/engine.version
-git add bin/internal/engine.version
-git commit -a -m 'chore: Update engine version to shorebird-3.7.10'
-```
-Again we should save off our new hash:
-`git rev-parse stable`
-c2185f5f6cce5c6c47e7f71c682ecae1e3817d18
-
-This will need a similar force push:
-```
-git push origin --force
+dart run cutler --dry-run --root=$HOME/Documents/GitHub --flutter-channel=beta
 ```
 
-11.  Finally we need to update the shorebird cli itself.  Currently located at:
-https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_cli/lib/src/engine_revision.dart
+Eventually we'll automate stable, beta and master updates in the cloud.
+
+Example output from updating 3.7.10 to 3.10.0:
+
+```
+dart run cutler --no-update --root=$HOME/Documents/GitHub --flutter-channel=beta --dry-run
+Building package executable... 
+Built cutler:cutler.
+Shorebird stable:
+  flutter   83305b5088e6fe327fb3334a73ff190828d85713
+  engine    c415419390e4751ddfa3110e0808e7abb3d45a18
+  buildroot 7383548fa2306b5d53979ac5e9d176b35258811b
+Forkpoints:
+  flutter   4d9e56e694b656610ab87fcf2efbcd226e0ed8cf (3.7.12)
+  engine    1a65d409c7a1438a34d21b60bf30a6fd5db59314 (3.7.12)
+  buildroot 8747bce41d0dc6d9dc45c4d1b46d2100bb9ee688
+Upstream beta:
+  flutter   b1c77b7ed32346fe829c0ca97bd85d19290d54ae (3.10.0-1.5.pre)
+  engine    50e509c2bd0d7788feb675e38321cc5711c8d2d6 (3.10.0-1.5.pre)
+  buildroot f24f62fa5381c0e415b6ca2000600fc0600c11c8
+Rebasing buildroot...
+git rebase --onto f24f62fa5381c0e415b6ca2000600fc0600c11c8 8747bce41d0dc6d9dc45c4d1b46d2100bb9ee688 7383548fa2306b5d53979ac5e9d176b35258811b
+Rebasing engine...
+git rebase --onto 3.10.0-1.5.pre 3.7.12 c415419390e4751ddfa3110e0808e7abb3d45a18
+Rebasing flutter...
+git rebase --onto 3.10.0-1.5.pre 3.7.12 83305b5088e6fe327fb3334a73ff190828d85713
+Updating engine DEPS...
+Would have changed DEPS lines:
+(  'src': 'https://github.com/shorebirdtech/buildroot.git' + '@' + 'new-buildroot-hash',)
+Updating flutter engine version...
+  Change engine.version: b426644a712b0cfd32c896d947ddd1a1245eb713 from c415419390e4751ddfa3110e0808e7abb3d45a18
+Updating shorebird flutter version...
+  Change flutter.version: f0f67059dfa254be219b07d6d784eebec89c4fae from 83305b5088e6fe327fb3334a73ff190828d85713
+```
+
+
+1. Rebase buildroot on top of the new buildroot hash, e.g.
+```
+git rebase --onto f24f62fa5381c0e415b6ca2000600fc0600c11c8 8747bce41d0dc6d9dc45c4d1b46d2100bb9ee688 7383548fa2306b5d53979ac5e9d176b35258811b
+```
+2. Save the commit id from that rebase you'll need it to edit the DEPS file in
+the engine repo.  In this example it was "d6c410f19de5947de40ce110c1e768c887870072".
+
+3. Rebase the engine on top of the new engine hash, e.g.
+```
+git rebase --onto 3.10.0-1.5.pre 3.7.12 c415419390e4751ddfa3110e0808e7abb3d45a18
+```
+This might have conflicts, if so you'll need to resolve them, if the conflict
+is in the DEPS file, you can take it as an opportunity to insert the new
+buildroot hash.
+
+4. Save the commit id from that rebase you'll need it to edit the engine.version
+file in the flutter repo.  In this example it was "94bc1218b84cc0199068f8788cda96e3128784a0".
+
+5. Rebase the flutter repo on top of the new flutter hash, e.g.
+```
+git rebase --onto 3.10.0-1.5.pre 3.7.12 83305b5088e6fe327fb3334a73ff190828d85713
+```
+This might have conflicts, if so you'll need to resolve them, if the conflict
+is in the DEPS file, you can take it as an opportunity to insert the new
+engine hash.
+
+6. Save the commit id from that rebase you'll need it to edit the flutter.version
+file in the shorebird repo.  In this example it was "f498c3913890e7a022596029c7f07f467b0889da".
+
+7. Update the flutter.version file in the shorebird repo to the new flutter
+hash, e.g.
+```
+echo 'f498c3913890e7a022596029c7f07f467b0889da' > bin/internal/flutter.version
+commit -a -m "Update flutter version to 3.10.0-1.5.pre"
+```
+
+8. Now that we've prepared these versions it should be possible to build the
+   engine and test our work!
+   `gclient sync` is only needed if buildroot (`src`) changed.
+```
+cd $HOME/Documents/GitHub
+cd engine
+gclient sync
+cd ..
+./build_engine/build_engine/build.sh $HOME/Documents/GitHub/engine
+```
+build.sh currently requires an absolute path to the engine directory or it fails
+with a cryptic error message crashing in `cargo ndk build`.
+
+Building will take up to 45 mins on a M2 machine (it builds the engine 3 times)
+if it's a clean build.
+
+We don't currently have any integration tests, but we can test manually with an
+app:
+```
+shorebird run --local-engine-src-path=$HOME/Documents/GitHub/engine/src --local-engine android_release_arm64
+```
+
+If things look good now we need to tag and push our changes to the git repos
+we touched earlier.
+
+9. Tag the buildroot repo with the new buildroot hash, e.g.
+```
+cd $HOME/Documents/GitHub/engine/src
+git tag -a -m "shorebird-3.10.0-1.5.pre" shorebird-3.10.0-1.5.pre d6c410f19de5947de40ce110c1e768c887870072
+git push origin shorebird-3.10.0-1.5.pre
+```
+
+10. Tag the engine repo with the new engine hash, e.g.
+```
+cd $HOME/Documents/GitHub/engine/src/flutter
+git tag -a -m "shorebird-3.10.0-1.5.pre" shorebird-3.10.0-1.5.pre 94bc1218b84cc0199068f8788cda96e3128784a0
+git push origin shorebird-3.10.0-1.5.pre
+```
+
+11. Tag the flutter repo with the new flutter hash, e.g.
+```
+cd $HOME/Documents/GitHub/flutter
+git tag -a -m "shorebird-3.10.0-1.5.pre" shorebird-3.10.0-1.5.pre f498c3913890e7a022596029c7f07f467b0889da
+git push origin shorebird-3.10.0-1.5.pre
+```
 
 12. If there were changes to the `patch` binary in the `updater` library we
 will need to trigger github actions before we can publish the new version of
@@ -103,8 +162,12 @@ engine for all the platforms we support.  We do that by running the
 That script should be run in the cloud, but right now I've not figured that out
 yet, so we run it locally on an arm64 Mac.
 
-13. Once we've built all artifacts we need to teach the artifact_proxy how to
-serve them.  We do that by adding entries to:
-https://github.com/shorebirdtech/shorebird/blob/main/packages/artifact_proxy/lib/config.dart
-
-Obviously all this needs to be made better/automated.
+14. Once we've built all artifacts the final step is to push the new version
+of shorebird to the appropriate branch.  e.g.
+(untested)
+```
+cd $HOME/Documents/GitHub/_shorebird/shorebird
+git tag -a -m "shorebird-3.10.0-1.5.pre" shorebird-3.10.0-1.5.pre $VERSION
+git push origin shorebird-3.10.0-1.5.pre
+git push origin/beta shorebird-3.10.0-1.5.pre
+```


### PR DESCRIPTION
I wrote these while trying to update to 3.10.0.  They seem to work.