### PR TITLE
fix(shorebird_cli): make ShorebirdJavaMixin work on Windows

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_flavor_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flavor_mixin.dart
@@ -13,7 +13,7 @@ mixin ShorebirdFlavorMixin on ShorebirdJavaMixin {
     Platform platform = const LocalPlatform(),
   }) async {
     final executable = platform.isWindows ? 'gradlew.bat' : 'gradlew';
-    final javaPath = getJavaPath(platform);
+    final javaPath = getJavaHome(platform);
     final result = await process.run(
       p.join(appRoot, 'android', executable),
       ['app:tasks', '--all', '--console=auto'],

--- a/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
@@ -13,7 +13,7 @@ mixin ShorebirdJavaMixin on ShorebirdCommand {
 
     final javaPath = getJavaPath(platform);
     if (javaPath == null) return null;
-    return p.join(javaPath, 'java.exe');
+    return p.join(javaPath, 'bin', 'java.exe');
   }
 
   String? getJavaPath([Platform platform = const LocalPlatform()]) {
@@ -36,8 +36,8 @@ mixin ShorebirdJavaMixin on ShorebirdCommand {
     }
 
     final candidateLocations = [
-      p.join(androidStudioPath, 'jbr', 'bin'),
-      p.join(androidStudioPath, 'jre', 'bin'),
+      p.join(androidStudioPath, 'jbr'),
+      p.join(androidStudioPath, 'jre'),
     ];
 
     return candidateLocations.firstWhereOrNull(

--- a/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
@@ -11,12 +11,12 @@ mixin ShorebirdJavaMixin on ShorebirdCommand {
   String? getJavaExecutable([Platform platform = const LocalPlatform()]) {
     if (!platform.isWindows) return 'java';
 
-    final javaPath = getJavaPath(platform);
+    final javaPath = getJavaHome(platform);
     if (javaPath == null) return null;
     return p.join(javaPath, 'bin', 'java.exe');
   }
 
-  String? getJavaPath([Platform platform = const LocalPlatform()]) {
+  String? getJavaHome([Platform platform = const LocalPlatform()]) {
     if (platform.environment.containsKey('JAVA_HOME')) {
       return platform.environment['JAVA_HOME'];
     }

--- a/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
@@ -9,13 +9,11 @@ import 'package:shorebird_cli/src/command.dart';
 /// for determining the java path.
 mixin ShorebirdJavaMixin on ShorebirdCommand {
   String? getJavaExecutable([Platform platform = const LocalPlatform()]) {
+    if (!platform.isWindows) return 'java';
+
     final javaPath = getJavaPath(platform);
     if (javaPath == null) return null;
-    if (platform.isWindows) {
-      return p.join(javaPath, 'java.exe');
-    } else {
-      return p.join(javaPath, 'java');
-    }
+    return p.join(javaPath, 'java.exe');
   }
 
   String? getJavaPath([Platform platform = const LocalPlatform()]) {

--- a/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
@@ -11,9 +11,9 @@ mixin ShorebirdJavaMixin on ShorebirdCommand {
   String? getJavaExecutable([Platform platform = const LocalPlatform()]) {
     if (!platform.isWindows) return 'java';
 
-    final javaPath = getJavaHome(platform);
-    if (javaPath == null) return null;
-    return p.join(javaPath, 'bin', 'java.exe');
+    final javaHome = getJavaHome(platform);
+    if (javaHome == null) return null;
+    return p.join(javaHome, 'bin', 'java.exe');
   }
 
   String? getJavaHome([Platform platform = const LocalPlatform()]) {

--- a/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
@@ -8,6 +8,16 @@ import 'package:shorebird_cli/src/command.dart';
 /// Mixin on [ShorebirdCommand] which exposes methods
 /// for determining the java path.
 mixin ShorebirdJavaMixin on ShorebirdCommand {
+  String? getJavaExecutable([Platform platform = const LocalPlatform()]) {
+    final javaPath = getJavaPath(platform);
+    if (javaPath == null) return null;
+    if (platform.isWindows) {
+      return p.join(javaPath, 'java.exe');
+    }else {}
+      return p.join(javaPath, 'java');
+    } 
+  }
+
   String? getJavaPath([Platform platform = const LocalPlatform()]) {
     if (platform.environment.containsKey('JAVA_HOME')) {
       return platform.environment['JAVA_HOME'];

--- a/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
@@ -28,8 +28,8 @@ mixin ShorebirdJavaMixin on ShorebirdCommand {
     }
 
     final candidateLocations = [
-      p.join(androidStudioPath, 'jbr'),
-      p.join(androidStudioPath, 'jre'),
+      p.join(androidStudioPath, 'jbr', 'bin'),
+      p.join(androidStudioPath, 'jre', 'bin'),
     ];
 
     return candidateLocations.firstWhereOrNull(

--- a/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_java_mixin.dart
@@ -13,9 +13,9 @@ mixin ShorebirdJavaMixin on ShorebirdCommand {
     if (javaPath == null) return null;
     if (platform.isWindows) {
       return p.join(javaPath, 'java.exe');
-    }else {}
+    } else {
       return p.join(javaPath, 'java');
-    } 
+    }
   }
 
   String? getJavaPath([Platform platform = const LocalPlatform()]) {

--- a/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
@@ -34,9 +34,10 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdJavaMixin {
     ];
 
     final javaPath = getJavaPath();
+    final javaExecutable = getJavaExecutable() ?? 'java';
     final results = await Future.wait([
       process.run(
-        p.join(javaPath ?? '', 'java.exe'),
+        javaExecutable,
         versionNameArguments,
         runInShell: true,
         environment: {
@@ -44,7 +45,7 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdJavaMixin {
         },
       ),
       process.run(
-        p.join(javaPath ?? '', 'java.exe'),
+        javaExecutable,
         versionCodeArguments,
         runInShell: true,
         environment: {

--- a/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
@@ -36,7 +36,7 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdJavaMixin {
     final javaPath = getJavaPath();
     final results = await Future.wait([
       process.run(
-        'java',
+        p.join(javaPath ?? '', 'java.exe'),
         versionNameArguments,
         runInShell: true,
         environment: {
@@ -44,7 +44,7 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdJavaMixin {
         },
       ),
       process.run(
-        'java',
+        p.join(javaPath ?? '', 'java.exe'),
         versionCodeArguments,
         runInShell: true,
         environment: {

--- a/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
@@ -33,7 +33,7 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdJavaMixin {
       '/manifest/@android:versionCode'
     ];
 
-    final javaPath = getJavaPath();
+    final javaHome = getJavaHome();
     final javaExecutable = getJavaExecutable() ?? 'java';
     final results = await Future.wait([
       process.run(
@@ -41,7 +41,7 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdJavaMixin {
         versionNameArguments,
         runInShell: true,
         environment: {
-          if (javaPath != null) 'JAVA_HOME': javaPath,
+          if (javaHome != null) 'JAVA_HOME': javaHome,
         },
       ),
       process.run(
@@ -49,7 +49,7 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdJavaMixin {
         versionCodeArguments,
         runInShell: true,
         environment: {
-          if (javaPath != null) 'JAVA_HOME': javaPath,
+          if (javaHome != null) 'JAVA_HOME': javaHome,
         },
       )
     ]);


### PR DESCRIPTION
## Description

Without this change, `shorebird release` fails with the error: 

```
✗ Exception: Failed to extract version name from app bundle: 'java' is not recognized as an internal or external command, operable program or batch file.
```

I'm not sure if this is the most elegant or correct fix, but it works. We'll likely want to reference what flutter_tool does to handle this.

I've verified this fix on my Windows 11 laptop and my M2 MBP. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
