### PR TITLE
fix(cutler): don't use --fork-point flag in rebase command

### DIFF
--- a/packages/cutler/lib/git_extensions.dart
+++ b/packages/cutler/lib/git_extensions.dart
@@ -77,7 +77,7 @@ extension RepoCommands on Repo {
   Version getForkPoint(String forkBranch) {
     final hash = runCommand(
       'git',
-      ['merge-base', '--fork-point', upstreamBranch, forkBranch],
+      ['merge-base', upstreamBranch, forkBranch],
       workingDirectory: workingDirectory,
     );
     return versionFrom(hash);


### PR DESCRIPTION
## Description

After debugging with @eseidel, we found that the `git merge-base --fork-point upstream/stable [FLUTTER_HASH]` command was only working for him due to local changes to his checkout. `merge-base` seems to do what we want without the flag.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
