### PR TITLE
docs: use `shorebird/main` branch

### DIFF
--- a/packages/cutler/FORKING_FLUTTER.md
+++ b/packages/cutler/FORKING_FLUTTER.md
@@ -10,7 +10,7 @@ We maintain forks of:
 * flutter/engine
 * flutter/buildroot
 
-We keep our forked changes on the `main` branch of each repo which we rebase
+We keep our forked changes on the `shorebird/main` branch of each repo which we rebase
 periodically on top of `main` from the upstream repo.
 
 When Flutter makes a release, we make a branch in each repo for the Flutter
@@ -35,7 +35,7 @@ following branches:
 * flutter/flutter: `flutter_release/3.7.10`
 * flutter/engine: `flutter_release/3.7.10`
 * flutter/buildroot: `flutter_release/3.7.10`
-* shorebird: no branch or tag, just a commit to the `main` branch which will
+* shorebird: no branch or tag, just a commit to the `shorebird/main` branch which will
   eventually get pushed to `beta` and `stable` branches for Shorebird.
 
 It's rare that we will ever need to add commits to one of these branches,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- Adjusted the branching strategy to apply shorebird changes to `shorebird/main` instead of `main` in order to:
  1. Have a single place where we can point to for anyone to see the "shorebird changes"
  1. Be able to sync main easily
  1. Maintain a clear separation between "shorebird" and official changes

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
