### PR TITLE
fix(shorebird_cli): prune vended flutter branches on upgrade

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
@@ -83,6 +83,15 @@ class UpgradeCommand extends ShorebirdCommand with ShorebirdVersionMixin {
     return ExitCode.success.code;
   }
 
+  // Inteneded to fix an issue caused by a change in our remote branches.
+  // We deleted (origin/shorebird) and created (origin/shorebird/main)
+  //
+  // The error manifested at:
+  // $ shorebird --version
+  //   Updating Flutter...
+  //   error: cannot lock ref 'refs/remotes/origin/shorebird/main': 'refs/remotes/origin/shorebird' exists; cannot create 'refs/remotes/origin/shorebird/main'
+  //   From https://github.com/shorebirdtech/flutter
+  //    ! [new branch]          shorebird/main -> origin/shorebird/main  (unable to update local ref)
   Future<void> _pruneFlutterOrigin() async {
     const executable = 'git';
     final args = ['remote', 'prune', 'origin'];

--- a/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
@@ -83,7 +83,7 @@ class UpgradeCommand extends ShorebirdCommand with ShorebirdVersionMixin {
     return ExitCode.success.code;
   }
 
-  // Inteneded to fix an issue caused by a change in our remote branches.
+  // Intended to fix an issue caused by a change in our remote branches.
   // We deleted (origin/shorebird) and created (origin/shorebird/main)
   //
   // The error manifested at:


### PR DESCRIPTION
## Description

This is intended to fix an issue caused by our recent remote branch change:

```
$ shorebird --version
Updating Flutter...
error: cannot lock ref 'refs/remotes/origin/shorebird/main': 'refs/remotes/origin/shorebird' exists; cannot create 'refs/remotes/origin/shorebird/main'
From https://github.com/shorebirdtech/flutter
 ! [new branch]          shorebird/main -> origin/shorebird/main  (unable to update local ref)
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
