### PR TITLE
fix(shorebird_cli): remove lookup of nonexistent argument

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -144,7 +144,7 @@ Did you forget to run "shorebird init"?''',
       return ExitCode.software.code;
     }
 
-    final platform = results['platform'] as String;
+    const platform = 'android';
     final archNames = architectures.keys.map(
       (arch) => arch.name,
     );


### PR DESCRIPTION
## Description

Fixes a crash when running `shorebird release android`:

```
$ shorebird release android
✓ Building release (4.9s)
✓ Fetching apps (0.2s)
✓ Detecting release version (0.4s)
Unhandled exception:
Invalid argument(s): Could not find an option named "platform".
#0      ArgResults.[] (package:args/src/arg_results.dart:65:7)
#1      ReleaseAndroidCommand.run (package:shorebird_cli/src/commands/release/release_android_command.dart:147:29)
<asynchronous suspension>
#2      CommandRunner.runCommand (package:args/command_runner.dart:212:13)
<asynchronous suspension>
#3      ShorebirdCliCommandRunner.runCommand (package:shorebird_cli/src/command_runner.dart:132:18)
<asynchronous suspension>
#4      ShorebirdCliCommandRunner.run (package:shorebird_cli/src/command_runner.dart:93:14)
<asynchronous suspension>
#5      main (file:///C:/Users/bryan/Documents/shorebirdtech/_shorebird/shorebird/packages/shorebird_cli/bin/shorebird.dart:6:24)
<asynchronous suspension>
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
