### PR TITLE
fix(shorebird_cli): only use / path separators when reading zip archive

### DIFF
--- a/packages/shorebird_cli/lib/src/aab/aab_differ.dart
+++ b/packages/shorebird_cli/lib/src/aab/aab_differ.dart
@@ -70,7 +70,7 @@ class AabDiffer {
     final archive = ZipDecoder().decodeBuffer(inputStream);
     return utf8.decode(
       archive.files
-          .firstWhere((file) => file.name == p.join('META-INF', 'MANIFEST.MF'))
+          .firstWhere((file) => file.name == 'META-INF/MANIFEST.MF')
           .content as List<int>,
     );
   }


### PR DESCRIPTION
## Description

Fixes an issue where the `AabDiffer` was unable to find `META-INF/MANIFEST.MF` in .aab files.

This was happening because the `ZipDecoder` class we use to read .aabs uses `/` as a path separator regardless of platform. We were using `path.join` to construct the path to `MANIFEST.MF`, which meant we were trying and failing to find `META-INF\MANIFEST.MF` on Windows.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
