### PR TITLE
fix(shorebird_cli): fix tests that mock Process.run with java

### DIFF
--- a/packages/shorebird_cli/test/src/commands/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch_command_test.dart
@@ -238,20 +238,7 @@ flutter:
       });
       when(
         () => shorebirdProcess.run(
-          'java',
-          any(),
-          runInShell: any(named: 'runInShell'),
-          environment: any(named: 'environment'),
-        ),
-      ).thenAnswer((invocation) async {
-        final args = invocation.positionalArguments[1] as List<String>;
-        return args.last == '/manifest/@android:versionCode'
-            ? releaseVersionCodeProcessResult
-            : releaseVersionNameProcessResult;
-      });
-      when(
-        () => shorebirdProcess.run(
-          any(that: endsWith('java.exe')),
+          any(that: contains('java')),
           any(),
           runInShell: any(named: 'runInShell'),
           environment: any(named: 'environment'),

--- a/packages/shorebird_cli/test/src/commands/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch_command_test.dart
@@ -249,6 +249,19 @@ flutter:
             ? releaseVersionCodeProcessResult
             : releaseVersionNameProcessResult;
       });
+      when(
+        () => shorebirdProcess.run(
+          any(that: endsWith('java.exe')),
+          any(),
+          runInShell: any(named: 'runInShell'),
+          environment: any(named: 'environment'),
+        ),
+      ).thenAnswer((invocation) async {
+        final args = invocation.positionalArguments[1] as List<String>;
+        return args.last == '/manifest/@android:versionCode'
+            ? releaseVersionCodeProcessResult
+            : releaseVersionNameProcessResult;
+      });
 
       when(() => aabDiffer.aabContentDifferences(any(), any())).thenReturn({});
       when(() => argResults.rest).thenReturn([]);

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -194,7 +194,7 @@ flutter:
       ).thenAnswer((_) async => flutterRevisionProcessResult);
       when(
         () => shorebirdProcess.run(
-          'java',
+          any(that: contains('java')),
           any(),
           runInShell: any(named: 'runInShell'),
           environment: any(named: 'environment'),

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -194,7 +194,7 @@ flutter:
       ).thenAnswer((_) async => flutterRevisionProcessResult);
       when(
         () => shorebirdProcess.run(
-          'java',
+          any(that: contains('java')),
           any(),
           runInShell: any(named: 'runInShell'),
           environment: any(named: 'environment'),


### PR DESCRIPTION
## Description

Because Windows runs `java.exe` instead of `java`, we need to tell our mock to handle that as well.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
