### PR TITLE
fix(shorebird_cli): don't fail if a release artifact has already been uploaded

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -211,6 +211,8 @@ ${summary.join('\n')}
       }
     }
 
+    // TODO(bryanoltman): Consolidate aab and other artifact creation.
+    // TODO(bryanoltman): Parallelize artifact creation.
     final createArtifactProgress = logger.progress('Creating artifacts');
     for (final archMetadata in architectures.values) {
       final artifactPath = p.join(
@@ -236,6 +238,13 @@ ${summary.join('\n')}
           platform: platform,
           hash: hash,
         );
+      } on ResourceConflictException catch (_) {
+        // Newlines are due to how logger.info interacts with logger.progress.
+        logger.info(
+          '''
+
+${archMetadata.arch} artifact already exists, continuing...''',
+        );
       } catch (error) {
         createArtifactProgress.fail('$error');
         return ExitCode.software.code;
@@ -249,6 +258,13 @@ ${summary.join('\n')}
         arch: 'aab',
         platform: platform,
         hash: _hashFn(await File(bundlePath).readAsBytes()),
+      );
+    } on ResourceConflictException catch (_) {
+      // Newlines are due to how logger.info interacts with logger.progress.
+      logger.info(
+        '''
+
+aab artifact already exists, continuing...''',
       );
     } catch (error) {
       createArtifactProgress.fail('$error');

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -238,7 +238,7 @@ ${summary.join('\n')}
           platform: platform,
           hash: hash,
         );
-      } on ResourceConflictException catch (_) {
+      } on CodePushConflictException catch (_) {
         // Newlines are due to how logger.info interacts with logger.progress.
         logger.info(
           '''
@@ -259,7 +259,7 @@ ${archMetadata.arch} artifact already exists, continuing...''',
         platform: platform,
         hash: _hashFn(await File(bundlePath).readAsBytes()),
       );
-    } on ResourceConflictException catch (_) {
+    } on CodePushConflictException catch (_) {
       // Newlines are due to how logger.info interacts with logger.progress.
       logger.info(
         '''

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -487,7 +487,7 @@ Did you forget to run "shorebird init"?''',
           platform: any(named: 'platform'),
           hash: any(named: 'hash'),
         ),
-      ).thenThrow(ResourceConflictException(message: error));
+      ).thenThrow(const CodePushConflictException(message: error));
       final tempDir = setUpTempDir();
       setUpTempArtifacts(tempDir);
       final exitCode = await IOOverrides.runZoned(
@@ -497,8 +497,9 @@ Did you forget to run "shorebird init"?''',
 
       // 1 for each arch, 1 for the aab
       final numArtifactsUploaded = Arch.values.length + 1;
-      verify(() => logger.info(any(that: contains('already exists'))))
-          .called(numArtifactsUploaded);
+      verify(
+        () => logger.info(any(that: contains('already exists'))),
+      ).called(numArtifactsUploaded);
       verifyNever(() => progress.fail(error));
       expect(exitCode, ExitCode.success.code);
     });
@@ -516,7 +517,7 @@ Did you forget to run "shorebird init"?''',
           platform: any(named: 'platform'),
           hash: any(named: 'hash'),
         ),
-      ).thenThrow(ResourceConflictException(message: error));
+      ).thenThrow(const CodePushConflictException(message: error));
       final tempDir = setUpTempDir();
       setUpTempArtifacts(tempDir);
       final exitCode = await IOOverrides.runZoned(

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -21,12 +21,12 @@ class CodePushException implements Exception {
   String toString() => '$message${details != null ? '\n$details' : ''}';
 }
 
-/// {@template resource_conflict_exception}
+/// {@template code_push_conflict_exception}
 /// Exception thrown when a 409 response is received.
 /// {@endtemplate}
-class ResourceConflictException extends CodePushException {
-  /// {@macro resource_conflict_exception}
-  ResourceConflictException({required super.message, super.details});
+class CodePushConflictException extends CodePushException {
+  /// {@macro code_push_conflict_exception}
+  const CodePushConflictException({required super.message, super.details});
 }
 
 /// {@template code_push_client}
@@ -62,7 +62,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.created) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
   }
 
@@ -74,7 +74,7 @@ class CodePushClient {
     if (response.statusCode == HttpStatus.notFound) {
       return null;
     } else if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;
@@ -104,7 +104,9 @@ class CodePushClient {
     final response = await _httpClient.send(request);
     final body = await response.stream.bytesToString();
 
-    if (response.statusCode != HttpStatus.ok) throw _parseErrorResponse(body);
+    if (response.statusCode != HttpStatus.ok) {
+      throw _parseErrorResponse(response.statusCode, body);
+    }
 
     return PatchArtifact.fromJson(json.decode(body) as Map<String, dynamic>);
   }
@@ -116,7 +118,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
 
     return CreatePaymentLinkResponse.fromJson(
@@ -147,12 +149,8 @@ class CodePushClient {
     final response = await _httpClient.send(request);
     final body = await response.stream.bytesToString();
 
-    if (response.statusCode == HttpStatus.conflict) {
-      throw ResourceConflictException(
-        message: 'An artifact already exists for arch:$arch platform:$platform',
-      );
-    } else if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(body);
+    if (response.statusCode != HttpStatus.ok) {
+      throw _parseErrorResponse(response.statusCode, body);
     }
 
     return ReleaseArtifact.fromJson(json.decode(body) as Map<String, dynamic>);
@@ -167,7 +165,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
     final body = json.decode(response.body) as Map<String, dynamic>;
     return App.fromJson(body);
@@ -184,7 +182,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
     final body = json.decode(response.body) as Map<String, dynamic>;
     return Channel.fromJson(body);
@@ -198,7 +196,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
 
     final body = json.decode(response.body) as Map<String, dynamic>;
@@ -223,7 +221,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
     final body = json.decode(response.body) as Map<String, dynamic>;
     return Release.fromJson(body);
@@ -239,7 +237,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.noContent) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
   }
 
@@ -250,7 +248,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.noContent) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
   }
 
@@ -266,7 +264,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.created) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
 
     final body = json.decode(response.body) as Json;
@@ -280,7 +278,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.noContent) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
   }
 
@@ -289,7 +287,7 @@ class CodePushClient {
     final response = await _httpClient.get(Uri.parse('$_v1/apps'));
 
     if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
 
     final apps = json.decode(response.body) as List;
@@ -307,7 +305,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
 
     final channels = json.decode(response.body) as List;
@@ -323,7 +321,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
 
     final releases = json.decode(response.body) as List;
@@ -343,7 +341,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
 
     final releases = json.decode(response.body) as List;
@@ -368,7 +366,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
 
     final body = json.decode(response.body) as Map<String, dynamic>;
@@ -386,7 +384,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.created) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
   }
 
@@ -397,7 +395,7 @@ class CodePushClient {
     );
 
     if (response.statusCode != HttpStatus.ok) {
-      throw _parseErrorResponse(response.body);
+      throw _parseErrorResponse(response.statusCode, response.body);
     }
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;
@@ -408,14 +406,18 @@ class CodePushClient {
   /// Closes the client.
   void close() => _httpClient.close();
 
-  CodePushException _parseErrorResponse(String response) {
+  CodePushException _parseErrorResponse(int statusCode, String response) {
+    final exceptionBuilder = statusCode == HttpStatus.conflict
+        ? CodePushConflictException.new
+        : CodePushException.new;
+
     final ErrorResponse error;
     try {
       final body = json.decode(response) as Map<String, dynamic>;
       error = ErrorResponse.fromJson(body);
     } catch (_) {
-      throw const CodePushException(message: unknownErrorMessage);
+      throw exceptionBuilder(message: unknownErrorMessage);
     }
-    return CodePushException(message: error.message, details: error.details);
+    return exceptionBuilder(message: error.message, details: error.details);
   }
 }

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -387,7 +387,7 @@ void main() {
       });
 
       test(
-          'throws a ResourceConflictException if the http response code is 409',
+          'throws a CodePushConflictException if the http response code is 409',
           () {
         when(() => httpClient.send(any())).thenAnswer((_) async {
           return http.StreamedResponse(
@@ -408,7 +408,7 @@ void main() {
             platform: platform,
             hash: hash,
           ),
-          throwsA(isA<ResourceConflictException>()),
+          throwsA(isA<CodePushConflictException>()),
         );
       });
 

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -386,6 +386,32 @@ void main() {
         );
       });
 
+      test(
+          'throws a ResourceConflictException if the http response code is 409',
+          () {
+        when(() => httpClient.send(any())).thenAnswer((_) async {
+          return http.StreamedResponse(
+            Stream.value(utf8.encode(json.encode(errorResponse.toJson()))),
+            HttpStatus.conflict,
+          );
+        });
+
+        final tempDir = Directory.systemTemp.createTempSync();
+        final fixture = File(path.join(tempDir.path, 'release.txt'))
+          ..createSync();
+
+        expect(
+          codePushClient.createReleaseArtifact(
+            artifactPath: fixture.path,
+            releaseId: releaseId,
+            arch: arch,
+            platform: platform,
+            hash: hash,
+          ),
+          throwsA(isA<ResourceConflictException>()),
+        );
+      });
+
       test('throws an exception if the http request fails', () async {
         when(() => httpClient.send(any())).thenAnswer((_) async {
           return http.StreamedResponse(


### PR DESCRIPTION
## Description

`shorebird release` currently fails if it detects that an artifact already exists for a given architecture. This can cause problems if a user's connection is unstable and only some artifact uploads succeed, leaving them in a state where they are unable to complete their release.

This change updates the release artifact upload logic to log when 409s (HttpStatus.conflict) are received instead of aborting the release.

Fixes https://github.com/shorebirdtech/shorebird/issues/553

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
