### PR TITLE
get release and patch working with a very very specific aar setup

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -93,6 +93,34 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
     }
   }
 
+  Future<void> buildAar({String? flavor, String? target}) async {
+    const executable = 'flutter';
+    final arguments = [
+      'build',
+      'aar',
+      '--no-debug',
+      '--no-profile',
+      if (flavor != null) '--flavor=$flavor',
+      if (target != null) '--target=$target',
+      ...results.rest,
+    ];
+
+    final result = await process.run(
+      executable,
+      arguments,
+      runInShell: true,
+    );
+
+    if (result.exitCode != ExitCode.success.code) {
+      throw ProcessException(
+        'flutter',
+        arguments,
+        result.stderr.toString(),
+        result.exitCode,
+      );
+    }
+  }
+
   Future<void> buildApk({String? flavor, String? target}) async {
     const executable = 'flutter';
     final arguments = [


### PR DESCRIPTION
# DO NOT MERGE THIS

This is merely for recordkeeping until we productionize aar generation

## Description

Updates the CLI to release and patch aar artifacts. This is very very hacky, but it works. Steps are detailed in https://docs.google.com/document/d/1he8V7pdKrrXU9XwdV99E0TnwLXbPF4_9E4dWSUTj1-c/edit#.

Roughly:

1. Following the "Depend on the Android Archive" part of https://docs.flutter.dev/add-to-app/android/project-setup#create-a-flutter-module, I created an Android app and a flutter module as sibling directories
   1. android app created through android studio
   2. flutter module created with `flutter create -t module --org com.example my_flutter_module`, which flutter is our vended flutter
1. Set version numbers in android app's build.gradle and what the CLI uses to be the same
2. launched the android app using the release configuration from android studio
3. Ran `FLUTTER_STORAGE_BASE_URL=https://download.shorebird.dev/ flutter build aar --no-debug --no-profile` to generate the aar
4. unzipped it to a specific location where the CLI could look
5. Ran `shorebird release android`
6. updated lib/main.dart to use a different theme color
7. rebuilt the aar
8. unzipped the aar to the same location as before
9. ran shorebird patch
10. it works!

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
