### PR TITLE
chore(shorebird_cli): change `patch` to `patch android` to prepare for ios and aars

### DIFF
--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -62,7 +62,7 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
     addCommand(InitCommand(logger: _logger));
     addCommand(LoginCommand(logger: _logger));
     addCommand(LogoutCommand(logger: _logger));
-    addCommand(PatchAndroidCommand(logger: _logger));
+    addCommand(PatchCommand(logger: _logger));
     addCommand(ReleaseCommand(logger: _logger));
     addCommand(ReleasesCommand(logger: _logger));
     addCommand(RunCommand(logger: _logger));

--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -62,7 +62,7 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
     addCommand(InitCommand(logger: _logger));
     addCommand(LoginCommand(logger: _logger));
     addCommand(LogoutCommand(logger: _logger));
-    addCommand(PatchCommand(logger: _logger));
+    addCommand(PatchAndroidCommand(logger: _logger));
     addCommand(ReleaseCommand(logger: _logger));
     addCommand(ReleasesCommand(logger: _logger));
     addCommand(RunCommand(logger: _logger));

--- a/packages/shorebird_cli/lib/src/commands/commands.dart
+++ b/packages/shorebird_cli/lib/src/commands/commands.dart
@@ -7,7 +7,7 @@ export 'doctor_command.dart';
 export 'init_command.dart';
 export 'login_command.dart';
 export 'logout_command.dart';
-export 'patch_command.dart';
+export 'patch/patch.dart';
 export 'release/release.dart';
 export 'releases/releases.dart';
 export 'run_command.dart';

--- a/packages/shorebird_cli/lib/src/commands/patch/patch.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch.dart
@@ -1,0 +1,2 @@
+export 'patch_android_command.dart';
+export 'patch_command.dart';

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -38,7 +38,7 @@ class PatchArtifactBundle {
 }
 
 /// {@template patch_android_command}
-/// `shorebird patch`
+/// `shorebird patch android`
 /// Publish new patches for a specific Android release to the Shorebird code
 /// push server.
 /// {@endtemplate}

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -103,10 +103,10 @@ class PatchAndroidCommand extends ShorebirdCommand
 
   @override
   String get description =>
-      'Publish new patches for a specific release to Shorebird.';
+      'Publish new patches for a specific android release to Shorebird.';
 
   @override
-  String get name => 'patch';
+  String get name => 'android';
 
   final AabDiffer _aabDiffer;
   final HashFunction _hashFn;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -37,11 +37,12 @@ class PatchArtifactBundle {
   final String hash;
 }
 
-/// {@template patch_command}
+/// {@template patch_android_command}
 /// `shorebird patch`
-/// Publish new patches for a specific release to the Shorebird CodePush server.
+/// Publish new patches for a specific Android release to the Shorebird code
+/// push server.
 /// {@endtemplate}
-class PatchCommand extends ShorebirdCommand
+class PatchAndroidCommand extends ShorebirdCommand
     with
         AuthLoggerMixin,
         ShorebirdValidationMixin,
@@ -50,8 +51,8 @@ class PatchCommand extends ShorebirdCommand
         ShorebirdCreateAppMixin,
         ShorebirdJavaMixin,
         ShorebirdReleaseVersionMixin {
-  /// {@macro patch_command}
-  PatchCommand({
+  /// {@macro patch_android_command}
+  PatchAndroidCommand({
     required super.logger,
     super.auth,
     super.buildCodePushClient,
@@ -67,13 +68,6 @@ class PatchCommand extends ShorebirdCommand
       ..addOption(
         'release-version',
         help: 'The version of the release (e.g. "1.0.0").',
-      )
-      ..addOption(
-        'platform',
-        help: 'The platform of the release (e.g. "android").',
-        allowed: ['android'],
-        allowedHelp: {'android': 'The Android platform.'},
-        defaultsTo: 'android',
       )
       ..addOption(
         'channel',
@@ -213,7 +207,7 @@ Did you forget to run "shorebird init"?''',
       return ExitCode.success.code;
     }
 
-    final platform = results['platform'] as String;
+    const platform = 'android';
     final channelName = results['channel'] as String;
 
     final List<Release> releases;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -13,7 +13,7 @@ class PatchCommand extends ShorebirdCommand {
 
   @override
   String get description =>
-      'Publish new patches for a specific release to Shorebird.';
+      'Manage patches for a specific release in Shorebird.';
 
   @override
   String get name => 'patch';

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -1,0 +1,20 @@
+import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/commands/commands.dart';
+
+/// {@template patch_command}
+/// `shorebird patch`
+/// Create new app release patch.
+/// {@endtemplate}
+class PatchCommand extends ShorebirdCommand {
+  /// {@macro patch_command}
+  PatchCommand({required super.logger}) {
+    addSubcommand(PatchAndroidCommand(logger: logger));
+  }
+
+  @override
+  String get description =>
+      'Publish new patches for a specific release to Shorebird.';
+
+  @override
+  String get name => 'patch';
+}

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -9,7 +9,7 @@ import 'package:platform/platform.dart';
 import 'package:shorebird_cli/src/aab/aab.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/cache.dart' show Cache;
-import 'package:shorebird_cli/src/commands/patch_command.dart';
+import 'package:shorebird_cli/src/commands/patch/patch_android_command.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_environment.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
@@ -47,7 +47,7 @@ class _MockShorebirdProcess extends Mock implements ShorebirdProcess {}
 class _FakeShorebirdProcess extends Fake implements ShorebirdProcess {}
 
 void main() {
-  group(PatchCommand, () {
+  group(PatchAndroidCommand, () {
     const flutterRevision = '83305b5088e6fe327fb3334a73ff190828d85713';
     const appId = 'test-app-id';
     const versionName = '1.2.3';
@@ -119,7 +119,7 @@ flutter:
     late http.Client httpClient;
     late CodePushClient codePushClient;
     late Cache cache;
-    late PatchCommand command;
+    late PatchAndroidCommand command;
     late Uri? capturedHostedUri;
     late ShorebirdFlutterValidator flutterValidator;
     late ShorebirdProcess shorebirdProcess;
@@ -177,7 +177,7 @@ flutter:
       flutterValidator = _MockShorebirdFlutterValidator();
       cache = _MockCache();
       shorebirdProcess = _MockShorebirdProcess();
-      command = PatchCommand(
+      command = PatchAndroidCommand(
         aabDiffer: aabDiffer,
         auth: auth,
         buildCodePushClient: ({
@@ -253,7 +253,6 @@ flutter:
       when(() => aabDiffer.aabContentDifferences(any(), any())).thenReturn({});
       when(() => argResults.rest).thenReturn([]);
       when(() => argResults['arch']).thenReturn(arch);
-      when(() => argResults['platform']).thenReturn(platform);
       when(() => argResults['channel']).thenReturn(channelName);
       when(() => argResults['dry-run']).thenReturn(false);
       when(() => argResults['force']).thenReturn(false);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -356,6 +356,10 @@ flutter:
       expect(exitCode, ExitCode.config.code);
     });
 
+    test('has a description', () {
+      expect(command.description, isNotEmpty);
+    });
+
     test('throws no user error when user is not logged in', () async {
       when(() => auth.isAuthenticated).thenReturn(false);
       final tempDir = setUpTempDir();


### PR DESCRIPTION
## Description

Updates the `shorebird patch` command to `shorebird patch android` to prepare for the introduction of `shorebird patch ios` and `shorebird patch android_archive`, following the pattern of `shorebird release`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
