### PR TITLE
chore(shorebird_cli): warn for iOS commands

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -82,6 +82,10 @@ class PatchIosCommand extends ShorebirdCommand
       return error.exitCode.code;
     }
 
+    logger.warn(
+      '''iOS support is in an experimental state and will not work without Flutter engine changes that have not yet been published.''',
+    );
+
     const channelName = 'stable';
     const platform = 'ios';
     final force = results['force'] == true;

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -67,6 +67,10 @@ make smaller updates to your app.
       return e.exitCode.code;
     }
 
+    logger.warn(
+      '''iOS support is in an experimental state and will not work without Flutter engine changes that have not yet been published.''',
+    );
+
     const platform = 'ios';
     final flavor = results['flavor'] as String?;
     final shorebirdYaml = getShorebirdYaml()!;


### PR DESCRIPTION
## Description

Adds warnings for `shorebird release ios-preview` and `shorebird patch ios-preview` commands.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
