### PR TITLE
fix(shorebird_cli): use aarch64 instead of arm64 as iOS architecture

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -84,6 +84,7 @@ class PatchIosCommand extends ShorebirdCommand
       '''iOS support is in an experimental state and will not work without Flutter engine changes that have not yet been published.''',
     );
 
+    const arch = 'aarch64';
     const channelName = 'stable';
     const platform = 'ios';
     final force = results['force'] == true;
@@ -201,7 +202,7 @@ https://github.com/shorebirdtech/shorebird/issues/472
       if (flavor != null) '🍧 Flavor: ${lightCyan.wrap(flavor)}',
       '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
       '📺 Channel: ${lightCyan.wrap(channelName)}',
-      '''🕹️  Platform: ${lightCyan.wrap(platform)} ${lightCyan.wrap('[arm64 (${formatBytes(aotFileSize)})]')}''',
+      '''🕹️  Platform: ${lightCyan.wrap(platform)} ${lightCyan.wrap('[$arch (${formatBytes(aotFileSize)})]')}''',
     ];
 
     logger.info(
@@ -232,7 +233,7 @@ ${summary.join('\n')}
       channelName: channelName,
       patchArtifactBundles: {
         Arch.arm64: PatchArtifactBundle(
-          arch: 'arm64',
+          arch: arch,
           path: aotFile.path,
           hash: _hashFn(aotFile.readAsBytesSync()),
           size: aotFileSize,

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -405,7 +405,7 @@ https://github.com/shorebirdtech/shorebird/issues/472
         () => logger.info(
           any(
             that: contains(
-              '''🕹️  Platform: ${lightCyan.wrap(platform)} ${lightCyan.wrap('[arm64 (0 B)]')}''',
+              '''🕹️  Platform: ${lightCyan.wrap(platform)} ${lightCyan.wrap('[aarch64 (0 B)]')}''',
             ),
           ),
         ),


### PR DESCRIPTION
## Description

`aarch64` is a more correct description of the architecture we're building, and more consistent with what C++ calls it.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
