### PR TITLE
fix(shorebird_cli): handle case where IPA generation failed with exit code 0

### DIFF
--- a/.github/actions/dart_package/action.yaml
+++ b/.github/actions/dart_package/action.yaml
@@ -34,6 +34,9 @@ inputs:
     required: false
     default: "vm"
     description: Platform to use when running tests
+  secrets:
+    required: true
+    description: GitHub secretes
 
 runs:
   using: "composite"
@@ -64,10 +67,10 @@ runs:
         dart pub global activate coverage
         dart test -j ${{inputs.concurrency}} --coverage=coverage --platform=${{inputs.platform}} && dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=${{inputs.report_on}} --check-ignore
 
-    # - name: Upload Coverage
-    #   uses: codecov/codecov-action@v3
-    #   with:
-    #     token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - uses: VeryGoodOpenSource/very_good_coverage@v2
       with:

--- a/.github/actions/dart_package/action.yaml
+++ b/.github/actions/dart_package/action.yaml
@@ -34,9 +34,6 @@ inputs:
     required: false
     default: "vm"
     description: Platform to use when running tests
-  secrets:
-    required: true
-    description: GitHub secrets
 
 runs:
   using: "composite"
@@ -67,10 +64,10 @@ runs:
         dart pub global activate coverage
         dart test -j ${{inputs.concurrency}} --coverage=coverage --platform=${{inputs.platform}} && dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=${{inputs.report_on}} --check-ignore
 
-    - name: Upload Coverage
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+    # - name: Upload Coverage
+    #   uses: codecov/codecov-action@v3
+    #   with:
+    #     token: ${{ secrets.CODECOV_TOKEN }}
 
     - uses: VeryGoodOpenSource/very_good_coverage@v2
       with:

--- a/.github/actions/dart_package/action.yaml
+++ b/.github/actions/dart_package/action.yaml
@@ -64,10 +64,10 @@ runs:
         dart pub global activate coverage
         dart test -j ${{inputs.concurrency}} --coverage=coverage --platform=${{inputs.platform}} && dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=${{inputs.report_on}} --check-ignore
 
-    - name: Upload Coverage
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+    # - name: Upload Coverage
+    #   uses: codecov/codecov-action@v3
+    #   with:
+    #     token: ${{ secrets.CODECOV_TOKEN }}
 
     - uses: VeryGoodOpenSource/very_good_coverage@v2
       with:

--- a/.github/actions/dart_package/action.yaml
+++ b/.github/actions/dart_package/action.yaml
@@ -36,7 +36,7 @@ inputs:
     description: Platform to use when running tests
   secrets:
     required: true
-    description: GitHub secretes
+    description: GitHub secrets
 
 runs:
   using: "composite"

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -75,7 +75,11 @@ make smaller updates to your app.
     try {
       await buildIpa(flavor: flavor);
     } on ProcessException catch (error) {
-      buildProgress.fail('Failed to build: ${error.message}');
+      buildProgress.fail('Failed to build IPA: ${error.message}');
+      return ExitCode.software.code;
+    } on BuildException catch (error) {
+      buildProgress.fail('Failed to build IPA');
+      logger.err(error.message);
       return ExitCode.software.code;
     }
 

--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -33,9 +33,6 @@ class BuildException implements Exception {
 
   /// Information about the build failure.
   final String message;
-
-  @override
-  String toString() => message;
 }
 
 mixin ShorebirdBuildMixin on ShorebirdCommand {

--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -24,6 +24,20 @@ class ArchMetadata {
   final String enginePath;
 }
 
+/// {@template build_exception}
+/// Thrown when a build fails.
+/// {@endtemplate}
+class BuildException implements Exception {
+  /// {@macro build_exception}
+  BuildException(this.message);
+
+  /// Information about the build failure.
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 mixin ShorebirdBuildMixin on ShorebirdCommand {
   // This exists only so tests can get the full list.
   static const allAndroidArchitectures = <Arch, ArchMetadata>{
@@ -182,7 +196,40 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
         result.stderr.toString(),
         result.exitCode,
       );
+    } else if (result.stderr
+        .toString()
+        .contains('Encountered error while creating the IPA')) {
+      final errorMessage = _failedToCreateIpaErrorMessage(
+        stderr: result.stderr.toString(),
+      );
+
+      throw BuildException(errorMessage);
     }
+  }
+
+  String _failedToCreateIpaErrorMessage({required String stderr}) {
+    // The full error text consists of many repeated lines of the format:
+    // (newlines added for line length)
+    //
+    //    error: exportArchive: No signing certificate "iOS Distribution" found
+    //    error: exportArchive: Communication with Apple failed
+    //    error: exportArchive: No signing certificate "iOS Distribution" found
+    //    error: exportArchive: Team "My Team" does not have permission to
+    //      create "iOS App Store" provisioning profiles.
+    //    error: exportArchive: No profiles for 'com.example.demo' were found
+    //    error: exportArchive: Communication with Apple failed
+    //    error: exportArchive: No signing certificate "iOS Distribution" found
+    //    error: exportArchive: Communication with Apple failed
+    final exportArchiveRegex = RegExp(r'^error: exportArchive: (.+)$');
+
+    return stderr
+        .split('\n')
+        .map((l) => l.trim())
+        .toSet()
+        .map(exportArchiveRegex.firstMatch)
+        .whereType<Match>()
+        .map((m) => '    ${m.group(1)!}')
+        .join('\n');
   }
 
   Future<String> createDiff({


### PR DESCRIPTION
## Description

Handles the case where the command to build an IPA "succeeds" but does not actually generate an IPA.

Fixes https://github.com/shorebirdtech/shorebird/issues/606

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
