### PR TITLE
chore(shorebird_cli): hide ios commands

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -59,7 +59,10 @@ class PatchIosCommand extends ShorebirdCommand
   }
 
   @override
-  String get name => 'ios-preview';
+  bool get hidden => true;
+
+  @override
+  String get name => 'ios';
 
   @override
   String get description =>

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -40,6 +40,9 @@ class ReleaseIosCommand extends ShorebirdCommand
   final IpaReader _ipaReader;
 
   @override
+  bool get hidden => true;
+
+  @override
   String get description => '''
 Builds and submits your iOS app to Shorebird.
 Shorebird saves the compiled Dart code from your application in order to
@@ -47,7 +50,7 @@ make smaller updates to your app.
 ''';
 
   @override
-  String get name => 'ios-preview';
+  String get name => 'ios';
 
   @override
   Future<int> run() async {

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -217,6 +217,10 @@ flutter:
       expect(command.description, isNotEmpty);
     });
 
+    test('is hidden', () {
+      expect(command.hidden, isTrue);
+    });
+
     test('throws no user error when user is not logged in', () async {
       when(() => auth.isAuthenticated).thenReturn(false);
       final tempDir = setUpTempDir();

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -203,6 +203,10 @@ flutter:
       expect(command.description, isNotEmpty);
     });
 
+    test('is hidden', () {
+      expect(command.hidden, isTrue);
+    });
+
     test('throws config error when shorebird is not initialized', () async {
       final tempDir = Directory.systemTemp.createTempSync();
       final exitCode = await IOOverrides.runZoned(


### PR DESCRIPTION
This also changes their names from `ios-preview` to `ios` now that they're hidden. We may also consider removing the warnings in the future.