### PR TITLE
feat(shorebird_cli): add release instructions to `shorebird release ios`

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -143,7 +143,9 @@ class PatchAndroidCommand extends ShorebirdCommand
     try {
       releaseVersion = releaseVersionArg ??
           await extractReleaseVersionFromAppBundle(bundlePath);
-      detectReleaseVersionProgress.complete();
+      detectReleaseVersionProgress.complete(
+        'Detected release version $releaseVersion',
+      );
     } catch (error) {
       detectReleaseVersionProgress.fail('$error');
       return ExitCode.software.code;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -140,7 +140,9 @@ class PatchIosCommand extends ShorebirdCommand
         ),
       );
       releaseVersion = ipa.versionNumber;
-      detectReleaseVersionProgress.complete();
+      detectReleaseVersionProgress.complete(
+        'Detected release version $releaseVersion',
+      );
     } catch (error) {
       detectReleaseVersionProgress.fail(
         'Failed to determine release version: $error',

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -89,18 +89,17 @@ make smaller updates to your app.
     buildProgress.complete();
 
     final releaseVersionProgress = logger.progress('Getting release version');
+    final pubspec = getPubspecYaml()!;
+    final ipaPath = p.join(
+      Directory.current.path,
+      'build',
+      'ios',
+      'ipa',
+      '${pubspec.name}.ipa',
+    );
     String releaseVersion;
     try {
-      final pubspec = getPubspecYaml()!;
-      final ipa = _ipaReader.read(
-        p.join(
-          Directory.current.path,
-          'build',
-          'ios',
-          'ipa',
-          '${pubspec.name}.ipa',
-        ),
-      );
+      final ipa = _ipaReader.read(ipaPath);
       releaseVersion = ipa.versionNumber;
     } catch (error) {
       releaseVersionProgress.fail(
@@ -166,7 +165,20 @@ Please bump your version number and try again.''',
       flutterRevision: shorebirdFlutterRevision,
     );
 
-    logger.success('\n✅ Published Release!');
+    final relativeIpaPath = p.relative(ipaPath);
+
+    logger
+      ..success('\n✅ Published Release!')
+      ..info('''
+
+Your next step is to upload the ipa to App Store Connect.
+${lightCyan.wrap(relativeIpaPath)}
+
+To upload to the App Store either:
+    1. Drag and drop the "$relativeIpaPath" bundle into the Apple Transporter macOS app (https://apps.apple.com/us/app/transporter/id1450874784)
+    2. Run ${lightCyan.wrap('xcrun altool --upload-app --type ios -f $relativeIpaPath --apiKey your_api_key --apiIssuer your_issuer_id')}.
+       See "man altool" for details about how to authenticate with the App Store Connect API key.
+''');
 
     return ExitCode.success.code;
   }

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -483,6 +483,19 @@ https://github.com/shorebirdtech/shorebird/issues/472
       ).called(1);
     });
 
+    test('prints release version when detected', () async {
+      final tempDir = setUpTempDir();
+      setUpTempArtifacts(tempDir);
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(exitCode, equals(ExitCode.success.code));
+      verify(() => progress.complete('Detected release version 1.2.3+1'))
+          .called(1);
+    });
+
     test('throws error when release artifact does not exist.', () async {
       when(() => httpClient.send(any())).thenAnswer(
         (_) async => http.StreamedResponse(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -344,6 +344,19 @@ https://github.com/shorebirdtech/shorebird/issues/472
       ).called(1);
     });
 
+    test('prints release version when detected', () async {
+      final tempDir = setUpTempDir();
+      setUpTempArtifacts(tempDir);
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(exitCode, equals(ExitCode.success.code));
+      verify(() => progress.complete('Detected release version 1.2.3+1'))
+          .called(1);
+    });
+
     test('throws error when creating aot snapshot fails', () async {
       const error = 'oops something went wrong';
       when(() => aotBuildProcessResult.exitCode).thenReturn(1);

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -432,6 +432,18 @@ Please bump your version number and try again.'''),
       );
 
       verify(() => logger.success('\n✅ Published Release!')).called(1);
+      verify(
+        () => logger.info(
+          any(
+            that: stringContainsInOrder(
+              [
+                'Your next step is to upload the ipa to App Store Connect.',
+                'build/ios/ipa/example.ipa',
+              ],
+            ),
+          ),
+        ),
+      ).called(1);
       expect(exitCode, ExitCode.success.code);
     });
 
@@ -456,6 +468,18 @@ flavors:
       );
 
       verify(() => logger.success('\n✅ Published Release!')).called(1);
+      verify(
+        () => logger.info(
+          any(
+            that: stringContainsInOrder(
+              [
+                'Your next step is to upload the ipa to App Store Connect.',
+                'build/ios/ipa/example.ipa',
+              ],
+            ),
+          ),
+        ),
+      ).called(1);
       expect(exitCode, ExitCode.success.code);
     });
   });


### PR DESCRIPTION
## Description

Add release instructions to `shorebird release ipa` (taken from `flutter build ipa`).

<img width="1022" alt="Screenshot 2023-06-09 at 6 05 03 PM" src="https://github.com/shorebirdtech/shorebird/assets/581764/90534e1b-44a1-42da-8130-c20ff9cc674c">

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
