### PR TITLE
fix(shorebird_cli): pass flavor argument to createAndroidReleaseArtifacts

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -169,6 +169,7 @@ Please bump your version number and try again.''',
       aabPath: bundlePath,
       platform: platform,
       architectures: architectures,
+      flavor: flavor,
     );
 
     logger

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -218,6 +218,7 @@ flutter:
           aabPath: any(named: 'aabPath'),
           platform: any(named: 'platform'),
           architectures: any(named: 'architectures'),
+          flavor: any(named: 'flavor'),
         ),
       ).thenAnswer((_) async {});
       when(() => flutterValidator.validate(any())).thenAnswer((_) async => []);
@@ -457,6 +458,7 @@ flavors:
           platform: platform,
           aabPath: any(named: 'aabPath'),
           architectures: any(named: 'architectures'),
+          flavor: flavor,
         ),
       ).called(1);
       expect(exitCode, ExitCode.success.code);


### PR DESCRIPTION
## Description

Forwards the currently missing `flavor` argument to `codePushClientWrapper.createAndroidReleaseArtifacts`.

Verified this works with `shorebird release android --flavor=internal` in `shorebirdtech\samples\multiple_deployments`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
