### PR TITLE
fix(shorebird_cli): tell xcodebuild not to manage ipa build number

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -210,6 +210,8 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
   /// not manage the app version and build number. If we don't do this, then
   /// xcodebuild will increment the build number if it detects an App Store
   /// Connect build with the same version and build number.
+  /// See
+  /// https://developer.apple.com/forums/thread/690647?answerId=689925022#689925022
   File _createExportOptionsPlist() {
     const plistContents = '''
 <?xml version="1.0" encoding="UTF-8"?>

--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -209,7 +209,9 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
   /// Creates an ExportOptions.plist file, which is used to tell xcodebuild to
   /// not manage the app version and build number. If we don't do this, then
   /// xcodebuild will increment the build number if it detects an App Store
-  /// Connect build with the same version and build number.
+  /// Connect build with the same version and build number. This is a problem
+  /// for us when patching, as patches need to have the same version and build
+  /// number as the release they are patching.
   /// See
   /// https://developer.apple.com/forums/thread/690647?answerId=689925022#689925022
   File _createExportOptionsPlist() {

--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -218,10 +218,10 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>manageAppVersionAndBuildNumber</key>
-	<false/>
+  <key>manageAppVersionAndBuildNumber</key>
+  <false/>
   <key>signingStyle</key>
-	<string>automatic</string>
+  <string>automatic</string>
   <key>uploadBitcode</key>
   <false/>
   <key>method</key>

--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -170,10 +170,12 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
     bool codesign = true,
   }) async {
     const executable = 'flutter';
+    final exportPlistFile = _createExportOptionsPlist();
     final arguments = [
       'build',
       'ipa',
       '--release',
+      '--export-options-plist=${exportPlistFile.path}',
       if (flavor != null) '--flavor=$flavor',
       if (target != null) '--target=$target',
       if (!codesign) '--no-codesign',
@@ -202,6 +204,34 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
 
       throw BuildException(errorMessage);
     }
+  }
+
+  /// Creates an ExportOptions.plist file, which is used to tell xcodebuild to
+  /// not manage the app version and build number. If we don't do this, then
+  /// xcodebuild will increment the build number if it detects an App Store
+  /// Connect build with the same version and build number.
+  File _createExportOptionsPlist() {
+    const plistContents = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>manageAppVersionAndBuildNumber</key>
+	<false/>
+  <key>signingStyle</key>
+	<string>automatic</string>
+  <key>uploadBitcode</key>
+  <false/>
+  <key>method</key>
+  <string>app-store</string>
+</dict>
+</plist>
+''';
+    final tempDir = Directory.systemTemp.createTempSync();
+    final exportPlistFile = File(p.join(tempDir.path, 'ExportOptions.plist'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(plistContents);
+    return exportPlistFile;
   }
 
   String _failedToCreateIpaErrorMessage({required String stderr}) {

--- a/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
+import 'package:propertylistserialization/propertylistserialization.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/commands/build/build.dart';
@@ -109,7 +110,11 @@ void main() {
       verify(
         () => shorebirdProcess.run(
           'flutter',
-          ['build', 'ipa', '--release'],
+          any(
+            that: containsAll(
+              ['build', 'ipa', '--release'],
+            ),
+          ),
           runInShell: any(named: 'runInShell'),
         ),
       ).called(1);
@@ -128,7 +133,11 @@ void main() {
       verify(
         () => shorebirdProcess.run(
           'flutter',
-          ['build', 'ipa', '--release'],
+          any(
+            that: containsAll(
+              ['build', 'ipa', '--release'],
+            ),
+          ),
           runInShell: true,
         ),
       ).called(1);
@@ -166,13 +175,17 @@ ${lightCyan.wrap(p.join('build', 'ios', 'ipa', 'Runner.ipa'))}''',
       verify(
         () => shorebirdProcess.run(
           'flutter',
-          [
-            'build',
-            'ipa',
-            '--release',
-            '--flavor=$flavor',
-            '--target=$target',
-          ],
+          any(
+            that: containsAll(
+              [
+                'build',
+                'ipa',
+                '--release',
+                '--flavor=$flavor',
+                '--target=$target',
+              ],
+            ),
+          ),
           runInShell: true,
         ),
       ).called(1);
@@ -207,7 +220,9 @@ ${lightCyan.wrap(p.join('build', 'ios', 'ipa', 'Runner.ipa'))}''',
       verify(
         () => shorebirdProcess.run(
           'flutter',
-          ['build', 'ipa', '--release', '--no-codesign'],
+          any(
+            that: containsAll(['build', 'ipa', '--release', '--no-codesign']),
+          ),
           runInShell: true,
         ),
       ).called(1);
@@ -280,6 +295,42 @@ ${lightCyan.wrap(p.join('build', 'ios', 'ipa', 'Runner.ipa'))}''',
           ),
         ),
       ).called(1);
+    });
+
+    test('provides appropriate ExportOptions.plist to build ipa command',
+        () async {
+      when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+      final tempDir = Directory.systemTemp.createTempSync();
+      final result = await IOOverrides.runZoned(
+        () async => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(result, equals(ExitCode.success.code));
+      expect(exitCode, ExitCode.success.code);
+      final capturedArgs = verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          captureAny(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).captured.first as List<String>;
+      final exportOptionsPlistFile = File(
+        capturedArgs
+            .whereType<String>()
+            .firstWhere((arg) => arg.contains('export-options-plist'))
+            .split('=')
+            .last,
+      );
+      expect(exportOptionsPlistFile.existsSync(), isTrue);
+      final exportOptionsPlist =
+          PropertyListSerialization.propertyListWithString(
+        exportOptionsPlistFile.readAsStringSync(),
+      ) as Map<String, Object>;
+      expect(exportOptionsPlist['manageAppVersionAndBuildNumber'], isFalse);
+      expect(exportOptionsPlist['signingStyle'], 'automatic');
+      expect(exportOptionsPlist['uploadBitcode'], isFalse);
+      expect(exportOptionsPlist['method'], 'app-store');
     });
   });
 }

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
+import 'package:propertylistserialization/propertylistserialization.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
@@ -472,6 +473,42 @@ base_url: $baseUrl''',
         () => runWithOverrides(command.run),
         getCurrentDirectory: () => tempDir,
       );
+    });
+
+    test('provides appropriate ExportOptions.plist to build ipa command',
+        () async {
+      final tempDir = setUpTempDir();
+      setUpTempArtifacts(tempDir);
+
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(exitCode, ExitCode.success.code);
+      final capturedArgs = verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          captureAny(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).captured.first as List<String>;
+      final exportOptionsPlistFile = File(
+        capturedArgs
+            .whereType<String>()
+            .firstWhere((arg) => arg.contains('export-options-plist'))
+            .split('=')
+            .last,
+      );
+      expect(exportOptionsPlistFile.existsSync(), isTrue);
+      final exportOptionsPlist =
+          PropertyListSerialization.propertyListWithString(
+        exportOptionsPlistFile.readAsStringSync(),
+      ) as Map<String, Object>;
+      expect(exportOptionsPlist['manageAppVersionAndBuildNumber'], isFalse);
+      expect(exportOptionsPlist['signingStyle'], 'automatic');
+      expect(exportOptionsPlist['uploadBitcode'], isFalse);
+      expect(exportOptionsPlist['method'], 'app-store');
     });
 
     test('prints flutter validation warnings', () async {

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -6,6 +6,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
+import 'package:propertylistserialization/propertylistserialization.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
@@ -481,6 +482,41 @@ flavors:
         ),
       ).called(1);
       expect(exitCode, ExitCode.success.code);
+    });
+
+    test('provides appropriate ExportOptions.plist to build ipa command',
+        () async {
+      final tempDir = setUpTempDir();
+
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(exitCode, ExitCode.success.code);
+      final capturedArgs = verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          captureAny(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).captured.first as List<String>;
+      final exportOptionsPlistFile = File(
+        capturedArgs
+            .whereType<String>()
+            .firstWhere((arg) => arg.contains('export-options-plist'))
+            .split('=')
+            .last,
+      );
+      expect(exportOptionsPlistFile.existsSync(), isTrue);
+      final exportOptionsPlist =
+          PropertyListSerialization.propertyListWithString(
+        exportOptionsPlistFile.readAsStringSync(),
+      ) as Map<String, Object>;
+      expect(exportOptionsPlist['manageAppVersionAndBuildNumber'], isFalse);
+      expect(exportOptionsPlist['signingStyle'], 'automatic');
+      expect(exportOptionsPlist['uploadBitcode'], isFalse);
+      expect(exportOptionsPlist['method'], 'app-store');
     });
   });
 }


### PR DESCRIPTION
## Description

By default, xcodebuild will auto-increment an ipa's build number if there is an existing build on app store connect (see https://developer.apple.com/forums/thread/690647?answerId=689925022#689925022). To fix this, we provide an ExportOptions.plist telling it specifically not to do so.

Fixes https://github.com/shorebirdtech/shorebird/issues/625

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
