### PR TITLE
feat(code_push_client): Allow release commands to be run if no release artifacts exist for the given platform

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -124,6 +124,35 @@ Did you forget to run "shorebird init"?''',
     }
   }
 
+  /// Exits if [platform] release artifacts already exist for an
+  /// [existingRelease].
+  Future<void> verifyCanRelease({
+    required Release existingRelease,
+    required String platform,
+  }) async {
+    logger.detail('Verifying ability to release');
+
+    final artifacts = await codePushClient.getReleaseArtifacts(
+      releaseId: existingRelease.id,
+      platform: platform,
+    );
+
+    logger.detail(
+      '''
+Artifacts for release:${existingRelease.version} platform:$platform
+  $artifacts''',
+    );
+
+    if (artifacts.isNotEmpty) {
+      logger.err(
+        '''
+It looks like you have an existing $platform release for version ${lightCyan.wrap(existingRelease.version)}.
+Please bump your version number and try again.''',
+      );
+      exit(ExitCode.software.code);
+    }
+  }
+
   Future<Release> getRelease({
     required String appId,
     required String releaseVersion,
@@ -189,18 +218,26 @@ Please create a release using "shorebird release" and try again.
     required Map<Arch, ArchMetadata> architectures,
     required String platform,
   }) async {
+    // TODO(bryanoltman): update this function to only make one call to
+    // getReleaseArtifacts.
     final releaseArtifacts = <Arch, ReleaseArtifact>{};
     final fetchReleaseArtifactProgress = logger.progress(
       'Fetching release artifacts',
     );
     for (final entry in architectures.entries) {
       try {
-        final releaseArtifact = await codePushClient.getReleaseArtifact(
+        final artifacts = await codePushClient.getReleaseArtifacts(
           releaseId: releaseId,
           arch: entry.value.arch,
           platform: platform,
         );
-        releaseArtifacts[entry.key] = releaseArtifact;
+        if (artifacts.isEmpty) {
+          throw CodePushNotFoundException(
+            message:
+                '''No artifact found for architecture ${entry.value.arch} in release $releaseId''',
+          );
+        }
+        releaseArtifacts[entry.key] = artifacts.first;
       } catch (error) {
         fetchReleaseArtifactProgress.fail('$error');
         exit(ExitCode.software.code);
@@ -220,13 +257,19 @@ Please create a release using "shorebird release" and try again.
       'Fetching $arch artifact',
     );
     try {
-      final artifact = await codePushClient.getReleaseArtifact(
+      final artifacts = await codePushClient.getReleaseArtifacts(
         releaseId: releaseId,
         arch: arch,
         platform: platform,
       );
+      if (artifacts.isEmpty) {
+        throw CodePushNotFoundException(
+          message:
+              '''No artifact found for architecture $arch in release $releaseId''',
+        );
+      }
       fetchReleaseArtifactProgress.complete();
-      return artifact;
+      return artifacts.first;
     } catch (error) {
       fetchReleaseArtifactProgress.fail('$error');
       exit(ExitCode.software.code);
@@ -242,13 +285,19 @@ Please create a release using "shorebird release" and try again.
       'Fetching $arch artifact',
     );
     try {
-      final artifact = await codePushClient.getReleaseArtifact(
+      final artifacts = await codePushClient.getReleaseArtifacts(
         releaseId: releaseId,
         arch: arch,
         platform: platform,
       );
+      if (artifacts.isEmpty) {
+        throw CodePushNotFoundException(
+          message:
+              '''No artifact found for architecture $arch in release $releaseId''',
+        );
+      }
       fetchReleaseArtifactProgress.complete();
-      return artifact;
+      return artifacts.first;
     } on CodePushNotFoundException {
       fetchReleaseArtifactProgress.complete();
       return null;

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -126,7 +126,7 @@ Did you forget to run "shorebird init"?''',
 
   /// Exits if [platform] release artifacts already exist for an
   /// [existingRelease].
-  Future<void> verifyCanRelease({
+  Future<void> ensureReleaseHasNoArtifacts({
     required Release existingRelease,
     required String platform,
   }) async {

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -105,7 +105,7 @@ make smaller updates to your app.
       releaseVersion: releaseVersion,
     );
     if (existingRelease != null) {
-      await codePushClientWrapper.verifyCanRelease(
+      await codePushClientWrapper.ensureReleaseHasNoArtifacts(
         existingRelease: existingRelease,
         platform: platformName,
       );

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -111,7 +111,7 @@ make smaller updates to your app.
     );
 
     if (existingRelease != null) {
-      await codePushClientWrapper.verifyCanRelease(
+      await codePushClientWrapper.ensureReleaseHasNoArtifacts(
         existingRelease: existingRelease,
         platform: platformName,
       );

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -109,13 +109,12 @@ make smaller updates to your app.
       appId: appId,
       releaseVersion: releaseVersion,
     );
+
     if (existingRelease != null) {
-      logger.err(
-        '''
-It looks like you have an existing release for version ${lightCyan.wrap(releaseVersion)}.
-Please bump your version number and try again.''',
+      await codePushClientWrapper.verifyCanRelease(
+        existingRelease: existingRelease,
+        platform: platformName,
       );
-      return ExitCode.software.code;
     }
 
     final archNames = architectures.keys.map(
@@ -158,11 +157,12 @@ ${summary.join('\n')}
       return ExitCode.software.code;
     }
 
-    final release = await codePushClientWrapper.createRelease(
-      appId: appId,
-      version: releaseVersion,
-      flutterRevision: shorebirdFlutterRevision,
-    );
+    final release = existingRelease ??
+        await codePushClientWrapper.createRelease(
+          appId: appId,
+          version: releaseVersion,
+          flutterRevision: shorebirdFlutterRevision,
+        );
 
     await codePushClientWrapper.createAndroidReleaseArtifacts(
       releaseId: release.id,

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -114,14 +114,11 @@ make smaller updates to your app.
       appId: appId,
       releaseVersion: releaseVersion,
     );
-
     if (existingRelease != null) {
-      logger.err(
-        '''
-It looks like you have an existing release for version ${lightCyan.wrap(releaseVersion)}.
-Please bump your version number and try again.''',
+      await codePushClientWrapper.verifyCanRelease(
+        existingRelease: existingRelease,
+        platform: platformName,
       );
-      return ExitCode.software.code;
     }
 
     final summary = [
@@ -159,11 +156,13 @@ ${summary.join('\n')}
       return ExitCode.software.code;
     }
 
-    await codePushClientWrapper.createRelease(
-      appId: appId,
-      version: releaseVersion,
-      flutterRevision: shorebirdFlutterRevision,
-    );
+    if (existingRelease == null) {
+      await codePushClientWrapper.createRelease(
+        appId: appId,
+        version: releaseVersion,
+        flutterRevision: shorebirdFlutterRevision,
+      );
+    }
 
     final relativeIpaPath = p.relative(ipaPath);
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -115,7 +115,7 @@ make smaller updates to your app.
       releaseVersion: releaseVersion,
     );
     if (existingRelease != null) {
-      await codePushClientWrapper.verifyCanRelease(
+      await codePushClientWrapper.ensureReleaseHasNoArtifacts(
         existingRelease: existingRelease,
         platform: platformName,
       );

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -618,6 +618,33 @@ Please bump your version number and try again.''',
           verify(() => progress.fail(error)).called(1);
         });
 
+        test('exits with code 70 if release artifact does not exist', () async {
+          when(
+            () => codePushClient.getReleaseArtifacts(
+              releaseId: any(named: 'releaseId'),
+              arch: any(named: 'arch'),
+              platform: any(named: 'platform'),
+            ),
+          ).thenAnswer((_) async => []);
+
+          await expectLater(
+            () async => runWithOverrides(
+              () => codePushClientWrapper.getReleaseArtifacts(
+                releaseId: releaseId,
+                architectures: archMap,
+                platform: platformName,
+              ),
+            ),
+            exitsWithCode(ExitCode.software),
+          );
+
+          verify(
+            () => progress.fail(
+              '''No artifact found for architecture aarch64 in release $releaseId''',
+            ),
+          ).called(1);
+        });
+
         test('returns release artifacts when release artifacts exist',
             () async {
           when(

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -348,7 +348,7 @@ void main() {
 
             await expectLater(
               runWithOverrides(
-                () async => codePushClientWrapper.verifyCanRelease(
+                () async => codePushClientWrapper.ensureReleaseHasNoArtifacts(
                   existingRelease: release,
                   platform: platformName,
                 ),
@@ -378,7 +378,7 @@ Please bump your version number and try again.''',
 
             await expectLater(
               runWithOverrides(
-                () => codePushClientWrapper.verifyCanRelease(
+                () => codePushClientWrapper.ensureReleaseHasNoArtifacts(
                   existingRelease: release,
                   platform: platformName,
                 ),

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -226,7 +226,7 @@ flutter:
         ),
       ).thenAnswer((_) async => null);
       when(
-        () => codePushClientWrapper.verifyCanRelease(
+        () => codePushClientWrapper.ensureReleaseHasNoArtifacts(
           existingRelease: any(named: 'existingRelease'),
           platform: any(named: 'platform'),
         ),

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -166,6 +166,7 @@ flutter:
       shorebirdProcess = _MockShorebirdProcess();
       shorebirdRoot = Directory.systemTemp.createTempSync();
 
+      registerFallbackValue(release);
       registerFallbackValue(shorebirdProcess);
 
       when(() => auth.client).thenReturn(httpClient);
@@ -224,6 +225,12 @@ flutter:
           releaseVersion: any(named: 'releaseVersion'),
         ),
       ).thenAnswer((_) async => null);
+      when(
+        () => codePushClientWrapper.verifyCanRelease(
+          existingRelease: any(named: 'existingRelease'),
+          platform: any(named: 'platform'),
+        ),
+      ).thenAnswer((_) async => {});
       when(
         () => codePushClientWrapper.createRelease(
           appId: any(named: 'appId'),
@@ -337,29 +344,6 @@ flutter:
       ).called(1);
       verify(() => progress.fail(any(that: contains('Failed to build'))))
           .called(1);
-    });
-
-    test('throws error when existing releases exists.', () async {
-      when(
-        () => codePushClientWrapper.maybeGetRelease(
-          appId: any(named: 'appId'),
-          releaseVersion: any(named: 'releaseVersion'),
-        ),
-      ).thenAnswer((_) async => release);
-      final tempDir = setUpTempDir();
-      setUpTempArtifacts(tempDir);
-
-      final exitCode = await IOOverrides.runZoned(
-        () => runWithOverrides(command.run),
-        getCurrentDirectory: () => tempDir,
-      );
-
-      verify(
-        () => logger.err('''
-It looks like you have an existing release for version ${lightCyan.wrap(versionName)}.
-Please bump your version number and try again.'''),
-      ).called(1);
-      expect(exitCode, ExitCode.software.code);
     });
 
     test('aborts when user opts out', () async {
@@ -493,6 +477,32 @@ flavors:
           architectures: any(named: 'architectures'),
         ),
       ).called(1);
+    });
+
+    test('does not create new release if existing release is present',
+        () async {
+      when(
+        () => codePushClientWrapper.maybeGetRelease(
+          appId: any(named: 'appId'),
+          releaseVersion: any(named: 'releaseVersion'),
+        ),
+      ).thenAnswer((_) async => release);
+      final tempDir = setUpTempDir();
+      setUpTempArtifacts(tempDir);
+
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(exitCode, ExitCode.success.code);
+      verifyNever(
+        () => codePushClientWrapper.createRelease(
+          appId: any(named: 'appId'),
+          version: any(named: 'version'),
+          flutterRevision: any(named: 'flutterRevision'),
+        ),
+      );
     });
 
     test('prints flutter validation warnings', () async {

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -214,7 +214,7 @@ flutter:
         ),
       ).thenAnswer((_) async => null);
       when(
-        () => codePushClientWrapper.verifyCanRelease(
+        () => codePushClientWrapper.ensureReleaseHasNoArtifacts(
           existingRelease: any(named: 'existingRelease'),
           platform: any(named: 'platform'),
         ),

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -128,6 +128,7 @@ flutter:
       flutterValidator = _MockShorebirdFlutterValidator();
       shorebirdProcess = _MockShorebirdProcess();
 
+      registerFallbackValue(release);
       registerFallbackValue(shorebirdProcess);
 
       when(() => platform.script).thenReturn(
@@ -212,6 +213,12 @@ flutter:
           releaseVersion: any(named: 'releaseVersion'),
         ),
       ).thenAnswer((_) async => null);
+      when(
+        () => codePushClientWrapper.verifyCanRelease(
+          existingRelease: any(named: 'existingRelease'),
+          platform: any(named: 'platform'),
+        ),
+      ).thenAnswer((_) async => {});
       when(
         () => codePushClientWrapper.createRelease(
           appId: any(named: 'appId'),
@@ -377,28 +384,6 @@ flutter:
       ).called(1);
     });
 
-    test('throws error when existing releases exists.', () async {
-      when(
-        () => codePushClientWrapper.maybeGetRelease(
-          appId: any(named: 'appId'),
-          releaseVersion: version,
-        ),
-      ).thenAnswer((_) async => release);
-      final tempDir = setUpTempDir();
-
-      final exitCode = await IOOverrides.runZoned(
-        () => runWithOverrides(command.run),
-        getCurrentDirectory: () => tempDir,
-      );
-
-      verify(
-        () => logger.err('''
-It looks like you have an existing release for version ${lightCyan.wrap(release.version)}.
-Please bump your version number and try again.'''),
-      ).called(1);
-      expect(exitCode, ExitCode.software.code);
-    });
-
     test(
         'does not prompt for confirmation '
         'when --release-version and --force are used', () async {
@@ -469,6 +454,31 @@ flavors:
         ),
       ).called(1);
       expect(exitCode, ExitCode.success.code);
+    });
+
+    test('does not create new release if existing release is present',
+        () async {
+      when(
+        () => codePushClientWrapper.maybeGetRelease(
+          appId: any(named: 'appId'),
+          releaseVersion: any(named: 'releaseVersion'),
+        ),
+      ).thenAnswer((_) async => release);
+      final tempDir = setUpTempDir();
+
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(exitCode, ExitCode.success.code);
+      verifyNever(
+        () => codePushClientWrapper.createRelease(
+          appId: any(named: 'appId'),
+          version: any(named: 'version'),
+          flutterRevision: any(named: 'flutterRevision'),
+        ),
+      );
     });
 
     test('prints flutter validation warnings', () async {

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -130,6 +130,7 @@ flutter:
       flutterValidator = _MockShorebirdFlutterValidator();
       shorebirdProcess = _MockShorebirdProcess();
 
+      registerFallbackValue(release);
       registerFallbackValue(shorebirdProcess);
 
       when(() => environmentPlatform.script).thenReturn(
@@ -187,6 +188,12 @@ flutter:
           releaseVersion: any(named: 'releaseVersion'),
         ),
       ).thenAnswer((_) async => null);
+      when(
+        () => codePushClientWrapper.verifyCanRelease(
+          existingRelease: any(named: 'existingRelease'),
+          platform: any(named: 'platform'),
+        ),
+      ).thenAnswer((_) async => {});
       when(
         () => codePushClientWrapper.createRelease(
           appId: any(named: 'appId'),
@@ -390,28 +397,6 @@ error: exportArchive: No signing certificate "iOS Distribution" found
       ).called(1);
     });
 
-    test('throws error when existing releases exists.', () async {
-      when(
-        () => codePushClientWrapper.maybeGetRelease(
-          appId: any(named: 'appId'),
-          releaseVersion: any(named: 'releaseVersion'),
-        ),
-      ).thenAnswer((_) async => release);
-      final tempDir = setUpTempDir();
-
-      final exitCode = await IOOverrides.runZoned(
-        () => runWithOverrides(command.run),
-        getCurrentDirectory: () => tempDir,
-      );
-
-      verify(
-        () => logger.err('''
-It looks like you have an existing release for version ${lightCyan.wrap(release.version)}.
-Please bump your version number and try again.'''),
-      ).called(1);
-      expect(exitCode, ExitCode.software.code);
-    });
-
     test(
         'does not prompt for confirmation '
         'when --release-version and --force are used', () async {
@@ -489,6 +474,31 @@ flavors:
         ),
       ).called(1);
       expect(exitCode, ExitCode.success.code);
+    });
+
+    test('does not create new release if existing release is present',
+        () async {
+      when(
+        () => codePushClientWrapper.maybeGetRelease(
+          appId: any(named: 'appId'),
+          releaseVersion: any(named: 'releaseVersion'),
+        ),
+      ).thenAnswer((_) async => release);
+      final tempDir = setUpTempDir();
+
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(exitCode, ExitCode.success.code);
+      verifyNever(
+        () => codePushClientWrapper.createRelease(
+          appId: any(named: 'appId'),
+          version: any(named: 'version'),
+          flutterRevision: any(named: 'flutterRevision'),
+        ),
+      );
     });
 
     test('provides appropriate ExportOptions.plist to build ipa command',

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -189,7 +189,7 @@ flutter:
         ),
       ).thenAnswer((_) async => null);
       when(
-        () => codePushClientWrapper.verifyCanRelease(
+        () => codePushClientWrapper.ensureReleaseHasNoArtifacts(
           existingRelease: any(named: 'existingRelease'),
           platform: any(named: 'platform'),
         ),

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -419,7 +419,8 @@ class CodePushClient {
         .toList();
   }
 
-  /// Get a release artifact for a specific [releaseId], [arch], and [platform].
+  /// Get all release artifacts for a specific [releaseId]
+  /// and optional [arch] and [platform].
   Future<List<ReleaseArtifact>> getReleaseArtifacts({
     required int releaseId,
     String? arch,

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -429,8 +429,8 @@ class CodePushClient {
     final response = await _httpClient.get(
       Uri.parse('$_v1/releases/$releaseId/artifacts').replace(
         queryParameters: {
-          'arch': arch,
-          'platform': platform,
+          if (arch != null) 'arch': arch,
+          if (platform != null) 'platform': platform,
         },
       ),
     );

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -420,10 +420,10 @@ class CodePushClient {
   }
 
   /// Get a release artifact for a specific [releaseId], [arch], and [platform].
-  Future<ReleaseArtifact> getReleaseArtifact({
+  Future<List<ReleaseArtifact>> getReleaseArtifacts({
     required int releaseId,
-    required String arch,
-    required String platform,
+    String? arch,
+    String? platform,
   }) async {
     final response = await _httpClient.get(
       Uri.parse('$_v1/releases/$releaseId/artifacts').replace(
@@ -438,8 +438,10 @@ class CodePushClient {
       throw _parseErrorResponse(response.statusCode, response.body);
     }
 
-    final body = json.decode(response.body) as Map<String, dynamic>;
-    return ReleaseArtifact.fromJson(body);
+    final decoded = GetReleaseArtifactsResponse.fromJson(
+      json.decode(response.body) as Map<String, dynamic>,
+    );
+    return decoded.artifacts;
   }
 
   /// Promote the [patchId] to the [channelId].

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -1753,14 +1753,14 @@ void main() {
       });
     });
 
-    group('getReleaseArtifact', () {
+    group('getReleaseArtifacts', () {
       const releaseId = 0;
       const arch = 'aarch64';
       const platform = 'android';
 
       test('makes the correct request', () async {
         codePushClient
-            .getReleaseArtifact(
+            .getReleaseArtifacts(
               releaseId: releaseId,
               arch: arch,
               platform: platform,
@@ -1788,7 +1788,7 @@ void main() {
         );
 
         expect(
-          codePushClient.getReleaseArtifact(
+          codePushClient.getReleaseArtifacts(
             releaseId: releaseId,
             arch: arch,
             platform: platform,
@@ -1812,7 +1812,7 @@ void main() {
         );
 
         expect(
-          codePushClient.getReleaseArtifact(
+          codePushClient.getReleaseArtifacts(
             releaseId: releaseId,
             arch: arch,
             platform: platform,
@@ -1828,24 +1828,30 @@ void main() {
       });
 
       test('completes when request succeeds', () async {
-        final expected = ReleaseArtifact(
-          id: 0,
-          releaseId: releaseId,
-          arch: arch,
-          platform: platform,
-          url: 'https://example.com',
-          hash: '#',
-          size: 42,
-        );
+        final expected = [
+          ReleaseArtifact(
+            id: 0,
+            releaseId: releaseId,
+            arch: arch,
+            platform: platform,
+            url: 'https://example.com',
+            hash: '#',
+            size: 42,
+          )
+        ];
 
         when(() => httpClient.send(any())).thenAnswer(
           (_) async => http.StreamedResponse(
-            Stream.value(utf8.encode(json.encode(expected))),
+            Stream.value(
+              utf8.encode(
+                json.encode(GetReleaseArtifactsResponse(artifacts: expected)),
+              ),
+            ),
             HttpStatus.ok,
           ),
         );
 
-        final actual = await codePushClient.getReleaseArtifact(
+        final actual = await codePushClient.getReleaseArtifacts(
           releaseId: releaseId,
           arch: arch,
           platform: platform,

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_artifact.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_artifact.dart
@@ -46,4 +46,7 @@ class ReleaseArtifact {
 
   /// The url of the artifact.
   final String url;
+
+  @override
+  String toString() => toJson().toString();
 }

--- a/packages/shorebird_code_push_protocol/test/src/models/release_artifact_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/release_artifact_test.dart
@@ -18,5 +18,22 @@ void main() {
         equals(artifact.toJson()),
       );
     });
+
+    test('toString prints a json representation of the object', () {
+      const artifact = ReleaseArtifact(
+        id: 1,
+        releaseId: 1,
+        arch: 'aarch64',
+        platform: 'android',
+        url: 'https://example.com',
+        size: 42,
+        hash: 'sha256:1234567890',
+      );
+      final artifactString = artifact.toString();
+      expect(
+        artifactString,
+        '{id: 1, release_id: 1, arch: aarch64, platform: android, hash: sha256:1234567890, size: 42, url: https://example.com}',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Description

If a `shorebird release` command detects an existing release, verify that there are existing release artifacts before telling the user that they cannot release. If there are none, assume that the release was created for a different platform and let them continue.

Fixes https://github.com/shorebirdtech/shorebird/issues/658
Fixes https://github.com/shorebirdtech/shorebird/issues/610

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
