### PR TITLE
feat: Migrate from `buildCodePushClient` to `buildCodePushClientWrapper`

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -406,6 +406,18 @@ aar artifact already exists, continuing...''',
     }
   }
 
+  Future<App> createApp({required String displayName}) async {
+    // final createAppProgress = logger.progress('Creating App');
+    try {
+      final patch = await codePushClient.createApp(displayName: displayName);
+      // createAppProgress.complete();
+      return patch;
+    } catch (error) {
+      logger.err('$error');
+      exit(ExitCode.software.code);
+    }
+  }
+
   @visibleForTesting
   Future<void> createPatchArtifacts({
     required Patch patch,

--- a/packages/shorebird_cli/lib/src/commands/apps/create_apps_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/apps/create_apps_command.dart
@@ -7,6 +7,7 @@ import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_create_app_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_validation_mixin.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
+import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 
 /// {@template create_app_command}
 ///

--- a/packages/shorebird_cli/lib/src/shorebird_create_app_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_create_app_mixin.dart
@@ -3,6 +3,7 @@ import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_environment.dart';
+import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 mixin ShorebirdCreateAppMixin on ShorebirdConfigMixin {
@@ -27,6 +28,7 @@ mixin ShorebirdCreateAppMixin on ShorebirdConfigMixin {
       hostedUri: ShorebirdEnvironment.hostedUri,
     );
 
-    return client.createApp(displayName: displayName);
+    final codePushClientWrapper = CodePushClientWrapper(codePushClient: client);
+    return codePushClientWrapper.createApp(displayName: displayName);
   }
 }


### PR DESCRIPTION
This PR migrates from the `buildCodePushClient` to `buildCodePushClientWrapper`