### PR TITLE
fix(shorebird_cli): only run project-specific validators when in a shorebird project directory

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/doctor_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/doctor_command.dart
@@ -42,6 +42,8 @@ class DoctorCommand extends ShorebirdCommand with ShorebirdVersionMixin {
   @override
   Future<int> run() async {
     final shouldFix = results['fix'] == true;
+    final isInProject =
+        ShorebirdEnvironment.getShorebirdYamlFile().existsSync();
 
     logger.info('''
 
@@ -51,6 +53,10 @@ Shorebird Engine • revision ${ShorebirdEnvironment.shorebirdEngineRevision}'''
     final allIssues = <ValidationIssue>[];
     final allFixableIssues = <ValidationIssue>[];
     for (final validator in validators) {
+      if (validator.scope == ValidatorScope.project && !isInProject) {
+        continue;
+      }
+
       final failedFixes = <ValidationIssue, dynamic>{};
       final progress = logger.progress(validator.description);
       final issues = await validator.validate(process);

--- a/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
@@ -19,11 +19,12 @@ class AndroidInternetPermissionValidator extends Validator {
     'AndroidManifest.xml',
   );
 
-  // coverage:ignore-start
   @override
   String get description =>
       'AndroidManifest.xml files contain INTERNET permission';
-  // coverage:ignore-end
+
+  @override
+  ValidatorScope get scope => ValidatorScope.project;
 
   @override
   Future<List<ValidationIssue>> validate(ShorebirdProcess process) async {

--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -18,10 +18,11 @@ class ShorebirdFlutterValidator extends Validator {
 
   final _flutterVersionRegex = RegExp(r'Flutter (\d+.\d+.\d+)');
 
-  // coverage:ignore-start
   @override
   String get description => 'Flutter install is correct';
-  // coverage:ignore-end
+
+  @override
+  ValidatorScope get scope => ValidatorScope.installation;
 
   @override
   Future<List<ValidationIssue>> validate(ShorebirdProcess process) async {

--- a/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
@@ -11,10 +11,11 @@ class ShorebirdVersionValidator extends Validator {
   final Future<bool> Function({required String workingDirectory})
       isShorebirdVersionCurrent;
 
-  // coverage:ignore-start
   @override
   String get description => 'Shorebird is up-to-date';
-  // coverage:ignore-end
+
+  @override
+  ValidatorScope get scope => ValidatorScope.installation;
 
   @override
   Future<List<ValidationIssue>> validate(ShorebirdProcess process) async {

--- a/packages/shorebird_cli/lib/src/validators/validators.dart
+++ b/packages/shorebird_cli/lib/src/validators/validators.dart
@@ -18,6 +18,12 @@ enum ValidationIssueSeverity {
   warning,
 }
 
+/// The level at which validation is being performed.
+enum ValidatorScope {
+  project,
+  installation,
+}
+
 /// Display helpers for printing [ValidationIssue]s.
 extension Display on ValidationIssueSeverity {
   String get leading {
@@ -87,4 +93,7 @@ abstract class Validator {
   /// Returns an empty list if no issues are found.
   /// Not all validators use [process].
   Future<List<ValidationIssue>> validate(ShorebirdProcess process);
+
+  /// Whether this validator is project-specific or system-wide.
+  ValidatorScope get scope;
 }

--- a/packages/shorebird_cli/test/src/validators/android_internet_permission_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/android_internet_permission_validator_test.dart
@@ -37,7 +37,7 @@ void main() {
 </manifest>
 ''';
 
-  group('AndroidInternetPermissionValidator', () {
+  group(AndroidInternetPermissionValidator, () {
     late ShorebirdProcess shorebirdProcess;
 
     setUp(() {
@@ -51,6 +51,17 @@ void main() {
       File(p.join(path, 'AndroidManifest.xml'))
           .writeAsStringSync(manifestContents);
     }
+
+    test('has a non-empty description', () {
+      expect(AndroidInternetPermissionValidator().description, isNotEmpty);
+    });
+
+    test('is a project-specific validator', () {
+      expect(
+        AndroidInternetPermissionValidator().scope,
+        ValidatorScope.project,
+      );
+    });
 
     test(
       'returns successful result if all AndroidManifest.xml files have the '

--- a/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
@@ -116,6 +116,14 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
       when(() => gitStatusProcessResult.stdout).thenReturn(gitStatusMessage);
     });
 
+    test('has a non-empty description', () {
+      expect(validator.description, isNotEmpty);
+    });
+
+    test('is not project-specific', () {
+      expect(validator.scope, ValidatorScope.installation);
+    });
+
     test('returns no issues when the Flutter install is good', () async {
       final results = await runWithOverrides(
         () => validator.validate(shorebirdProcess),

--- a/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
@@ -71,6 +71,14 @@ void main() {
       ).thenReturn(currentShorebirdRevision);
     });
 
+    test('has a non-empty description', () {
+      expect(validator.description, isNotEmpty);
+    });
+
+    test('is not project-specific', () {
+      expect(validator.scope, ValidatorScope.installation);
+    });
+
     test('returns no issues when shorebird is up-to-date', () async {
       final results = await validator.validate(shorebirdProcess);
       expect(results, isEmpty);


### PR DESCRIPTION
## Description

Adds `ValidationScope` enum to validators to allow them to specify whether they perform project-specific validation or system-wide validation and updates `shorebird doctor` to only run project-specific validators when in a project directory.

Fixes https://github.com/shorebirdtech/shorebird/issues/669

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
