### PR TITLE
fix(shorebird_cli): don't prompt about asset changes with --force

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -239,7 +239,7 @@ https://github.com/shorebirdtech/shorebird/issues/472
           '''⚠️ The Android Archive contains asset changes, which will not be included in the patch.''',
         ),
       );
-      final shouldContinue = logger.confirm('Continue anyways?');
+      final shouldContinue = force || logger.confirm('Continue anyways?');
       if (!shouldContinue) {
         return ExitCode.success.code;
       }

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -271,7 +271,8 @@ If you believe you're seeing this in error, please reach out to us for support a
           '''The Android App Bundle contains asset changes, which will not be included in the patch.''',
         )
         ..info(yellow.wrap(contentDiffs.assetChanges.prettyString));
-      final shouldContinue = logger.confirm('Continue anyways?');
+
+      final shouldContinue = force || logger.confirm('Continue anyways?');
       if (!shouldContinue) {
         return ExitCode.success.code;
       }

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -671,10 +671,12 @@ https://github.com/shorebirdtech/shorebird/issues/472
       when(() => argResults['force']).thenReturn(true);
       final tempDir = setUpTempDir();
       setUpTempArtifacts(tempDir);
+
       final exitCode = await IOOverrides.runZoned(
         () => runWithOverrides(command.run),
         getCurrentDirectory: () => tempDir,
       );
+
       expect(exitCode, equals(ExitCode.success.code));
       verifyNever(() => logger.confirm(any()));
       verify(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -661,6 +661,13 @@ https://github.com/shorebirdtech/shorebird/issues/472
     });
 
     test('does not prompt on --force', () async {
+      when(() => aarDiffer.changedFiles(any(), any())).thenReturn(
+        FileSetDiff(
+          addedPaths: {'assets/test.json'},
+          removedPaths: {},
+          changedPaths: {},
+        ),
+      );
       when(() => argResults['force']).thenReturn(true);
       final tempDir = setUpTempDir();
       setUpTempArtifacts(tempDir);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -720,12 +720,21 @@ https://github.com/shorebirdtech/shorebird/issues/472
 
     test('does not prompt on --force', () async {
       when(() => argResults['force']).thenReturn(true);
+      when(() => aabDiffer.changedFiles(any(), any())).thenReturn(
+        FileSetDiff(
+          addedPaths: {},
+          removedPaths: {},
+          changedPaths: {'assets/test.json'},
+        ),
+      );
       final tempDir = setUpTempDir();
       setUpTempArtifacts(tempDir);
+
       final exitCode = await IOOverrides.runZoned(
         () => runWithOverrides(command.run),
         getCurrentDirectory: () => tempDir,
       );
+
       expect(exitCode, equals(ExitCode.success.code));
       verifyNever(() => logger.confirm(any()));
       verify(


### PR DESCRIPTION
## Description

Don't ask the user to confirm asset changes when running `shorebird patch` commands if the force flag was provided.

Fixes https://github.com/shorebirdtech/shorebird/issues/712

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
