### PR TITLE
fix(shorebird_cli): add import to silence comment reference warning

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_environment.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_environment.dart
@@ -7,6 +7,7 @@ import 'package:platform/platform.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
 import 'package:shorebird_cli/src/platform.dart';
+import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 abstract class ShorebirdEnvironment {
   /// Environment variables from [Platform.environment].


### PR DESCRIPTION
The references to `CodePushClient` on line 110 of shorebird/packages/shorebird_cli/lib/src/shorebird_environment.dart were triggering an analyzer error ("The referenced name isn't visible in scope."). This import fixes that.