### PR TITLE
chore(shorebird_cli): improve error messaging for add collaborator 403s

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/collaborators/add_collaborators_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/collaborators/add_collaborators_command.dart
@@ -7,6 +7,7 @@ import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_environment.dart';
 import 'package:shorebird_cli/src/shorebird_validation_mixin.dart';
+import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// {@template add_collaborators_command}
 /// `shorebird collaborators add`
@@ -86,6 +87,12 @@ ${styleBold.wrap(lightGreen.wrap('🚀 Ready to add a new collaborator!'))}
     try {
       await client.createCollaborator(appId: appId, email: collaborator);
       progress.complete();
+    } on CodePushForbiddenException {
+      progress.fail();
+      logger.err(
+        'You do not have permission to add collaborators to this app.',
+      );
+      return ExitCode.software.code;
     } catch (error) {
       progress.fail();
       logger.err('$error');

--- a/packages/shorebird_cli/test/src/commands/collaborators/add_collaborators_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/collaborators/add_collaborators_command_test.dart
@@ -105,6 +105,26 @@ void main() {
     });
 
     test(
+        '''exits with code 70 if user does not have permission to add collaborators''',
+        () async {
+      final error = CodePushForbiddenException(
+        message: 'oops something went wrong',
+      );
+      when(
+        () => codePushClient.createCollaborator(
+          appId: any(named: 'appId'),
+          email: any(named: 'email'),
+        ),
+      ).thenThrow(error);
+      expect(await runWithOverrides(command.run), ExitCode.software.code);
+      verify(
+        () => logger.err(
+          'You do not have permission to add collaborators to this app.',
+        ),
+      ).called(1);
+    });
+
+    test(
         'returns ExitCode.software '
         'when adding a collaborator fails', () async {
       const error = 'oops something went wrong';

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -22,6 +22,14 @@ class CodePushException implements Exception {
   String toString() => '$message${details != null ? '\n$details' : ''}';
 }
 
+/// {@template code_push_permission_exception}
+/// Exception thrown when a 403 response is received.
+/// {@endtemplate}
+class CodePushPermissionException extends CodePushException {
+  /// {@macro code_push_permission_exception}
+  CodePushPermissionException({required super.message});
+}
+
 /// {@template code_push_conflict_exception}
 /// Exception thrown when a 409 response is received.
 /// {@endtemplate}
@@ -103,6 +111,12 @@ class CodePushClient {
       Uri.parse('$_v1/apps/$appId/collaborators'),
       body: json.encode(CreateAppCollaboratorRequest(email: email).toJson()),
     );
+
+    if (response.statusCode == HttpStatus.forbidden) {
+      throw CodePushPermissionException(
+        message: 'You do not have permission to add collaborators to this app.',
+      );
+    }
 
     if (response.statusCode != HttpStatus.created) {
       throw _parseErrorResponse(response.statusCode, response.body);

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -22,12 +22,12 @@ class CodePushException implements Exception {
   String toString() => '$message${details != null ? '\n$details' : ''}';
 }
 
-/// {@template code_push_permission_exception}
+/// {@template code_push_forbidden_exception}
 /// Exception thrown when a 403 response is received.
 /// {@endtemplate}
-class CodePushPermissionException extends CodePushException {
-  /// {@macro code_push_permission_exception}
-  CodePushPermissionException({required super.message});
+class CodePushForbiddenException extends CodePushException {
+  /// {@macro code_push_forbidden_exception}
+  CodePushForbiddenException({required super.message, super.details});
 }
 
 /// {@template code_push_conflict_exception}
@@ -111,12 +111,6 @@ class CodePushClient {
       Uri.parse('$_v1/apps/$appId/collaborators'),
       body: json.encode(CreateAppCollaboratorRequest(email: email).toJson()),
     );
-
-    if (response.statusCode == HttpStatus.forbidden) {
-      throw CodePushPermissionException(
-        message: 'You do not have permission to add collaborators to this app.',
-      );
-    }
 
     if (response.statusCode != HttpStatus.created) {
       throw _parseErrorResponse(response.statusCode, response.body);
@@ -508,6 +502,7 @@ class CodePushClient {
       HttpStatus.conflict => CodePushConflictException.new,
       HttpStatus.notFound => CodePushNotFoundException.new,
       HttpStatus.upgradeRequired => CodePushUpgradeRequiredException.new,
+      HttpStatus.forbidden => CodePushForbiddenException.new,
       _ => CodePushException.new,
     };
 

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -119,7 +119,7 @@ void main() {
 
         expect(
           codePushClient.createCollaborator(appId: appId, email: email),
-          throwsA(isA<CodePushPermissionException>()),
+          throwsA(isA<CodePushForbiddenException>()),
         );
       });
 

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -108,6 +108,21 @@ void main() {
         );
       });
 
+      test('throws a permission exception if the http response code is 403',
+          () async {
+        when(() => httpClient.send(any())).thenAnswer(
+          (_) async => http.StreamedResponse(
+            Stream.value(utf8.encode(json.encode(errorResponse.toJson()))),
+            HttpStatus.forbidden,
+          ),
+        );
+
+        expect(
+          codePushClient.createCollaborator(appId: appId, email: email),
+          throwsA(isA<CodePushPermissionException>()),
+        );
+      });
+
       test('throws an exception if the http request fails', () async {
         when(() => httpClient.send(any())).thenAnswer(
           (_) async => http.StreamedResponse(


### PR DESCRIPTION
## Description

Updates the error message shown to a user who cannot add collaborators from `Insufficient permissions.` to `You do not have permission to add collaborators to this app.`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
