### PR TITLE
chore(shorebird_cli): update 'app not found' message to better reflect collaborator support

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -63,12 +63,10 @@ class CodePushClientWrapper {
   Future<AppMetadata> getApp({required String appId}) async {
     final app = await maybeGetApp(appId: appId);
     if (app == null) {
-      // TODO(bryanoltman): improve this error message to indicate that a user
-      // may not have permission to view the app.
       logger.err(
         '''
 Could not find app with id: "$appId".
-Did you forget to run "shorebird init"?''',
+This app may not exist or you may not have permission to view it.''',
       );
       exit(ExitCode.software.code);
     }

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -79,6 +79,7 @@ class CodePushClient {
     Uri? hostedUri,
   })  : _httpClient = _CodePushHttpClient(httpClient ?? http.Client()),
         hostedUri = hostedUri ?? Uri.https('api.shorebird.dev');
+  // hostedUri = hostedUri ?? Uri.http('localhost:8080');
 
   /// The standard headers applied to all requests.
   static const headers = <String, String>{'x-version': packageVersion};

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -79,7 +79,6 @@ class CodePushClient {
     Uri? hostedUri,
   })  : _httpClient = _CodePushHttpClient(httpClient ?? http.Client()),
         hostedUri = hostedUri ?? Uri.https('api.shorebird.dev');
-  // hostedUri = hostedUri ?? Uri.http('localhost:8080');
 
   /// The standard headers applied to all requests.
   static const headers = <String, String>{'x-version': packageVersion};


### PR DESCRIPTION
## Description

Instead of prompting users to run `shorebird init` if we can't find their app id (which I'm not sure ever would have worked?), just tell them that the app either doesn't exist or they don't have permission to view it. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
