### PR TITLE
chore(shorebird_cli): improve shorebird init error for non-paid users

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -9,6 +9,7 @@ import 'package:shorebird_cli/src/shorebird_environment.dart';
 import 'package:shorebird_cli/src/shorebird_flavor_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_java_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_validation_mixin.dart';
+import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// {@template init_command}
 ///
@@ -102,6 +103,11 @@ If you want to reinitialize Shorebird, please run "shorebird init --force".''');
       } else {
         appId = (await createApp(appName: displayName)).id;
       }
+    } on CodePushForbiddenException {
+      logger.err('''
+A paid account is required to create apps.
+To upgrade, run ${lightCyan.wrap('shorebird account upgrade')}.''');
+      return ExitCode.software.code;
     } catch (error) {
       logger.err('$error');
       return ExitCode.software.code;

--- a/packages/shorebird_cli/test/src/commands/init_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/init_command_test.dart
@@ -401,6 +401,36 @@ If you want to reinitialize Shorebird, please run "shorebird init --force".''',
       expect(exitCode, ExitCode.software.code);
     });
 
+    test(
+        '''exits with code 70 and prints error if user does not have a paid account''',
+        () async {
+      final tempDir = Directory.systemTemp.createTempSync();
+      File(
+        p.join(tempDir.path, 'pubspec.yaml'),
+      ).writeAsStringSync(pubspecYamlContent);
+      when(
+        () => codePushClient.createApp(displayName: any(named: 'displayName')),
+      ).thenThrow(CodePushForbiddenException(message: 'oh no'));
+
+      final result = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(result, ExitCode.software.code);
+
+      verify(
+        () => logger.err(
+          any(
+            that: stringContainsInOrder([
+              'A paid account is required to create apps',
+              'shorebird account upgrade',
+            ]),
+          ),
+        ),
+      );
+    });
+
     test('creates shorebird.yaml for an app without flavors', () async {
       final tempDir = Directory.systemTemp.createTempSync();
       File(


### PR DESCRIPTION
## Description

Previously:
<img width="808" alt="Screenshot 2023-06-28 at 5 23 09 PM" src="https://github.com/shorebirdtech/shorebird/assets/581764/ed49ec53-d99d-4379-b10d-c8d61af65e39">

With this change:
<img width="719" alt="Screenshot 2023-06-28 at 5 21 21 PM" src="https://github.com/shorebirdtech/shorebird/assets/581764/9d383bb5-94e0-4f1e-958d-968d8e991c3e">

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
