### PR TITLE
fix(shorebird_cli): fix "& was unexpected at this time" when running shorebird in cmd.exe

### DIFF
--- a/bin/shorebird.bat
+++ b/bin/shorebird.bat
@@ -18,4 +18,4 @@ SET PowerShellScriptPath=%CurrentDirectory%shorebird.ps1
 
 REM Pass up to four arguments to the PowerShell script
 REM This number is arbitrary and can be increased if needed
-& %powershell_executable% -NoProfile -ExecutionPolicy Bypass -Command "& '%PowerShellScriptPath%' %1% %2% %3% %4%";
+%powershell_executable% -NoProfile -ExecutionPolicy Bypass -Command "& '%PowerShellScriptPath%' %1 %2 %3 %4";

--- a/bin/shorebird.bat
+++ b/bin/shorebird.bat
@@ -16,6 +16,6 @@ WHERE /Q pwsh.exe && (
 SET CurrentDirectory=%~dp0
 SET PowerShellScriptPath=%CurrentDirectory%shorebird.ps1
 
-REM Pass up to four arguments to the PowerShell script
+REM Pass up to nine arguments to the PowerShell script
 REM This number is arbitrary and can be increased if needed
-%powershell_executable% -NoProfile -ExecutionPolicy Bypass -Command "& '%PowerShellScriptPath%' %1 %2 %3 %4";
+%powershell_executable% -NoProfile -ExecutionPolicy Bypass -Command "& '%PowerShellScriptPath%' %1 %2 %3 %4 %5 %6 %7 %8 %9";


### PR DESCRIPTION
## Description

Fix the syntax in the batch script to unblock use of shorebird in cmd.exe.

Verified this works in powershell and cmd.exe

Fixes https://github.com/shorebirdtech/shorebird/issues/732
Fixes https://github.com/shorebirdtech/shorebird/issues/742

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
