### PR TITLE
fix(shorebird_cli): verify git is installed when running shorebird on Windows

### DIFF
--- a/bin/shorebird.ps1
+++ b/bin/shorebird.ps1
@@ -13,6 +13,15 @@ $flutter = [IO.Path]::Combine($shorebirdCacheDir, "flutter", "bin", "flutter.bat
 $shorebirdScript = [IO.Path]::Combine($shorebirdCliDir, "bin", "shorebird.dart")
 $dart = [IO.Path]::Combine($flutterPath, "bin", "cache", "dart-sdk", "bin", "dart.exe")
 
+function Test-GitInstalled {
+    if (Get-Command git -ErrorAction SilentlyContinue) {
+        Write-Debug "Git is installed."
+    } else {
+        Write-Output "No git installation detected. Git is required to use shorebird."
+        exit 1
+    }
+}
+
 function Update-Flutter {
     Write-Output "Updating Flutter..."
 
@@ -94,6 +103,8 @@ function Update-Shorebird {
         Write-Debug "Shorebird is up-to-date"
     }
 }
+
+Test-GitInstalled
 
 Update-Shorebird
 


### PR DESCRIPTION
## Description

Check for a git installation before attempting to run shorebird. Verified by uninstalling git, running shorebird, reinstalling git, and running shorebird again.

Part of https://github.com/shorebirdtech/shorebird/issues/734

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
