### PR TITLE
fix(shorebird_cli): remove runInShell from bundle version commands

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
@@ -39,7 +39,7 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdJavaMixin {
       process.run(
         javaExecutable,
         versionNameArguments,
-        runInShell: true,
+        // runInShell: true,
         environment: {
           if (javaHome != null) 'JAVA_HOME': javaHome,
         },
@@ -47,7 +47,7 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdJavaMixin {
       process.run(
         javaExecutable,
         versionCodeArguments,
-        runInShell: true,
+        // runInShell: true,
         environment: {
           if (javaHome != null) 'JAVA_HOME': javaHome,
         },

--- a/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
@@ -39,7 +39,6 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdJavaMixin {
       process.run(
         javaExecutable,
         versionNameArguments,
-        // runInShell: true,
         environment: {
           if (javaHome != null) 'JAVA_HOME': javaHome,
         },
@@ -47,7 +46,6 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdJavaMixin {
       process.run(
         javaExecutable,
         versionCodeArguments,
-        // runInShell: true,
         environment: {
           if (javaHome != null) 'JAVA_HOME': javaHome,
         },


### PR DESCRIPTION
## Description

This addresses the issue described in https://github.com/shorebirdtech/shorebird/issues/756 (`'C:\Program' is not recognized as an internal or external command`).

Fixes https://github.com/shorebirdtech/shorebird/issues/756

I've verified that `shorebird release android` and `shorebird patch android` work in zsh on macOS and cmd.exe and Powershell on Windows.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
