### PR TITLE
fix(shorebird_cli): wrap ∞ in lightCyan to fix usage command test

### DIFF
--- a/packages/shorebird_cli/test/src/commands/account/account_usage_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account/account_usage_command_test.dart
@@ -155,7 +155,7 @@ ${styleBold.wrap('*Usage data is not reported in real-time and may be delayed by
 │ Total      │ 84             │
 └────────────┴────────────────┘
 
-${styleBold.wrap('∞ patch installs remaining in the current billing period.')}
+${styleBold.wrap('${lightCyan.wrap('∞')} patch installs remaining in the current billing period.')}
 
 Current Billing Period: ${lightCyan.wrap(DateFormat.yMMMd().format(usage.currentPeriodStart))} - ${lightCyan.wrap(DateFormat.yMMMd().format(usage.currentPeriodEnd))}
 


### PR DESCRIPTION
## Description

Not sure why this was only failing when running `dart test` from the terminal (and not in vscode or in CI), but this fixes the `dart test` failure.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
