### PR TITLE
fix(shorebird_cli): fix price in  command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/account/account_usage_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/account_usage_command.dart
@@ -99,7 +99,7 @@ ${Table(
 ${styleBold.wrap('${lightCyan.wrap(remainingPatchInstalls)} patch installs remaining in the current billing period.')}
 
 Current Billing Period: ${lightCyan.wrap(DateFormat.yMMMd().format(currentPeriodStart))} - ${lightCyan.wrap(DateFormat.yMMMd().format(currentPeriodEnd))}
-Month-to-date cost: ${lightCyan.wrap('\$${currencyFormatter.format(currentPeriodCost * 100.0)}')}
+Month-to-date cost: ${lightCyan.wrap('\$${currencyFormatter.format(currentPeriodCost / 100.0)}')}
 
 ${styleBold.wrap('*Usage data is not reported in real-time and may be delayed by up to 48 hours.')}''';
   }

--- a/packages/shorebird_cli/test/src/commands/account/account_usage_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account/account_usage_command_test.dart
@@ -69,8 +69,8 @@ void main() {
     test('exits with code 0 when usage is fetched.', () async {
       final usage = GetUsageResponse(
         plan: const ShorebirdPlan(
-          name: 'Hobby',
-          monthlyCost: 0,
+          name: 'Team',
+          monthlyCost: 2000,
           patchInstallLimit: 1000,
           maxTeamSize: 1,
         ),
@@ -87,7 +87,7 @@ void main() {
           ),
         ],
         patchInstallLimit: 20000,
-        currentPeriodCost: 0,
+        currentPeriodCost: 2000,
         currentPeriodStart: DateTime(2023),
         currentPeriodEnd: DateTime(2023, 2),
       );
@@ -104,7 +104,7 @@ void main() {
           any(
             that: contains('''
 
-You are on the ${lightCyan.wrap('Hobby')} plan.
+You are on the ${lightCyan.wrap('Team')} plan.
 
 ┌────────────┬────────────────┐
 │ App        │ Patch Installs │
@@ -116,10 +116,10 @@ You are on the ${lightCyan.wrap('Hobby')} plan.
 │ Total      │ 84             │
 └────────────┴────────────────┘
 
-${styleBold.wrap('${lightCyan.wrap('${20000 - 84}')} patch installs remaining in the current billing period.')}
+${styleBold.wrap('${lightCyan.wrap('19916')} patch installs remaining in the current billing period.')}
 
 Current Billing Period: ${lightCyan.wrap(DateFormat.yMMMd().format(usage.currentPeriodStart))} - ${lightCyan.wrap(DateFormat.yMMMd().format(usage.currentPeriodEnd))}
-Month-to-date cost: ${lightCyan.wrap(r'$0.00')}
+Month-to-date cost: ${lightCyan.wrap(r'$20.00')}
 
 ${styleBold.wrap('*Usage data is not reported in real-time and may be delayed by up to 48 hours.')}'''),
           ),


### PR DESCRIPTION
## Description

Fixes a display error in `shorebird account usage` that was multiplying cents by 100 instead of dividing.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
