### PR TITLE
fix(shorebird_cli): `shorebird patch android` remove `runInShell`

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -279,11 +279,7 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
       diffPath,
     ];
 
-    final result = await process.run(
-      diffExecutable,
-      diffArguments,
-      runInShell: true,
-    );
+    final result = await process.run(diffExecutable, diffArguments);
 
     if (result.exitCode != 0) {
       throw Exception('Failed to create diff: ${result.stderr}');


### PR DESCRIPTION
## Description

Fixes a Windows-specific issue that would trigger a failure in `shorebird android patch`. This is caused by spaces in the Shorebird path. Installing shorebird to `~/shorebird files/`, for example, would yield the following error:

```
✗ Exception: Failed to create diff: 'C:\Users\user\shorebird' is not recognized as an internal or external command,
operable program or batch file.
```

- fix(shorebird_cli): `shorebird patch android` remove `runInShell` (closes #792)
  - related to #769

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
