### PR TITLE
feat(shorebird_cli): add `--force` flag to `apps delete` command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/apps/delete_apps_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/apps/delete_apps_command.dart
@@ -17,12 +17,20 @@ class DeleteAppCommand extends ShorebirdCommand
     with ShorebirdConfigMixin, ShorebirdValidationMixin {
   /// {@macro delete_app_command}
   DeleteAppCommand({super.buildCodePushClient}) {
-    argParser.addOption(
-      'app-id',
-      help: '''
+    argParser
+      ..addOption(
+        'app-id',
+        help: '''
 The unique application identifier.
 Defaults to the app_id in "shorebird.yaml".''',
-    );
+      )
+      ..addFlag(
+        'force',
+        abbr: 'f',
+        help: 'Release without confirmation if there are no errors.',
+        negatable: false,
+      );
+    ;
   }
 
   @override
@@ -42,6 +50,7 @@ Defaults to the app_id in "shorebird.yaml".''',
     }
 
     final appIdArg = results['app-id'] as String?;
+    final force = results['force'] == true;
     late final String appId;
 
     if (appIdArg == null) {
@@ -63,8 +72,9 @@ Defaults to the app_id in "shorebird.yaml".''',
       hostedUri: ShorebirdEnvironment.hostedUri,
     );
 
-    final confirm = logger.confirm('Deleting an app is permanent. Continue?');
-    if (!confirm) {
+    final shouldProceed =
+        force || logger.confirm('Deleting an app is permanent. Continue?');
+    if (!shouldProceed) {
       logger.info('Aborted.');
       return ExitCode.success.code;
     }

--- a/packages/shorebird_cli/test/src/commands/apps/delete_apps_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/apps/delete_apps_command_test.dart
@@ -98,6 +98,19 @@ void main() {
       verify(() => logger.info('Aborted.')).called(1);
     });
 
+    test('does not prompt for confirmation when force flag is provided',
+        () async {
+      when(() => argResults['app-id']).thenReturn(appId);
+      when(() => argResults['force']).thenReturn(true);
+      when(
+        () => codePushClient.deleteApp(appId: appId),
+      ).thenAnswer((_) async {});
+      final result = await runWithOverrides(command.run);
+      expect(result, ExitCode.success.code);
+      verify(() => codePushClient.deleteApp(appId: appId));
+      verifyNever(() => logger.confirm(any()));
+    });
+
     test('returns success when app is deleted', () async {
       when(() => logger.confirm(any())).thenReturn(true);
       when(() => argResults['app-id']).thenReturn(appId);


### PR DESCRIPTION
## Description

Adds the `--force` flag to `shorebird apps delete` to skip confirmation. Adding this because I plan on deleting apps created during the integration test to avoid cluttering our runner's app list.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
