### PR TITLE
chore(shorebird_cli): use currentPeriodCostMoney in account usage command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/account/account_usage_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/account_usage_command.dart
@@ -97,7 +97,7 @@ ${Table(
 ${styleBold.wrap('${lightCyan.wrap(remainingPatchInstalls)} patch installs remaining in the current billing period.')}
 
 Current Billing Period: ${lightCyan.wrap(DateFormat.yMMMd().format(currentPeriodStart))} - ${lightCyan.wrap(DateFormat.yMMMd().format(currentPeriodEnd))}
-Month-to-date cost: ${lightCyan.wrap(currentPeriodCostMoney.toString())}
+Month-to-date cost: ${lightCyan.wrap(currentPeriodCost.toString())}
 
 ${styleBold.wrap('*Usage data is not reported in real-time and may be delayed by up to 48 hours.')}''';
   }

--- a/packages/shorebird_cli/lib/src/commands/account/account_usage_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/account_usage_command.dart
@@ -42,8 +42,6 @@ class AccountUsageCommand extends ShorebirdCommand
 
 extension on GetUsageResponse {
   String prettyPrint() {
-    final currencyFormatter = NumberFormat('#,##0.00', 'en_US');
-
     const cellStyle = CellStyle(
       paddingLeft: 1,
       paddingRight: 1,
@@ -99,7 +97,7 @@ ${Table(
 ${styleBold.wrap('${lightCyan.wrap(remainingPatchInstalls)} patch installs remaining in the current billing period.')}
 
 Current Billing Period: ${lightCyan.wrap(DateFormat.yMMMd().format(currentPeriodStart))} - ${lightCyan.wrap(DateFormat.yMMMd().format(currentPeriodEnd))}
-Month-to-date cost: ${lightCyan.wrap('\$${currencyFormatter.format(currentPeriodCost / 100.0)}')}
+Month-to-date cost: ${lightCyan.wrap(currentPeriodCostMoney.toString())}
 
 ${styleBold.wrap('*Usage data is not reported in real-time and may be delayed by up to 48 hours.')}''';
   }

--- a/packages/shorebird_cli/lib/src/commands/apps/delete_apps_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/apps/delete_apps_command.dart
@@ -30,7 +30,6 @@ Defaults to the app_id in "shorebird.yaml".''',
         help: 'Release without confirmation if there are no errors.',
         negatable: false,
       );
-    ;
   }
 
   @override

--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -1,5 +1,5 @@
-import 'package:shorebird_cli/src/shorebird_environment.dart';
 import 'package:shorebird_cli/src/process.dart';
+import 'package:shorebird_cli/src/shorebird_environment.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:version/version.dart';
 

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   json_annotation: ^4.8.0
   mason_logger: ^0.2.4
   meta: ^1.9.0
+  money2: ^3.4.1
   path: ^1.8.3
   platform: ^3.1.0
   propertylistserialization: ^1.3.0

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -1,6 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:money2/money2.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:scoped/scoped.dart';
@@ -1679,9 +1680,9 @@ Please bump your version number and try again.''',
 
         test('returns usage when succeeds', () async {
           final usage = GetUsageResponse(
-            plan: const ShorebirdPlan(
+            plan: ShorebirdPlan(
               name: 'Hobby',
-              monthlyCost: 0,
+              monthlyCost: Money.fromIntWithCurrency(0, usd),
               patchInstallLimit: 1000,
               maxTeamSize: 1,
             ),
@@ -1693,7 +1694,7 @@ Please bump your version number and try again.''',
               ),
             ],
             patchInstallLimit: 20000,
-            currentPeriodCost: 0,
+            currentPeriodCost: Money.fromIntWithCurrency(0, usd),
             currentPeriodStart: DateTime(2023),
             currentPeriodEnd: DateTime(2023, 2),
           );

--- a/packages/shorebird_cli/test/src/command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/command_runner_test.dart
@@ -6,8 +6,8 @@ import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/auth/auth.dart' hide auth;
 import 'package:shorebird_cli/src/command_runner.dart';
 import 'package:shorebird_cli/src/logger.dart' hide logger;
-import 'package:shorebird_cli/src/shorebird_environment.dart';
 import 'package:shorebird_cli/src/process.dart';
+import 'package:shorebird_cli/src/shorebird_environment.dart';
 import 'package:shorebird_cli/src/version.dart';
 import 'package:test/test.dart';
 

--- a/packages/shorebird_cli/test/src/commands/account/account_usage_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account/account_usage_command_test.dart
@@ -1,6 +1,7 @@
 import 'package:intl/intl.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:money2/money2.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -68,9 +69,9 @@ void main() {
 
     test('exits with code 0 when usage is fetched.', () async {
       final usage = GetUsageResponse(
-        plan: const ShorebirdPlan(
+        plan: ShorebirdPlan(
           name: 'Team',
-          monthlyCost: 2000,
+          monthlyCost: Money.fromIntWithCurrency(2000, usd),
           patchInstallLimit: 1000,
           maxTeamSize: 1,
         ),
@@ -87,7 +88,7 @@ void main() {
           ),
         ],
         patchInstallLimit: 20000,
-        currentPeriodCost: 2000,
+        currentPeriodCost: Money.fromIntWithCurrency(2000, usd),
         currentPeriodStart: DateTime(2023),
         currentPeriodEnd: DateTime(2023, 2),
       );
@@ -129,9 +130,9 @@ ${styleBold.wrap('*Usage data is not reported in real-time and may be delayed by
 
     test('exits with code 0 when usage is fetched (unlimited).', () async {
       final usage = GetUsageResponse(
-        plan: const ShorebirdPlan(
+        plan: ShorebirdPlan(
           name: 'Hobby',
-          monthlyCost: 0,
+          monthlyCost: Money.fromIntWithCurrency(0, usd),
           patchInstallLimit: 1000,
           maxTeamSize: 1,
         ),
@@ -147,7 +148,7 @@ ${styleBold.wrap('*Usage data is not reported in real-time and may be delayed by
             patchInstallCount: 42,
           ),
         ],
-        currentPeriodCost: 0,
+        currentPeriodCost: Money.fromIntWithCurrency(0, usd),
         currentPeriodStart: DateTime(2023),
         currentPeriodEnd: DateTime(2023, 2),
       );

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -28,7 +28,6 @@ void main() {
       startProcess = _MockProcess();
       shorebirdProcess = ShorebirdProcess(
         processWrapper: processWrapper,
-        engineConfig: const EngineConfig.empty(),
       );
 
       when(

--- a/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
@@ -5,8 +5,8 @@ import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/platform.dart';
-import 'package:shorebird_cli/src/shorebird_environment.dart';
 import 'package:shorebird_cli/src/process.dart';
+import 'package:shorebird_cli/src/shorebird_environment.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:test/test.dart';
 

--- a/packages/shorebird_code_push_client/pubspec.yaml
+++ b/packages/shorebird_code_push_client/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   http: ^1.0.0
+  money2: ^3.4.1
   shorebird_code_push_protocol:
     path: ../shorebird_code_push_protocol
 

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:mocktail/mocktail.dart';
+import 'package:money2/money2.dart';
 import 'package:path/path.dart' as path;
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
@@ -1930,9 +1931,9 @@ void main() {
 
       test('completes when request succeeds', () async {
         final expected = GetUsageResponse(
-          plan: const ShorebirdPlan(
+          plan: ShorebirdPlan(
             name: 'Hobby',
-            monthlyCost: 0,
+            monthlyCost: Money.fromIntWithCurrency(0, usd),
             patchInstallLimit: 1000,
             maxTeamSize: 1,
           ),
@@ -1944,7 +1945,7 @@ void main() {
             )
           ],
           patchInstallLimit: 1337,
-          currentPeriodCost: 0,
+          currentPeriodCost: Money.fromIntWithCurrency(0, usd),
           currentPeriodStart: DateTime(2023),
           currentPeriodEnd: DateTime(2023, 2),
         );

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_usage/get_usage_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_usage/get_usage_response.dart
@@ -1,7 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:money2/money2.dart';
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
-import 'package:shorebird_code_push_protocol/src/converters/money_converter.dart';
 
 part 'get_usage_response.g.dart';
 


### PR DESCRIPTION
## Description

Replaces manual cents-to-dollars conversion with a `Money` object's `toString()`

Fixes https://github.com/shorebirdtech/shorebird/issues/803

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
