### PR TITLE
chore(shorebird_code_push_client): bump client version due to breaking changes re: Money

### DIFF
--- a/packages/shorebird_code_push_client/lib/src/version.dart
+++ b/packages/shorebird_code_push_client/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.4.0+1';
+const packageVersion = '0.5.0+1';

--- a/packages/shorebird_code_push_client/pubspec.yaml
+++ b/packages/shorebird_code_push_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_code_push_client
 description: Library which allows Dart applications to interact with the ShoreBird CodePush API
-version: 0.4.0+1
+version: 0.5.0+1
 repository: https://github.com/shorebirdtech/shorebird
 
 publish_to: none


### PR DESCRIPTION
## Description

The change of money values from `int` to `Money` is a breaking change, so bumping the client version.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
