### PR TITLE
chore: use int as Money transport type, expose money2 dependency from shorebird_code_push_protocol

### DIFF
--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   json_annotation: ^4.8.0
   mason_logger: ^0.2.4
   meta: ^1.9.0
-  money2: ^3.4.1
   path: ^1.8.3
   platform: ^3.1.0
   propertylistserialization: ^1.3.0

--- a/packages/shorebird_code_push_client/pubspec.yaml
+++ b/packages/shorebird_code_push_client/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 
 dependencies:
   http: ^1.0.0
-  money2: ^3.4.1
   shorebird_code_push_protocol:
     path: ../shorebird_code_push_protocol
 

--- a/packages/shorebird_code_push_protocol/lib/shorebird_code_push_protocol.dart
+++ b/packages/shorebird_code_push_protocol/lib/shorebird_code_push_protocol.dart
@@ -1,6 +1,7 @@
 /// The Shorebird CodePush Protocol
 library shorebird_code_push_protocol;
 
+export 'package:money2/money2.dart' show Currency, Money;
 export 'src/converters/converters.dart';
 export 'src/messages/messages.dart';
 export 'src/models/models.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/converters/money_converter.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/converters/money_converter.dart
@@ -5,15 +5,17 @@ import 'package:money2/money2.dart';
 Currency get usd => Currency.create('USD', 2);
 
 /// {@template money_converter}
-/// Converts between [Money] and [String].
+/// Converts between [Money] and [int].
 /// {@endtemplate}
-class MoneyConverter implements JsonConverter<Money, String> {
+// TODO(bryanoltman): change this to use String as the transport type the next
+// time we make a breaking change to the API.
+class MoneyConverter implements JsonConverter<Money, int> {
   /// {@macro money_converter}
   const MoneyConverter();
 
   @override
-  Money fromJson(String cents) => Money.parseWithCurrency(cents, usd);
+  Money fromJson(int cents) => Money.fromIntWithCurrency(cents, usd);
 
   @override
-  String toJson(Money money) => money.minorUnits.toString();
+  int toJson(Money money) => money.minorUnits.toInt();
 }

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_usage/get_usage_response.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_usage/get_usage_response.g.dart
@@ -26,7 +26,7 @@ GetUsageResponse _$GetUsageResponseFromJson(Map<String, dynamic> json) =>
           currentPeriodEnd: $checkedConvert(
               'current_period_end', (v) => DateTime.parse(v as String)),
           currentPeriodCost: $checkedConvert('current_period_cost',
-              (v) => const MoneyConverter().fromJson(v as String)),
+              (v) => const MoneyConverter().fromJson(v as int)),
           patchInstallLimit:
               $checkedConvert('patch_install_limit', (v) => v as int?),
         );

--- a/packages/shorebird_code_push_protocol/lib/src/models/shorebird_plan.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/shorebird_plan.g.dart
@@ -15,8 +15,8 @@ ShorebirdPlan _$ShorebirdPlanFromJson(Map<String, dynamic> json) =>
       ($checkedConvert) {
         final val = ShorebirdPlan(
           name: $checkedConvert('name', (v) => v as String),
-          monthlyCost: $checkedConvert('monthly_cost',
-              (v) => const MoneyConverter().fromJson(v as String)),
+          monthlyCost: $checkedConvert(
+              'monthly_cost', (v) => const MoneyConverter().fromJson(v as int)),
           patchInstallLimit:
               $checkedConvert('patch_install_limit', (v) => v as int?),
           maxTeamSize: $checkedConvert('max_team_size', (v) => v as int?),


### PR DESCRIPTION
## Description

- Exports `money2` dep so it can be use transitively
- Uses int as Money transport type to avoid API breaking changes

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
