### PR TITLE
chore(shorebird_cli): hide build commands

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/build/build_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_command.dart
@@ -19,4 +19,7 @@ class BuildCommand extends ShorebirdCommand {
 
   @override
   String get name => 'build';
+
+  @override
+  bool get hidden => true;
 }


### PR DESCRIPTION
## Description

Hides the `build` command to help avoid user confusion and reduce visible API surface.

Fixes https://github.com/shorebirdtech/shorebird/issues/768

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
