### PR TITLE
fix(shorebird_cli): allow user to proceed if java/kotlin changes are detected

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -246,19 +246,15 @@ https://github.com/shorebirdtech/shorebird/issues/472
 
     if (contentDiffs.nativeChanges.isNotEmpty) {
       logger
-        ..err(
+        ..warn(
           '''The Android App Bundle appears to contain Kotlin or Java changes, which cannot be applied via a patch.''',
         )
-        ..info(yellow.wrap(contentDiffs.nativeChanges.prettyString))
-        ..info(
-          yellow.wrap(
-            '''
-Please create a new release or revert those changes to create a patch.
+        ..info(yellow.wrap(contentDiffs.nativeChanges.prettyString));
+      final shouldContinue = force || logger.confirm('Continue anyways?');
 
-If you believe you're seeing this in error, please reach out to us for support at https://shorebird.dev/support''',
-          ),
-        );
-      return ExitCode.software.code;
+      if (!shouldContinue) {
+        return ExitCode.success.code;
+      }
     }
 
     if (contentDiffs.assetChanges.isNotEmpty) {

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -540,7 +540,8 @@ https://github.com/shorebirdtech/shorebird/issues/472
       expect(exitCode, ExitCode.software.code);
     });
 
-    test('throws error when Java/Kotlin code changes are detected', () async {
+    test('prompts user to continue when Java/Kotlin code changes are detected',
+        () async {
       when(() => aabDiffer.changedFiles(any(), any())).thenReturn(
         FileSetDiff(
           addedPaths: {},
@@ -556,12 +557,17 @@ https://github.com/shorebirdtech/shorebird/issues/472
         getCurrentDirectory: () => tempDir,
       );
 
-      expect(exitCode, ExitCode.software.code);
+      expect(exitCode, ExitCode.success.code);
       verify(
-        () => logger.err(
-          '''The Android App Bundle appears to contain Kotlin or Java changes, which cannot be applied via a patch.''',
+        () => logger.warn(
+          any(
+            that: contains(
+              '''The Android App Bundle appears to contain Kotlin or Java changes, which cannot be applied via a patch.''',
+            ),
+          ),
         ),
       ).called(1);
+      verify(() => logger.confirm('Continue anyways?')).called(1);
     });
 
     test('prompts user to continue when asset changes are detected', () async {


### PR DESCRIPTION
## Description

Because not all java/kotlin changes will prevent a patch from successfully applying, we should allow users to decide whether they want to proceed instead of blocking the patch.

Fixes https://github.com/shorebirdtech/shorebird/issues/839

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
