### PR TITLE
feat(shorebird_cli): warn users of incomplete release when patching

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -153,7 +153,7 @@ Artifacts for release:${existingRelease.version} platform:$platform
     if (artifacts.isNotEmpty) {
       logger.err(
         '''
-It looks like you have an existing $platform release for version ${lightCyan.wrap(existingRelease.version)}.
+It looks like you have an existing ${platform.name} release for version ${lightCyan.wrap(existingRelease.version)}.
 Please bump your version number and try again.''',
       );
       exit(ExitCode.software.code);

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -152,6 +152,15 @@ of the Android app that is using this module.''',
       releaseVersion: releaseVersion,
     );
 
+    if (release.platformStatuses[ReleasePlatform.android] ==
+        ReleaseStatus.draft) {
+      logger.err('''
+Release $releaseVersion is in an incomplete state. It's possible that the original release was terminated or failed to complete.
+
+Please re-run the release command for this version or create a new release.''');
+      return ExitCode.software.code;
+    }
+
     final flutterRevisionProgress = logger.progress(
       'Fetching Flutter revision',
     );

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -137,13 +137,6 @@ of the Android app that is using this module.''',
       return ExitCode.software.code;
     }
 
-    if (dryRun) {
-      logger
-        ..info('No issues detected.')
-        ..info('The server may enforce additional checks.');
-      return ExitCode.success.code;
-    }
-
     const platform = ReleasePlatform.android;
     final channelName = results['channel'] as String;
 
@@ -283,6 +276,13 @@ https://github.com/shorebirdtech/shorebird/issues/472
       final size = formatBytes(patchArtifactBundles[arch]!.size);
       return '$name ($size)';
     });
+
+    if (dryRun) {
+      logger
+        ..info('No issues detected.')
+        ..info('The server may enforce additional checks.');
+      return ExitCode.success.code;
+    }
 
     final summary = [
       '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('(${app.appId})')}''',

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -158,6 +158,15 @@ class PatchAndroidCommand extends ShorebirdCommand
       releaseVersion: releaseVersion,
     );
 
+    if (release.platformStatuses[ReleasePlatform.android] ==
+        ReleaseStatus.draft) {
+      logger.err('''
+Release $releaseVersion is in an incomplete state. It's possible that the original release was terminated or failed to complete.
+
+Please re-run the release command for this version or create a new release.''');
+      return ExitCode.software.code;
+    }
+
     final flutterRevisionProgress = logger.progress(
       'Fetching Flutter revision',
     );

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -146,13 +146,6 @@ class PatchAndroidCommand extends ShorebirdCommand
       return ExitCode.software.code;
     }
 
-    if (dryRun) {
-      logger
-        ..info('No issues detected.')
-        ..info('The server may enforce additional checks.');
-      return ExitCode.success.code;
-    }
-
     final release = await codePushClientWrapper.getRelease(
       appId: appId,
       releaseVersion: releaseVersion,
@@ -325,6 +318,13 @@ https://github.com/shorebirdtech/shorebird/issues/472
       final size = formatBytes(patchArtifactBundles[arch]!.size);
       return '$name ($size)';
     });
+
+    if (dryRun) {
+      logger
+        ..info('No issues detected.')
+        ..info('The server may enforce additional checks.');
+      return ExitCode.success.code;
+    }
 
     final summary = [
       '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('(${app.appId})')}''',

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -153,6 +153,14 @@ class PatchIosCommand extends ShorebirdCommand
       releaseVersion: releaseVersion,
     );
 
+    if (release.platformStatuses[ReleasePlatform.ios] == ReleaseStatus.draft) {
+      logger.err('''
+Release $releaseVersion is in an incomplete state. It's possible that the original release was terminated or failed to complete.
+
+Please re-run the release command for this version or create a new release.''');
+      return ExitCode.software.code;
+    }
+
     final flutterRevisionProgress = logger.progress(
       'Fetching Flutter revision',
     );

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -394,7 +394,7 @@ void main() {
             verify(
               () => logger.err(
                 '''
-It looks like you have an existing $releasePlatform release for version ${lightCyan.wrap(release.version)}.
+It looks like you have an existing ios release for version ${lightCyan.wrap(release.version)}.
 Please bump your version number and try again.''',
               ),
             ).called(1);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -403,6 +403,96 @@ flutter:
       expect(exitCode, equals(ExitCode.usage.code));
     });
 
+    test(
+      '''exits with code 70 if release is in draft state for the android platform''',
+      () async {
+        when(
+          () => codePushClientWrapper.getRelease(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+          ),
+        ).thenAnswer(
+          (_) async => const Release(
+            id: 0,
+            appId: appId,
+            version: version,
+            flutterRevision: flutterRevision,
+            displayName: '1.2.3+1',
+            platformStatuses: {ReleasePlatform.android: ReleaseStatus.draft},
+          ),
+        );
+        final tempDir = setUpTempDir();
+        setUpTempArtifacts(tempDir);
+        final exitCode = await IOOverrides.runZoned(
+          () => runWithOverrides(command.run),
+          getCurrentDirectory: () => tempDir,
+        );
+        expect(exitCode, ExitCode.software.code);
+        verify(
+          () => logger.err('''
+Release 1.2.3+1 is in an incomplete state. It's possible that the original release was terminated or failed to complete.
+
+Please re-run the release command for this version or create a new release.'''),
+        ).called(1);
+      },
+    );
+
+    test(
+      'proceeds if release is in draft state for non-android platform',
+      () async {
+        when(
+          () => codePushClientWrapper.getRelease(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+          ),
+        ).thenAnswer(
+          (_) async => const Release(
+            id: 0,
+            appId: appId,
+            version: version,
+            flutterRevision: flutterRevision,
+            displayName: '1.2.3+1',
+            platformStatuses: {ReleasePlatform.ios: ReleaseStatus.draft},
+          ),
+        );
+        final tempDir = setUpTempDir();
+        setUpTempArtifacts(tempDir);
+        final exitCode = await IOOverrides.runZoned(
+          () => runWithOverrides(command.run),
+          getCurrentDirectory: () => tempDir,
+        );
+        expect(exitCode, ExitCode.success.code);
+      },
+    );
+
+    test(
+      'proceeds if release is in draft state for non-android platform',
+      () async {
+        when(
+          () => codePushClientWrapper.getRelease(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+          ),
+        ).thenAnswer(
+          (_) async => const Release(
+            id: 0,
+            appId: appId,
+            version: version,
+            flutterRevision: flutterRevision,
+            displayName: '1.2.3+1',
+            platformStatuses: {ReleasePlatform.ios: ReleaseStatus.draft},
+          ),
+        );
+        final tempDir = setUpTempDir();
+        setUpTempArtifacts(tempDir);
+        final exitCode = await IOOverrides.runZoned(
+          () => runWithOverrides(command.run),
+          getCurrentDirectory: () => tempDir,
+        );
+        expect(exitCode, ExitCode.success.code);
+      },
+    );
+
     test('errors when unable to detect flutter revision', () async {
       const error = 'oops';
       when(() => flutterRevisionProcessResult.exitCode).thenReturn(1);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -392,6 +392,68 @@ flutter:
       verify(() => logger.info('Aborting.')).called(1);
     });
 
+    test(
+      '''exits with code 70 if release is in draft state for the android platform''',
+      () async {
+        when(
+          () => codePushClientWrapper.getRelease(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+          ),
+        ).thenAnswer(
+          (_) async => const Release(
+            id: 0,
+            appId: appId,
+            version: version,
+            flutterRevision: flutterRevision,
+            displayName: '1.2.3+1',
+            platformStatuses: {releasePlatform: ReleaseStatus.draft},
+          ),
+        );
+        final tempDir = setUpTempDir();
+        setUpTempArtifacts(tempDir);
+        final exitCode = await IOOverrides.runZoned(
+          () => runWithOverrides(command.run),
+          getCurrentDirectory: () => tempDir,
+        );
+        expect(exitCode, ExitCode.software.code);
+        verify(
+          () => logger.err('''
+Release 1.2.3+1 is in an incomplete state. It's possible that the original release was terminated or failed to complete.
+
+Please re-run the release command for this version or create a new release.'''),
+        ).called(1);
+      },
+    );
+
+    test(
+      'proceeds if release is in draft state for non-android platform',
+      () async {
+        when(
+          () => codePushClientWrapper.getRelease(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+          ),
+        ).thenAnswer(
+          (_) async => const Release(
+            id: 0,
+            appId: appId,
+            version: version,
+            flutterRevision: flutterRevision,
+            displayName: '1.2.3+1',
+            platformStatuses: {ReleasePlatform.ios: ReleaseStatus.draft},
+          ),
+        );
+        final tempDir = setUpTempDir();
+        setUpTempArtifacts(tempDir);
+        final exitCode = await IOOverrides.runZoned(
+          () => runWithOverrides(command.run),
+          getCurrentDirectory: () => tempDir,
+        );
+        expect(exitCode, ExitCode.success.code);
+      },
+    );
+
     test('errors when unable to detect flutter revision', () async {
       const error = 'oops';
       when(() => flutterRevisionProcessResult.exitCode).thenReturn(1);


### PR DESCRIPTION
## Description

If the release being patched is in a "draft" state, inform the user and tell them how to proceed.

Part of https://github.com/shorebirdtech/shorebird/issues/774

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
