### PR TITLE
refactor(shorebird_cli): refactor validators into Doctor class

### DIFF
--- a/packages/shorebird_cli/bin/shorebird.dart
+++ b/packages/shorebird_cli/bin/shorebird.dart
@@ -9,10 +9,12 @@ import 'package:shorebird_cli/src/bundletool.dart';
 import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command_runner.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/java.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
+import 'package:shorebird_cli/src/shorebird_version_manager.dart';
 
 Future<void> main(List<String> args) async {
   await _flushThenExit(
@@ -26,11 +28,13 @@ Future<void> main(List<String> args) async {
         bundletoolRef,
         cacheRef,
         codePushClientWrapperRef,
+        doctorRef,
         engineConfigRef,
         javaRef,
         loggerRef,
         platformRef,
         processRef,
+        shorebirdVersionManagerRef,
       },
     ),
   );

--- a/packages/shorebird_cli/lib/src/command.dart
+++ b/packages/shorebird_cli/lib/src/command.dart
@@ -5,7 +5,6 @@ import 'package:args/command_runner.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:shorebird_cli/src/command_runner.dart';
-import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// Signature for a function which takes a list of bytes and returns a hash.
@@ -25,16 +24,10 @@ typedef StartProcess = Future<Process> Function(
   bool runInShell,
 });
 
-List<Validator> _defaultValidators() => [
-      AndroidInternetPermissionValidator(),
-    ];
-
 abstract class ShorebirdCommand extends Command<int> {
   ShorebirdCommand({
     CodePushClientBuilder? buildCodePushClient,
-    List<Validator>? validators, // For mocking.
-  })  : buildCodePushClient = buildCodePushClient ?? CodePushClient.new,
-        validators = validators ?? _defaultValidators();
+  }) : buildCodePushClient = buildCodePushClient ?? CodePushClient.new;
 
   final CodePushClientBuilder buildCodePushClient;
 
@@ -45,9 +38,6 @@ abstract class ShorebirdCommand extends Command<int> {
   ShorebirdCliCommandRunner? get runner =>
       super.runner as ShorebirdCliCommandRunner?;
   // coverage:ignore-end
-
-  /// Checks that the Shorebird install and project are in a good state.
-  late List<Validator> validators;
 
   /// [ArgResults] used for testing purposes only.
   @visibleForTesting

--- a/packages/shorebird_cli/lib/src/commands/build/build_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_aar_command.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -16,7 +17,7 @@ import 'package:shorebird_cli/src/shorebird_validation_mixin.dart';
 /// {@endtemplate}
 class BuildAarCommand extends ShorebirdCommand
     with ShorebirdConfigMixin, ShorebirdValidationMixin, ShorebirdBuildMixin {
-  BuildAarCommand({super.validators}) {
+  BuildAarCommand() {
     // We would have a "target" option here, similar to what [BuildApkCommand]
     // and [BuildAabCommand] have, but target cannot currently be configured in
     // `flutter build aar` and is always assumed to be lib/main.dart.
@@ -46,6 +47,7 @@ class BuildAarCommand extends ShorebirdCommand
       await validatePreconditions(
         checkUserIsAuthenticated: true,
         checkShorebirdInitialized: true,
+        validators: doctor.androidCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -16,7 +17,7 @@ import 'package:shorebird_cli/src/shorebird_validation_mixin.dart';
 class BuildApkCommand extends ShorebirdCommand
     with ShorebirdConfigMixin, ShorebirdValidationMixin, ShorebirdBuildMixin {
   /// {@macro build_apk_command}
-  BuildApkCommand({super.validators}) {
+  BuildApkCommand() {
     argParser
       ..addOption(
         'target',
@@ -40,7 +41,7 @@ class BuildApkCommand extends ShorebirdCommand
     try {
       await validatePreconditions(
         checkUserIsAuthenticated: true,
-        checkValidators: true,
+        validators: doctor.androidCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -16,7 +17,7 @@ import 'package:shorebird_cli/src/shorebird_validation_mixin.dart';
 class BuildAppBundleCommand extends ShorebirdCommand
     with ShorebirdConfigMixin, ShorebirdValidationMixin, ShorebirdBuildMixin {
   /// {@macro build_app_bundle_command}
-  BuildAppBundleCommand({super.validators}) {
+  BuildAppBundleCommand() {
     argParser
       ..addOption(
         'target',
@@ -40,7 +41,7 @@ class BuildAppBundleCommand extends ShorebirdCommand
     try {
       await validatePreconditions(
         checkUserIsAuthenticated: true,
-        checkValidators: true,
+        validators: doctor.androidCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/build/build_ipa_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_ipa_command.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -16,7 +17,7 @@ import 'package:shorebird_cli/src/shorebird_validation_mixin.dart';
 class BuildIpaCommand extends ShorebirdCommand
     with ShorebirdConfigMixin, ShorebirdValidationMixin, ShorebirdBuildMixin {
   /// {@macro build_ipa_command}
-  BuildIpaCommand({super.validators}) {
+  BuildIpaCommand() {
     argParser
       ..addOption(
         'target',
@@ -46,7 +47,7 @@ class BuildIpaCommand extends ShorebirdCommand
     try {
       await validatePreconditions(
         checkUserIsAuthenticated: true,
-        checkValidators: true,
+        validators: doctor.iosCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -11,6 +11,7 @@ import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/formatters/file_size_formatter.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
@@ -32,7 +33,6 @@ class PatchAarCommand extends ShorebirdCommand
         ShorebirdArtifactMixin {
   /// {@macro patch_aar_command}
   PatchAarCommand({
-    super.validators,
     HashFunction? hashFn,
     UnzipFn? unzipFn,
     http.Client? httpClient,
@@ -99,7 +99,7 @@ of the Android app that is using this module.''',
       await validatePreconditions(
         checkUserIsAuthenticated: true,
         checkShorebirdInitialized: true,
-        checkValidators: true,
+        validators: doctor.androidCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -9,6 +9,7 @@ import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/formatters/formatters.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -31,7 +32,6 @@ class PatchAndroidCommand extends ShorebirdCommand
         ShorebirdReleaseVersionMixin {
   /// {@macro patch_android_command}
   PatchAndroidCommand({
-    super.validators,
     HashFunction? hashFn,
     http.Client? httpClient,
     AabDiffer? aabDiffer,
@@ -92,7 +92,7 @@ class PatchAndroidCommand extends ShorebirdCommand
       await validatePreconditions(
         checkUserIsAuthenticated: true,
         checkShorebirdInitialized: true,
-        checkValidators: true,
+        validators: doctor.androidCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -8,6 +8,7 @@ import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/formatters/file_size_formatter.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
@@ -28,7 +29,6 @@ class PatchIosCommand extends ShorebirdCommand
         ShorebirdArtifactMixin {
   /// {@macro patch_ios_command}
   PatchIosCommand({
-    super.validators,
     HashFunction? hashFn,
     IpaReader? ipaReader,
   })  : _hashFn = hashFn ?? ((m) => sha256.convert(m).toString()),
@@ -76,7 +76,7 @@ class PatchIosCommand extends ShorebirdCommand
       await validatePreconditions(
         checkShorebirdInitialized: true,
         checkUserIsAuthenticated: true,
-        checkValidators: true,
+        validators: doctor.iosCommandValidators,
       );
     } on PreconditionFailedException catch (error) {
       return error.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -20,7 +20,7 @@ import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 class PreviewCommand extends ShorebirdCommand
     with ShorebirdConfigMixin, ShorebirdValidationMixin {
   /// {@macro preview_command}
-  PreviewCommand({super.validators}) {
+  PreviewCommand() {
     argParser
       ..addOption(
         'device-id',
@@ -44,6 +44,8 @@ class PreviewCommand extends ShorebirdCommand
 
   @override
   Future<int> run() async {
+    // TODO(bryanoltman): check preview target and run either
+    // doctor.iosValidators or doctor.androidValidators as appropriate.
     try {
       await validatePreconditions(checkUserIsAuthenticated: true);
     } on PreconditionFailedException catch (error) {

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -6,6 +6,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -28,7 +29,6 @@ class ReleaseAarCommand extends ShorebirdCommand
         ShorebirdArtifactMixin {
   /// {@macro release_aar_command}
   ReleaseAarCommand({
-    super.validators,
     UnzipFn? unzipFn,
   }) : _unzipFn = unzipFn ?? extractFileToDisk {
     argParser
@@ -76,7 +76,7 @@ make smaller updates to your app.
       await validatePreconditions(
         checkUserIsAuthenticated: true,
         checkShorebirdInitialized: true,
-        checkValidators: true,
+        validators: doctor.androidCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -24,7 +25,7 @@ class ReleaseAndroidCommand extends ShorebirdCommand
         ShorebirdBuildMixin,
         ShorebirdReleaseVersionMixin {
   /// {@macro release_android_command}
-  ReleaseAndroidCommand({super.validators}) {
+  ReleaseAndroidCommand() {
     argParser
       ..addOption(
         'target',
@@ -69,7 +70,7 @@ make smaller updates to your app.
       await validatePreconditions(
         checkUserIsAuthenticated: true,
         checkShorebirdInitialized: true,
-        checkValidators: true,
+        validators: doctor.androidCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -6,6 +6,7 @@ import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -26,7 +27,6 @@ class ReleaseIosCommand extends ShorebirdCommand
         ShorebirdValidationMixin {
   /// {@macro release_ios_command}
   ReleaseIosCommand({
-    super.validators,
     IpaReader? ipaReader,
   }) : _ipaReader = ipaReader ?? IpaReader() {
     argParser
@@ -63,7 +63,7 @@ make smaller updates to your app.
       await validatePreconditions(
         checkUserIsAuthenticated: true,
         checkShorebirdInitialized: true,
-        checkValidators: true,
+        validators: doctor.iosCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
@@ -1,18 +1,17 @@
 import 'dart:io';
 
 import 'package:mason_logger/mason_logger.dart';
-import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_environment.dart';
-import 'package:shorebird_cli/src/shorebird_version_mixin.dart';
+import 'package:shorebird_cli/src/shorebird_version_manager.dart';
 
 /// {@template upgrade_command}
 /// `shorebird upgrade`
 /// A command which upgrades your copy of Shorebird.
 /// {@endtemplate}
-class UpgradeCommand extends ShorebirdCommand with ShorebirdVersionMixin {
+class UpgradeCommand extends ShorebirdCommand {
   /// {@macro upgrade_command}
   UpgradeCommand();
 
@@ -27,13 +26,10 @@ class UpgradeCommand extends ShorebirdCommand with ShorebirdVersionMixin {
   @override
   Future<int> run() async {
     final updateCheckProgress = logger.progress('Checking for updates');
-    final workingDirectory = p.dirname(Platform.script.toFilePath());
 
     late final String currentVersion;
     try {
-      currentVersion = await fetchCurrentGitHash(
-        workingDirectory: workingDirectory,
-      );
+      currentVersion = await shorebirdVersionManager.fetchCurrentGitHash();
     } on ProcessException catch (error) {
       updateCheckProgress.fail();
       logger.err('Fetching current version failed: ${error.message}');
@@ -42,9 +38,7 @@ class UpgradeCommand extends ShorebirdCommand with ShorebirdVersionMixin {
 
     late final String latestVersion;
     try {
-      latestVersion = await fetchLatestGitHash(
-        workingDirectory: workingDirectory,
-      );
+      latestVersion = await shorebirdVersionManager.fetchLatestGitHash();
     } on ProcessException catch (error) {
       updateCheckProgress.fail();
       logger.err('Checking for updates failed: ${error.message}');
@@ -62,10 +56,7 @@ class UpgradeCommand extends ShorebirdCommand with ShorebirdVersionMixin {
     final updateProgress = logger.progress('Updating');
 
     try {
-      await attemptReset(
-        newRevision: latestVersion,
-        workingDirectory: workingDirectory,
-      );
+      await shorebirdVersionManager.attemptReset(newRevision: latestVersion);
     } on ProcessException catch (error) {
       updateProgress.fail();
       logger.err('Updating failed: ${error.message}');

--- a/packages/shorebird_cli/lib/src/doctor.dart
+++ b/packages/shorebird_cli/lib/src/doctor.dart
@@ -1,0 +1,29 @@
+import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/validators/validators.dart';
+
+/// A reference to a [Doctor] instance.
+final doctorRef = create(Doctor.new);
+
+/// The [Doctor] instance available in the current zone.
+Doctor get doctor => read(doctorRef);
+
+/// {@template doctor}
+/// A class that provides a set of validators to check the current environment
+/// for potential issues.
+/// {@endtemplate}
+class Doctor {
+  /// Validators that verify shorebird will work on Android.
+  final List<Validator> androidCommandValidators = [
+    AndroidInternetPermissionValidator(),
+  ];
+
+  /// Validators that verify shorebird will work on iOS.
+  final List<Validator> iosCommandValidators = [];
+
+  /// All available validators.
+  List<Validator> allValidators = [
+    ShorebirdVersionValidator(),
+    ShorebirdFlutterValidator(),
+    AndroidInternetPermissionValidator(),
+  ];
+}

--- a/packages/shorebird_cli/lib/src/shorebird_version_manager.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_version_manager.dart
@@ -1,20 +1,27 @@
 import 'dart:io';
 
-import 'package:shorebird_cli/src/command.dart';
+import 'package:path/path.dart' as p;
+import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/process.dart';
 
-mixin ShorebirdVersionMixin on ShorebirdCommand {
-  /// Whether the current version of Shorebird is the latest available.
-  Future<bool> isShorebirdVersionCurrent({
-    required String workingDirectory,
-  }) async {
-    final currentVersion = await fetchCurrentGitHash(
-      workingDirectory: workingDirectory,
-    );
+/// A reference to a [ShorebirdVersionManager] instance.
+final shorebirdVersionManagerRef = create(ShorebirdVersionManager.new);
 
-    final latestVersion = await fetchLatestGitHash(
-      workingDirectory: workingDirectory,
-    );
+/// The [ShorebirdVersionManager] instance available in the current zone.
+ShorebirdVersionManager get shorebirdVersionManager =>
+    read(shorebirdVersionManagerRef);
+
+/// {@template shorebird_version_manager}
+/// Provides information about installed and available versions of Shorebird.
+/// {@endtemplate}
+class ShorebirdVersionManager {
+  String get _workingDirectory => p.dirname(Platform.script.toFilePath());
+
+  /// Whether the current version of Shorebird is the latest available.
+  Future<bool> isShorebirdVersionCurrent() async {
+    final currentVersion = await fetchCurrentGitHash();
+
+    final latestVersion = await fetchLatestGitHash();
 
     return currentVersion == latestVersion;
   }
@@ -22,36 +29,31 @@ mixin ShorebirdVersionMixin on ShorebirdCommand {
   /// Returns the remote HEAD shorebird hash.
   ///
   /// Exits if HEAD isn't pointing to a branch, or there is no upstream.
-  Future<String> fetchLatestGitHash({required String workingDirectory}) async {
+  Future<String> fetchLatestGitHash() async {
     // Fetch upstream branch's commits and tags
     await process.run(
       'git',
       ['fetch', '--tags'],
-      workingDirectory: workingDirectory,
+      workingDirectory: _workingDirectory,
     );
     // Get the latest commit revision of the upstream
-    return _gitRevParse('@{upstream}', workingDirectory: workingDirectory);
+    return _gitRevParse('@{upstream}');
   }
 
   /// Returns the local HEAD shorebird hash.
   ///
   /// Exits if HEAD isn't pointing to a branch, or there is no upstream.
-  Future<String> fetchCurrentGitHash({
-    required String workingDirectory,
-  }) async {
+  Future<String> fetchCurrentGitHash() async {
     // Get the commit revision of HEAD
-    return _gitRevParse('HEAD', workingDirectory: workingDirectory);
+    return _gitRevParse('HEAD');
   }
 
-  Future<String> _gitRevParse(
-    String revision, {
-    String? workingDirectory,
-  }) async {
+  Future<String> _gitRevParse(String revision) async {
     // Get the commit revision of HEAD
     final result = await process.run(
       'git',
       ['rev-parse', '--verify', revision],
-      workingDirectory: workingDirectory,
+      workingDirectory: _workingDirectory,
     );
     if (result.exitCode != 0) {
       throw ProcessException(
@@ -71,12 +73,11 @@ mixin ShorebirdVersionMixin on ShorebirdCommand {
   /// to the next release.
   Future<void> attemptReset({
     required String newRevision,
-    required String workingDirectory,
   }) async {
     final result = await process.run(
       'git',
       ['reset', '--hard', newRevision],
-      workingDirectory: workingDirectory,
+      workingDirectory: _workingDirectory,
     );
     if (result.exitCode != 0) {
       throw ProcessException(

--- a/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
-import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:xml/xml.dart';
 
@@ -27,7 +26,7 @@ class AndroidInternetPermissionValidator extends Validator {
   ValidatorScope get scope => ValidatorScope.project;
 
   @override
-  Future<List<ValidationIssue>> validate(ShorebirdProcess process) async {
+  Future<List<ValidationIssue>> validate() async {
     const manifestFileName = 'AndroidManifest.xml';
     final androidSrcDir = [
       p.join(

--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -25,7 +25,7 @@ class ShorebirdFlutterValidator extends Validator {
   ValidatorScope get scope => ValidatorScope.installation;
 
   @override
-  Future<List<ValidationIssue>> validate(ShorebirdProcess process) async {
+  Future<List<ValidationIssue>> validate() async {
     final issues = <ValidationIssue>[];
 
     if (!ShorebirdEnvironment.flutterDirectory.existsSync()) {

--- a/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
@@ -1,15 +1,11 @@
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
-import 'package:shorebird_cli/src/process.dart';
+import 'package:shorebird_cli/src/shorebird_version_manager.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 
 /// Verifies that the currently installed version of Shorebird is the latest.
 class ShorebirdVersionValidator extends Validator {
-  ShorebirdVersionValidator({required this.isShorebirdVersionCurrent});
-
-  final Future<bool> Function({required String workingDirectory})
-      isShorebirdVersionCurrent;
+  ShorebirdVersionValidator();
 
   @override
   String get description => 'Shorebird is up-to-date';
@@ -18,14 +14,12 @@ class ShorebirdVersionValidator extends Validator {
   ValidatorScope get scope => ValidatorScope.installation;
 
   @override
-  Future<List<ValidationIssue>> validate(ShorebirdProcess process) async {
-    final workingDirectory = p.dirname(Platform.script.toFilePath());
+  Future<List<ValidationIssue>> validate() async {
     final bool isShorebirdUpToDate;
 
     try {
-      isShorebirdUpToDate = await isShorebirdVersionCurrent(
-        workingDirectory: workingDirectory,
-      );
+      isShorebirdUpToDate =
+          await shorebirdVersionManager.isShorebirdVersionCurrent();
     } on ProcessException catch (e) {
       return [
         ValidationIssue(

--- a/packages/shorebird_cli/lib/src/validators/validators.dart
+++ b/packages/shorebird_cli/lib/src/validators/validators.dart
@@ -82,9 +82,6 @@ class ValidationIssue {
 /// Checks for a specific issue with either the Shorebird installation or the
 /// current Shorebird project.
 abstract class Validator {
-  /// A unique identifer for this class.
-  String get id => '$runtimeType';
-
   /// A one-sentence explanation of what this validator is checking.
   String get description;
 

--- a/packages/shorebird_cli/lib/src/validators/validators.dart
+++ b/packages/shorebird_cli/lib/src/validators/validators.dart
@@ -92,7 +92,7 @@ abstract class Validator {
   ///
   /// Returns an empty list if no issues are found.
   /// Not all validators use [process].
-  Future<List<ValidationIssue>> validate(ShorebirdProcess process);
+  Future<List<ValidationIssue>> validate();
 
   /// Whether this validator is project-specific or system-wide.
   ValidatorScope get scope;

--- a/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/commands/build/build.dart';
+import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:test/test.dart';
@@ -15,6 +16,8 @@ import 'package:test/test.dart';
 class _MockArgResults extends Mock implements ArgResults {}
 
 class _MockAuth extends Mock implements Auth {}
+
+class _MockDoctor extends Mock implements Doctor {}
 
 class _MockHttpClient extends Mock implements http.Client {}
 
@@ -56,6 +59,7 @@ flutter:
 
     late ArgResults argResults;
     late Auth auth;
+    late Doctor doctor;
     late http.Client httpClient;
     late Logger logger;
     late Progress progress;
@@ -68,6 +72,7 @@ flutter:
         body,
         values: {
           authRef.overrideWith(() => auth),
+          doctorRef.overrideWith(() => doctor),
           loggerRef.overrideWith(() => logger),
           processRef.overrideWith(() => shorebirdProcess),
         },
@@ -90,6 +95,7 @@ flutter:
     setUp(() {
       argResults = _MockArgResults();
       auth = _MockAuth();
+      doctor = _MockDoctor();
       httpClient = _MockHttpClient();
       logger = _MockLogger();
       processResult = _MockProcessResult();
@@ -100,6 +106,7 @@ flutter:
       when(() => argResults.rest).thenReturn([]);
       when(() => auth.client).thenReturn(httpClient);
       when(() => auth.isAuthenticated).thenReturn(true);
+      when(() => doctor.androidCommandValidators).thenReturn([]);
       when(() => logger.progress(any())).thenReturn(progress);
 
       when(
@@ -112,7 +119,7 @@ flutter:
         return processResult;
       });
 
-      command = runWithOverrides(() => BuildAarCommand(validators: []))
+      command = runWithOverrides(BuildAarCommand.new)
         ..testArgResults = argResults;
     });
 

--- a/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
@@ -86,8 +86,6 @@ void main() {
       shorebirdProcess = _MockShorebirdProcess();
       registerFallbackValue(shorebirdProcess);
 
-      when(() => androidInternetPermissionValidator.id)
-          .thenReturn('$AndroidInternetPermissionValidator');
       when(() => androidInternetPermissionValidator.description)
           .thenReturn(androidValidatorDescription);
       when(() => androidInternetPermissionValidator.scope)
@@ -95,16 +93,12 @@ void main() {
       when(androidInternetPermissionValidator.validate)
           .thenAnswer((_) async => []);
 
-      when(() => shorebirdVersionValidator.id)
-          .thenReturn('$ShorebirdVersionValidator');
       when(() => shorebirdVersionValidator.description)
           .thenReturn('Shorebird Version');
       when(() => shorebirdVersionValidator.scope)
           .thenReturn(ValidatorScope.installation);
       when(shorebirdVersionValidator.validate).thenAnswer((_) async => []);
 
-      when(() => shorebirdFlutterValidator.id)
-          .thenReturn('$ShorebirdFlutterValidator');
       when(() => shorebirdFlutterValidator.description)
           .thenReturn('Shorebird Flutter');
       when(() => shorebirdFlutterValidator.scope)

--- a/packages/shorebird_cli/test/src/commands/upgrade_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/upgrade_command_test.dart
@@ -1,9 +1,12 @@
+import 'dart:io';
+
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/process.dart';
+import 'package:shorebird_cli/src/shorebird_version_manager.dart';
 import 'package:test/test.dart';
 
 class _MockLogger extends Mock implements Logger {}
@@ -14,18 +17,18 @@ class _MockProgress extends Mock implements Progress {}
 
 class _MockShorebirdProcess extends Mock implements ShorebirdProcess {}
 
+class _MockShorebirdVersionManager extends Mock
+    implements ShorebirdVersionManager {}
+
 void main() {
   const currentShorebirdRevision = 'revision-1';
   const newerShorebirdRevision = 'revision-2';
 
   group('upgrade', () {
     late Logger logger;
-    late ShorebirdProcessResult fetchCurrentVersionResult;
-    late ShorebirdProcessResult fetchTagsResult;
-    late ShorebirdProcessResult fetchLatestVersionResult;
-    late ShorebirdProcessResult hardResetResult;
     late ShorebirdProcessResult pruneFlutterOriginResult;
     late ShorebirdProcess shorebirdProcess;
+    late ShorebirdVersionManager shorebirdVersionManager;
     late UpgradeCommand command;
 
     R runWithOverrides<R>(R Function() body) {
@@ -34,6 +37,8 @@ void main() {
         values: {
           loggerRef.overrideWith(() => logger),
           processRef.overrideWith(() => shorebirdProcess),
+          shorebirdVersionManagerRef
+              .overrideWith(() => shorebirdVersionManager),
         },
       );
     }
@@ -43,42 +48,23 @@ void main() {
       final progressLogs = <String>[];
 
       logger = _MockLogger();
-      fetchCurrentVersionResult = _MockProcessResult();
-      fetchTagsResult = _MockProcessResult();
-      fetchLatestVersionResult = _MockProcessResult();
-      hardResetResult = _MockProcessResult();
       pruneFlutterOriginResult = _MockProcessResult();
       shorebirdProcess = _MockShorebirdProcess();
+      shorebirdVersionManager = _MockShorebirdVersionManager();
       command = runWithOverrides(UpgradeCommand.new);
 
       when(
-        () => shorebirdProcess.run(
-          'git',
-          ['rev-parse', '--verify', 'HEAD'],
-          workingDirectory: any(named: 'workingDirectory'),
-        ),
-      ).thenAnswer((_) async => fetchCurrentVersionResult);
+        shorebirdVersionManager.fetchCurrentGitHash,
+      ).thenAnswer((_) async => currentShorebirdRevision);
       when(
-        () => shorebirdProcess.run(
-          'git',
-          ['fetch', '--tags'],
-          workingDirectory: any(named: 'workingDirectory'),
-        ),
-      ).thenAnswer((_) async => fetchTagsResult);
+        shorebirdVersionManager.fetchLatestGitHash,
+      ).thenAnswer((_) async => newerShorebirdRevision);
       when(
-        () => shorebirdProcess.run(
-          'git',
-          ['rev-parse', '--verify', '@{upstream}'],
-          workingDirectory: any(named: 'workingDirectory'),
+        () => shorebirdVersionManager.attemptReset(
+          newRevision: any(named: 'newRevision'),
         ),
-      ).thenAnswer((_) async => fetchLatestVersionResult);
-      when(
-        () => shorebirdProcess.run(
-          'git',
-          ['reset', '--hard', newerShorebirdRevision],
-          workingDirectory: any(named: 'workingDirectory'),
-        ),
-      ).thenAnswer((_) async => hardResetResult);
+      ).thenAnswer((_) async => {});
+
       when(
         () => shorebirdProcess.run(
           'git',
@@ -86,23 +72,10 @@ void main() {
           workingDirectory: any(named: 'workingDirectory'),
         ),
       ).thenAnswer((_) async => pruneFlutterOriginResult);
-
-      when(
-        () => fetchCurrentVersionResult.exitCode,
-      ).thenReturn(ExitCode.success.code);
-      when(
-        () => fetchCurrentVersionResult.stdout,
-      ).thenReturn(currentShorebirdRevision);
-      when(
-        () => fetchLatestVersionResult.exitCode,
-      ).thenReturn(ExitCode.success.code);
       when(
         () => pruneFlutterOriginResult.exitCode,
       ).thenReturn(ExitCode.success.code);
-      when(
-        () => fetchLatestVersionResult.stdout,
-      ).thenReturn(currentShorebirdRevision);
-      when(() => hardResetResult.exitCode).thenReturn(ExitCode.success.code);
+
       when(() => progress.complete(any())).thenAnswer((_) {
         final message = _.positionalArguments.elementAt(0) as String?;
         if (message != null) progressLogs.add(message);
@@ -119,9 +92,16 @@ void main() {
       'handles errors when determining the current version',
       () async {
         const errorMessage = 'oops';
-        when(() => fetchCurrentVersionResult.exitCode).thenReturn(1);
-        when(() => fetchCurrentVersionResult.stderr).thenReturn(errorMessage);
+        when(shorebirdVersionManager.fetchCurrentGitHash).thenThrow(
+          const ProcessException(
+            'git',
+            ['rev-parse'],
+            errorMessage,
+          ),
+        );
+
         final result = await runWithOverrides(command.run);
+
         expect(result, equals(ExitCode.software.code));
         verify(() => logger.progress('Checking for updates')).called(1);
         verify(
@@ -134,35 +114,38 @@ void main() {
       'handles errors when determining the latest version',
       () async {
         const errorMessage = 'oops';
-        when(() => fetchLatestVersionResult.exitCode).thenReturn(1);
-        when(() => fetchLatestVersionResult.stderr).thenReturn(errorMessage);
+        when(shorebirdVersionManager.fetchLatestGitHash).thenThrow(
+          const ProcessException(
+            'git',
+            ['rev-parse'],
+            errorMessage,
+          ),
+        );
+
         final result = await runWithOverrides(command.run);
+
         expect(result, equals(ExitCode.software.code));
         verify(() => logger.progress('Checking for updates')).called(1);
         verify(() => logger.err('Checking for updates failed: oops')).called(1);
       },
     );
 
-    test(
-      'handles errors when updating',
-      () async {
-        const errorMessage = 'oops';
-        when(
-          () => fetchLatestVersionResult.stdout,
-        ).thenReturn(newerShorebirdRevision);
-        when(() => hardResetResult.exitCode).thenReturn(1);
-        when(() => hardResetResult.stderr).thenReturn(errorMessage);
-        final result = await runWithOverrides(command.run);
-        expect(result, equals(ExitCode.software.code));
-        verify(() => logger.progress('Checking for updates')).called(1);
-        verify(() => logger.err('Updating failed: oops')).called(1);
-      },
-    );
+    test('handles errors when updating', () async {
+      const errorMessage = 'oops';
+      when(
+        () => shorebirdVersionManager.attemptReset(
+          newRevision: any(named: 'newRevision'),
+        ),
+      ).thenThrow(const ProcessException('git', ['reset'], errorMessage));
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.software.code));
+      verify(() => logger.progress('Checking for updates')).called(1);
+      verify(() => logger.err('Updating failed: oops')).called(1);
+    });
 
     test('handles errors on failure to prune Flutter branches', () async {
-      when(
-        () => fetchLatestVersionResult.stdout,
-      ).thenReturn(newerShorebirdRevision);
       when(() => pruneFlutterOriginResult.exitCode).thenReturn(1);
       when(() => logger.progress(any())).thenReturn(_MockProgress());
 
@@ -174,11 +157,10 @@ void main() {
     test(
       'updates when newer version exists',
       () async {
-        when(
-          () => fetchLatestVersionResult.stdout,
-        ).thenReturn(newerShorebirdRevision);
         when(() => logger.progress(any())).thenReturn(_MockProgress());
+
         final result = await runWithOverrides(command.run);
+
         expect(result, equals(ExitCode.success.code));
         verify(() => logger.progress('Checking for updates')).called(1);
         verify(() => logger.progress('Updating')).called(1);
@@ -188,8 +170,12 @@ void main() {
     test(
       'does not update when already on latest version',
       () async {
+        when(shorebirdVersionManager.fetchLatestGitHash)
+            .thenAnswer((_) async => currentShorebirdRevision);
         when(() => logger.progress(any())).thenReturn(_MockProgress());
+
         final result = await runWithOverrides(command.run);
+
         expect(result, equals(ExitCode.success.code));
         verify(
           () => logger.info('Shorebird is already at the latest version.'),

--- a/packages/shorebird_cli/test/src/shorebird_version_manager_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_version_manager_test.dart
@@ -118,6 +118,29 @@ void main() {
           );
         },
       );
+
+      test(
+          'throws ProcessException if git command exits with code other than 0',
+          () async {
+        const errorMessage = 'oh no!';
+        when(
+          () => fetchCurrentVersionResult.exitCode,
+        ).thenReturn(ExitCode.software.code);
+        when(() => fetchCurrentVersionResult.stderr).thenReturn(errorMessage);
+
+        expect(
+          runWithOverrides(
+            shorebirdVersionManager.isShorebirdVersionCurrent,
+          ),
+          throwsA(
+            isA<ProcessException>().having(
+              (e) => e.message,
+              'message',
+              errorMessage,
+            ),
+          ),
+        );
+      });
     });
 
     group('attemptReset', () {
@@ -133,14 +156,23 @@ void main() {
       test(
         '''throws ProcessException when git command exits with code other than 0''',
         () async {
-          when(() => hardResetResult.exitCode)
-              .thenReturn(ExitCode.software.code);
+          const errorMessage = 'oh no!';
+          when(
+            () => hardResetResult.exitCode,
+          ).thenReturn(ExitCode.software.code);
+          when(() => hardResetResult.stderr).thenReturn(errorMessage);
 
           expect(
             runWithOverrides(
               () => shorebirdVersionManager.attemptReset(newRevision: 'HEAD'),
             ),
-            throwsA(isA<ProcessException>()),
+            throwsA(
+              isA<ProcessException>().having(
+                (e) => e.message,
+                'message',
+                errorMessage,
+              ),
+            ),
           );
         },
       );

--- a/packages/shorebird_cli/test/src/validators/android_internet_permission_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/android_internet_permission_validator_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:collection/collection.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
+import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:test/test.dart';
@@ -39,6 +40,15 @@ void main() {
 
   group(AndroidInternetPermissionValidator, () {
     late ShorebirdProcess shorebirdProcess;
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        () => body(),
+        values: {
+          processRef.overrideWith(() => shorebirdProcess),
+        },
+      );
+    }
 
     setUp(() {
       shorebirdProcess = _MockShorebirdProcess();
@@ -78,7 +88,7 @@ void main() {
         );
 
         final results = await IOOverrides.runZoned(
-          () => AndroidInternetPermissionValidator().validate(shorebirdProcess),
+          () => runWithOverrides(AndroidInternetPermissionValidator().validate),
           getCurrentDirectory: () => tempDirectory,
         );
 
@@ -87,8 +97,7 @@ void main() {
     );
 
     test('returns an error if no android project is found', () async {
-      final results =
-          await AndroidInternetPermissionValidator().validate(shorebirdProcess);
+      final results = await AndroidInternetPermissionValidator().validate();
 
       expect(results, hasLength(1));
       expect(results.first.severity, ValidationIssueSeverity.error);
@@ -103,7 +112,7 @@ void main() {
           .createSync(recursive: true);
 
       final results = await IOOverrides.runZoned(
-        () => AndroidInternetPermissionValidator().validate(shorebirdProcess),
+        () => runWithOverrides(AndroidInternetPermissionValidator().validate),
         getCurrentDirectory: () => tempDirectory,
       );
 
@@ -159,7 +168,7 @@ void main() {
         );
 
         final results = await IOOverrides.runZoned(
-          () => AndroidInternetPermissionValidator().validate(shorebirdProcess),
+          () => runWithOverrides(AndroidInternetPermissionValidator().validate),
           getCurrentDirectory: () => tempDirectory,
         );
 
@@ -195,7 +204,7 @@ void main() {
       );
 
       var results = await IOOverrides.runZoned(
-        () => AndroidInternetPermissionValidator().validate(shorebirdProcess),
+        () => runWithOverrides(AndroidInternetPermissionValidator().validate),
         getCurrentDirectory: () => tempDirectory,
       );
       expect(results, hasLength(1));
@@ -207,7 +216,7 @@ void main() {
       );
 
       results = await IOOverrides.runZoned(
-        () => AndroidInternetPermissionValidator().validate(shorebirdProcess),
+        () => runWithOverrides(AndroidInternetPermissionValidator().validate),
         getCurrentDirectory: () => tempDirectory,
       );
       expect(results, isEmpty);

--- a/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
@@ -51,6 +51,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
         () => body(),
         values: {
           platformRef.overrideWith(() => platform),
+          processRef.overrideWith(() => shorebirdProcess),
         },
       );
     }
@@ -125,9 +126,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
     });
 
     test('returns no issues when the Flutter install is good', () async {
-      final results = await runWithOverrides(
-        () => validator.validate(shorebirdProcess),
-      );
+      final results = await runWithOverrides(validator.validate);
 
       expect(results, isEmpty);
     });
@@ -135,7 +134,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
     test('errors when Flutter does not exist', () async {
       flutterDirectory(tempDir).deleteSync();
 
-      final results = await validator.validate(shorebirdProcess);
+      final results = await runWithOverrides(validator.validate);
 
       expect(results, hasLength(1));
       expect(results.first.severity, ValidationIssueSeverity.error);
@@ -146,9 +145,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
       when(() => gitStatusProcessResult.stdout)
           .thenReturn('Changes not staged for commit');
 
-      final results = await runWithOverrides(
-        () => validator.validate(shorebirdProcess),
-      );
+      final results = await runWithOverrides(validator.validate);
 
       expect(results, hasLength(1));
       expect(results.first.severity, ValidationIssueSeverity.warning);
@@ -164,7 +161,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
         );
 
         final results = await runWithOverrides(
-          () => validator.validate(shorebirdProcess),
+          () => validator.validate(),
         );
 
         expect(results, isEmpty);
@@ -179,9 +176,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
           pathFlutterVersionMessage.replaceAll('3.7.9', '3.8.9'),
         );
 
-        final results = await runWithOverrides(
-          () => validator.validate(shorebirdProcess),
-        );
+        final results = await runWithOverrides(validator.validate);
 
         expect(results, hasLength(1));
         expect(results.first.severity, ValidationIssueSeverity.warning);
@@ -202,9 +197,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
           {'FLUTTER_STORAGE_BASE_URL': 'https://storage.flutter-io.cn'},
         );
 
-        final results = await runWithOverrides(
-          () => validator.validate(shorebirdProcess),
-        );
+        final results = await runWithOverrides(validator.validate);
 
         expect(results, hasLength(1));
         expect(results.first.severity, ValidationIssueSeverity.warning);
@@ -223,9 +216,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
       when(() => pathFlutterVersionProcessResult.stdout)
           .thenReturn('OH NO THERE IS NO FLUTTER VERSION HERE');
 
-      final results = await runWithOverrides(
-        () => validator.validate(shorebirdProcess),
-      );
+      final results = await runWithOverrides(validator.validate);
 
       expect(results, hasLength(1));
       expect(
@@ -244,9 +235,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
       when(() => pathFlutterVersionProcessResult.stderr)
           .thenReturn('error getting Flutter version');
 
-      final results = await runWithOverrides(
-        () => validator.validate(shorebirdProcess),
-      );
+      final results = await runWithOverrides(validator.validate);
 
       expect(results, hasLength(1));
       expect(
@@ -264,9 +253,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
       when(() => shorebirdFlutterVersionProcessResult.stdout)
           .thenReturn('OH NO THERE IS NO FLUTTER VERSION HERE');
 
-      final results = await runWithOverrides(
-        () => validator.validate(shorebirdProcess),
-      );
+      final results = await runWithOverrides(validator.validate);
 
       expect(results, hasLength(1));
       expect(
@@ -285,9 +272,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
       when(() => shorebirdFlutterVersionProcessResult.stderr)
           .thenReturn('error getting Flutter version');
 
-      final results = await runWithOverrides(
-        () => validator.validate(shorebirdProcess),
-      );
+      final results = await runWithOverrides(validator.validate);
 
       expect(results, hasLength(1));
       expect(

--- a/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
@@ -1,83 +1,35 @@
-import 'dart:io';
-
-import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:scoped/scoped.dart';
-import 'package:shorebird_cli/src/commands/doctor_command.dart';
-import 'package:shorebird_cli/src/process.dart';
+import 'package:shorebird_cli/src/shorebird_version_manager.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:test/test.dart';
 
-class _MockProcessResult extends Mock implements ShorebirdProcessResult {}
-
-class _MockShorebirdProcess extends Mock implements ShorebirdProcess {}
+class _MockShorebirdVersionManager extends Mock
+    implements ShorebirdVersionManager {}
 
 void main() {
-  const currentShorebirdRevision = 'revision-1';
-  const newerShorebirdRevision = 'revision-2';
-
   group('ShorebirdVersionValidator', () {
+    late ShorebirdVersionManager shorebirdVersionManager;
     late ShorebirdVersionValidator validator;
-    late ShorebirdProcessResult fetchCurrentVersionResult;
-    late ShorebirdProcessResult fetchLatestVersionResult;
-    late ShorebirdProcess shorebirdProcess;
-    late DoctorCommand command;
 
     R runWithOverrides<R>(R Function() body) {
       return runScoped(
         body,
         values: {
-          engineConfigRef.overrideWith(() => const EngineConfig.empty()),
-          processRef.overrideWith(() => shorebirdProcess),
+          shorebirdVersionManagerRef
+              .overrideWith(() => shorebirdVersionManager),
         },
       );
     }
 
     setUp(() {
-      fetchCurrentVersionResult = _MockProcessResult();
-      fetchLatestVersionResult = _MockProcessResult();
-      shorebirdProcess = _MockShorebirdProcess();
+      shorebirdVersionManager = _MockShorebirdVersionManager();
 
-      command = runWithOverrides(DoctorCommand.new);
-
-      validator = ShorebirdVersionValidator(
-        isShorebirdVersionCurrent: command.isShorebirdVersionCurrent,
-      );
+      validator = ShorebirdVersionValidator();
 
       when(
-        () => shorebirdProcess.run(
-          'git',
-          ['rev-parse', '--verify', 'HEAD'],
-          workingDirectory: any(named: 'workingDirectory'),
-        ),
-      ).thenAnswer((_) async => fetchCurrentVersionResult);
-      when(
-        () => shorebirdProcess.run(
-          'git',
-          ['rev-parse', '--verify', '@{upstream}'],
-          workingDirectory: any(named: 'workingDirectory'),
-        ),
-      ).thenAnswer((_) async => fetchLatestVersionResult);
-      when(
-        () => shorebirdProcess.run(
-          'git',
-          ['fetch', '--tags'],
-          workingDirectory: any(named: 'workingDirectory'),
-        ),
-      ).thenAnswer((_) async => _MockProcessResult());
-
-      when(
-        () => fetchCurrentVersionResult.exitCode,
-      ).thenReturn(ExitCode.success.code);
-      when(
-        () => fetchCurrentVersionResult.stdout,
-      ).thenReturn(currentShorebirdRevision);
-      when(
-        () => fetchLatestVersionResult.exitCode,
-      ).thenReturn(ExitCode.success.code);
-      when(
-        () => fetchLatestVersionResult.stdout,
-      ).thenReturn(currentShorebirdRevision);
+        shorebirdVersionManager.isShorebirdVersionCurrent,
+      ).thenAnswer((_) async => false);
     });
 
     test('has a non-empty description', () {
@@ -89,20 +41,18 @@ void main() {
     });
 
     test('returns no issues when shorebird is up-to-date', () async {
-      final results = await runWithOverrides(
-        () => validator.validate(shorebirdProcess),
-      );
+      when(shorebirdVersionManager.isShorebirdVersionCurrent)
+          .thenAnswer((_) async => true);
+
+      final results = await runWithOverrides(validator.validate);
       expect(results, isEmpty);
     });
 
     test('returns a warning when a newer shorebird is available', () async {
-      when(
-        () => fetchLatestVersionResult.stdout,
-      ).thenReturn(newerShorebirdRevision);
+      when(shorebirdVersionManager.isShorebirdVersionCurrent)
+          .thenAnswer((_) async => false);
 
-      final results = await runWithOverrides(
-        () => validator.validate(shorebirdProcess),
-      );
+      final results = await runWithOverrides(validator.validate);
       expect(results, hasLength(1));
       expect(results.first.severity, ValidationIssueSeverity.warning);
       expect(
@@ -110,31 +60,5 @@ void main() {
         contains('A new version of shorebird is available!'),
       );
     });
-
-    test(
-      'returns an error on failure to retrieve shorebird version',
-      () async {
-        when(
-          () => fetchLatestVersionResult.stdout,
-        ).thenThrow(
-          const ProcessException(
-            'git',
-            ['--rev'],
-            'Some error',
-          ),
-        );
-
-        final results = await runWithOverrides(
-          () => validator.validate(shorebirdProcess),
-        );
-
-        expect(results, hasLength(1));
-        expect(results.first.severity, ValidationIssueSeverity.error);
-        expect(
-          results.first.message,
-          'Failed to get shorebird version. Error: Some error',
-        );
-      },
-    );
   });
 }


### PR DESCRIPTION
## Description

- Moves validators from command constructor parameters to a new `Doctor` class
- Moves `ShorebirdValidationMixin` to `ShorebirdVersionManager`.

Fixes https://github.com/shorebirdtech/shorebird/issues/672.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
