### PR TITLE
fix(shorebird_cli): print more friendly error if cli upgrade is required

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -67,8 +67,7 @@ class CodePushClientWrapper {
       fetchAppsProgress.complete();
       return apps;
     } catch (error) {
-      fetchAppsProgress.fail('$error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(error, progress: fetchAppsProgress);
     }
   }
 
@@ -105,8 +104,7 @@ This app may not exist or you may not have permission to view it.''',
       fetchChannelsProgress.complete();
       return channel;
     } catch (error) {
-      fetchChannelsProgress.fail('$error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(error, progress: fetchChannelsProgress);
     }
   }
 
@@ -124,8 +122,7 @@ This app may not exist or you may not have permission to view it.''',
       createChannelProgress.complete();
       return channel;
     } catch (error) {
-      createChannelProgress.fail('$error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(error, progress: createChannelProgress);
     }
   }
 
@@ -191,8 +188,7 @@ Please create a release using "shorebird release" and try again.
       fetchReleasesProgress.complete();
       return releases;
     } catch (error) {
-      fetchReleasesProgress.fail('$error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(error, progress: fetchReleasesProgress);
     }
   }
 
@@ -226,8 +222,7 @@ Please create a release using "shorebird release" and try again.
       createReleaseProgress.complete();
       return release;
     } catch (error) {
-      createReleaseProgress.fail('$error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(error, progress: createReleaseProgress);
     }
   }
 
@@ -247,8 +242,7 @@ Please create a release using "shorebird release" and try again.
       );
       updateStatusProgress.complete();
     } catch (error) {
-      updateStatusProgress.fail();
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(error, progress: updateStatusProgress);
     }
   }
 
@@ -280,8 +274,7 @@ Please create a release using "shorebird release" and try again.
         }
         releaseArtifacts[entry.key] = artifacts.first;
       } catch (error) {
-        fetchReleaseArtifactProgress.fail('$error');
-        exit(ExitCode.software.code);
+        _handleErrorAndExit(error, progress: fetchReleaseArtifactProgress);
       }
     }
 
@@ -314,8 +307,7 @@ Please create a release using "shorebird release" and try again.
       fetchReleaseArtifactProgress.complete();
       return artifacts.first;
     } catch (error) {
-      fetchReleaseArtifactProgress.fail('$error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(error, progress: fetchReleaseArtifactProgress);
     }
   }
 
@@ -347,8 +339,7 @@ Please create a release using "shorebird release" and try again.
       fetchReleaseArtifactProgress.complete();
       return null;
     } catch (error) {
-      fetchReleaseArtifactProgress.fail('$error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(error, progress: fetchReleaseArtifactProgress);
     }
   }
 
@@ -395,8 +386,11 @@ Please create a release using "shorebird release" and try again.
 ${archMetadata.arch} artifact already exists, continuing...''',
         );
       } catch (error) {
-        createArtifactProgress.fail('Error uploading ${artifact.path}: $error');
-        exit(ExitCode.software.code);
+        _handleErrorAndExit(
+          error,
+          progress: createArtifactProgress,
+          message: 'Error uploading ${artifact.path}: $error',
+        );
       }
     }
 
@@ -418,8 +412,11 @@ ${archMetadata.arch} artifact already exists, continuing...''',
 aab artifact already exists, continuing...''',
       );
     } catch (error) {
-      createArtifactProgress.fail('Error uploading $aabPath: $error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(
+        error,
+        progress: createArtifactProgress,
+        message: 'Error uploading $aabPath: $error',
+      );
     }
 
     createArtifactProgress.complete();
@@ -463,8 +460,11 @@ aab artifact already exists, continuing...''',
 ${archMetadata.arch} artifact already exists, continuing...''',
         );
       } catch (error) {
-        createArtifactProgress.fail('Error uploading ${artifact.path}: $error');
-        exit(ExitCode.software.code);
+        _handleErrorAndExit(
+          error,
+          progress: createArtifactProgress,
+          message: 'Error uploading ${artifact.path}: $error',
+        );
       }
     }
 
@@ -486,8 +486,11 @@ ${archMetadata.arch} artifact already exists, continuing...''',
 aar artifact already exists, continuing...''',
       );
     } catch (error) {
-      createArtifactProgress.fail('Error uploading $aarPath: $error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(
+        error,
+        progress: createArtifactProgress,
+        message: 'Error uploading $aarPath: $error',
+      );
     }
 
     createArtifactProgress.complete();
@@ -511,8 +514,11 @@ aar artifact already exists, continuing...''',
         hash: sha256.convert(await ipaFile.readAsBytes()).toString(),
       );
     } catch (error) {
-      createArtifactProgress.fail('Error uploading ipa: $error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(
+        error,
+        progress: createArtifactProgress,
+        message: 'Error uploading ipa: $error',
+      );
     }
 
     createArtifactProgress.complete();
@@ -532,8 +538,7 @@ aar artifact already exists, continuing...''',
       createPatchProgress.complete();
       return patch;
     } catch (error) {
-      createPatchProgress.fail('$error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(error, progress: createPatchProgress);
     }
   }
 
@@ -556,8 +561,7 @@ aar artifact already exists, continuing...''',
           hash: artifact.hash,
         );
       } catch (error) {
-        createArtifactProgress.fail('$error');
-        exit(ExitCode.software.code);
+        _handleErrorAndExit(error, progress: createArtifactProgress);
       }
     }
     createArtifactProgress.complete();
@@ -580,8 +584,7 @@ aar artifact already exists, continuing...''',
       );
       promotePatchProgress.complete();
     } catch (error) {
-      promotePatchProgress.fail('$error');
-      exit(ExitCode.software.code);
+      _handleErrorAndExit(error, progress: promotePatchProgress);
     }
   }
 
@@ -614,5 +617,27 @@ aar artifact already exists, continuing...''',
         );
 
     await promotePatch(appId: appId, patchId: patch.id, channel: channel);
+  }
+
+  /// Prints an appropriate error message for the given error and exits with
+  /// code 70. If [progress] is provided, it will be failed with the given
+  /// [message] or [error.toString()] if [message] is null.
+  Never _handleErrorAndExit(
+    Object error, {
+    Progress? progress,
+    String? message,
+  }) {
+    if (error is CodePushUpgradeRequiredException) {
+      progress?.fail();
+      logger
+        ..err('Your version of shorebird is out of date.')
+        ..info(
+          '''Run ${lightCyan.wrap('shorebird upgrade')} to get the latest version.''',
+        );
+    } else if (progress != null) {
+      progress.fail(message ?? '$error');
+    }
+
+    exit(ExitCode.software.code);
   }
 }

--- a/packages/shorebird_cli/lib/src/commands/apps/list_apps_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/apps/list_apps_command.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:barbecue/barbecue.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
+import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -18,7 +19,7 @@ import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 class ListAppsCommand extends ShorebirdCommand
     with ShorebirdConfigMixin, ShorebirdValidationMixin {
   /// {@macro list_apps_command}
-  ListAppsCommand({super.buildCodePushClient});
+  ListAppsCommand();
 
   @override
   String get description => 'List all apps using Shorebird.';
@@ -39,18 +40,7 @@ class ListAppsCommand extends ShorebirdCommand
       return e.exitCode.code;
     }
 
-    final client = buildCodePushClient(
-      httpClient: auth.client,
-      hostedUri: ShorebirdEnvironment.hostedUri,
-    );
-
-    final List<AppMetadata> apps;
-    try {
-      apps = await client.getApps();
-    } catch (error) {
-      logger.err('$error');
-      return ExitCode.software.code;
-    }
+    final apps = await codePushClientWrapper.getApps();
 
     logger.info('📱 Apps');
 

--- a/packages/shorebird_cli/lib/src/commands/apps/list_apps_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/apps/list_apps_command.dart
@@ -2,12 +2,10 @@ import 'dart:async';
 
 import 'package:barbecue/barbecue.dart';
 import 'package:mason_logger/mason_logger.dart';
-import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
-import 'package:shorebird_cli/src/shorebird_environment.dart';
 import 'package:shorebird_cli/src/shorebird_validation_mixin.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -175,6 +175,32 @@ void main() {
           verify(() => progress.fail(error)).called(1);
         });
 
+        test(
+          '''prints upgrade message when client throws CodePushUpgradeRequiredException''',
+          () async {
+            when(codePushClient.getApps).thenThrow(
+              const CodePushUpgradeRequiredException(
+                message: 'upgrade required',
+              ),
+            );
+            await expectLater(
+              () async => runWithOverrides(
+                () => codePushClientWrapper.getApps(),
+              ),
+              exitsWithCode(ExitCode.software),
+            );
+            verify(() => progress.fail()).called(1);
+            verify(
+              () => logger.err('Your version of shorebird is out of date.'),
+            ).called(1);
+            verify(
+              () => logger.info(
+                '''Run ${lightCyan.wrap('shorebird upgrade')} to get the latest version.''',
+              ),
+            ).called(1);
+          },
+        );
+
         test('returns apps on success', () async {
           when(() => codePushClient.getApps()).thenAnswer((_) async => [app]);
 

--- a/packages/shorebird_cli/test/src/commands/apps/list_apps_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/apps/list_apps_command_test.dart
@@ -1,26 +1,24 @@
-import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
+import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
 
-class _MockHttpClient extends Mock implements http.Client {}
-
 class _MockAuth extends Mock implements Auth {}
 
-class _MockCodePushClient extends Mock implements CodePushClient {}
+class _MockCodePushClientWrapper extends Mock
+    implements CodePushClientWrapper {}
 
 class _MockLogger extends Mock implements Logger {}
 
 void main() {
   group(ListAppsCommand, () {
-    late http.Client httpClient;
     late Auth auth;
-    late CodePushClient codePushClient;
+    late CodePushClientWrapper codePushClientWrapper;
     late Logger logger;
     late ListAppsCommand command;
 
@@ -29,30 +27,19 @@ void main() {
         body,
         values: {
           authRef.overrideWith(() => auth),
+          codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           loggerRef.overrideWith(() => logger)
         },
       );
     }
 
     setUp(() {
-      httpClient = _MockHttpClient();
       auth = _MockAuth();
-      codePushClient = _MockCodePushClient();
+      codePushClientWrapper = _MockCodePushClientWrapper();
       logger = _MockLogger();
+      command = ListAppsCommand();
 
       when(() => auth.isAuthenticated).thenReturn(true);
-      when(() => auth.client).thenReturn(httpClient);
-
-      command = runWithOverrides(
-        () => ListAppsCommand(
-          buildCodePushClient: ({
-            required http.Client httpClient,
-            Uri? hostedUri,
-          }) {
-            return codePushClient;
-          },
-        ),
-      );
     });
 
     test('description is correct', () {
@@ -64,13 +51,8 @@ void main() {
       expect(await runWithOverrides(command.run), ExitCode.noUser.code);
     });
 
-    test('returns ExitCode.software when unable to get apps', () async {
-      when(() => codePushClient.getApps()).thenThrow(Exception());
-      expect(await runWithOverrides(command.run), ExitCode.software.code);
-    });
-
     test('returns ExitCode.success when apps are empty', () async {
-      when(() => codePushClient.getApps()).thenAnswer((_) async => []);
+      when(codePushClientWrapper.getApps).thenAnswer((_) async => []);
       expect(await runWithOverrides(command.run), ExitCode.success.code);
       verify(() => logger.info('(empty)')).called(1);
     });
@@ -88,7 +70,7 @@ void main() {
           displayName: 'Shorebird Clock',
         ),
       ];
-      when(() => codePushClient.getApps()).thenAnswer((_) async => apps);
+      when(codePushClientWrapper.getApps).thenAnswer((_) async => apps);
       expect(await runWithOverrides(command.run), ExitCode.success.code);
       verify(
         () => logger.info(


### PR DESCRIPTION
## Description

When the CodePushClient throws a CodePushUpgradeRequiredException, print an error telling the user to run `shorebird upgrade` instead of the server-provided message about an out of date code push client version.

<img width="488" alt="Screenshot 2023-07-22 at 10 52 24 PM" src="https://github.com/shorebirdtech/shorebird/assets/581764/ef23db79-f9d0-4760-acb9-f44afe9ddbc6">

Fixes https://github.com/shorebirdtech/shorebird/issues/884

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
