### PR TITLE
fix(shorebird_cli): update archive diffing to ignore certain sets of asset files

### DIFF
--- a/packages/shorebird_cli/lib/src/archive_analysis/aab_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/aab_differ.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:archive/archive_io.dart';
+import 'package:shorebird_cli/src/archive_analysis/android_archive_differ.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
-import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/archive_analysis/mf_reader.dart';
 
 /// Finds differences between two AABs.
@@ -26,7 +26,7 @@ import 'package:shorebird_cli/src/archive_analysis/mf_reader.dart';
 ///
 /// See https://developer.android.com/guide/app-bundle/app-bundle-format for
 /// reference.
-class AabDiffer extends ArchiveDiffer {
+class AabDiffer extends AndroidArchiveDiffer {
   /// Returns a set of file paths whose hashes differ between the AABs at the
   /// provided paths.
   @override

--- a/packages/shorebird_cli/lib/src/archive_analysis/aar_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/aar_differ.dart
@@ -2,8 +2,8 @@ import 'dart:io';
 
 import 'package:archive/archive_io.dart';
 import 'package:crypto/crypto.dart';
+import 'package:shorebird_cli/src/archive_analysis/android_archive_differ.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
-import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 
 /// Finds differences between two AABs.
 ///
@@ -19,7 +19,7 @@ import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 /// https://developer.android.com/studio/projects/android-library.html#aar-contents
 /// for reference. Note that .aars produced by Flutter modules do not contain
 /// .jar files, so only asset and dart changes are possible.
-class AarDiffer extends ArchiveDiffer {
+class AarDiffer extends AndroidArchiveDiffer {
   String _hash(List<int> bytes) => sha256.convert(bytes).toString();
 
   @override

--- a/packages/shorebird_cli/lib/src/archive_analysis/android_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/android_archive_differ.dart
@@ -1,0 +1,68 @@
+import 'package:collection/collection.dart';
+import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
+import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
+
+abstract class AndroidArchiveDiffer extends ArchiveDiffer {
+  @override
+  bool containsPotentiallyBreakingAssetDiffs(FileSetDiff fileSetDiff) {
+    // If only files in this set have changed, we don't need to warn the user
+    // about asset differences.
+    const assetFileNamesToIgnore = {
+      'AssetManifest.bin',
+      'AssetManifest.json',
+      'NOTICES.Z',
+    };
+
+    final assetsDiff = assetsFileSetDiff(fileSetDiff);
+
+    // If assets were added, we need to warn the user about asset differences.
+    if (assetsDiff.addedPaths.isNotEmpty) {
+      return true;
+    }
+
+    return assetsDiff.changedPaths
+        .whereNot((path) => assetFileNamesToIgnore.contains(p.basename(path)))
+        .isNotEmpty;
+  }
+
+  @override
+  bool containsPotentiallyBreakingNativeDiffs(FileSetDiff fileSetDiff) =>
+      nativeFileSetDiff(fileSetDiff).isNotEmpty;
+
+  FileSetDiff assetsFileSetDiff(FileSetDiff fileSetDiff) => FileSetDiff(
+        addedPaths: fileSetDiff.addedPaths.where(_isAssetFilePath).toSet(),
+        removedPaths: fileSetDiff.removedPaths.where(_isAssetFilePath).toSet(),
+        changedPaths: fileSetDiff.changedPaths.where(_isAssetFilePath).toSet(),
+      );
+
+  FileSetDiff dartFileSetDiff(FileSetDiff fileSetDiff) => FileSetDiff(
+        addedPaths: fileSetDiff.addedPaths.where(_isDartFilePath).toSet(),
+        removedPaths: fileSetDiff.removedPaths.where(_isDartFilePath).toSet(),
+        changedPaths: fileSetDiff.changedPaths.where(_isDartFilePath).toSet(),
+      );
+
+  FileSetDiff nativeFileSetDiff(FileSetDiff fileSetDiff) => FileSetDiff(
+        addedPaths: fileSetDiff.addedPaths.where(_isNativeFilePath).toSet(),
+        removedPaths: fileSetDiff.removedPaths.where(_isNativeFilePath).toSet(),
+        changedPaths: fileSetDiff.changedPaths.where(_isNativeFilePath).toSet(),
+      );
+
+  static bool _isAssetFilePath(String filePath) {
+    const assetDirNames = ['assets', 'res'];
+    const assetFileNames = ['AssetManifest.json'];
+
+    return p
+            .split(filePath)
+            .any((component) => assetDirNames.contains(component)) ||
+        assetFileNames.contains(p.basename(filePath));
+  }
+
+  static bool _isDartFilePath(String filePath) {
+    const dartFileNames = ['libapp.so', 'libflutter.so'];
+    return dartFileNames.contains(p.basename(filePath));
+  }
+
+  static bool _isNativeFilePath(String filePath) =>
+      p.extension(filePath) == '.dex';
+}

--- a/packages/shorebird_cli/lib/src/archive_analysis/archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/archive_differ.dart
@@ -1,4 +1,3 @@
-import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 
 /// Computes content differences between two archives.
@@ -7,32 +6,11 @@ abstract class ArchiveDiffer {
   /// archives at the two provided paths.
   FileSetDiff changedFiles(String oldArchivePath, String newArchivePath);
 
-  /// Whether any changed files correspond to a change in assets.
-  static Set<String> assetChanges(Set<String> paths) {
-    const assetDirNames = ['assets', 'res'];
-    const assetFileNames = ['AssetManifest.json'];
-    return paths
-        .where(
-          (path) =>
-              p
-                  .split(path)
-                  .any((component) => assetDirNames.contains(component)) ||
-              assetFileNames.contains(p.basename(path)),
-        )
-        .toSet();
-  }
+  /// Whether there are asset differences between the archives that may cause
+  /// issues when patching a release.
+  bool containsPotentiallyBreakingAssetDiffs(FileSetDiff fileSetDiff);
 
-  /// Whether any changed files correspond to a change in Dart code.
-  static Set<String> dartChanges(Set<String> paths) {
-    const dartFileNames = ['libapp.so', 'libflutter.so'];
-    return paths
-        .where((path) => dartFileNames.contains(p.basename(path)))
-        .toSet();
-  }
-
-  /// Whether changed files correspond to a change in native code.
-  static Set<String> nativeChanges(Set<String> path) {
-    // TODO(bryanoltman): add support for iOS native code changes.
-    return path.where((path) => p.extension(path) == '.dex').toSet();
-  }
+  /// Whether there are native code differences between the archives that may
+  /// cause issues when patching a release.
+  bool containsPotentiallyBreakingNativeDiffs(FileSetDiff fileSetDiff);
 }

--- a/packages/shorebird_cli/lib/src/archive_analysis/file_set_diff.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/file_set_diff.dart
@@ -1,5 +1,4 @@
 import 'package:collection/collection.dart';
-import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 
 /// Maps file paths to SHA-256 hash digests.
 typedef PathHashes = Map<String, String>;
@@ -43,6 +42,12 @@ class FileSetDiff {
   /// File paths that were changed.
   final Set<String> changedPaths;
 
+  Set<String> get allPaths => {
+        ...addedPaths,
+        ...removedPaths,
+        ...changedPaths,
+      };
+
   /// Whether all path sets are empty.
   bool get isEmpty => !isNotEmpty;
 
@@ -51,30 +56,6 @@ class FileSetDiff {
       addedPaths.isNotEmpty ||
       removedPaths.isNotEmpty ||
       changedPaths.isNotEmpty;
-
-  /// A subset of this [FileSetDiff] that only contains paths that correspond
-  /// to a change in Dart code.
-  FileSetDiff get dartChanges => FileSetDiff(
-        addedPaths: ArchiveDiffer.dartChanges(addedPaths),
-        removedPaths: ArchiveDiffer.dartChanges(removedPaths),
-        changedPaths: ArchiveDiffer.dartChanges(changedPaths),
-      );
-
-  /// A subset of this [FileSetDiff] that only contains paths that correspond
-  /// to changes in native code.
-  FileSetDiff get nativeChanges => FileSetDiff(
-        addedPaths: ArchiveDiffer.nativeChanges(addedPaths),
-        removedPaths: ArchiveDiffer.nativeChanges(removedPaths),
-        changedPaths: ArchiveDiffer.nativeChanges(changedPaths),
-      );
-
-  /// A subset of this [FileSetDiff] that only contains paths that correspond
-  /// to changes in bundled assets.
-  FileSetDiff get assetChanges => FileSetDiff(
-        addedPaths: ArchiveDiffer.assetChanges(addedPaths),
-        removedPaths: ArchiveDiffer.assetChanges(removedPaths),
-        changedPaths: ArchiveDiffer.assetChanges(changedPaths),
-      );
 
   /// A printable string representation of this [FileSetDiff].
   String get prettyString => [

--- a/packages/shorebird_cli/lib/src/archive_analysis/file_set_diff.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/file_set_diff.dart
@@ -42,12 +42,6 @@ class FileSetDiff {
   /// File paths that were changed.
   final Set<String> changedPaths;
 
-  Set<String> get allPaths => {
-        ...addedPaths,
-        ...removedPaths,
-        ...changedPaths,
-      };
-
   /// Whether all path sets are empty.
   bool get isEmpty => !isNotEmpty;
 

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -235,7 +235,7 @@ https://github.com/shorebirdtech/shorebird/issues/472
 
     aarDiffProgress.complete();
 
-    if (contentDiffs.assetChanges.isNotEmpty) {
+    if (_aarDiffer.containsPotentiallyBreakingAssetDiffs(contentDiffs)) {
       logger.info(
         yellow.wrap(
           '''⚠️ The Android Archive contains asset changes, which will not be included in the patch.''',

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -249,12 +249,14 @@ https://github.com/shorebirdtech/shorebird/issues/472
 
     logger.detail('aab content differences: $contentDiffs');
 
-    if (contentDiffs.nativeChanges.isNotEmpty) {
+    if (_aabDiffer.containsPotentiallyBreakingNativeDiffs(contentDiffs)) {
       logger
         ..warn(
           '''The Android App Bundle appears to contain Kotlin or Java changes, which cannot be applied via a patch.''',
         )
-        ..info(yellow.wrap(contentDiffs.nativeChanges.prettyString));
+        ..info(
+          yellow.wrap(_aabDiffer.nativeFileSetDiff(contentDiffs).prettyString),
+        );
       final shouldContinue = force || logger.confirm('Continue anyways?');
 
       if (!shouldContinue) {
@@ -262,12 +264,14 @@ https://github.com/shorebirdtech/shorebird/issues/472
       }
     }
 
-    if (contentDiffs.assetChanges.isNotEmpty) {
+    if (_aabDiffer.containsPotentiallyBreakingAssetDiffs(contentDiffs)) {
       logger
         ..warn(
           '''The Android App Bundle contains asset changes, which will not be included in the patch.''',
         )
-        ..info(yellow.wrap(contentDiffs.assetChanges.prettyString));
+        ..info(
+          yellow.wrap(_aabDiffer.assetsFileSetDiff(contentDiffs).prettyString),
+        );
 
       final shouldContinue = force || logger.confirm('Continue anyways?');
       if (!shouldContinue) {

--- a/packages/shorebird_cli/test/src/archive_analysis/aab_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/aab_differ_test.dart
@@ -46,33 +46,33 @@ void main() {
       test('detects asset changes', () {
         final fileSetDiff =
             differ.changedFiles(baseAabPath, changedAssetAabPath);
-        expect(fileSetDiff.assetChanges.isEmpty, isFalse);
-        expect(fileSetDiff.dartChanges.isEmpty, isTrue);
-        expect(fileSetDiff.nativeChanges.isEmpty, isTrue);
+        expect(differ.assetsFileSetDiff(fileSetDiff), isNotEmpty);
+        expect(differ.dartFileSetDiff(fileSetDiff), isEmpty);
+        expect(differ.nativeFileSetDiff(fileSetDiff), isEmpty);
       });
 
       test('detects kotlin changes', () {
         final fileSetDiff =
             differ.changedFiles(baseAabPath, changedKotlinAabPath);
-        expect(fileSetDiff.assetChanges.isEmpty, isTrue);
-        expect(fileSetDiff.dartChanges.isEmpty, isTrue);
-        expect(fileSetDiff.nativeChanges.isEmpty, isFalse);
+        expect(differ.assetsFileSetDiff(fileSetDiff), isEmpty);
+        expect(differ.dartFileSetDiff(fileSetDiff), isEmpty);
+        expect(differ.nativeFileSetDiff(fileSetDiff), isNotEmpty);
       });
 
       test('detects dart changes', () {
         final fileSetDiff =
             differ.changedFiles(baseAabPath, changedDartAabPath);
-        expect(fileSetDiff.assetChanges.isEmpty, isTrue);
-        expect(fileSetDiff.dartChanges.isEmpty, isFalse);
-        expect(fileSetDiff.nativeChanges.isEmpty, isTrue);
+        expect(differ.assetsFileSetDiff(fileSetDiff), isEmpty);
+        expect(differ.dartFileSetDiff(fileSetDiff), isNotEmpty);
+        expect(differ.nativeFileSetDiff(fileSetDiff), isEmpty);
       });
 
       test('detects dart and asset changes', () {
         final fileSetDiff =
             differ.changedFiles(baseAabPath, changedDartAndAssetAabPath);
-        expect(fileSetDiff.assetChanges.isEmpty, isFalse);
-        expect(fileSetDiff.dartChanges.isEmpty, isFalse);
-        expect(fileSetDiff.nativeChanges.isEmpty, isTrue);
+        expect(differ.assetsFileSetDiff(fileSetDiff), isNotEmpty);
+        expect(differ.dartFileSetDiff(fileSetDiff), isNotEmpty);
+        expect(differ.nativeFileSetDiff(fileSetDiff), isEmpty);
       });
     });
   });

--- a/packages/shorebird_cli/test/src/archive_analysis/aar_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/aar_differ_test.dart
@@ -36,24 +36,24 @@ void main() {
 
     test('detects asset changes', () {
       final fileSetDiff = differ.changedFiles(baseAarPath, changedAssetAarPath);
-      expect(fileSetDiff.assetChanges.isEmpty, isFalse);
-      expect(fileSetDiff.dartChanges.isEmpty, isTrue);
-      expect(fileSetDiff.nativeChanges.isEmpty, isTrue);
+      expect(differ.assetsFileSetDiff(fileSetDiff), isNotEmpty);
+      expect(differ.dartFileSetDiff(fileSetDiff), isEmpty);
+      expect(differ.nativeFileSetDiff(fileSetDiff), isEmpty);
     });
 
     test('detects dart changes', () {
       final fileSetDiff = differ.changedFiles(baseAarPath, changedDartAarPath);
-      expect(fileSetDiff.assetChanges.isEmpty, isTrue);
-      expect(fileSetDiff.dartChanges.isEmpty, isFalse);
-      expect(fileSetDiff.nativeChanges.isEmpty, isTrue);
+      expect(differ.assetsFileSetDiff(fileSetDiff), isEmpty);
+      expect(differ.dartFileSetDiff(fileSetDiff), isNotEmpty);
+      expect(differ.nativeFileSetDiff(fileSetDiff), isEmpty);
     });
 
     test('detects dart and asset changes', () {
       final fileSetDiff =
           differ.changedFiles(baseAarPath, changedDartAndAssetAarPath);
-      expect(fileSetDiff.assetChanges.isEmpty, isFalse);
-      expect(fileSetDiff.dartChanges.isEmpty, isFalse);
-      expect(fileSetDiff.nativeChanges.isEmpty, isTrue);
+      expect(differ.assetsFileSetDiff(fileSetDiff), isNotEmpty);
+      expect(differ.dartFileSetDiff(fileSetDiff), isNotEmpty);
+      expect(differ.nativeFileSetDiff(fileSetDiff), isEmpty);
     });
   });
 }

--- a/packages/shorebird_cli/test/src/archive_analysis/android_archive_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/android_archive_differ_test.dart
@@ -1,0 +1,112 @@
+import 'package:shorebird_cli/src/archive_analysis/android_archive_differ.dart';
+import 'package:shorebird_cli/src/archive_analysis/file_set_diff.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(AndroidArchiveDiffer, () {
+    late TestAndroidArchiveDiffer differ;
+
+    setUp(() {
+      differ = TestAndroidArchiveDiffer();
+    });
+
+    group('containsPotentiallyBreakingAssetDiffs', () {
+      test('returns true if assets were added', () {
+        final fileSetDiff = FileSetDiff(
+          addedPaths: {'base/assets/flutter_assets/file.json'},
+          removedPaths: {},
+          changedPaths: {},
+        );
+        expect(
+          differ.containsPotentiallyBreakingAssetDiffs(fileSetDiff),
+          isTrue,
+        );
+      });
+
+      test('returns true if changed assets are not in the ignore list', () {
+        final fileSetDiff = FileSetDiff(
+          addedPaths: {},
+          removedPaths: {},
+          changedPaths: {
+            'AssetManifest.bin',
+            'AssetManifest.json',
+            'base/assets/file.json',
+          },
+        );
+        expect(
+          differ.containsPotentiallyBreakingAssetDiffs(fileSetDiff),
+          isTrue,
+        );
+      });
+
+      test('returns false if changed assets are in the ignore list', () {
+        final fileSetDiff = FileSetDiff(
+          addedPaths: {},
+          removedPaths: {},
+          changedPaths: {
+            'base/assets/flutter_assets/AssetManifest.bin',
+            'base/assets/flutter_assets/AssetManifest.json',
+            'base/assets/flutter_assets/NOTICES.Z',
+          },
+        );
+        expect(
+          differ.containsPotentiallyBreakingAssetDiffs(fileSetDiff),
+          isFalse,
+        );
+      });
+    });
+
+    group('containsPotentiallyBreakingNativeDiffs', () {
+      test('returns true if any native files have been added', () {
+        final fileSetDiff = FileSetDiff(
+          addedPaths: {'base/lib/arm64-v8a/test.dex'},
+          removedPaths: {},
+          changedPaths: {},
+        );
+        expect(
+          differ.containsPotentiallyBreakingNativeDiffs(fileSetDiff),
+          isTrue,
+        );
+      });
+
+      test('returns true if any native files have been removed', () {
+        final fileSetDiff = FileSetDiff(
+          addedPaths: {},
+          removedPaths: {'base/lib/arm64-v8a/test.dex'},
+          changedPaths: {},
+        );
+        expect(
+          differ.containsPotentiallyBreakingNativeDiffs(fileSetDiff),
+          isTrue,
+        );
+      });
+
+      test('returns true if any native files have been changed', () {
+        final fileSetDiff = FileSetDiff(
+          addedPaths: {},
+          removedPaths: {},
+          changedPaths: {'base/lib/arm64-v8a/test.dex'},
+        );
+        expect(
+          differ.containsPotentiallyBreakingNativeDiffs(fileSetDiff),
+          isTrue,
+        );
+      });
+
+      test('returns false if no native files have been changed', () {
+        final fileSetDiff = FileSetDiff.empty();
+        expect(
+          differ.containsPotentiallyBreakingNativeDiffs(fileSetDiff),
+          isFalse,
+        );
+      });
+    });
+  });
+}
+
+/// An empty subclass of [AndroidArchiveDiffer] to allow instantiation.
+class TestAndroidArchiveDiffer extends AndroidArchiveDiffer {
+  @override
+  FileSetDiff changedFiles(String oldArchivePath, String newArchivePath) =>
+      FileSetDiff.empty();
+}


### PR DESCRIPTION
## Description

- Refactors asset diffing to make it easier to add iOS asset diffing in the future
- Does not warn if Android asset changes only include a NOTICES.Z file in addition to the manifest

Fixes https://github.com/shorebirdtech/shorebird/issues/892

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
