### PR TITLE
feat(shorebird_cli): upload xcarchive as part of ios release

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -94,13 +94,13 @@ make smaller updates to your app.
     buildProgress.complete();
 
     final releaseVersionProgress = logger.progress('Getting release version');
+    final iosBuildDir = p.join(Directory.current.path, 'build', 'ios');
     final ipaPath = p.join(
-      Directory.current.path,
-      'build',
-      'ios',
+      iosBuildDir,
       'ipa',
       '${getIpaName()}.ipa',
     );
+    final xcArchivePath = p.join(iosBuildDir, 'archive', 'Runner.xcarchive');
     String releaseVersion;
     try {
       final ipa = _ipaReader.read(ipaPath);
@@ -181,10 +181,11 @@ ${summary.join('\n')}
 
     final relativeIpaPath = p.relative(ipaPath);
 
-    await codePushClientWrapper.createIosReleaseArtifact(
+    await codePushClientWrapper.createIosReleaseArtifacts(
       appId: app.appId,
       releaseId: release.id,
       ipaPath: ipaPath,
+      xcArchivePath: xcArchivePath,
     );
 
     await codePushClientWrapper.updateReleaseStatus(

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -1423,6 +1423,7 @@ Please bump your version number and try again.''',
 
     group('createIosReleaseArtifact', () {
       final ipaPath = p.join('path', 'to', 'app.ipa');
+      final xcarchivePath = p.join('path', 'to', 'app.xcarchive');
 
       Directory setUpTempDir({String? flavor}) {
         final tempDir = Directory.systemTemp.createTempSync();
@@ -1460,10 +1461,11 @@ Please bump your version number and try again.''',
         await IOOverrides.runZoned(
           () async => expectLater(
             () async => runWithOverrides(
-              () async => codePushClientWrapper.createIosReleaseArtifact(
+              () async => codePushClientWrapper.createIosReleaseArtifacts(
                 appId: app.appId,
                 releaseId: releaseId,
                 ipaPath: p.join(tempDir.path, ipaPath),
+                xcArchivePath: p.join(tempDir.path, xcarchivePath),
               ),
             ),
             exitsWithCode(ExitCode.software),
@@ -1492,10 +1494,11 @@ Please bump your version number and try again.''',
         await IOOverrides.runZoned(
           () async => expectLater(
             () async => runWithOverrides(
-              () async => codePushClientWrapper.createIosReleaseArtifact(
+              () async => codePushClientWrapper.createIosReleaseArtifacts(
                 appId: app.appId,
                 releaseId: releaseId,
                 ipaPath: p.join(tempDir.path, ipaPath),
+                xcArchivePath: p.join(tempDir.path, xcarchivePath),
               ),
             ),
             exitsWithCode(ExitCode.software),
@@ -1521,10 +1524,11 @@ Please bump your version number and try again.''',
 
         await runWithOverrides(
           () async => IOOverrides.runZoned(
-            () async => codePushClientWrapper.createIosReleaseArtifact(
+            () async => codePushClientWrapper.createIosReleaseArtifacts(
               appId: app.appId,
               releaseId: releaseId,
               ipaPath: p.join(tempDir.path, ipaPath),
+              xcArchivePath: p.join(tempDir.path, xcarchivePath),
             ),
             getCurrentDirectory: () => tempDir,
           ),

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -229,10 +229,11 @@ flutter:
         ),
       ).thenAnswer((_) async => release);
       when(
-        () => codePushClientWrapper.createIosReleaseArtifact(
+        () => codePushClientWrapper.createIosReleaseArtifacts(
           appId: any(named: 'appId'),
           releaseId: any(named: 'releaseId'),
           ipaPath: any(named: 'ipaPath'),
+          xcArchivePath: any(named: 'xcArchivePath'),
         ),
       ).thenAnswer((_) async => release);
       when(
@@ -415,10 +416,11 @@ error: exportArchive: No signing certificate "iOS Distribution" found
       expect(exitCode, ExitCode.success.code);
       verify(() => logger.info('Aborting.')).called(1);
       verifyNever(
-        () => codePushClientWrapper.createIosReleaseArtifact(
+        () => codePushClientWrapper.createIosReleaseArtifacts(
           appId: appId,
           releaseId: release.id,
           ipaPath: any(named: 'ipaPath', that: endsWith('.ipa')),
+          xcArchivePath: any(named: 'xcArchivePath'),
         ),
       );
     });
@@ -490,10 +492,11 @@ error: exportArchive: No signing certificate "iOS Distribution" found
         ),
       ).called(1);
       verify(
-        () => codePushClientWrapper.createIosReleaseArtifact(
+        () => codePushClientWrapper.createIosReleaseArtifacts(
           appId: appId,
           releaseId: release.id,
           ipaPath: any(named: 'ipaPath', that: endsWith('.ipa')),
+          xcArchivePath: any(named: 'xcArchivePath'),
         ),
       ).called(1);
       verify(
@@ -541,10 +544,11 @@ flavors:
         ),
       ).called(1);
       verify(
-        () => codePushClientWrapper.createIosReleaseArtifact(
+        () => codePushClientWrapper.createIosReleaseArtifacts(
           appId: appId,
           releaseId: release.id,
           ipaPath: any(named: 'ipaPath', that: endsWith('.ipa')),
+          xcArchivePath: any(named: 'xcArchivePath'),
         ),
       ).called(1);
       expect(exitCode, ExitCode.success.code);
@@ -575,10 +579,11 @@ flavors:
         ),
       );
       verify(
-        () => codePushClientWrapper.createIosReleaseArtifact(
+        () => codePushClientWrapper.createIosReleaseArtifacts(
           appId: appId,
           releaseId: release.id,
           ipaPath: any(named: 'ipaPath', that: endsWith('.ipa')),
+          xcArchivePath: any(named: 'xcArchivePath'),
         ),
       ).called(1);
       verify(


### PR DESCRIPTION
## Description

Upload the built `.xcarchive` file as part of `release ios-preview` to allow the `shorebird preview` command to work on iOS.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
