### PR TITLE
fix(shorebird_cli): use platform status instead of artifacts when checking existing release

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -129,8 +129,8 @@ This app may not exist or you may not have permission to view it.''',
     }
   }
 
-  /// Checks whether [release] is in an active state for [platform]. If so,
-  /// exits with code 70.
+  /// Prints an error message and exits with code 70 if [release] is in an
+  /// active state for [platform].
   void ensureReleaseIsIsNotActive({
     required Release release,
     required ReleasePlatform platform,

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -131,7 +131,7 @@ This app may not exist or you may not have permission to view it.''',
 
   /// Prints an error message and exits with code 70 if [release] is in an
   /// active state for [platform].
-  void ensureReleaseIsIsNotActive({
+  void ensureReleaseIsNotActive({
     required Release release,
     required ReleasePlatform platform,
   }) {

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -129,31 +129,16 @@ This app may not exist or you may not have permission to view it.''',
     }
   }
 
-  /// Exits if [platform] release artifacts already exist for an
-  /// [existingRelease].
-  Future<void> ensureReleaseHasNoArtifacts({
-    required String appId,
-    required Release existingRelease,
+  /// Checks whether [release] is in an active state for [platform]. If so,
+  /// exits with code 70.
+  void ensureReleaseIsIsNotActive({
+    required Release release,
     required ReleasePlatform platform,
-  }) async {
-    logger.detail('Verifying ability to release');
-
-    final artifacts = await codePushClient.getReleaseArtifacts(
-      appId: appId,
-      releaseId: existingRelease.id,
-      platform: platform,
-    );
-
-    logger.detail(
-      '''
-Artifacts for release:${existingRelease.version} platform:$platform
-  $artifacts''',
-    );
-
-    if (artifacts.isNotEmpty) {
+  }) {
+    if (release.platformStatuses[platform] == ReleaseStatus.active) {
       logger.err(
         '''
-It looks like you have an existing ${platform.name} release for version ${lightCyan.wrap(existingRelease.version)}.
+It looks like you have an existing ${platform.name} release for version ${lightCyan.wrap(release.version)}.
 Please bump your version number and try again.''',
       );
       exit(ExitCode.software.code);

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -102,7 +102,7 @@ make smaller updates to your app.
       releaseVersion: releaseVersion,
     );
     if (existingRelease != null) {
-      codePushClientWrapper.ensureReleaseIsIsNotActive(
+      codePushClientWrapper.ensureReleaseIsNotActive(
         release: existingRelease,
         platform: platform,
       );

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -102,9 +102,8 @@ make smaller updates to your app.
       releaseVersion: releaseVersion,
     );
     if (existingRelease != null) {
-      await codePushClientWrapper.ensureReleaseHasNoArtifacts(
-        appId: app.appId,
-        existingRelease: existingRelease,
+      codePushClientWrapper.ensureReleaseIsIsNotActive(
+        release: existingRelease,
         platform: platform,
       );
     }

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -122,7 +122,7 @@ make smaller updates to your app.
     );
 
     if (existingRelease != null) {
-      codePushClientWrapper.ensureReleaseIsIsNotActive(
+      codePushClientWrapper.ensureReleaseIsNotActive(
         release: existingRelease,
         platform: platform,
       );

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -122,9 +122,8 @@ make smaller updates to your app.
     );
 
     if (existingRelease != null) {
-      await codePushClientWrapper.ensureReleaseHasNoArtifacts(
-        appId: app.appId,
-        existingRelease: existingRelease,
+      codePushClientWrapper.ensureReleaseIsIsNotActive(
+        release: existingRelease,
         platform: platform,
       );
     }

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -126,7 +126,7 @@ make smaller updates to your app.
       releaseVersion: releaseVersion,
     );
     if (existingRelease != null) {
-      codePushClientWrapper.ensureReleaseIsIsNotActive(
+      codePushClientWrapper.ensureReleaseIsNotActive(
         release: existingRelease,
         platform: platform,
       );

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -119,9 +119,8 @@ make smaller updates to your app.
       releaseVersion: releaseVersion,
     );
     if (existingRelease != null) {
-      await codePushClientWrapper.ensureReleaseHasNoArtifacts(
-        appId: app.appId,
-        existingRelease: existingRelease,
+      codePushClientWrapper.ensureReleaseIsIsNotActive(
+        release: existingRelease,
         platform: platform,
       );
     }

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -398,7 +398,7 @@ void main() {
           () {
             expect(
               () => runWithOverrides(
-                () => codePushClientWrapper.ensureReleaseIsIsNotActive(
+                () => codePushClientWrapper.ensureReleaseIsNotActive(
                   release: const Release(
                     id: releaseId,
                     appId: appId,
@@ -430,7 +430,7 @@ Please bump your version number and try again.''',
           () async {
             await expectLater(
               runWithOverrides(
-                () async => codePushClientWrapper.ensureReleaseIsIsNotActive(
+                () async => codePushClientWrapper.ensureReleaseIsNotActive(
                   release: const Release(
                     id: releaseId,
                     appId: appId,
@@ -452,7 +452,7 @@ Please bump your version number and try again.''',
           () async {
             await expectLater(
               runWithOverrides(
-                () async => codePushClientWrapper.ensureReleaseIsIsNotActive(
+                () async => codePushClientWrapper.ensureReleaseIsNotActive(
                   release: const Release(
                     id: releaseId,
                     appId: appId,

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -393,24 +393,23 @@ void main() {
     });
 
     group('release', () {
-      group('ensureReleaseHasNoArtifacts', () {
-        const appId = 'test-app-id';
+      group('ensureReleaseIsIsNotActive', () {
         test(
-          '''exits with code 70 if release artifacts exist for the given release and platform''',
-          () async {
-            when(
-              () => codePushClient.getReleaseArtifacts(
-                appId: any(named: 'appId'),
-                releaseId: any(named: 'releaseId'),
-                platform: any(named: 'platform'),
-              ),
-            ).thenAnswer((_) async => [releaseArtifact]);
-
-            await expectLater(
-              runWithOverrides(
-                () async => codePushClientWrapper.ensureReleaseHasNoArtifacts(
-                  appId: appId,
-                  existingRelease: release,
+          '''exits with code 70 if release is in an active state for the given platform''',
+          () {
+            expect(
+              () => runWithOverrides(
+                () => codePushClientWrapper.ensureReleaseIsIsNotActive(
+                  release: const Release(
+                    id: releaseId,
+                    appId: appId,
+                    version: releaseVersion,
+                    flutterRevision: flutterRevision,
+                    displayName: displayName,
+                    platformStatuses: {
+                      releasePlatform: ReleaseStatus.active,
+                    },
+                  ),
                   platform: releasePlatform,
                 ),
               ),
@@ -428,21 +427,41 @@ Please bump your version number and try again.''',
         );
 
         test(
-          '''completes without error if release artifacts exist for the given release and platform''',
+          '''completes without error if release has no status for the given platform''',
           () async {
-            when(
-              () => codePushClient.getReleaseArtifacts(
-                appId: any(named: 'appId'),
-                releaseId: any(named: 'releaseId'),
-                platform: any(named: 'platform'),
-              ),
-            ).thenAnswer((_) async => []);
-
             await expectLater(
               runWithOverrides(
-                () => codePushClientWrapper.ensureReleaseHasNoArtifacts(
-                  appId: appId,
-                  existingRelease: release,
+                () async => codePushClientWrapper.ensureReleaseIsIsNotActive(
+                  release: const Release(
+                    id: releaseId,
+                    appId: appId,
+                    version: releaseVersion,
+                    flutterRevision: flutterRevision,
+                    displayName: displayName,
+                    platformStatuses: {},
+                  ),
+                  platform: releasePlatform,
+                ),
+              ),
+              completes,
+            );
+          },
+        );
+
+        test(
+          '''completes without error if release has draft status for the given platform''',
+          () async {
+            await expectLater(
+              runWithOverrides(
+                () async => codePushClientWrapper.ensureReleaseIsIsNotActive(
+                  release: const Release(
+                    id: releaseId,
+                    appId: appId,
+                    version: releaseVersion,
+                    flutterRevision: flutterRevision,
+                    displayName: displayName,
+                    platformStatuses: {releasePlatform: ReleaseStatus.draft},
+                  ),
                   platform: releasePlatform,
                 ),
               ),

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -246,7 +246,7 @@ flutter:
         ),
       ).thenAnswer((_) async => null);
       when(
-        () => codePushClientWrapper.ensureReleaseIsIsNotActive(
+        () => codePushClientWrapper.ensureReleaseIsNotActive(
           release: any(named: 'release'),
           platform: any(named: 'platform'),
         ),

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -246,9 +246,8 @@ flutter:
         ),
       ).thenAnswer((_) async => null);
       when(
-        () => codePushClientWrapper.ensureReleaseHasNoArtifacts(
-          appId: any(named: 'appId'),
-          existingRelease: any(named: 'existingRelease'),
+        () => codePushClientWrapper.ensureReleaseIsIsNotActive(
+          release: any(named: 'release'),
           platform: any(named: 'platform'),
         ),
       ).thenAnswer((_) async => {});

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -215,7 +215,7 @@ flutter:
         ),
       ).thenAnswer((_) async => null);
       when(
-        () => codePushClientWrapper.ensureReleaseIsIsNotActive(
+        () => codePushClientWrapper.ensureReleaseIsNotActive(
           release: any(named: 'release'),
           platform: any(named: 'platform'),
         ),

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -215,9 +215,8 @@ flutter:
         ),
       ).thenAnswer((_) async => null);
       when(
-        () => codePushClientWrapper.ensureReleaseHasNoArtifacts(
-          appId: any(named: 'appId'),
-          existingRelease: any(named: 'existingRelease'),
+        () => codePushClientWrapper.ensureReleaseIsIsNotActive(
+          release: any(named: 'release'),
           platform: any(named: 'platform'),
         ),
       ).thenAnswer((_) async => {});

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -214,9 +214,8 @@ flutter:
         ),
       ).thenAnswer((_) async => null);
       when(
-        () => codePushClientWrapper.ensureReleaseHasNoArtifacts(
-          appId: any(named: 'appId'),
-          existingRelease: any(named: 'existingRelease'),
+        () => codePushClientWrapper.ensureReleaseIsIsNotActive(
+          release: any(named: 'release'),
           platform: any(named: 'platform'),
         ),
       ).thenAnswer((_) async => {});

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -214,7 +214,7 @@ flutter:
         ),
       ).thenAnswer((_) async => null);
       when(
-        () => codePushClientWrapper.ensureReleaseIsIsNotActive(
+        () => codePushClientWrapper.ensureReleaseIsNotActive(
           release: any(named: 'release'),
           platform: any(named: 'platform'),
         ),


### PR DESCRIPTION
## Description

Instead of checking for existing artifacts (which might yield a false positive if a release command was terminated or otherwise failed before it completed), check the release's release status for the given platform.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
