### PR TITLE
fix(shorebird_cli): install ios-deploy for preview if not installed

### DIFF
--- a/packages/shorebird_cli/lib/src/ios_deploy.dart
+++ b/packages/shorebird_cli/lib/src/ios_deploy.dart
@@ -5,13 +5,15 @@ import 'package:shorebird_cli/src/shorebird_environment.dart';
 /// Wrapper around the `ios-deploy` command cached by the Flutter tool.
 /// https://github.com/ios-control/ios-deploy
 class IOSDeploy {
-  /// Installs the .app file at [bundlePath] to the device identified by [deviceId].
+  /// Installs the .app file at [bundlePath]
+  /// to the device identified by [deviceId]
+  /// and attaches the debugger.
   ///
   /// Uses ios-deploy and returns the exit code.
-  /// `ios-deploy --id [deviceId] --bundle [bundlePath]`
-  Future<int> installApp({
-    required String deviceId,
+  /// `ios-deploy --id [deviceId] --debug --bundle [bundlePath]`
+  Future<int> installAndLaunchApp({
     required String bundlePath,
+    String? deviceId,
   }) async {
     final iosDeployExecutable = p.join(
       ShorebirdEnvironment.flutterDirectory.path,
@@ -24,8 +26,8 @@ class IOSDeploy {
     final result = await process.run(
       iosDeployExecutable,
       [
-        '--id',
-        deviceId,
+        '--debug',
+        if (deviceId != null) ...['--id', deviceId],
         '--bundle',
         bundlePath,
       ],

--- a/packages/shorebird_cli/lib/src/ios_deploy.dart
+++ b/packages/shorebird_cli/lib/src/ios_deploy.dart
@@ -1,13 +1,29 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_environment.dart';
 
 /// Wrapper around the `ios-deploy` command cached by the Flutter tool.
 /// https://github.com/ios-control/ios-deploy
 class IOSDeploy {
-  /// Installs the .app file at [bundlePath]
-  /// to the device identified by [deviceId]
-  /// and attaches the debugger.
+  File get _iosDeployExecutable => File(
+        p.join(
+          ShorebirdEnvironment.flutterDirectory.path,
+          'bin',
+          'cache',
+          'artifacts',
+          'ios-deploy',
+          'ios-deploy',
+        ),
+      );
+
+  bool get _isInstalled => _iosDeployExecutable.existsSync();
+
+  /// Installs the .app file at [bundlePath] to the device identified by
+  /// [deviceId] and attaches the debugger.
   ///
   /// Uses ios-deploy and returns the exit code.
   /// `ios-deploy --id [deviceId] --debug --bundle [bundlePath]`
@@ -15,16 +31,8 @@ class IOSDeploy {
     required String bundlePath,
     String? deviceId,
   }) async {
-    final iosDeployExecutable = p.join(
-      ShorebirdEnvironment.flutterDirectory.path,
-      'bin',
-      'cache',
-      'artifacts',
-      'ios-deploy',
-      'ios-deploy',
-    );
     final result = await process.run(
-      iosDeployExecutable,
+      _iosDeployExecutable.path,
       [
         '--debug',
         if (deviceId != null) ...['--id', deviceId],
@@ -33,5 +41,22 @@ class IOSDeploy {
       ],
     );
     return result.exitCode;
+  }
+
+  /// Installs ios-deploy if it is not already installed.
+  Future<void> installIfNeeded() async {
+    if (_isInstalled) return;
+
+    final progress = logger.progress('Installing ios-deploy');
+
+    final result = await process.run('flutter', ['precache', '--ios']);
+
+    if (result.exitCode != ExitCode.success.code || !_isInstalled) {
+      const errorMessage = 'Failed to install ios-deploy.';
+      progress.fail(errorMessage);
+      throw Exception(errorMessage);
+    }
+
+    progress.complete();
   }
 }

--- a/packages/shorebird_cli/lib/src/ios_deploy.dart
+++ b/packages/shorebird_cli/lib/src/ios_deploy.dart
@@ -47,11 +47,16 @@ class IOSDeploy {
   Future<void> installIfNeeded() async {
     if (_isInstalled) return;
 
+    const executable = 'flutter';
+    const arguments = ['precache', '--ios'];
     final progress = logger.progress('Installing ios-deploy');
 
-    final result = await process.run('flutter', ['precache', '--ios']);
+    final result = await process.run(executable, arguments);
 
-    if (result.exitCode != ExitCode.success.code || !_isInstalled) {
+    if (result.exitCode != ExitCode.success.code) {
+      progress.fail();
+      throw ProcessException(executable, arguments, result.stderr as String);
+    } else if (!_isInstalled) {
       const errorMessage = 'Failed to install ios-deploy.';
       progress.fail(errorMessage);
       throw Exception(errorMessage);

--- a/packages/shorebird_cli/test/src/ios_deploy_test.dart
+++ b/packages/shorebird_cli/test/src/ios_deploy_test.dart
@@ -46,9 +46,9 @@ void main() {
         expect(result, equals(processResult.exitCode));
         verify(
           () => process.run(any(that: endsWith('ios-deploy')), [
+            '--debug',
             '--id',
             deviceId,
-            '--debug',
             '--bundle',
             bundlePath,
           ]),

--- a/packages/shorebird_cli/test/src/ios_deploy_test.dart
+++ b/packages/shorebird_cli/test/src/ios_deploy_test.dart
@@ -25,32 +25,60 @@ void main() {
       iosDeploy = IOSDeploy();
     });
 
-    test('executes correct command', () async {
-      const processResult = ShorebirdProcessResult(
-        exitCode: 0,
-        stdout: '',
-        stderr: '',
-      );
-      when(
-        () => process.run(any(), any()),
-      ).thenAnswer((_) async => processResult);
-      const deviceId = 'test-device-id';
-      const bundlePath = 'test-bundle-path';
-      final result = await runWithOverrides(
-        () => iosDeploy.installApp(
-          deviceId: deviceId,
-          bundlePath: bundlePath,
-        ),
-      );
-      expect(result, equals(processResult.exitCode));
-      verify(
-        () => process.run(any(that: endsWith('ios-deploy')), [
-          '--id',
-          deviceId,
-          '--bundle',
-          bundlePath,
-        ]),
-      ).called(1);
+    group('installAndLaunchApp', () {
+      test('executes correct command w/deviceId', () async {
+        const processResult = ShorebirdProcessResult(
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+        );
+        when(
+          () => process.run(any(), any()),
+        ).thenAnswer((_) async => processResult);
+        const deviceId = 'test-device-id';
+        const bundlePath = 'test-bundle-path';
+        final result = await runWithOverrides(
+          () => iosDeploy.installAndLaunchApp(
+            deviceId: deviceId,
+            bundlePath: bundlePath,
+          ),
+        );
+        expect(result, equals(processResult.exitCode));
+        verify(
+          () => process.run(any(that: endsWith('ios-deploy')), [
+            '--id',
+            deviceId,
+            '--debug',
+            '--bundle',
+            bundlePath,
+          ]),
+        ).called(1);
+      });
+
+      test('executes correct command w/out deviceId', () async {
+        const processResult = ShorebirdProcessResult(
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+        );
+        when(
+          () => process.run(any(), any()),
+        ).thenAnswer((_) async => processResult);
+        const bundlePath = 'test-bundle-path';
+        final result = await runWithOverrides(
+          () => iosDeploy.installAndLaunchApp(
+            bundlePath: bundlePath,
+          ),
+        );
+        expect(result, equals(processResult.exitCode));
+        verify(
+          () => process.run(any(that: endsWith('ios-deploy')), [
+            '--debug',
+            '--bundle',
+            bundlePath,
+          ]),
+        ).called(1);
+      });
     });
   });
 }

--- a/packages/shorebird_cli/test/src/ios_deploy_test.dart
+++ b/packages/shorebird_cli/test/src/ios_deploy_test.dart
@@ -44,10 +44,19 @@ void main() {
       process = _MockShorebirdProcess();
       progress = _MockProgress();
       iosDeploy = IOSDeploy();
+
+      final tempDir = Directory.systemTemp.createTempSync();
+
+      final shorebirdScriptFile = File(
+        p.join(tempDir.path, 'bin', 'cache', 'shorebird.snapshot'),
+      )..create(recursive: true);
+      when(() => platform.script).thenReturn(shorebirdScriptFile.uri);
+
+      when(() => logger.progress(any())).thenReturn(progress);
     });
 
     group('installAndLaunchApp', () {
-      test('executes correct command w/deviceId', () async {
+      test('executes correct command when deviceId is provided', () async {
         const processResult = ShorebirdProcessResult(
           exitCode: 0,
           stdout: '',
@@ -76,7 +85,7 @@ void main() {
         ).called(1);
       });
 
-      test('executes correct command w/out deviceId', () async {
+      test('executes correct command when deviceId is not provided', () async {
         const processResult = ShorebirdProcessResult(
           exitCode: 0,
           stdout: '',
@@ -103,17 +112,6 @@ void main() {
     });
 
     group('installIfNeeded', () {
-      setUp(() {
-        final tempDir = Directory.systemTemp.createTempSync();
-
-        final shorebirdScriptFile = File(
-          p.join(tempDir.path, 'bin', 'cache', 'shorebird.snapshot'),
-        )..create(recursive: true);
-        when(() => platform.script).thenReturn(shorebirdScriptFile.uri);
-
-        when(() => logger.progress(any())).thenReturn(progress);
-      });
-
       test('does nothing if ios-deploy is already installed', () async {
         runWithOverrides(
           () => IOSDeploy.iosDeployExecutable.createSync(recursive: true),


### PR DESCRIPTION
## Description

Uses `flutter precache --ios` to install `ios-deploy` if the `ios-deploy` executable is not found.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
