### PR TITLE
chore(shorebird_cli): exit early if ios commands are run on non-mac OS

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -11,6 +11,7 @@ import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/formatters/file_size_formatter.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -72,6 +73,11 @@ class PatchIosCommand extends ShorebirdCommand
 
   @override
   Future<int> run() async {
+    if (!platform.isMacOS) {
+      logger.err('This command is only supported on macOS.');
+      return ExitCode.unavailable.code;
+    }
+
     try {
       await validatePreconditions(
         checkShorebirdInitialized: true,
@@ -88,7 +94,7 @@ class PatchIosCommand extends ShorebirdCommand
 
     const arch = 'aarch64';
     const channelName = 'stable';
-    const platform = ReleasePlatform.ios;
+    const releasePlatform = ReleasePlatform.ios;
     final force = results['force'] == true;
     final dryRun = results['dry-run'] == true;
     final flavor = results['flavor'] as String?;
@@ -213,7 +219,7 @@ https://github.com/shorebirdtech/shorebird/issues/472
       if (flavor != null) '🍧 Flavor: ${lightCyan.wrap(flavor)}',
       '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
       '📺 Channel: ${lightCyan.wrap(channelName)}',
-      '''🕹️  Platform: ${lightCyan.wrap(platform.name)} ${lightCyan.wrap('[$arch (${formatBytes(aotFileSize)})]')}''',
+      '''🕹️  Platform: ${lightCyan.wrap(releasePlatform.name)} ${lightCyan.wrap('[$arch (${formatBytes(aotFileSize)})]')}''',
     ];
 
     logger.info(
@@ -240,7 +246,7 @@ ${summary.join('\n')}
     await codePushClientWrapper.publishPatch(
       appId: appId,
       releaseId: release.id,
-      platform: platform,
+      platform: releasePlatform,
       channelName: channelName,
       patchArtifactBundles: {
         Arch.arm64: PatchArtifactBundle(

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -8,6 +8,7 @@ import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -59,6 +60,11 @@ make smaller updates to your app.
 
   @override
   Future<int> run() async {
+    if (!platform.isMacOS) {
+      logger.err('This command is only supported on macOS.');
+      return ExitCode.unavailable.code;
+    }
+
     try {
       await validatePreconditions(
         checkUserIsAuthenticated: true,
@@ -73,7 +79,7 @@ make smaller updates to your app.
       '''iOS support is in an alpha state. See https://docs.shorebird.dev/faq#ios-alpha for more information.''',
     );
 
-    const platform = ReleasePlatform.ios;
+    const releasePlatform = ReleasePlatform.ios;
     final flavor = results['flavor'] as String?;
     final shorebirdYaml = ShorebirdEnvironment.getShorebirdYaml()!;
     final appId = shorebirdYaml.getAppId(flavor: flavor);
@@ -128,7 +134,7 @@ make smaller updates to your app.
     if (existingRelease != null) {
       codePushClientWrapper.ensureReleaseIsNotActive(
         release: existingRelease,
-        platform: platform,
+        platform: releasePlatform,
       );
     }
 
@@ -136,7 +142,7 @@ make smaller updates to your app.
       '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('($appId)')}''',
       if (flavor != null) '🍧 Flavor: ${lightCyan.wrap(flavor)}',
       '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
-      '''🕹️  Platform: ${lightCyan.wrap(platform.name)}''',
+      '''🕹️  Platform: ${lightCyan.wrap(releasePlatform.name)}''',
     ];
 
     logger.info('''
@@ -173,7 +179,7 @@ ${summary.join('\n')}
       await codePushClientWrapper.updateReleaseStatus(
         appId: appId,
         releaseId: release.id,
-        platform: platform,
+        platform: releasePlatform,
         status: ReleaseStatus.draft,
       );
     } else {
@@ -181,7 +187,7 @@ ${summary.join('\n')}
         appId: appId,
         version: releaseVersion,
         flutterRevision: shorebirdFlutterRevision,
-        platform: platform,
+        platform: releasePlatform,
       );
     }
 
@@ -197,7 +203,7 @@ ${summary.join('\n')}
     await codePushClientWrapper.updateReleaseStatus(
       appId: app.appId,
       releaseId: release.id,
-      platform: platform,
+      platform: releasePlatform,
       status: ReleaseStatus.active,
     );
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -213,6 +213,7 @@ flutter:
       when(flutterValidator.validate).thenAnswer((_) async => []);
       when(() => logger.confirm(any())).thenReturn(true);
       when(() => logger.progress(any())).thenReturn(progress);
+      when(() => platform.isMacOS).thenReturn(true);
       when(() => platform.environment).thenReturn({});
       when(() => platform.script).thenReturn(
         Uri.file(
@@ -266,6 +267,16 @@ flutter:
 
     test('is hidden', () {
       expect(command.hidden, isTrue);
+    });
+
+    test('exits with unavailable code if run on non-macOS platform', () async {
+      when(() => platform.isMacOS).thenReturn(false);
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.unavailable.code));
+      verify(() => logger.err('This command is only supported on macOS.'))
+          .called(1);
     });
 
     test('throws no user error when user is not logged in', () async {


### PR DESCRIPTION
## Description

Because iOS commands only work on macOS, exit early with a clear message if they are run on non-macOS platforms.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
