### PR TITLE
chore(shorebird_cli): unhide iOS commands

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -60,9 +60,6 @@ class PatchIosCommand extends ShorebirdCommand
   }
 
   @override
-  bool get hidden => true;
-
-  @override
   String get name => 'ios-alpha';
 
   @override

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -47,9 +47,6 @@ class ReleaseIosCommand extends ShorebirdCommand
   final IpaReader _ipaReader;
 
   @override
-  bool get hidden => true;
-
-  @override
   String get description => '''
 Builds and submits your iOS app to Shorebird.
 Shorebird saves the compiled Dart code from your application in order to

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -265,10 +265,6 @@ flutter:
       expect(command.description, isNotEmpty);
     });
 
-    test('is hidden', () {
-      expect(command.hidden, isTrue);
-    });
-
     test('exits with unavailable code if run on non-macOS platform', () async {
       when(() => platform.isMacOS).thenReturn(false);
 

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -256,10 +256,6 @@ flutter:
       expect(command.description, isNotEmpty);
     });
 
-    test('is hidden', () {
-      expect(command.hidden, isTrue);
-    });
-
     test('exits with unavailable code if run on non-macOS platform', () async {
       when(() => platform.isMacOS).thenReturn(false);
 


### PR DESCRIPTION
## Description

Remove `hidden` from iOS release and patch commands.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
