### PR TITLE
fix(shorebird_cli): don't rely on display-friendly git status output

### DIFF
--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -114,12 +114,10 @@ This can cause unexpected behavior if you are switching between the tools and th
   Future<bool> _flutterDirectoryIsClean(ShorebirdProcess process) async {
     final result = await process.run(
       'git',
-      ['status'],
+      ['status', '--untracked-files=no', '--porcelain'],
       workingDirectory: ShorebirdEnvironment.flutterDirectory.path,
     );
-    return result.stdout
-        .toString()
-        .contains('nothing to commit, working tree clean');
+    return result.stdout.toString().isEmpty;
   }
 
   Future<String> _shorebirdFlutterVersion(ShorebirdProcess process) {

--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -117,7 +117,7 @@ This can cause unexpected behavior if you are switching between the tools and th
       ['status', '--untracked-files=no', '--porcelain'],
       workingDirectory: ShorebirdEnvironment.flutterDirectory.path,
     );
-    return result.stdout.toString().isEmpty;
+    return result.stdout.toString().trim().isEmpty;
   }
 
   Future<String> _shorebirdFlutterVersion(ShorebirdProcess process) {

--- a/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
@@ -19,10 +19,6 @@ class _MockShorebirdProcess extends Mock implements ShorebirdProcess {}
 void main() {
   group(ShorebirdFlutterValidator, () {
     const flutterRevision = '45fc514f1a9c347a3af76b02baf980a4d88b7879';
-    const gitStatusMessage = '''
-HEAD detached at 45fc514f
-nothing to commit, working tree clean
-''';
 
     const pathFlutterVersionMessage = '''
 Flutter 3.7.9 • channel unknown • unknown source
@@ -86,7 +82,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
       when(
         () => shorebirdProcess.run(
           'git',
-          ['status'],
+          ['status', '--untracked-files=no', '--porcelain'],
           workingDirectory: any(named: 'workingDirectory'),
         ),
       ).thenAnswer((_) async => gitStatusProcessResult);
@@ -114,7 +110,7 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
           .thenReturn(shorebirdFlutterVersionMessage);
       when(() => shorebirdFlutterVersionProcessResult.stderr).thenReturn('');
       when(() => shorebirdFlutterVersionProcessResult.exitCode).thenReturn(0);
-      when(() => gitStatusProcessResult.stdout).thenReturn(gitStatusMessage);
+      when(() => gitStatusProcessResult.stdout).thenReturn('');
     });
 
     test('has a non-empty description', () {


### PR DESCRIPTION
## Description

Uses `git status --untracked-files=no --porcelain` instead of `git status` to avoid reliance on a specific English-language string in console output.

Fixes https://github.com/shorebirdtech/shorebird/issues/925.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
