### PR TITLE
feat(shorebird_cli): add release ios-framework-alpha command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release.dart
@@ -2,3 +2,4 @@ export 'release_aar_command.dart';
 export 'release_android_command.dart';
 export 'release_command.dart';
 export 'release_ios_command.dart';
+export 'release_ios_framework_command.dart';

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -11,6 +11,7 @@ class ReleaseCommand extends ShorebirdCommand {
     addSubcommand(ReleaseAarCommand());
     addSubcommand(ReleaseAndroidCommand());
     addSubcommand(ReleaseIosCommand());
+    addSubcommand(ReleaseIosFrameworkCommand());
   }
 
   @override

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
+import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/config/config.dart';
+import 'package:shorebird_cli/src/doctor.dart';
+import 'package:shorebird_cli/src/ios.dart';
+import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/platform.dart';
+import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
+import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
+import 'package:shorebird_cli/src/shorebird_environment.dart';
+import 'package:shorebird_cli/src/shorebird_validation_mixin.dart';
+import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
+
+class ReleaseIosFrameworkCommand extends ShorebirdCommand
+    with ShorebirdConfigMixin, ShorebirdValidationMixin, ShorebirdBuildMixin {
+  ReleaseIosFrameworkCommand() {
+    argParser
+      ..addOption(
+        'release-version',
+        help: '''
+The version of the associated release (e.g. "1.0.0"). This should be the version
+of the iOS app that is using this module.''',
+        mandatory: true,
+      )
+      ..addFlag(
+        'force',
+        abbr: 'f',
+        help: 'Release without confirmation if there are no errors.',
+        negatable: false,
+      );
+  }
+
+  @override
+  String get description =>
+      'Builds and submits your iOS framework to Shorebird.';
+
+  @override
+  String get name => 'ios-framework-alpha';
+
+  @override
+  Future<int> run() async {
+    if (!platform.isMacOS) {
+      logger.err('This command is only supported on macOS.');
+      return ExitCode.unavailable.code;
+    }
+
+    try {
+      await validatePreconditions(
+        checkUserIsAuthenticated: true,
+        checkShorebirdInitialized: true,
+        validators: doctor.iosCommandValidators,
+      );
+    } on PreconditionFailedException catch (e) {
+      return e.exitCode.code;
+    }
+
+    showiOSStatusWarning();
+
+    const releasePlatform = ReleasePlatform.ios;
+    final releaseVersion = results['release-version'] as String;
+    final shorebirdYaml = ShorebirdEnvironment.getShorebirdYaml()!;
+    final appId = shorebirdYaml.getAppId();
+    final app = await codePushClientWrapper.getApp(appId: appId);
+
+    final existingRelease = await codePushClientWrapper.maybeGetRelease(
+      appId: appId,
+      releaseVersion: releaseVersion,
+    );
+    if (existingRelease != null) {
+      codePushClientWrapper.ensureReleaseIsNotActive(
+        release: existingRelease,
+        platform: releasePlatform,
+      );
+    }
+
+    final buildProgress = logger.progress('Building iOS framework');
+
+    try {
+      await buildIosFramework();
+    } catch (error) {
+      buildProgress.fail('Failed to build iOS framework: $error');
+      return ExitCode.software.code;
+    }
+
+    buildProgress.complete();
+
+    final summary = [
+      '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('($appId)')}''',
+      // TODO(felangel): uncomment once flavor support is added.
+      // if (flavor != null) '🍧 Flavor: ${lightCyan.wrap(flavor)}',
+      '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
+      '''🕹️  Platform: ${lightCyan.wrap(releasePlatform.name)}''',
+    ];
+
+    logger.info('''
+
+${styleBold.wrap(lightGreen.wrap('🚀 Ready to create a new release!'))}
+
+${summary.join('\n')}
+''');
+
+    final force = results['force'] == true;
+    final needConfirmation = !force;
+    if (needConfirmation) {
+      final confirm = logger.confirm('Would you like to continue?');
+
+      if (!confirm) {
+        logger.info('Aborting.');
+        return ExitCode.success.code;
+      }
+    }
+
+    final flutterRevisionProgress = logger.progress(
+      'Fetching Flutter revision',
+    );
+    final String shorebirdFlutterRevision;
+    try {
+      shorebirdFlutterRevision = await getShorebirdFlutterRevision();
+      flutterRevisionProgress.complete();
+    } catch (error) {
+      flutterRevisionProgress.fail('$error');
+      return ExitCode.software.code;
+    }
+
+    final Release release;
+    if (existingRelease != null) {
+      release = existingRelease;
+      await codePushClientWrapper.updateReleaseStatus(
+        appId: appId,
+        releaseId: release.id,
+        platform: releasePlatform,
+        status: ReleaseStatus.draft,
+      );
+    } else {
+      release = await codePushClientWrapper.createRelease(
+        appId: appId,
+        version: releaseVersion,
+        flutterRevision: shorebirdFlutterRevision,
+        platform: releasePlatform,
+      );
+    }
+
+    final iosBuildDir = p.join(Directory.current.path, 'build', 'ios');
+    final frameworkDirectory = Directory(
+      p.join(iosBuildDir, 'framework', 'Release'),
+    );
+    final xcframeworkPath = p.join(frameworkDirectory.path, 'App.xcframework');
+
+    await codePushClientWrapper.createIosFrameworkReleaseArtifacts(
+      appId: appId,
+      releaseId: release.id,
+      appFrameworkPath: xcframeworkPath,
+    );
+
+    await codePushClientWrapper.updateReleaseStatus(
+      appId: app.appId,
+      releaseId: release.id,
+      platform: releasePlatform,
+      status: ReleaseStatus.active,
+    );
+
+    final relativeFrameworkDirectoryPath = p.relative(frameworkDirectory.path);
+    logger
+      ..success('\n✅ Published Release!')
+      ..info('''
+
+Your next step is to include the framework in your iOS app.
+${lightCyan.wrap(relativeFrameworkDirectoryPath)}
+
+To do this:
+    1. Add the relative path to $relativeFrameworkDirectoryPath to your app's Framework Search Paths in your Xcode build settings.
+    2. Embed the App.xcframework and Flutter.framework in your Xcode project.
+
+Instructions for these steps can be found at https://docs.flutter.dev/add-to-app/ios/project-setup#option-b---embed-frameworks-in-xcode.
+''');
+
+    return ExitCode.success.code;
+  }
+}

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -162,8 +162,7 @@ ${summary.join('\n')}
       ..success('\n✅ Published Release!')
       ..info('''
 
-Your next step is to include the framework in your iOS app.
-${lightCyan.wrap(relativeFrameworkDirectoryPath)}
+Your next step is to include the .xcframework files in ${lightCyan.wrap(relativeFrameworkDirectoryPath)} in your iOS app.
 
 To do this:
     1. Add the relative path to $relativeFrameworkDirectoryPath to your app's Framework Search Paths in your Xcode build settings.

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -129,12 +129,6 @@ ${summary.join('\n')}
     final Release release;
     if (existingRelease != null) {
       release = existingRelease;
-      await codePushClientWrapper.updateReleaseStatus(
-        appId: appId,
-        releaseId: release.id,
-        platform: releasePlatform,
-        status: ReleaseStatus.draft,
-      );
     } else {
       release = await codePushClientWrapper.createRelease(
         appId: appId,

--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -208,6 +208,33 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
     }
   }
 
+  /// Builds a release iOS framework (.xcframework) for the current project.
+  Future<void> buildIosFramework() async {
+    const executable = 'flutter';
+    final arguments = [
+      'build',
+      'ios-framework',
+      '--no-debug',
+      '--no-profile',
+      ...results.rest,
+    ];
+
+    final result = await process.run(
+      executable,
+      arguments,
+      runInShell: true,
+    );
+
+    if (result.exitCode != ExitCode.success.code) {
+      throw ProcessException(
+        'flutter',
+        arguments,
+        result.stderr.toString(),
+        result.exitCode,
+      );
+    }
+  }
+
   /// Creates an ExportOptions.plist file, which is used to tell xcodebuild to
   /// not manage the app version and build number. If we don't do this, then
   /// xcodebuild will increment the build number if it detects an App Store

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -317,6 +317,28 @@ flutter:
       verify(() => logger.err('Aborting due to validation errors.')).called(1);
     });
 
+    test('checks that release is not active if release exists', () async {
+      when(
+        () => codePushClientWrapper.maybeGetRelease(
+          appId: any(named: 'appId'),
+          releaseVersion: any(named: 'releaseVersion'),
+        ),
+      ).thenAnswer((_) async => release);
+      final tempDir = setUpTempDir();
+
+      await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      verify(
+        () => codePushClientWrapper.ensureReleaseIsNotActive(
+          release: release,
+          platform: releasePlatform,
+        ),
+      ).called(1);
+    });
+
     test('aborts when user opts out', () async {
       when(() => logger.confirm(any())).thenReturn(false);
       final tempDir = setUpTempDir();

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -1,0 +1,428 @@
+import 'dart:io' hide Platform;
+
+import 'package:args/args.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
+import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/auth/auth.dart';
+import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
+import 'package:shorebird_cli/src/commands/release/release.dart';
+import 'package:shorebird_cli/src/doctor.dart';
+import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/platform.dart';
+import 'package:shorebird_cli/src/process.dart';
+import 'package:shorebird_cli/src/validators/validators.dart';
+import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
+import 'package:test/test.dart';
+
+class _MockArgResults extends Mock implements ArgResults {}
+
+class _MockAuth extends Mock implements Auth {}
+
+class _MockCodePushClientWrapper extends Mock
+    implements CodePushClientWrapper {}
+
+class _MockDoctor extends Mock implements Doctor {}
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockPlatform extends Mock implements Platform {}
+
+class _MockProgress extends Mock implements Progress {}
+
+class _MockProcessResult extends Mock implements ShorebirdProcessResult {}
+
+class _MockShorebirdFlutterValidator extends Mock
+    implements ShorebirdFlutterValidator {}
+
+class _MockShorebirdProcess extends Mock implements ShorebirdProcess {}
+
+void main() {
+  group(ReleaseIosFrameworkCommand, () {
+    const appId = 'test-app-id';
+    const flutterRevision = '83305b5088e6fe327fb3334a73ff190828d85713';
+    const versionName = '1.2.3';
+    const versionCode = '1';
+    const version = '$versionName+$versionCode';
+    const appDisplayName = 'Test App';
+    const releasePlatform = ReleasePlatform.ios;
+    const appMetadata = AppMetadata(appId: appId, displayName: appDisplayName);
+    const release = Release(
+      id: 0,
+      appId: appId,
+      version: version,
+      flutterRevision: flutterRevision,
+      displayName: '1.2.3+1',
+      platformStatuses: {},
+    );
+    const pubspecYamlContent = '''
+name: example
+version: $version
+environment:
+  sdk: ">=2.19.0 <3.0.0"
+  
+flutter:
+  assets:
+    - shorebird.yaml''';
+
+    late ArgResults argResults;
+    late CodePushClientWrapper codePushClientWrapper;
+    late Directory shorebirdRoot;
+    late Doctor doctor;
+    late Platform platform;
+    late Auth auth;
+    late Progress progress;
+    late Logger logger;
+    late ShorebirdProcessResult flutterBuildProcessResult;
+    late ShorebirdProcessResult flutterRevisionProcessResult;
+    late ReleaseIosFrameworkCommand command;
+    late ShorebirdFlutterValidator flutterValidator;
+    late ShorebirdProcess shorebirdProcess;
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        body,
+        values: {
+          authRef.overrideWith(() => auth),
+          codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
+          doctorRef.overrideWith(() => doctor),
+          loggerRef.overrideWith(() => logger),
+          platformRef.overrideWith(() => platform),
+          processRef.overrideWith(() => shorebirdProcess),
+        },
+      );
+    }
+
+    Directory setUpTempDir() {
+      final tempDir = Directory.systemTemp.createTempSync();
+      File(
+        p.join(tempDir.path, 'pubspec.yaml'),
+      ).writeAsStringSync(pubspecYamlContent);
+      File(
+        p.join(tempDir.path, 'shorebird.yaml'),
+      ).writeAsStringSync('app_id: $appId');
+      return tempDir;
+    }
+
+    setUpAll(() {
+      registerFallbackValue(ReleasePlatform.ios);
+      registerFallbackValue(ReleaseStatus.draft);
+    });
+
+    setUp(() {
+      argResults = _MockArgResults();
+      codePushClientWrapper = _MockCodePushClientWrapper();
+      doctor = _MockDoctor();
+      platform = _MockPlatform();
+      shorebirdRoot = Directory.systemTemp.createTempSync();
+      auth = _MockAuth();
+      progress = _MockProgress();
+      logger = _MockLogger();
+      flutterBuildProcessResult = _MockProcessResult();
+      flutterRevisionProcessResult = _MockProcessResult();
+      flutterValidator = _MockShorebirdFlutterValidator();
+      shorebirdProcess = _MockShorebirdProcess();
+
+      registerFallbackValue(release);
+      registerFallbackValue(shorebirdProcess);
+
+      when(() => platform.script).thenReturn(
+        Uri.file(
+          p.join(
+            shorebirdRoot.path,
+            'bin',
+            'cache',
+            'shorebird.snapshot',
+          ),
+        ),
+      );
+      when(
+        () => shorebirdProcess.run(
+          'flutter',
+          any(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).thenAnswer((_) async => flutterBuildProcessResult);
+      when(
+        () => shorebirdProcess.run(
+          'git',
+          any(),
+          runInShell: any(named: 'runInShell'),
+          workingDirectory: any(named: 'workingDirectory'),
+        ),
+      ).thenAnswer((_) async => flutterRevisionProcessResult);
+      when(() => argResults['release-version']).thenReturn(version);
+      when(() => argResults['force']).thenReturn(false);
+      when(() => argResults.rest).thenReturn([]);
+      when(() => auth.isAuthenticated).thenReturn(true);
+      when(() => doctor.iosCommandValidators).thenReturn([flutterValidator]);
+      when(
+        () => flutterBuildProcessResult.exitCode,
+      ).thenReturn(ExitCode.success.code);
+      when(
+        () => flutterRevisionProcessResult.exitCode,
+      ).thenReturn(ExitCode.success.code);
+      when(
+        () => flutterRevisionProcessResult.stdout,
+      ).thenReturn(flutterRevision);
+      when(flutterValidator.validate).thenAnswer((_) async => []);
+      when(() => logger.progress(any())).thenReturn(progress);
+      when(() => logger.confirm(any())).thenReturn(true);
+      when(() => platform.isMacOS).thenReturn(true);
+      when(
+        () => codePushClientWrapper.getApp(appId: any(named: 'appId')),
+      ).thenAnswer((_) async => appMetadata);
+      when(
+        () => codePushClientWrapper.createIosFrameworkReleaseArtifacts(
+          appId: any(named: 'appId'),
+          releaseId: any(named: 'releaseId'),
+          appFrameworkPath: any(named: 'appFrameworkPath'),
+        ),
+      ).thenAnswer((_) async => {});
+      when(
+        () => codePushClientWrapper.createRelease(
+          appId: any(named: 'appId'),
+          version: any(named: 'version'),
+          flutterRevision: any(named: 'flutterRevision'),
+          platform: any(named: 'platform'),
+        ),
+      ).thenAnswer((_) async => release);
+      when(
+        () => codePushClientWrapper.maybeGetRelease(
+          appId: any(named: 'appId'),
+          releaseVersion: any(named: 'releaseVersion'),
+        ),
+      ).thenAnswer((_) async => null);
+      when(
+        () => codePushClientWrapper.ensureReleaseIsNotActive(
+          release: any(named: 'release'),
+          platform: any(named: 'platform'),
+        ),
+      ).thenAnswer((_) async => {});
+      when(
+        () => codePushClientWrapper.updateReleaseStatus(
+          appId: any(named: 'appId'),
+          releaseId: any(named: 'releaseId'),
+          platform: any(named: 'platform'),
+          status: any(named: 'status'),
+        ),
+      ).thenAnswer((_) async => {});
+
+      command = runWithOverrides(ReleaseIosFrameworkCommand.new)
+        ..testArgResults = argResults;
+    });
+
+    test('has a description', () {
+      expect(command.description, isNotEmpty);
+    });
+
+    test('exits with unavailable code if run on non-macOS platform', () async {
+      when(() => platform.isMacOS).thenReturn(false);
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.unavailable.code));
+      verify(() => logger.err('This command is only supported on macOS.'))
+          .called(1);
+    });
+
+    test('throws config error when shorebird is not initialized', () async {
+      final tempDir = Directory.systemTemp.createTempSync();
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+      verify(
+        () => logger.err(
+          'Shorebird is not initialized. Did you run "shorebird init"?',
+        ),
+      ).called(1);
+      expect(exitCode, ExitCode.config.code);
+    });
+
+    test('throws no user error when user is not logged in', () async {
+      when(() => auth.isAuthenticated).thenReturn(false);
+      final tempDir = setUpTempDir();
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+      expect(exitCode, equals(ExitCode.noUser.code));
+    });
+
+    test('exits with code 70 when build fails with non-zero exit code',
+        () async {
+      when(() => flutterBuildProcessResult.exitCode).thenReturn(1);
+      when(() => flutterBuildProcessResult.stderr).thenReturn('oops');
+
+      final tempDir = setUpTempDir();
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(exitCode, equals(ExitCode.software.code));
+      verify(
+        () => progress.fail(any(that: contains('Failed to build'))),
+      ).called(1);
+    });
+
+    test('prints flutter validation warnings', () async {
+      when(flutterValidator.validate).thenAnswer(
+        (_) async => [
+          const ValidationIssue(
+            severity: ValidationIssueSeverity.warning,
+            message: 'Flutter issue 1',
+          ),
+          const ValidationIssue(
+            severity: ValidationIssueSeverity.warning,
+            message: 'Flutter issue 2',
+          ),
+        ],
+      );
+      final tempDir = setUpTempDir();
+
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(exitCode, ExitCode.success.code);
+      verify(
+        () => logger.info(any(that: contains('Flutter issue 1'))),
+      ).called(1);
+      verify(
+        () => logger.info(any(that: contains('Flutter issue 2'))),
+      ).called(1);
+    });
+
+    test('aborts if validation errors are present', () async {
+      when(flutterValidator.validate).thenAnswer(
+        (_) async => [
+          const ValidationIssue(
+            severity: ValidationIssueSeverity.error,
+            message: 'There was an issue',
+          ),
+        ],
+      );
+
+      final tempDir = setUpTempDir();
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+      expect(exitCode, equals(ExitCode.config.code));
+      verify(() => logger.err('Aborting due to validation errors.')).called(1);
+    });
+
+    test('aborts when user opts out', () async {
+      when(() => logger.confirm(any())).thenReturn(false);
+      final tempDir = setUpTempDir();
+
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(exitCode, ExitCode.success.code);
+      verify(() => logger.info('Aborting.')).called(1);
+      verifyNever(
+        () => codePushClientWrapper.createIosReleaseArtifacts(
+          appId: appId,
+          releaseId: release.id,
+          ipaPath: any(named: 'ipaPath', that: endsWith('.ipa')),
+          runnerPath: any(named: 'runnerPath', that: endsWith('Runner.app')),
+        ),
+      );
+    });
+
+    test('throws error when unable to detect flutter revision', () async {
+      const error = 'oops';
+      when(() => flutterRevisionProcessResult.exitCode).thenReturn(1);
+      when(() => flutterRevisionProcessResult.stderr).thenReturn(error);
+      final tempDir = setUpTempDir();
+
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+      expect(exitCode, ExitCode.software.code);
+      verify(
+        () => progress.fail(
+          'Exception: Unable to determine flutter revision: $error',
+        ),
+      ).called(1);
+    });
+
+    test(
+        'does not prompt for confirmation '
+        'when --release-version and --force are used', () async {
+      when(() => argResults['force']).thenReturn(true);
+      when(() => argResults['release-version']).thenReturn(version);
+      final tempDir = setUpTempDir();
+
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      verify(() => logger.success('\n✅ Published Release!')).called(1);
+      expect(exitCode, ExitCode.success.code);
+      verifyNever(
+        () => logger.prompt(any(), defaultValue: any(named: 'defaultValue')),
+      );
+      verify(
+        () => codePushClientWrapper.updateReleaseStatus(
+          appId: appId,
+          releaseId: release.id,
+          platform: releasePlatform,
+          status: ReleaseStatus.active,
+        ),
+      ).called(1);
+    });
+
+    test('succeeds when release is successful', () async {
+      final tempDir = setUpTempDir();
+
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      verify(() => logger.success('\n✅ Published Release!')).called(1);
+      verify(
+        () => logger.info(
+          any(
+            that: stringContainsInOrder(
+              [
+                'Your next step is to include the framework in your iOS app.',
+                '${lightCyan.wrap('build/ios/framework/Release')}'
+              ],
+            ),
+          ),
+        ),
+      ).called(1);
+      verify(
+        () => codePushClientWrapper.createIosFrameworkReleaseArtifacts(
+          appId: appId,
+          releaseId: release.id,
+          appFrameworkPath: any(
+            named: 'appFrameworkPath',
+            that: endsWith('build/ios/framework/Release/App.xcframework'),
+          ),
+        ),
+      ).called(1);
+      verify(
+        () => codePushClientWrapper.updateReleaseStatus(
+          appId: appId,
+          releaseId: release.id,
+          platform: releasePlatform,
+          status: ReleaseStatus.active,
+        ),
+      ).called(1);
+      expect(exitCode, ExitCode.success.code);
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -419,8 +419,9 @@ flutter:
           any(
             that: stringContainsInOrder(
               [
-                'Your next step is to include the framework in your iOS app.',
-                '${lightCyan.wrap('build/ios/framework/Release')}'
+                'Your next step is to include the .xcframework files in',
+                '/build/ios/framework/Release',
+                'in your iOS app.'
               ],
             ),
           ),


### PR DESCRIPTION
## Description

Adds the `release ios-framework-alpha` command, used to create a framework release for add-to-app scenarios.

Part of https://github.com/shorebirdtech/shorebird/issues/896

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
