### PR TITLE
fix(shorebird_cli): remove android internet permission validation for aar builds

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/build/build_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_aar_command.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/command.dart';
-import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_config_mixin.dart';
@@ -47,7 +46,6 @@ class BuildAarCommand extends ShorebirdCommand
       await validatePreconditions(
         checkUserIsAuthenticated: true,
         checkShorebirdInitialized: true,
-        validators: doctor.androidCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -11,7 +11,6 @@ import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
-import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/formatters/file_size_formatter.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
@@ -99,7 +98,6 @@ of the Android app that is using this module.''',
       await validatePreconditions(
         checkUserIsAuthenticated: true,
         checkShorebirdInitialized: true,
-        validators: doctor.androidCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -6,7 +6,6 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
-import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -76,7 +75,6 @@ make smaller updates to your app.
       await validatePreconditions(
         checkUserIsAuthenticated: true,
         checkShorebirdInitialized: true,
-        validators: doctor.androidCommandValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:xml/xml.dart';

--- a/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
@@ -28,22 +28,16 @@ class AndroidInternetPermissionValidator extends Validator {
   @override
   Future<List<ValidationIssue>> validate() async {
     const manifestFileName = 'AndroidManifest.xml';
-    final androidSrcDir = [
+    final androidSrcDir = Directory(
       p.join(
         Directory.current.path,
         'android',
         'app',
         'src',
       ),
-      p.join(
-        Directory.current.path,
-        '.android',
-        'Flutter',
-        'src',
-      ),
-    ].map(Directory.new).firstWhereOrNull((dir) => dir.existsSync());
+    );
 
-    if (androidSrcDir == null) {
+    if (!androidSrcDir.existsSync()) {
       return [
         const ValidationIssue(
           severity: ValidationIssueSeverity.error,

--- a/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
@@ -8,7 +8,6 @@ import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/commands/build/build.dart';
-import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:test/test.dart';
@@ -16,8 +15,6 @@ import 'package:test/test.dart';
 class _MockArgResults extends Mock implements ArgResults {}
 
 class _MockAuth extends Mock implements Auth {}
-
-class _MockDoctor extends Mock implements Doctor {}
 
 class _MockHttpClient extends Mock implements http.Client {}
 
@@ -59,7 +56,6 @@ flutter:
 
     late ArgResults argResults;
     late Auth auth;
-    late Doctor doctor;
     late http.Client httpClient;
     late Logger logger;
     late Progress progress;
@@ -72,7 +68,6 @@ flutter:
         body,
         values: {
           authRef.overrideWith(() => auth),
-          doctorRef.overrideWith(() => doctor),
           loggerRef.overrideWith(() => logger),
           processRef.overrideWith(() => shorebirdProcess),
         },
@@ -95,7 +90,6 @@ flutter:
     setUp(() {
       argResults = _MockArgResults();
       auth = _MockAuth();
-      doctor = _MockDoctor();
       httpClient = _MockHttpClient();
       logger = _MockLogger();
       processResult = _MockProcessResult();
@@ -106,7 +100,6 @@ flutter:
       when(() => argResults.rest).thenReturn([]);
       when(() => auth.client).thenReturn(httpClient);
       when(() => auth.isAuthenticated).thenReturn(true);
-      when(() => doctor.androidCommandValidators).thenReturn([]);
       when(() => logger.progress(any())).thenReturn(progress);
 
       when(


### PR DESCRIPTION
## Description

Because the .android project included in flutter module project isn't used, we don't need to validate that it contains the internet permission.

Fixes https://github.com/shorebirdtech/shorebird/issues/972

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
