### PR TITLE
fix(shorebird_cli): don't check for flavors in flutter module

### DIFF
--- a/packages/shorebird_cli/lib/src/gradlew.dart
+++ b/packages/shorebird_cli/lib/src/gradlew.dart
@@ -58,8 +58,6 @@ class Gradlew {
   /// Returns an empty set for apps that do not use product flavors.
   Future<Set<String>> productFlavors(String projectPath) async {
     final javaHome = java.home;
-    // Flutter apps have android files in root/android
-    // Flutter modules have android files in root/.android
     final androidRoot = Directory(p.join(projectPath, 'android'));
 
     if (!androidRoot.existsSync()) {

--- a/packages/shorebird_cli/lib/src/gradlew.dart
+++ b/packages/shorebird_cli/lib/src/gradlew.dart
@@ -60,12 +60,11 @@ class Gradlew {
     final javaHome = java.home;
     // Flutter apps have android files in root/android
     // Flutter modules have android files in root/.android
-    final androidRoot = [
-      Directory(p.join(projectPath, 'android')),
-      Directory(p.join(projectPath, '.android')),
-    ].firstWhereOrNull((dir) => dir.existsSync());
+    final androidRoot = Directory(p.join(projectPath, 'android'));
 
-    if (androidRoot == null) throw MissingAndroidProjectException(projectPath);
+    if (!androidRoot.existsSync()) {
+      throw MissingAndroidProjectException(projectPath);
+    }
 
     final executableFile = File(p.join(androidRoot.path, executable));
 

--- a/packages/shorebird_cli/test/src/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/gradlew_test.dart
@@ -189,6 +189,45 @@ Make sure you have run "flutter build apk" at least once.''',
           ),
         ).called(1);
       });
+
+      test('extracts flavors', () async {
+        when(() => platform.isLinux).thenReturn(true);
+        when(() => platform.isMacOS).thenReturn(false);
+        when(() => platform.isWindows).thenReturn(false);
+        final tempDir = setUpAppTempDir();
+        File(
+          p.join(tempDir.path, 'android', 'gradlew'),
+        ).createSync(recursive: true);
+        const javaHome = 'test_java_home';
+        when(() => platform.environment).thenReturn({'JAVA_HOME': javaHome});
+        when(() => result.stdout).thenReturn(
+          File(
+            p.join('test', 'fixtures', 'gradle_app_tasks.txt'),
+          ).readAsStringSync(),
+        );
+        await expectLater(
+          runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
+          completion(
+            equals({
+              'development',
+              'developmentInternal',
+              'staging',
+              'stagingInternal',
+              'production',
+              'productionInternal',
+            }),
+          ),
+        );
+        verify(
+          () => process.run(
+            p.join(tempDir.path, 'android', 'gradlew'),
+            ['app:tasks', '--all', '--console=auto'],
+            runInShell: true,
+            workingDirectory: p.join(tempDir.path, 'android'),
+            environment: {'JAVA_HOME': javaHome},
+          ),
+        ).called(1);
+      });
     });
   });
 }

--- a/packages/shorebird_cli/test/src/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/gradlew_test.dart
@@ -90,12 +90,6 @@ Make sure you have run "flutter build apk" at least once.''',
         return tempDir;
       }
 
-      Directory setUpModuleTempDir() {
-        final tempDir = Directory.systemTemp.createTempSync();
-        Directory(p.join(tempDir.path, '.android')).createSync(recursive: true);
-        return tempDir;
-      }
-
       test(
           'throws MissingAndroidProjectException '
           'when android root does not exist', () async {
@@ -191,70 +185,6 @@ Make sure you have run "flutter build apk" at least once.''',
             ['app:tasks', '--all', '--console=auto'],
             runInShell: true,
             workingDirectory: p.join(tempDir.path, 'android'),
-            environment: {'JAVA_HOME': javaHome},
-          ),
-        ).called(1);
-      });
-
-      test('extracts flavors', () async {
-        when(() => platform.isLinux).thenReturn(true);
-        when(() => platform.isMacOS).thenReturn(false);
-        when(() => platform.isWindows).thenReturn(false);
-        final tempDir = setUpModuleTempDir();
-        File(
-          p.join(tempDir.path, '.android', 'gradlew'),
-        ).createSync(recursive: true);
-        const javaHome = 'test_java_home';
-        when(() => platform.environment).thenReturn({'JAVA_HOME': javaHome});
-        when(() => result.stdout).thenReturn(
-          File(
-            p.join('test', 'fixtures', 'gradle_app_tasks.txt'),
-          ).readAsStringSync(),
-        );
-        await expectLater(
-          runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
-          completion(
-            equals({
-              'development',
-              'developmentInternal',
-              'staging',
-              'stagingInternal',
-              'production',
-              'productionInternal',
-            }),
-          ),
-        );
-        verify(
-          () => process.run(
-            p.join(tempDir.path, '.android', 'gradlew'),
-            ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
-            workingDirectory: p.join(tempDir.path, '.android'),
-            environment: {'JAVA_HOME': javaHome},
-          ),
-        ).called(1);
-      });
-
-      test('extracts flavors from module directory structure', () async {
-        when(() => platform.isLinux).thenReturn(true);
-        when(() => platform.isMacOS).thenReturn(false);
-        when(() => platform.isWindows).thenReturn(false);
-        final tempDir = setUpModuleTempDir();
-        File(
-          p.join(tempDir.path, '.android', 'gradlew'),
-        ).createSync(recursive: true);
-        const javaHome = 'test_java_home';
-        when(() => platform.environment).thenReturn({'JAVA_HOME': javaHome});
-        await expectLater(
-          runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
-          completes,
-        );
-        verify(
-          () => process.run(
-            p.join(tempDir.path, '.android', 'gradlew'),
-            ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
-            workingDirectory: p.join(tempDir.path, '.android'),
             environment: {'JAVA_HOME': javaHome},
           ),
         ).called(1);


### PR DESCRIPTION
## Description

Because flavors aren't supported in flutter modules, don't try to read them from the bundled (potentially missing) android project.

Fixes https://github.com/shorebirdtech/shorebird/issues/985

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
