### PR TITLE
fix(shorebird_cli): don't run AndroidInternetPermissionValidator if no android project exists

### DIFF
--- a/packages/shorebird_cli/lib/src/doctor.dart
+++ b/packages/shorebird_cli/lib/src/doctor.dart
@@ -1,7 +1,6 @@
 import 'package:mason_logger/mason_logger.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/logger.dart';
-import 'package:shorebird_cli/src/shorebird_environment.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 
 /// A reference to a [Doctor] instance.
@@ -36,15 +35,12 @@ class Doctor {
     List<Validator> validators, {
     bool applyFixes = false,
   }) async {
-    final isInProject =
-        ShorebirdEnvironment.getShorebirdYamlFile().existsSync();
-
     final allIssues = <ValidationIssue>[];
     final allFixableIssues = <ValidationIssue>[];
 
     var numIssuesFixed = 0;
     for (final validator in validators) {
-      if (validator.scope == ValidatorScope.project && !isInProject) {
+      if (!validator.canRunInCurrentContext()) {
         continue;
       }
 

--- a/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
@@ -22,30 +22,13 @@ class AndroidInternetPermissionValidator extends Validator {
       'AndroidManifest.xml files contain INTERNET permission';
 
   @override
-  ValidatorScope get scope => ValidatorScope.project;
+  bool canRunInCurrentContext() => _androidSrcDirectory.existsSync();
 
   @override
   Future<List<ValidationIssue>> validate() async {
     const manifestFileName = 'AndroidManifest.xml';
-    final androidSrcDir = Directory(
-      p.join(
-        Directory.current.path,
-        'android',
-        'app',
-        'src',
-      ),
-    );
 
-    if (!androidSrcDir.existsSync()) {
-      return [
-        const ValidationIssue(
-          severity: ValidationIssueSeverity.error,
-          message: 'No Android project found',
-        ),
-      ];
-    }
-
-    final manifestFiles = androidSrcDir
+    final manifestFiles = _androidSrcDirectory
         .listSync()
         .whereType<Directory>()
         .where(
@@ -61,7 +44,7 @@ class AndroidInternetPermissionValidator extends Validator {
         ValidationIssue(
           severity: ValidationIssueSeverity.error,
           message:
-              'No AndroidManifest.xml files found in ${androidSrcDir.path}',
+              '''No AndroidManifest.xml files found in ${_androidSrcDirectory.path}''',
         ),
       ];
     }
@@ -87,6 +70,15 @@ class AndroidInternetPermissionValidator extends Validator {
 
     return [];
   }
+
+  Directory get _androidSrcDirectory => Directory(
+        p.join(
+          Directory.current.path,
+          'android',
+          'app',
+          'src',
+        ),
+      );
 
   bool _androidManifestHasInternetPermission(String path) {
     final xmlDocument = XmlDocument.parse(File(path).readAsStringSync());

--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -22,7 +22,7 @@ class ShorebirdFlutterValidator extends Validator {
   String get description => 'Flutter install is correct';
 
   @override
-  ValidatorScope get scope => ValidatorScope.installation;
+  bool canRunInCurrentContext() => true;
 
   @override
   Future<List<ValidationIssue>> validate() async {

--- a/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
@@ -11,7 +11,7 @@ class ShorebirdVersionValidator extends Validator {
   String get description => 'Shorebird is up-to-date';
 
   @override
-  ValidatorScope get scope => ValidatorScope.installation;
+  bool canRunInCurrentContext() => true;
 
   @override
   Future<List<ValidationIssue>> validate() async {

--- a/packages/shorebird_cli/lib/src/validators/validators.dart
+++ b/packages/shorebird_cli/lib/src/validators/validators.dart
@@ -18,12 +18,6 @@ enum ValidationIssueSeverity {
   warning,
 }
 
-/// The level at which validation is being performed.
-enum ValidatorScope {
-  project,
-  installation,
-}
-
 /// Display helpers for printing [ValidationIssue]s.
 extension Display on ValidationIssueSeverity {
   String get leading {
@@ -91,6 +85,5 @@ abstract class Validator {
   /// Not all validators use [process].
   Future<List<ValidationIssue>> validate();
 
-  /// Whether this validator is project-specific or system-wide.
-  ValidatorScope get scope;
+  bool canRunInCurrentContext();
 }

--- a/packages/shorebird_cli/test/src/doctor_test.dart
+++ b/packages/shorebird_cli/test/src/doctor_test.dart
@@ -67,7 +67,7 @@ void main() {
       when(() => errorValidator.description).thenReturn('error validator');
     });
 
-    group('validate', () {
+    group('runValidators', () {
       test('prints messages when warnings and errors found', () async {
         final validators = [
           warningValidator,
@@ -102,11 +102,23 @@ void main() {
         ];
         when(() => warningValidator.canRunInCurrentContext()).thenReturn(false);
 
-        await runWithOverrides(() => doctor.runValidators(validators));
+        await runWithOverrides(() async => doctor.runValidators(validators));
 
         verify(noIssuesValidator.validate).called(1);
         verifyNever(warningValidator.validate);
         verify(errorValidator.validate).called(1);
+      });
+
+      test('tells the user when no issues are found', () async {
+        final validators = [
+          noIssuesValidator,
+        ];
+
+        await runWithOverrides(() async => doctor.runValidators(validators));
+
+        verify(
+          () => logger.info(any(that: contains('No issues detected!'))),
+        ).called(1);
       });
 
       group('fix', () {

--- a/packages/shorebird_cli/test/src/doctor_test.dart
+++ b/packages/shorebird_cli/test/src/doctor_test.dart
@@ -1,8 +1,5 @@
-import 'dart:io';
-
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
@@ -55,20 +52,18 @@ void main() {
       when(() => logger.info(any())).thenReturn(null);
 
       when(noIssuesValidator.validate).thenAnswer((_) async => []);
-      when(() => noIssuesValidator.scope)
-          .thenReturn(ValidatorScope.installation);
+      when(noIssuesValidator.canRunInCurrentContext).thenReturn(true);
       when(() => noIssuesValidator.description)
           .thenReturn('no issues validator');
 
       when(warningValidator.validate).thenAnswer(
         (_) async => [validationWarning],
       );
-      when(() => warningValidator.scope)
-          .thenReturn(ValidatorScope.installation);
+      when(warningValidator.canRunInCurrentContext).thenReturn(true);
       when(() => warningValidator.description).thenReturn('warning validator');
 
       when(errorValidator.validate).thenAnswer((_) async => [validationError]);
-      when(() => errorValidator.scope).thenReturn(ValidatorScope.installation);
+      when(errorValidator.canRunInCurrentContext).thenReturn(true);
       when(() => errorValidator.description).thenReturn('error validator');
     });
 
@@ -98,64 +93,20 @@ void main() {
         ).called(1);
       });
 
-      group('validator scope', () {
-        const appId = 'test-app-id';
-        late Validator projectScopeValidator;
-        late Validator installationScopeValidator;
+      test('only runs validators that can run in the current context',
+          () async {
+        final validators = [
+          noIssuesValidator,
+          warningValidator,
+          errorValidator,
+        ];
+        when(() => warningValidator.canRunInCurrentContext()).thenReturn(false);
 
-        Directory setUpTempDir() {
-          final tempDir = Directory.systemTemp.createTempSync();
-          File(
-            p.join(tempDir.path, 'shorebird.yaml'),
-          ).writeAsStringSync('app_id: $appId');
-          return tempDir;
-        }
+        await runWithOverrides(() => doctor.runValidators(validators));
 
-        setUp(() {
-          projectScopeValidator = _MockValidator();
-          installationScopeValidator = _MockValidator();
-
-          when(projectScopeValidator.validate).thenAnswer((_) async => []);
-          when(() => projectScopeValidator.scope)
-              .thenReturn(ValidatorScope.project);
-          when(() => projectScopeValidator.description)
-              .thenReturn('project-scoped validator');
-
-          when(installationScopeValidator.validate).thenAnswer((_) async => []);
-          when(() => installationScopeValidator.scope)
-              .thenReturn(ValidatorScope.installation);
-          when(() => installationScopeValidator.description)
-              .thenReturn('installation-scoped validator');
-        });
-
-        test('does not run project-scoped validators in project directory',
-            () async {
-          final validators = [
-            projectScopeValidator,
-            installationScopeValidator
-          ];
-          await runWithOverrides(
-            () => doctor.runValidators(validators),
-          );
-          verify(installationScopeValidator.validate).called(1);
-          verifyNever(projectScopeValidator.validate);
-        });
-
-        test('runs project-scoped validators in project directory', () async {
-          final tempDir = setUpTempDir();
-          final validators = [
-            projectScopeValidator,
-            installationScopeValidator
-          ];
-          await runWithOverrides(
-            () async => IOOverrides.runZoned(
-              () => doctor.runValidators(validators),
-              getCurrentDirectory: () => tempDir,
-            ),
-          );
-          verify(installationScopeValidator.validate).called(1);
-          verify(projectScopeValidator.validate).called(1);
-        });
+        verify(noIssuesValidator.validate).called(1);
+        verifyNever(warningValidator.validate);
+        verify(errorValidator.validate).called(1);
       });
 
       group('fix', () {
@@ -180,10 +131,9 @@ void main() {
           when(fixableWarningValidator.validate).thenAnswer(
             (_) async => [fixableValidationWarning],
           );
-          when(() => fixableWarningValidator.scope)
-              .thenReturn(ValidatorScope.installation);
           when(() => fixableWarningValidator.description)
               .thenReturn('fixable warning validator');
+          when(fixableWarningValidator.canRunInCurrentContext).thenReturn(true);
         });
 
         test(

--- a/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
@@ -117,8 +117,8 @@ Tools • Dart 2.19.6 • DevTools 2.20.1
       expect(validator.description, isNotEmpty);
     });
 
-    test('is not project-specific', () {
-      expect(validator.scope, ValidatorScope.installation);
+    test('canRunInContext always returns true', () {
+      expect(validator.canRunInCurrentContext(), isTrue);
     });
 
     test('returns no issues when the Flutter install is good', () async {

--- a/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_version_validator_test.dart
@@ -38,8 +38,8 @@ void main() {
       expect(validator.description, isNotEmpty);
     });
 
-    test('is not project-specific', () {
-      expect(validator.scope, ValidatorScope.installation);
+    test('canRunInContext always returns true', () {
+      expect(validator.canRunInCurrentContext(), isTrue);
     });
 
     test('returns no issues when shorebird is up-to-date', () async {


### PR DESCRIPTION
## Description

Refactors validators to replace `scope` with `canRunInCurrentContext` to allow for cases where `shorebird doctor` is being run within a project but no Android project exists.

Fixes https://github.com/shorebirdtech/shorebird/issues/988

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
