### PR TITLE
chore(shorebird_cli): fix shorebird validator test

### DIFF
--- a/packages/shorebird_cli/test/src/shorebird_validator_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_validator_test.dart
@@ -138,7 +138,8 @@ void main() {
         verify(
           () => logger.err('Aborting due to validation errors.'),
         ).called(1);
-        verify(() => logger.info('[✗] ${issue.message}')).called(1);
+        verify(() => logger.info('${red.wrap('[✗]')} ${issue.message}'))
+            .called(1);
         verify(
           () => logger.info(
             '''1 issue can be fixed automatically with ${lightCyan.wrap('shorebird doctor --fix')}.''',


### PR DESCRIPTION
## Description

This test was failing when run with `dart test` due to the `[x]` not being wrapped in `red`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
