### PR TITLE
feat(shorebird_cli): warn users of asset changes when patching ios releases

### DIFF
--- a/packages/shorebird_cli/bin/shorebird.dart
+++ b/packages/shorebird_cli/bin/shorebird.dart
@@ -14,6 +14,7 @@ import 'package:shorebird_cli/src/gradlew.dart';
 import 'package:shorebird_cli/src/ios_deploy.dart';
 import 'package:shorebird_cli/src/java.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -40,6 +41,7 @@ Future<void> main(List<String> args) async {
         iosDeployRef,
         javaRef,
         loggerRef,
+        patchDiffCheckerRef,
         platformRef,
         processRef,
         shorebirdEnvRef,

--- a/packages/shorebird_cli/lib/src/patch_diff_checker.dart
+++ b/packages/shorebird_cli/lib/src/patch_diff_checker.dart
@@ -19,7 +19,9 @@ PatchDiffChecker get patchDiffChecker => read(patchDiffCheckerRef);
 class PatchDiffChecker {
   /// {@macro patch_verifier}
   PatchDiffChecker({http.Client? httpClient})
+      // coverage:ignore-start
       : _httpClient = httpClient ?? http.Client();
+  // coverage:ignore-end
 
   final http.Client _httpClient;
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -616,6 +616,22 @@ Please re-run the release command for this version or create a new release.'''),
       );
     });
 
+    test('throws error when creating diff fails', () async {
+      const error = 'oops something went wrong';
+      when(() => patchProcessResult.exitCode).thenReturn(1);
+      when(() => patchProcessResult.stderr).thenReturn(error);
+      final tempDir = setUpTempDir();
+      setUpTempArtifacts(tempDir);
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+      verify(
+        () => progress.fail('Exception: Failed to create diff: $error'),
+      ).called(1);
+      expect(exitCode, ExitCode.software.code);
+    });
+
     test('does not create patch on --dry-run', () async {
       when(() => argResults['dry-run']).thenReturn(true);
       final tempDir = setUpTempDir();

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -14,6 +14,7 @@ import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -37,6 +38,8 @@ class _MockCodePushClientWrapper extends Mock
     implements CodePushClientWrapper {}
 
 class _MockLogger extends Mock implements Logger {}
+
+class _MockPatchDiffChecker extends Mock implements PatchDiffChecker {}
 
 class _MockPlatform extends Mock implements Platform {}
 
@@ -107,6 +110,7 @@ void main() {
     late CodePushClientWrapper codePushClientWrapper;
     late Directory shorebirdRoot;
     late Directory flutterDirectory;
+    late PatchDiffChecker patchDiffChecker;
     late Platform platform;
     late Progress progress;
     late Logger logger;
@@ -129,6 +133,7 @@ void main() {
           codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           engineConfigRef.overrideWith(() => const EngineConfig.empty()),
           loggerRef.overrideWith(() => logger),
+          patchDiffCheckerRef.overrideWith(() => patchDiffChecker),
           platformRef.overrideWith(() => platform),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
@@ -171,7 +176,9 @@ void main() {
     }
 
     setUpAll(() {
+      registerFallbackValue(File(''));
       registerFallbackValue(FileSetDiff.empty());
+      registerFallbackValue(Uri.parse('https://example.com'));
       registerFallbackValue(_FakeBaseRequest());
       registerFallbackValue(_FakeShorebirdProcess());
     });
@@ -185,6 +192,7 @@ void main() {
       flutterDirectory = Directory(
         p.join(shorebirdRoot.path, 'bin', 'cache', 'flutter'),
       );
+      patchDiffChecker = _MockPatchDiffChecker();
       platform = _MockPlatform();
       progress = _MockProgress();
       logger = _MockLogger();
@@ -310,6 +318,14 @@ void main() {
           checkShorebirdInitialized: any(named: 'checkShorebirdInitialized'),
         ),
       ).thenAnswer((_) async {});
+      when(
+        () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+          localArtifact: any(named: 'localArtifact'),
+          releaseArtifactUrl: any(named: 'releaseArtifactUrl'),
+          archiveDiffer: archiveDiffer,
+          force: any(named: 'force'),
+        ),
+      ).thenAnswer((_) async => true);
 
       command = runWithOverrides(
         () => PatchAarCommand(
@@ -562,125 +578,42 @@ Please re-run the release command for this version or create a new release.'''),
       expect(exitCode, ExitCode.software.code);
     });
 
-    test('throws error when aar fails to download', () async {
+    test('exits if confirmUnpatchableDiffsIfNecessary returns false', () async {
+      when(() => argResults['force']).thenReturn(false);
       when(
-        () => httpClient.send(
-          any(
-            that: isA<http.Request>().having(
-              (req) => req.url.toString(),
-              'url',
-              endsWith('aar'),
-            ),
-          ),
+        () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+          localArtifact: any(named: 'localArtifact'),
+          releaseArtifactUrl: any(named: 'releaseArtifactUrl'),
+          archiveDiffer: archiveDiffer,
+          force: any(named: 'force'),
         ),
-      ).thenAnswer(
-        (_) async => http.StreamedResponse(
-          const Stream.empty(),
-          HttpStatus.internalServerError,
-          reasonPhrase: 'Internal Server Error',
-        ),
-      );
-
+      ).thenAnswer((_) async => false);
       final tempDir = setUpTempDir();
       setUpTempArtifacts(tempDir);
+
       final exitCode = await IOOverrides.runZoned(
         () => runWithOverrides(command.run),
         getCurrentDirectory: () => tempDir,
       );
 
-      expect(exitCode, ExitCode.software.code);
-    });
-
-    test('prompts user to continue when asset changes are detected', () async {
-      when(() => archiveDiffer.containsPotentiallyBreakingAssetDiffs(any()))
-          .thenReturn(true);
-
-      final tempDir = setUpTempDir();
-      setUpTempArtifacts(tempDir);
-      final exitCode = await IOOverrides.runZoned(
-        () => runWithOverrides(command.run),
-        getCurrentDirectory: () => tempDir,
-      );
-
-      expect(exitCode, ExitCode.success.code);
+      expect(exitCode, equals(ExitCode.success.code));
       verify(
-        () => logger.info(
-          any(
-            that: contains(
-              '''The Android Archive contains asset changes, which will not be included in the patch.''',
-            ),
-          ),
+        () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+          localArtifact: any(named: 'localArtifact'),
+          releaseArtifactUrl: Uri.parse(aarArtifact.url),
+          archiveDiffer: archiveDiffer,
+          force: false,
         ),
       ).called(1);
-      verify(() => logger.confirm('Continue anyways?')).called(1);
-    });
-
-    test(
-      '''does not warn user of asset or code changes if only dart changes are detected''',
-      () async {
-        final tempDir = setUpTempDir();
-        setUpTempArtifacts(tempDir);
-        final exitCode = await IOOverrides.runZoned(
-          () => runWithOverrides(command.run),
-          getCurrentDirectory: () => tempDir,
-        );
-
-        expect(exitCode, ExitCode.success.code);
-        verifyNever(
-          () => logger.confirm(
-            any(
-              that: contains(
-                '''The Android Archive contains asset changes, which will not be included in the patch.''',
-              ),
-            ),
-          ),
-        );
-      },
-    );
-
-    test(
-      '''exits if user decides to not proceed after being warned of non-dart changes''',
-      () async {
-        when(() => archiveDiffer.containsPotentiallyBreakingAssetDiffs(any()))
-            .thenReturn(true);
-        when(
-          () => logger.confirm(any(that: contains('Continue anyways?'))),
-        ).thenReturn(false);
-
-        final tempDir = setUpTempDir();
-        setUpTempArtifacts(tempDir);
-        final exitCode = await IOOverrides.runZoned(
-          () => runWithOverrides(command.run),
-          getCurrentDirectory: () => tempDir,
-        );
-
-        expect(exitCode, ExitCode.success.code);
-        verifyNever(
-          () => codePushClientWrapper.publishPatch(
-            appId: any(named: 'appId'),
-            releaseId: any(named: 'releaseId'),
-            platform: any(named: 'platform'),
-            channelName: any(named: 'channelName'),
-            patchArtifactBundles: any(named: 'patchArtifactBundles'),
-          ),
-        );
-      },
-    );
-
-    test('throws error when creating diff fails', () async {
-      const error = 'oops something went wrong';
-      when(() => patchProcessResult.exitCode).thenReturn(1);
-      when(() => patchProcessResult.stderr).thenReturn(error);
-      final tempDir = setUpTempDir();
-      setUpTempArtifacts(tempDir);
-      final exitCode = await IOOverrides.runZoned(
-        () => runWithOverrides(command.run),
-        getCurrentDirectory: () => tempDir,
+      verifyNever(
+        () => codePushClientWrapper.publishPatch(
+          appId: any(named: 'appId'),
+          releaseId: any(named: 'releaseId'),
+          platform: any(named: 'platform'),
+          channelName: any(named: 'channelName'),
+          patchArtifactBundles: any(named: 'patchArtifactBundles'),
+        ),
       );
-      verify(
-        () => progress.fail('Exception: Failed to create diff: $error'),
-      ).called(1);
-      expect(exitCode, ExitCode.software.code);
     });
 
     test('does not create patch on --dry-run', () async {

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -717,6 +717,22 @@ Please re-run the release command for this version or create a new release.'''),
       );
     });
 
+    test('throws error when creating diff fails', () async {
+      const error = 'oops something went wrong';
+      when(() => patchProcessResult.exitCode).thenReturn(1);
+      when(() => patchProcessResult.stderr).thenReturn(error);
+      final tempDir = setUpTempDir();
+      setUpTempArtifacts(tempDir);
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+      verify(
+        () => progress.fail('Exception: Failed to create diff: $error'),
+      ).called(1);
+      expect(exitCode, ExitCode.software.code);
+    });
+
     test('does not create patch on --dry-run', () async {
       when(() => argResults['dry-run']).thenReturn(true);
       final tempDir = setUpTempDir();

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -621,6 +621,22 @@ Please re-run the release command for this version or create a new release.'''),
       expect(exitCode, ExitCode.software.code);
     });
 
+    test('exits with code 70 when ipa not found', () async {
+      final tempDir = setUpTempDir();
+      setUpTempArtifacts(tempDir);
+      File(p.join(tempDir.path, ipaPath)).deleteSync();
+
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      expect(exitCode, equals(ExitCode.software.code));
+      verify(
+        () => logger.err(any(that: contains('Could not find ipa file'))),
+      ).called(1);
+    });
+
     test('exits if confirmUnpatchableDiffsIfNecessary returns false', () async {
       when(() => argResults['force']).thenReturn(false);
       when(

--- a/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
+++ b/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
@@ -1,0 +1,273 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
+import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
+import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/patch_diff_checker.dart';
+import 'package:test/test.dart';
+
+class _FakeBaseRequest extends Fake implements http.BaseRequest {}
+
+class _MockArchiveDiffer extends Mock implements ArchiveDiffer {}
+
+class _MockFileSetDiff extends Mock implements FileSetDiff {}
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockProgress extends Mock implements Progress {}
+
+void main() {
+  group(PatchDiffChecker, () {
+    const assetsDiffPrettyString = 'assets diff pretty string';
+    const nativeDiffPrettyString = 'native diff pretty string';
+    final localArtifact = File('local.artifact');
+    final releaseArtifactUrl = Uri.parse('https://example.com');
+
+    late ArchiveDiffer archiveDiffer;
+    late FileSetDiff assetsFileSetDiff;
+    late FileSetDiff nativeFileSetDiff;
+    late http.Client httpClient;
+    late Logger logger;
+    late Progress progress;
+    late PatchDiffChecker patchDiffChecker;
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        body,
+        values: {
+          loggerRef.overrideWith(() => logger),
+        },
+      );
+    }
+
+    setUpAll(() {
+      registerFallbackValue(FileSetDiff.empty());
+      registerFallbackValue(_FakeBaseRequest());
+    });
+
+    setUp(() {
+      archiveDiffer = _MockArchiveDiffer();
+      assetsFileSetDiff = _MockFileSetDiff();
+      nativeFileSetDiff = _MockFileSetDiff();
+      httpClient = _MockHttpClient();
+      logger = _MockLogger();
+      progress = _MockProgress();
+      patchDiffChecker = PatchDiffChecker(httpClient: httpClient);
+
+      when(() => archiveDiffer.changedFiles(any(), any()))
+          .thenReturn(FileSetDiff.empty());
+      when(() => archiveDiffer.assetsFileSetDiff(any()))
+          .thenReturn(assetsFileSetDiff);
+      when(() => archiveDiffer.nativeFileSetDiff(any()))
+          .thenReturn(nativeFileSetDiff);
+      when(() => archiveDiffer.containsPotentiallyBreakingAssetDiffs(any()))
+          .thenReturn(false);
+      when(() => archiveDiffer.containsPotentiallyBreakingNativeDiffs(any()))
+          .thenReturn(false);
+
+      when(() => httpClient.send(any())).thenAnswer(
+        (_) async => http.StreamedResponse(const Stream.empty(), HttpStatus.ok),
+      );
+
+      when(() => logger.confirm(any())).thenReturn(true);
+      when(() => logger.progress(any())).thenReturn(progress);
+
+      when(() => assetsFileSetDiff.prettyString)
+          .thenReturn(assetsDiffPrettyString);
+      when(() => nativeFileSetDiff.prettyString)
+          .thenReturn(nativeDiffPrettyString);
+    });
+
+    group('confirmUnpatchableDiffsIfNecessary', () {
+      test('throws Exception when release artifact fails to download',
+          () async {
+        when(() => httpClient.send(any())).thenAnswer(
+          (_) async => http.StreamedResponse(
+            const Stream.empty(),
+            HttpStatus.internalServerError,
+            reasonPhrase: 'Internal Server Error',
+          ),
+        );
+
+        await expectLater(
+          runWithOverrides(
+            () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+              localArtifact: localArtifact,
+              releaseArtifactUrl: releaseArtifactUrl,
+              archiveDiffer: archiveDiffer,
+              force: false,
+            ),
+          ),
+          throwsA(isA<Exception>()),
+        );
+
+        verify(() => progress.fail()).called(1);
+      });
+
+      group('when native diffs are detected', () {
+        setUp(() {
+          when(
+            () => archiveDiffer.containsPotentiallyBreakingNativeDiffs(any()),
+          ).thenReturn(true);
+        });
+
+        test('logs warning', () async {
+          final result = await runWithOverrides(
+            () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+              localArtifact: localArtifact,
+              releaseArtifactUrl: releaseArtifactUrl,
+              archiveDiffer: archiveDiffer,
+              force: false,
+            ),
+          );
+
+          expect(result, isTrue);
+          verify(
+            () => logger.warn(
+              '''The release artifact contains native changes, which cannot be applied with a patch.''',
+            ),
+          ).called(1);
+          verify(
+            () => logger.info(yellow.wrap(nativeDiffPrettyString)),
+          ).called(1);
+        });
+
+        test('prompts user if force is false', () async {
+          final result = await runWithOverrides(
+            () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+              localArtifact: localArtifact,
+              releaseArtifactUrl: releaseArtifactUrl,
+              archiveDiffer: archiveDiffer,
+              force: false,
+            ),
+          );
+
+          expect(result, isTrue);
+          verify(() => logger.confirm('Continue anyways?')).called(1);
+        });
+
+        test('does not prompt user if force is true', () async {
+          final result = await runWithOverrides(
+            () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+              localArtifact: localArtifact,
+              releaseArtifactUrl: releaseArtifactUrl,
+              archiveDiffer: archiveDiffer,
+              force: true,
+            ),
+          );
+
+          expect(result, isTrue);
+          verifyNever(() => logger.confirm('Continue anyways?'));
+        });
+
+        test('returns false if user declines to continue', () async {
+          when(() => logger.confirm(any())).thenReturn(false);
+
+          final result = await runWithOverrides(
+            () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+              localArtifact: localArtifact,
+              releaseArtifactUrl: releaseArtifactUrl,
+              archiveDiffer: archiveDiffer,
+              force: false,
+            ),
+          );
+
+          expect(result, isFalse);
+          verify(() => logger.confirm('Continue anyways?')).called(1);
+        });
+      });
+
+      group('when asset diffs are detected', () {
+        setUp(() {
+          when(
+            () => archiveDiffer.containsPotentiallyBreakingAssetDiffs(any()),
+          ).thenReturn(true);
+        });
+
+        test('logs warning', () async {
+          final result = await runWithOverrides(
+            () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+              localArtifact: localArtifact,
+              releaseArtifactUrl: releaseArtifactUrl,
+              archiveDiffer: archiveDiffer,
+              force: false,
+            ),
+          );
+
+          expect(result, isTrue);
+          verify(
+            () => logger.warn(
+                '''The release artifact contains asset changes, which will not be included in the patch.'''),
+          ).called(1);
+          verify(
+            () => logger.info(yellow.wrap(assetsDiffPrettyString)),
+          ).called(1);
+        });
+
+        test('prompts user if force is false', () async {
+          final result = await runWithOverrides(
+            () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+              localArtifact: localArtifact,
+              releaseArtifactUrl: releaseArtifactUrl,
+              archiveDiffer: archiveDiffer,
+              force: false,
+            ),
+          );
+
+          expect(result, isTrue);
+          verify(() => logger.confirm('Continue anyways?')).called(1);
+        });
+
+        test('does not prompt user if force is true', () async {
+          final result = await runWithOverrides(
+            () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+              localArtifact: localArtifact,
+              releaseArtifactUrl: releaseArtifactUrl,
+              archiveDiffer: archiveDiffer,
+              force: true,
+            ),
+          );
+
+          expect(result, isTrue);
+          verifyNever(() => logger.confirm('Continue anyways?'));
+        });
+
+        test('returns false if user declines to continue', () async {
+          when(() => logger.confirm(any())).thenReturn(false);
+
+          final result = await runWithOverrides(
+            () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+              localArtifact: localArtifact,
+              releaseArtifactUrl: releaseArtifactUrl,
+              archiveDiffer: archiveDiffer,
+              force: false,
+            ),
+          );
+
+          expect(result, isFalse);
+          verify(() => logger.confirm('Continue anyways?')).called(1);
+        });
+      });
+
+      test('returns true if no potentially breaking diffs are detected',
+          () async {
+        final result = await runWithOverrides(
+          () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+            localArtifact: localArtifact,
+            releaseArtifactUrl: releaseArtifactUrl,
+            archiveDiffer: archiveDiffer,
+            force: false,
+          ),
+        );
+
+        expect(result, isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

Notifies users of unpatchable changes when patching an iOS release. This change also pulls repeated patch check/warning logic into a new PatchDiffChecker class.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
