### PR TITLE
feat(shorebird_code_push_protocol): Add generic PatchEvent type and CreatePatchEventRequest

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_event/create_patch_event.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_event/create_patch_event.dart
@@ -1,0 +1,1 @@
+export 'create_patch_event_request.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_event/create_patch_event_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_event/create_patch_event_request.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:shorebird_code_push_protocol/src/models/patch_events/patch_events.dart';
+
+part 'create_patch_event_request.g.dart';
+
+/// {@template create_patch_event_request}
+/// Request to create a patch event.
+/// {@endtemplate}
+@JsonSerializable()
+class CreatePatchEventRequest {
+  /// {@macro create_patch_event_request}
+  CreatePatchEventRequest({required this.event});
+
+  /// Converts a Map<String, dynamic> to a [CreatePatchEventRequest]
+  factory CreatePatchEventRequest.fromJson(Map<String, dynamic> json) =>
+      _$CreatePatchEventRequestFromJson(json);
+
+  /// Converts a [CreatePatchEventRequest] to a Map<String, dynamic>
+  Map<String, dynamic> toJson() => _$CreatePatchEventRequestToJson(this);
+
+  /// The event being created.
+  final PatchEvent event;
+}

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_event/create_patch_event_request.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_event/create_patch_event_request.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, require_trailing_commas, cast_nullable_to_non_nullable, lines_longer_than_80_chars
+
+part of 'create_patch_event_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CreatePatchEventRequest _$CreatePatchEventRequestFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      'CreatePatchEventRequest',
+      json,
+      ($checkedConvert) {
+        final val = CreatePatchEventRequest(
+          event: $checkedConvert(
+              'event', (v) => PatchEvent.fromJson(v as Map<String, dynamic>)),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$CreatePatchEventRequestToJson(
+        CreatePatchEventRequest instance) =>
+    <String, dynamic>{
+      'event': instance.event.toJson(),
+    };

--- a/packages/shorebird_code_push_protocol/lib/src/messages/messages.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/messages.dart
@@ -5,7 +5,7 @@ export 'create_app_collaborator/create_app_collaborator.dart';
 export 'create_channel/create_channel.dart';
 export 'create_patch/create_patch.dart';
 export 'create_patch_artifact/create_patch_artifact.dart';
-export 'record_patch_install/record_patch_install.dart';
+export 'create_patch_event/create_patch_event.dart';
 export 'create_payment_link/create_payment_link.dart';
 export 'create_release/create_release.dart';
 export 'create_release_artifact/create_release_artifact.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/record_patch_install/record_patch_install.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/record_patch_install/record_patch_install.dart
@@ -1,1 +1,0 @@
-export 'record_patch_install_request.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/models.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/models.dart
@@ -5,6 +5,7 @@ export 'collaborator.dart';
 export 'error_response.dart';
 export 'patch.dart';
 export 'patch_artifact.dart';
+export 'patch_events/patch_events.dart';
 export 'release.dart';
 export 'release_artifact.dart';
 export 'release_platform.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/patch_events/patch_event.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/patch_events/patch_event.dart
@@ -1,0 +1,32 @@
+import 'package:shorebird_code_push_protocol/src/models/patch_events/patch_events.dart';
+
+export 'patch_install_event.dart';
+
+/// {@template patch_event}
+/// Base class for patch events.
+/// {@endtemplate}
+abstract class PatchEvent {
+  /// {@macro patch_event}
+  const PatchEvent({required this.type});
+
+  /// Converts a Map<String, dynamic> to a [PatchEvent]
+  factory PatchEvent.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String;
+    switch (type) {
+      case PatchInstallEvent.identifier:
+        return PatchInstallEvent.fromJson(json);
+      default:
+        throw ArgumentError.value(
+          type,
+          'type',
+          'Invalid patch event type',
+        );
+    }
+  }
+
+  /// The type of patch event.
+  final String type;
+
+  /// Converts a [PatchEvent] to a Map<String, dynamic>
+  Map<String, dynamic> toJson();
+}

--- a/packages/shorebird_code_push_protocol/lib/src/models/patch_events/patch_event.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/patch_events/patch_event.dart
@@ -24,9 +24,9 @@ abstract class PatchEvent {
     }
   }
 
-  /// The type of patch event.
-  final String type;
-
   /// Converts a [PatchEvent] to a Map<String, dynamic>
   Map<String, dynamic> toJson();
+
+  /// The type of patch event.
+  final String type;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/patch_events/patch_events.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/patch_events/patch_events.dart
@@ -1,0 +1,2 @@
+export 'patch_event.dart';
+export 'patch_install_event.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/patch_events/patch_install_event.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/patch_events/patch_install_event.dart
@@ -1,29 +1,34 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 
-part 'record_patch_install_request.g.dart';
+part 'patch_install_event.g.dart';
 
-/// {@template record_patch_install_request}
-/// Request to record a patch install.
+/// {@template patch_install_event}
+/// Event for when a patch is installed.
 /// {@endtemplate}
 @JsonSerializable()
-class RecordPatchInstallRequest {
-  /// {@macro record_patch_install_request}
-  RecordPatchInstallRequest({
+class PatchInstallEvent extends PatchEvent {
+  /// {@macro patch_install_event}
+  PatchInstallEvent({
     required this.clientId,
     required this.appId,
     required this.releaseVersion,
     required this.patchNumber,
     required this.platform,
     required this.arch,
+    super.type = PatchInstallEvent.identifier,
   });
 
-  /// Converts a Map<String, dynamic> to a [RecordPatchInstallRequest]
-  factory RecordPatchInstallRequest.fromJson(Map<String, dynamic> json) =>
-      _$RecordPatchInstallRequestFromJson(json);
+  /// Converts a Map<String, dynamic> to a [PatchInstallEvent]
+  factory PatchInstallEvent.fromJson(Map<String, dynamic> json) =>
+      _$PatchInstallEventFromJson(json);
 
-  /// Converts a [RecordPatchInstallRequest] to a Map<String, dynamic>
-  Map<String, dynamic> toJson() => _$RecordPatchInstallRequestToJson(this);
+  /// Converts a [PatchInstallEvent] to a Map<String, dynamic>
+  @override
+  Map<String, dynamic> toJson() => _$PatchInstallEventToJson(this);
+
+  /// The patch install event type identifier.
+  static const identifier = '__patch_install__';
 
   /// The client id of the device being updated.
   final String clientId;

--- a/packages/shorebird_code_push_protocol/lib/src/models/patch_events/patch_install_event.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/patch_events/patch_install_event.g.dart
@@ -2,19 +2,18 @@
 
 // ignore_for_file: implicit_dynamic_parameter, require_trailing_commas, cast_nullable_to_non_nullable, lines_longer_than_80_chars
 
-part of 'record_patch_install_request.dart';
+part of 'patch_install_event.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-RecordPatchInstallRequest _$RecordPatchInstallRequestFromJson(
-        Map<String, dynamic> json) =>
+PatchInstallEvent _$PatchInstallEventFromJson(Map<String, dynamic> json) =>
     $checkedCreate(
-      'RecordPatchInstallRequest',
+      'PatchInstallEvent',
       json,
       ($checkedConvert) {
-        final val = RecordPatchInstallRequest(
+        final val = PatchInstallEvent(
           clientId: $checkedConvert('client_id', (v) => v as String),
           appId: $checkedConvert('app_id', (v) => v as String),
           releaseVersion:
@@ -23,6 +22,8 @@ RecordPatchInstallRequest _$RecordPatchInstallRequestFromJson(
           platform: $checkedConvert(
               'platform', (v) => $enumDecode(_$ReleasePlatformEnumMap, v)),
           arch: $checkedConvert('arch', (v) => v as String),
+          type: $checkedConvert(
+              'type', (v) => v as String? ?? PatchInstallEvent.identifier),
         );
         return val;
       },
@@ -34,9 +35,9 @@ RecordPatchInstallRequest _$RecordPatchInstallRequestFromJson(
       },
     );
 
-Map<String, dynamic> _$RecordPatchInstallRequestToJson(
-        RecordPatchInstallRequest instance) =>
+Map<String, dynamic> _$PatchInstallEventToJson(PatchInstallEvent instance) =>
     <String, dynamic>{
+      'type': instance.type,
       'client_id': instance.clientId,
       'app_id': instance.appId,
       'release_version': instance.releaseVersion,

--- a/packages/shorebird_code_push_protocol/test/src/messages/create_patch_event/create_patch_event_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/create_patch_event/create_patch_event_request_test.dart
@@ -1,0 +1,23 @@
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(CreatePatchEventRequest, () {
+    test('can be (de)serialized', () {
+      final response = CreatePatchEventRequest(
+        event: PatchInstallEvent(
+          clientId: 'some-client-id',
+          appId: 'some-app-id',
+          patchNumber: 2,
+          arch: 'arm64',
+          platform: ReleasePlatform.android,
+          releaseVersion: '1.0.0',
+        ),
+      );
+      expect(
+        CreatePatchEventRequest.fromJson(response.toJson()).toJson(),
+        equals(response.toJson()),
+      );
+    });
+  });
+}

--- a/packages/shorebird_code_push_protocol/test/src/messages/create_patch_event/create_patch_event_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/create_patch_event/create_patch_event_request_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   group(CreatePatchEventRequest, () {
     test('can be (de)serialized', () {
-      final response = CreatePatchEventRequest(
+      final request = CreatePatchEventRequest(
         event: PatchInstallEvent(
           clientId: 'some-client-id',
           appId: 'some-app-id',
@@ -15,8 +15,8 @@ void main() {
         ),
       );
       expect(
-        CreatePatchEventRequest.fromJson(response.toJson()).toJson(),
-        equals(response.toJson()),
+        CreatePatchEventRequest.fromJson(request.toJson()).toJson(),
+        equals(request.toJson()),
       );
     });
   });

--- a/packages/shorebird_code_push_protocol/test/src/models/patch_event/patch_event_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/patch_event/patch_event_test.dart
@@ -1,0 +1,35 @@
+import 'package:shorebird_code_push_protocol/src/models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(PatchEvent, () {
+    group(PatchInstallEvent, () {
+      test('can be (de)serialized', () {
+        late PatchEvent event;
+        event = PatchInstallEvent(
+          clientId: 'some-client-id',
+          appId: 'some-app-id',
+          patchNumber: 2,
+          arch: 'arm64',
+          platform: ReleasePlatform.android,
+          releaseVersion: '1.0.0',
+        );
+        expect(
+          event.toJson(),
+          equals(
+            PatchEvent.fromJson(event.toJson()).toJson(),
+          ),
+        );
+      });
+    });
+
+    group('unrecognized type', () {
+      test('throws ArgumentError if type is unrecognized', () {
+        expect(
+          () => PatchEvent.fromJson(<String, dynamic>{'type': 'foo'}),
+          throwsArgumentError,
+        );
+      });
+    });
+  });
+}

--- a/packages/shorebird_code_push_protocol/test/src/models/patch_event/patch_install_event_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/patch_event/patch_install_event_test.dart
@@ -2,9 +2,9 @@ import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group(RecordPatchInstallRequest, () {
+  group(PatchInstallEvent, () {
     test('can be (de)serialized', () {
-      final response = RecordPatchInstallRequest(
+      final event = PatchInstallEvent(
         clientId: 'some-client-id',
         appId: 'some-app-id',
         patchNumber: 2,
@@ -13,8 +13,8 @@ void main() {
         releaseVersion: '1.0.0',
       );
       expect(
-        RecordPatchInstallRequest.fromJson(response.toJson()).toJson(),
-        equals(response.toJson()),
+        PatchInstallEvent.fromJson(event.toJson()).toJson(),
+        equals(event.toJson()),
       );
     });
   });


### PR DESCRIPTION
## Description

Replaces `ReportPatchInstallRequest` with the more generic `CreatePatchEventRequest` that supports a variety of patch-related events (currently just install, but conceivable other events could include download, crash, etc.)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
