### PR TITLE
feat(shorebird_cli): add the concept of an extension command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Cached files
 bin/cache/
+
+# IDE files
+.idea/

--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -81,6 +81,7 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
   @override
   Future<int> run(Iterable<String> args) async {
     try {
+      preprocess(args);
       final topLevelResults = parse(args);
 
       // Set up our context before running the command.

--- a/packages/shorebird_cli/lib/src/commands/commands.dart
+++ b/packages/shorebird_cli/lib/src/commands/commands.dart
@@ -4,6 +4,7 @@ export 'build/build_command.dart';
 export 'cache/cache.dart';
 export 'collaborators/collaborators.dart';
 export 'doctor_command.dart';
+export 'extension_command.dart';
 export 'flutter/flutter.dart';
 export 'init_command.dart';
 export 'login_ci_command.dart';

--- a/packages/shorebird_cli/lib/src/commands/extension_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/extension_command.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:shorebird_cli/src/logger.dart';
+
+class ExtensionCommand extends Command<int> {
+  ExtensionCommand(this.commandName, this.executableName, this.commandUsage);
+
+  final String commandName;
+  final String executableName;
+  final String commandUsage;
+
+  @override
+  String get description => 'a Shorebird extension command';
+
+  @override
+  String get name => commandName;
+
+  @override
+  String get usage {
+    return commandUsage;
+  }
+
+  @override
+  FutureOr<int> run() async {
+    final arguments = argResults?.arguments ?? List<String>.empty();
+    final process = await Process.start(executableName, arguments);
+    Future<void> outStream(p) async {
+      await process.stdout.transform(utf8.decoder).forEach(logger.info);
+    }
+
+    Future<void> errStream(p) async {
+      await process.stderr.transform(utf8.decoder).forEach(logger.info);
+    }
+
+    await Future.wait([outStream(process), errStream(process)]);
+    return process.exitCode;
+  }
+}
+
+(bool, String) checkForExecutableExtension(String executableName) {
+  var extensionExists = false;
+  var extensionUsage = '';
+
+  try {
+    final processResult = Process.runSync(executableName, List.empty());
+    extensionExists = true;
+    extensionUsage = processResult.stdout.toString();
+  } catch (e) {
+    return (false, '');
+  }
+
+  return (extensionExists, extensionUsage);
+}
+
+extension ExtensionsLoader on CommandRunner<int> {
+  void preprocess(Iterable<String> args) {
+    for (final arg in args) {
+      if (arg.startsWith(RegExp('[-]+'))) {
+        continue;
+      }
+
+      final possibleExtension = !commands.containsKey(arg);
+      if (possibleExtension) {
+        final commandName = arg;
+        final executableName = 'shorebird-$commandName';
+        final (extensionExists, extensionUsage) =
+            checkForExecutableExtension(executableName);
+        if (extensionExists) {
+          addCommand(
+              ExtensionCommand(commandName, executableName, extensionUsage),);
+        }
+      }
+      break;
+    }
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Add the concept of an extension command to  Shorebird. 

An extension command follows the Git model of CLI extension where any command unknown to the git CLI that matches the pattern git-<command> and is executable can be used to extend the Git command set.

For example:

git lfs

If the 'lfs' command is not implemented within Git's internal commands then the Git command line parser would check to see if 'git-lfs' exists and is executable.  If so, then the Git CLI passes execution to that script.

A practical example relevant to Shorebird might be adding support for Fastlane to integrate with shorebird:

shorebird fastlane xxxxx

This extension mechanism would then allow this command to be implemented by simply having a 'shorebird-fastlane' executable on the system path.  The executable could be implement using Dart, a shell script, a Ruby script, etc...

This extension capability can be further improved by allowing reusable context can to passed to extensions using environment variables;  for example, an extension could receive the location of the shorebird cache through a SHOREBIRD_CACHE_DIR  environment variable.

Perhaps this extension mechanism can be used to seed the shorebird ecosystem with many new possibilities!

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
