### PR TITLE
fix(shorebird_cli): only redirect powershell stderr output if it won't cause the script to terminate

### DIFF
--- a/bin/shorebird.ps1
+++ b/bin/shorebird.ps1
@@ -22,7 +22,7 @@ $dart = [IO.Path]::Combine($flutterPath, "bin", "cache", "dart-sdk", "bin", "dar
 # stderr with $ErrorActionPreference = "Stop" as a terminating error. This is
 # fixed in Powershell 7.1.
 # 
-# See https://github.com/PowerShell/PowerShell/issues/3996 for more info.
+# See https://github.com/PowerShell/PowerShell/issues/4002 for more info.
 function Invoke-SilentlyIfPossible($command) {
     $psVersion = $PSVersionTable.PSVersion
     $shouldRedirectStdErr = $psVersion.Major -ge 7 -and $psVersion.Minor -ge 1

--- a/bin/shorebird.ps1
+++ b/bin/shorebird.ps1
@@ -16,21 +16,25 @@ $flutter = [IO.Path]::Combine($shorebirdCacheDir, "flutter", $flutterVersion, "b
 $shorebirdScript = [IO.Path]::Combine($shorebirdCliDir, "bin", "shorebird.dart")
 $dart = [IO.Path]::Combine($flutterPath, "bin", "cache", "dart-sdk", "bin", "dart.exe")
 
-# Executes $command and redirects all output to $null if possible.
+# Executes $command and redirects as much output to $null as possible.
 #
 # This is a workaround for old versions of Powershell treating any write to
-# stderr with $ErrorActionPreference = "Stop" as a terminating error. This is
-# fixed in Powershell 7.1.
+# the Error stream with $ErrorActionPreference = "Stop" as a terminating error.
+# This is fixed in Powershell 7.1.
 # 
 # See https://github.com/PowerShell/PowerShell/issues/4002 for more info.
 function Invoke-SilentlyIfPossible($command) {
     $psVersion = $PSVersionTable.PSVersion
     $shouldRedirectStdErr = $psVersion.Major -ge 7 -and $psVersion.Minor -ge 1
     if ($shouldRedirectStdErr) {
+        # Redirect everything to $null.
         & $command *> $null
     }
     else {
-        & $command 
+        # Otherwise redirect everything _but_ the Error stream to $null. See
+        # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_output_streams?view=powershell-7.3#long-description
+        # for a description of these streams.
+        & $command  1> $null 3> $null 4> $null 5> $null 6> $null
     }
 }
 


### PR DESCRIPTION
## Description

Introduces a workaround for https://github.com/PowerShell/PowerShell/issues/4002.

Older versions of Powershell (<7.1) will treat any redirected stderr output as a termination-worthy issue if `$ErrorActionPreference` is set to `"Stop"`. This change checks the current powershell version and only attempts to redirect output 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
