### PR TITLE
feat(code_push_protocol): Add GetReleasePatchesResponse

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches.dart
@@ -1,0 +1,1 @@
+export 'get_release_patches_response.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches_response.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+
+part 'get_release_patches_response.g.dart';
+
+/// {@template get_release_patches_response}
+/// The response to /api/v1/apps/$appId/releases/$releaseId/patches
+/// {@endtemplate}
+@JsonSerializable()
+class GetReleasePatchesResponse {
+  /// {@macro get_release_patches_response}
+  const GetReleasePatchesResponse({required this.patches});
+
+  /// Converts a Map<String, dynamic> to a [GetReleasePatchesResponse]
+  factory GetReleasePatchesResponse.fromJson(Map<String, dynamic> json) =>
+      _$GetReleasePatchesResponseFromJson(json);
+
+  /// Converts a [GetReleasePatchesResponse] to a Map<String, dynamic>
+  Json toJson() => _$GetReleasePatchesResponseToJson(this);
+
+  /// Patch numbers for a given release mapped to their artifacts.
+  final Map<int, List<PatchArtifact>> patches;
+}

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches_response.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches_response.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, require_trailing_commas, cast_nullable_to_non_nullable, lines_longer_than_80_chars
+
+part of 'get_release_patches_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+GetReleasePatchesResponse _$GetReleasePatchesResponseFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      'GetReleasePatchesResponse',
+      json,
+      ($checkedConvert) {
+        final val = GetReleasePatchesResponse(
+          patches: $checkedConvert(
+              'patches',
+              (v) => (v as Map<String, dynamic>).map(
+                    (k, e) => MapEntry(
+                        int.parse(k),
+                        (e as List<dynamic>)
+                            .map((e) => PatchArtifact.fromJson(
+                                e as Map<String, dynamic>))
+                            .toList()),
+                  )),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$GetReleasePatchesResponseToJson(
+        GetReleasePatchesResponse instance) =>
+    <String, dynamic>{
+      'patches': instance.patches.map(
+          (k, e) => MapEntry(k.toString(), e.map((e) => e.toJson()).toList())),
+    };

--- a/packages/shorebird_code_push_protocol/lib/src/messages/messages.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/messages.dart
@@ -12,6 +12,7 @@ export 'create_release_artifact/create_release_artifact.dart';
 export 'create_user/create_user.dart';
 export 'get_overages/get_overages.dart';
 export 'get_release_artifacts/get_release_artifacts.dart';
+export 'get_release_patches/get_release_patches.dart';
 export 'get_usage/get_usage.dart';
 export 'promote_patch/promote_patch.dart';
 export 'update_overages/update_overages.dart';

--- a/packages/shorebird_code_push_protocol/test/src/messages/get_release_patches/get_release_patches_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/get_release_patches/get_release_patches_response_test.dart
@@ -1,0 +1,57 @@
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(GetReleasePatchesResponse, () {
+    test('can be (de)serialized', () {
+      const response = GetReleasePatchesResponse(
+        patches: {
+          1: [
+            PatchArtifact(
+              id: 1,
+              patchId: 1,
+              arch: 'aarch64',
+              platform: ReleasePlatform.android,
+              url: 'https://example.com',
+              size: 42,
+              hash: 'sha256:1234567890',
+            ),
+            PatchArtifact(
+              id: 2,
+              patchId: 1,
+              arch: 'aarch64',
+              platform: ReleasePlatform.android,
+              url: 'https://example.com',
+              size: 42,
+              hash: 'sha256:1234567890',
+            ),
+          ],
+          2: [
+            PatchArtifact(
+              id: 3,
+              patchId: 2,
+              arch: 'aarch64',
+              platform: ReleasePlatform.android,
+              url: 'https://example.com',
+              size: 42,
+              hash: 'sha256:1234567890',
+            ),
+            PatchArtifact(
+              id: 4,
+              patchId: 3,
+              arch: 'aarch64',
+              platform: ReleasePlatform.android,
+              url: 'https://example.com',
+              size: 42,
+              hash: 'sha256:1234567890',
+            ),
+          ]
+        },
+      );
+      expect(
+        GetReleasePatchesResponse.fromJson(response.toJson()).toJson(),
+        equals(response.toJson()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

This will be used as a response type to `/api/v1/apps/$appId/releases/$releaseId/patches`, which will allow clients to list patches and their artifacts for a given release.

Part of https://github.com/shorebirdtech/shorebird/issues/1095

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
