### PR TITLE
fix(shorebird_cli): compare contents of .car files when checking for asset diffs

### DIFF
--- a/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
@@ -84,7 +84,7 @@ class IosArchiveDiffer extends ArchiveDiffer {
     return ZipDecoder()
         .decodeBuffer(InputFileStream(archivePath))
         .files
-        .where((file) => file.isFile && p.basename(file.name) == 'Assets.car')
+        .where((file) => file.isFile && p.extension(file.name) == '.car')
         .toList();
   }
 
@@ -145,7 +145,7 @@ class IosArchiveDiffer extends ArchiveDiffer {
     /// The flutter_assets directory contains the assets listed in the assets
     ///   section of the pubspec.yaml file.
     /// Assets.car is the compiled asset catalog(s) (.xcassets files).
-    return p.basename(filePath) == 'Assets.car' ||
+    return p.extension(filePath) == '.car' ||
         p.split(filePath).contains('flutter_assets');
   }
 

--- a/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
@@ -122,6 +122,9 @@ class IosArchiveDiffer extends ArchiveDiffer {
       // coverage:ignore-start
       Process.runSync('assetutil', ['--info', outPath, '-o', assetInfoPath]);
       // coverage:ignore-end
+    } else {
+      // This is just for testing
+      File(assetInfoPath).createSync(recursive: true);
     }
 
     // Remove the timestamp line from the json file

--- a/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:archive/archive_io.dart';
+import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
@@ -33,11 +34,11 @@ class IosArchiveDiffer extends ArchiveDiffer {
     final oldPathHashes = fileHashes(File(oldArchivePath));
     final newPathHashes = fileHashes(File(newArchivePath));
 
-    _updateToUnsignedHashes(
+    _updateHashes(
       archivePath: oldArchivePath,
       pathHashes: oldPathHashes,
     );
-    _updateToUnsignedHashes(
+    _updateHashes(
       archivePath: newArchivePath,
       pathHashes: newPathHashes,
     );
@@ -48,12 +49,20 @@ class IosArchiveDiffer extends ArchiveDiffer {
     );
   }
 
-  void _updateToUnsignedHashes({
+  /// Replaces crc32s from zip file headers where needed. This currently
+  /// includes:
+  ///   - Signed files (those with a .app extension)
+  ///   - Compiled asset catalogs (those with a .car extension)
+  void _updateHashes({
     required String archivePath,
     required PathHashes pathHashes,
   }) {
     for (final file in _filesToUnsign(archivePath)) {
       pathHashes[file.name] = _unsignedFileHash(file);
+    }
+
+    for (final file in _carFiles(archivePath)) {
+      pathHashes[file.name] = _carFileHash(file);
     }
   }
 
@@ -68,6 +77,14 @@ class IosArchiveDiffer extends ArchiveDiffer {
               file.name.endsWith('Flutter.framework/Flutter') ||
               appRegex.hasMatch(file.name),
         )
+        .toList();
+  }
+
+  List<ArchiveFile> _carFiles(String archivePath) {
+    return ZipDecoder()
+        .decodeBuffer(InputFileStream(archivePath))
+        .files
+        .where((file) => file.isFile && p.basename(file.name) == 'Assets.car')
         .toList();
   }
 
@@ -87,6 +104,32 @@ class IosArchiveDiffer extends ArchiveDiffer {
     final outFile = File(outPath);
     final hash = _hash(outFile.readAsBytesSync());
     return hash;
+  }
+
+  /// Uses assetutil to write a json description of a .car file to disk and
+  /// diffs the contents of that file, less a timestamp line that chnages based
+  /// on when the .car file was created.
+  String _carFileHash(ArchiveFile file) {
+    final tempDir = Directory.systemTemp.createTempSync();
+    final outPath = p.join(tempDir.path, file.name);
+    final outputStream = OutputFileStream(outPath);
+    file.writeContent(outputStream);
+    outputStream.close();
+
+    final assetInfoPath = '$outPath.json';
+
+    if (Platform.isMacOS) {
+      // coverage:ignore-start
+      Process.runSync('assetutil', ['--info', outPath, '-o', assetInfoPath]);
+      // coverage:ignore-end
+    }
+
+    // Remove the timestamp line from the json file
+    final jsonFile = File(assetInfoPath);
+    final lines = jsonFile.readAsLinesSync();
+    final timestampRegex = RegExp(r'^\W+"Timestamp" : \d+$');
+    final linesToKeep = lines.whereNot(timestampRegex.hasMatch);
+    return _hash(linesToKeep.join('\n').codeUnits);
   }
 
   @override


### PR DESCRIPTION
## Description

Because .car files (compiled asset catalogs) can differ on disk without having different content, use the `assetutil` tool to compare their contents, less a timestamp field.

A sample entry in the `assetutil` json output:

```json
  {
    "AssetType" : "Image",
    "BitsPerComponent" : 8,
    "ColorModel" : "Monochrome",
    "Colorspace" : "gray gamma 22",
    "Compression" : "deepmap2",
    "DeploymentTarget" : "2019",
    "Encoding" : "Gray",
    "Idiom" : "universal",
    "Name" : "chevron",
    "NameIdentifier" : 63291,
    "Opaque" : false,
    "PixelHeight" : 26,
    "PixelWidth" : 16,
    "RenditionName" : "chevron.pdf",
    "Scale" : 2,
    "SHA1Digest" : "93499EF86F3659DDDD0809122792CBCC1B2D109A0A70490D7C5416AC5D4C0D7A",
    "SizeOnDisk" : 338,
    "State" : "Normal",
    "Template Mode" : "automatic",
    "Value" : "Off"
  },
```

Fixes https://github.com/shorebirdtech/shorebird/issues/1102

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
