### PR TITLE
fix(shorebird_cli): fix iOS app file regex

### DIFF
--- a/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
@@ -23,7 +23,7 @@ class IosArchiveDiffer extends ArchiveDiffer {
     'App.framework/App',
     'Flutter.framework/Flutter',
   };
-  static RegExp appRegex = RegExp(r'^Payload/[\w\-. ]+.app/[\w\-. ]+$');
+  static RegExp appRegex = RegExp(r'^Payload/[\w\-. ]+.app/[\w\- ]+$');
 
   /// Files that have been added, removed, or that have changed between the
   /// archives at the two provided paths. This method will also unisgn mach-o

--- a/packages/shorebird_cli/test/src/archive_analysis/ios_archive_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/ios_archive_differ_test.dart
@@ -31,6 +31,22 @@ void main() {
         differ = IosArchiveDiffer();
       });
 
+      group('appRegex', () {
+        test('identifies Runner.app/Runner as an app file', () {
+          expect(
+            IosArchiveDiffer.appRegex.hasMatch('Payload/Runner.app/Runner'),
+            isTrue,
+          );
+        });
+
+        test('does not identify Runner.app/Assets.car as an app file', () {
+          expect(
+            IosArchiveDiffer.appRegex.hasMatch('Payload/Runner.app/Assets.car'),
+            isFalse,
+          );
+        });
+      });
+
       group('ipa', () {
         group('changedPaths', () {
           test('finds no differences between the same ipa', () {


### PR DESCRIPTION
## Description

The regular expression we were using to identify app files in iOS was incorrectly identifying asset catalogs (`Assets.car`, for example) as native changes.

Fixes https://github.com/shorebirdtech/shorebird/issues/1104

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
