### PR TITLE
fix(shorebird_cli): run flutter pub get after builds to reset `.dart_tool/package_config.json`

### DIFF
--- a/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
@@ -37,7 +37,8 @@ void main() {
     late ArgResults argResults;
     late Doctor doctor;
     late Logger logger;
-    late ShorebirdProcessResult processResult;
+    late ShorebirdProcessResult flutterPubGetProcessResult;
+    late ShorebirdProcessResult buildProcessResult;
     late BuildApkCommand command;
     late ShorebirdFlutterValidator flutterValidator;
     late ShorebirdProcess shorebirdProcess;
@@ -64,17 +65,28 @@ void main() {
       doctor = _MockDoctor();
       logger = _MockLogger();
       shorebirdProcess = _MockShorebirdProcess();
-      processResult = _MockProcessResult();
+      buildProcessResult = _MockProcessResult();
+      flutterPubGetProcessResult = _MockProcessResult();
       flutterValidator = _MockShorebirdFlutterValidator();
       shorebirdValidator = _MockShorebirdValidator();
 
+      when(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['pub', 'get', '--offline'],
+          runInShell: any(named: 'runInShell'),
+          useVendedFlutter: false,
+        ),
+      ).thenAnswer((_) async => flutterPubGetProcessResult);
+      when(() => flutterPubGetProcessResult.exitCode)
+          .thenReturn(ExitCode.success.code);
       when(
         () => shorebirdProcess.run(
           any(),
           any(),
           runInShell: any(named: 'runInShell'),
         ),
-      ).thenAnswer((_) async => processResult);
+      ).thenAnswer((_) async => buildProcessResult);
       when(() => argResults.rest).thenReturn([]);
       when(() => logger.progress(any())).thenReturn(_MockProgress());
       when(() => logger.info(any())).thenReturn(null);
@@ -120,8 +132,8 @@ void main() {
     });
 
     test('exits with code 70 when building apk fails', () async {
-      when(() => processResult.exitCode).thenReturn(1);
-      when(() => processResult.stderr).thenReturn('oops');
+      when(() => buildProcessResult.exitCode).thenReturn(1);
+      when(() => buildProcessResult.stderr).thenReturn('oops');
       final tempDir = Directory.systemTemp.createTempSync();
 
       final result = await IOOverrides.runZoned(
@@ -140,7 +152,7 @@ void main() {
     });
 
     test('exits with code 0 when building apk succeeds', () async {
-      when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+      when(() => buildProcessResult.exitCode).thenReturn(ExitCode.success.code);
       final tempDir = Directory.systemTemp.createTempSync();
       final result = await IOOverrides.runZoned(
         () async => runWithOverrides(command.run),
@@ -165,6 +177,26 @@ ${lightCyan.wrap(p.join('build', 'app', 'outputs', 'apk', 'release', 'app-releas
       ).called(1);
     });
 
+    test('runs flutter pub get with system flutter after successful build',
+        () async {
+      when(() => buildProcessResult.exitCode).thenReturn(ExitCode.success.code);
+      final tempDir = Directory.systemTemp.createTempSync();
+
+      await IOOverrides.runZoned(
+        () async => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['pub', 'get', '--offline'],
+          runInShell: any(named: 'runInShell'),
+          useVendedFlutter: false,
+        ),
+      ).called(1);
+    });
+
     test(
         'exits with code 0 when building apk succeeds '
         'with flavor and target', () async {
@@ -172,7 +204,7 @@ ${lightCyan.wrap(p.join('build', 'app', 'outputs', 'apk', 'release', 'app-releas
       final target = p.join('lib', 'main_development.dart');
       when(() => argResults['flavor']).thenReturn(flavor);
       when(() => argResults['target']).thenReturn(target);
-      when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+      when(() => buildProcessResult.exitCode).thenReturn(ExitCode.success.code);
       final tempDir = Directory.systemTemp.createTempSync();
       final result = await IOOverrides.runZoned(
         () async => runWithOverrides(command.run),

--- a/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
@@ -38,7 +38,8 @@ void main() {
     late ArgResults argResults;
     late Doctor doctor;
     late Logger logger;
-    late ShorebirdProcessResult processResult;
+    late ShorebirdProcessResult buildProcessResult;
+    late ShorebirdProcessResult flutterPubGetProcessResult;
     late BuildIpaCommand command;
     late ShorebirdFlutterValidator flutterValidator;
     late ShorebirdProcess shorebirdProcess;
@@ -65,17 +66,28 @@ void main() {
       doctor = _MockDoctor();
       logger = _MockLogger();
       shorebirdProcess = _MockShorebirdProcess();
-      processResult = _MockProcessResult();
+      buildProcessResult = _MockProcessResult();
+      flutterPubGetProcessResult = _MockProcessResult();
       flutterValidator = _MockShorebirdFlutterValidator();
       shorebirdValidator = _MockShorebirdValidator();
 
+      when(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['pub', 'get', '--offline'],
+          runInShell: any(named: 'runInShell'),
+          useVendedFlutter: false,
+        ),
+      ).thenAnswer((_) async => flutterPubGetProcessResult);
+      when(() => flutterPubGetProcessResult.exitCode)
+          .thenReturn(ExitCode.success.code);
       when(
         () => shorebirdProcess.run(
           any(),
           any(),
           runInShell: any(named: 'runInShell'),
         ),
-      ).thenAnswer((_) async => processResult);
+      ).thenAnswer((_) async => buildProcessResult);
       when(() => argResults['codesign']).thenReturn(true);
       when(() => argResults.rest).thenReturn([]);
       when(() => logger.progress(any())).thenReturn(_MockProgress());
@@ -120,8 +132,8 @@ void main() {
     });
 
     test('exits with code 70 when building ipa fails', () async {
-      when(() => processResult.exitCode).thenReturn(1);
-      when(() => processResult.stderr).thenReturn('oops');
+      when(() => buildProcessResult.exitCode).thenReturn(1);
+      when(() => buildProcessResult.stderr).thenReturn('oops');
       final tempDir = Directory.systemTemp.createTempSync();
 
       final result = await IOOverrides.runZoned(
@@ -144,7 +156,7 @@ void main() {
     });
 
     test('exits with code 0 when building ipa succeeds', () async {
-      when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+      when(() => buildProcessResult.exitCode).thenReturn(ExitCode.success.code);
       final tempDir = Directory.systemTemp.createTempSync();
       final result = await IOOverrides.runZoned(
         () async => runWithOverrides(command.run),
@@ -179,6 +191,26 @@ ${lightCyan.wrap(p.join('build', 'ios', 'ipa', 'Runner.ipa'))}''',
       ]);
     });
 
+    test('runs flutter pub get with system flutter after successful build',
+        () async {
+      when(() => buildProcessResult.exitCode).thenReturn(ExitCode.success.code);
+      final tempDir = Directory.systemTemp.createTempSync();
+
+      await IOOverrides.runZoned(
+        () async => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['pub', 'get', '--offline'],
+          runInShell: any(named: 'runInShell'),
+          useVendedFlutter: false,
+        ),
+      ).called(1);
+    });
+
     test(
         'exits with code 0 when building ipa succeeds '
         'with flavor and target', () async {
@@ -186,7 +218,7 @@ ${lightCyan.wrap(p.join('build', 'ios', 'ipa', 'Runner.ipa'))}''',
       final target = p.join('lib', 'main_development.dart');
       when(() => argResults['flavor']).thenReturn(flavor);
       when(() => argResults['target']).thenReturn(target);
-      when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+      when(() => buildProcessResult.exitCode).thenReturn(ExitCode.success.code);
       final tempDir = Directory.systemTemp.createTempSync();
       final result = await IOOverrides.runZoned(
         () async => runWithOverrides(command.run),
@@ -231,7 +263,7 @@ ${lightCyan.wrap(p.join('build', 'ios', 'ipa', 'Runner.ipa'))}''',
         'exits with code 0 when building ipa succeeds '
         'with --no-codesign', () async {
       when(() => argResults['codesign']).thenReturn(false);
-      when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+      when(() => buildProcessResult.exitCode).thenReturn(ExitCode.success.code);
       final tempDir = Directory.systemTemp.createTempSync();
       final result = await IOOverrides.runZoned(
         () async => runWithOverrides(command.run),
@@ -269,7 +301,7 @@ ${lightCyan.wrap(p.join('build', 'ios', 'ipa', 'Runner.ipa'))}''',
 
     test('provides appropriate ExportOptions.plist to build ipa command',
         () async {
-      when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+      when(() => buildProcessResult.exitCode).thenReturn(ExitCode.success.code);
       final tempDir = Directory.systemTemp.createTempSync();
       final result = await IOOverrides.runZoned(
         () async => runWithOverrides(command.run),

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -136,6 +136,7 @@ flutter:
     late Logger logger;
     late ShorebirdEnv shorebirdEnv;
     late ShorebirdProcessResult flutterBuildProcessResult;
+    late ShorebirdProcessResult flutterPubGetProcessResult;
     late ShorebirdProcessResult patchProcessResult;
     late http.Client httpClient;
     late Cache cache;
@@ -223,6 +224,7 @@ flutter:
       progress = _MockProgress();
       logger = _MockLogger();
       flutterBuildProcessResult = _MockProcessResult();
+      flutterPubGetProcessResult = _MockProcessResult();
       patchProcessResult = _MockProcessResult();
       httpClient = _MockHttpClient();
       flutterValidator = _MockShorebirdFlutterValidator();
@@ -249,6 +251,14 @@ flutter:
           runInShell: any(named: 'runInShell'),
         ),
       ).thenAnswer((_) async => flutterBuildProcessResult);
+      when(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['pub', 'get', '--offline'],
+          runInShell: any(named: 'runInShell'),
+          useVendedFlutter: false,
+        ),
+      ).thenAnswer((_) async => flutterPubGetProcessResult);
       when(
         () => shorebirdProcess.run(
           any(that: endsWith('patch')),
@@ -296,6 +306,9 @@ flutter:
       when(
         () => flutterBuildProcessResult.exitCode,
       ).thenReturn(ExitCode.success.code);
+      when(() => flutterPubGetProcessResult.exitCode).thenReturn(
+        ExitCode.success.code,
+      );
       when(() => httpClient.send(any())).thenAnswer(
         (_) async => http.StreamedResponse(const Stream.empty(), HttpStatus.ok),
       );
@@ -748,6 +761,25 @@ Or change your Flutter version and try again using:
       ).called(1);
       verify(() => logger.success('\n✅ Published Patch!')).called(1);
       expect(exitCode, ExitCode.success.code);
+    });
+
+    test('runs flutter pub get with system flutter after successful build',
+        () async {
+      final tempDir = setUpTempDir();
+      setUpTempArtifacts(tempDir);
+      await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['pub', 'get', '--offline'],
+          runInShell: any(named: 'runInShell'),
+          useVendedFlutter: false,
+        ),
+      ).called(1);
     });
 
     test(

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -98,6 +98,7 @@ void main() {
     late Progress progress;
     late Logger logger;
     late ShorebirdProcessResult flutterBuildProcessResult;
+    late ShorebirdProcessResult flutterPubGetProcessResult;
     late ShorebirdFlutterValidator flutterValidator;
     late ShorebirdProcess shorebirdProcess;
     late ShorebirdEnv shorebirdEnv;
@@ -145,6 +146,7 @@ void main() {
       progress = _MockProgress();
       logger = _MockLogger();
       flutterBuildProcessResult = _MockProcessResult();
+      flutterPubGetProcessResult = _MockProcessResult();
       flutterValidator = _MockShorebirdFlutterValidator();
       shorebirdProcess = _MockShorebirdProcess();
       shorebirdEnv = _MockShorebirdEnv();
@@ -155,6 +157,14 @@ void main() {
       when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
       when(() => shorebirdEnv.isRunningOnCI).thenReturn(false);
 
+      when(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['pub', 'get', '--offline'],
+          runInShell: any(named: 'runInShell'),
+          useVendedFlutter: false,
+        ),
+      ).thenAnswer((_) async => flutterPubGetProcessResult);
       when(
         () => shorebirdProcess.run(
           'flutter',
@@ -181,6 +191,8 @@ void main() {
       when(
         () => flutterBuildProcessResult.exitCode,
       ).thenReturn(ExitCode.success.code);
+      when(() => flutterPubGetProcessResult.exitCode)
+          .thenReturn(ExitCode.success.code);
       when(
         () => codePushClientWrapper.getApp(appId: any(named: 'appId')),
       ).thenAnswer((_) async => appMetadata);
@@ -424,6 +436,36 @@ void main() {
         ),
       ).called(1);
       expect(exitCode, ExitCode.success.code);
+    });
+
+    test('runs flutter pub get with system flutter after successful build',
+        () async {
+      await runWithOverrides(command.run);
+
+      verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['pub', 'get', '--offline'],
+          runInShell: any(named: 'runInShell'),
+          useVendedFlutter: false,
+        ),
+      ).called(1);
+    });
+
+    test('prints error message if system flutter pub get fails', () async {
+      when(() => flutterPubGetProcessResult.exitCode).thenReturn(1);
+
+      await runWithOverrides(command.run);
+
+      verify(
+        () => logger.warn(
+          '''
+Build was successful, but `flutter pub get` failed to run after the build completed. You may see unexpected behavior in VS Code.
+
+Either run `flutter pub get` manually, or follow the steps in ${link(uri: Uri.parse('https://docs.shorebird.dev/troubleshooting#i-installed-shorebird-and-now-i-cant-run-my-app-in-vs-code'))}.
+''',
+        ),
+      ).called(1);
     });
 
     test(


### PR DESCRIPTION
## Description

A hacky way to address https://github.com/shorebirdtech/shorebird/issues/1101. This change adds an invocation of `flutter pub get --offline` to all `release` and `patch` commands after the `flutter build` step. This does not cover `shorebird run` because we return an exit code before that command updates the `dart_tool/package_config.json` file.

Shorebird's invocation of `flutter build` with the Shorebird-vended version of Flutter points the flutter entry in `.dart_tool/package_config.json` to shorebird's Flutter, which makes VS Code use that version of Flutter, which causes the issue described in https://docs.shorebird.dev/troubleshooting#i-installed-shorebird-and-now-i-cant-run-my-app-in-vs-code.

Fixes https://github.com/shorebirdtech/shorebird/issues/1107

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
