### PR TITLE
fix(e2e): scoped logger in `LoggingClient`

### DIFF
--- a/packages/shorebird_cli/integration_test/shorebird_cli_integration_test.dart
+++ b/packages/shorebird_cli/integration_test/shorebird_cli_integration_test.dart
@@ -1,11 +1,13 @@
 import 'dart:io';
 
 import 'package:checked_yaml/checked_yaml.dart';
+import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/config/config.dart';
+import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -15,10 +17,17 @@ import 'package:uuid/uuid.dart';
 void main() {
   final logger = Logger();
   final client = runScoped(
-    () => CodePushClient(
-      httpClient: Auth().client,
-      hostedUri: Uri.parse(Platform.environment['SHOREBIRD_HOSTED_URL']!),
-    ),
+    () {
+      final auth = Auth(
+        httpClient: retryingHttpClient(
+          LoggingClient(httpClient: http.Client()),
+        ),
+      );
+      return CodePushClient(
+        httpClient: auth.client,
+        hostedUri: Uri.parse(Platform.environment['SHOREBIRD_HOSTED_URL']!),
+      );
+    },
     values: {loggerRef, platformRef},
   );
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- fix(e2e): scoped logger in `LoggingClient`
  - e2e tests were failing because the `Auth` instance has a static default `LoggingClient` which has a dependency on `logger` and the lookup was failing.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
