### PR TITLE
feat(shorebird_cli): add patch number to patch command output

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -680,6 +680,8 @@ aar artifact already exists, continuing...''',
         );
 
     await promotePatch(appId: appId, patchId: patch.id, channel: channel);
+
+    logger.success('\n✅ Published Patch ${patch.number}!');
   }
 
   /// Prints an appropriate error message for the given error and exits with

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -281,7 +281,6 @@ ${summary.join('\n')}
       patchArtifactBundles: patchArtifactBundles,
     );
 
-    logger.success('\n✅ Published Patch!');
     return ExitCode.success.code;
   }
 

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -299,7 +299,6 @@ ${summary.join('\n')}
       patchArtifactBundles: patchArtifactBundles,
     );
 
-    logger.success('\n✅ Published Patch!');
     return ExitCode.success.code;
   }
 

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -255,7 +255,6 @@ ${summary.join('\n')}
       },
     );
 
-    logger.success('\n✅ Published Patch!');
     return ExitCode.success.code;
   }
 }

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
@@ -248,7 +248,6 @@ ${summary.join('\n')}
       },
     );
 
-    logger.success('\n✅ Published Patch!');
     return ExitCode.success.code;
   }
 

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -2043,6 +2043,22 @@ Please bump your version number and try again.''',
             ),
           ).called(1);
         });
+
+        test('prints patch number on success', () async {
+          await runWithOverrides(
+            () => codePushClientWrapper.publishPatch(
+              appId: appId,
+              releaseId: releaseId,
+              platform: releasePlatform,
+              channelName: channelName,
+              patchArtifactBundles: patchArtifactBundles,
+            ),
+          );
+
+          verify(
+            () => logger.success(any(that: contains('Published Patch 2!'))),
+          ).called(1);
+        });
       });
     });
   });

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -832,7 +832,6 @@ Please re-run the release command for this version or create a new release.'''),
           ),
         ),
       ).called(1);
-      verify(() => logger.success('\n✅ Published Patch!')).called(1);
 
       verify(() => codePushClientWrapper.getApp(appId: appId)).called(1);
       verify(() => codePushClientWrapper.getReleases(appId: appId)).called(1);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -803,7 +803,15 @@ Or change your Flutter version and try again using:
           ),
         ),
       ).called(1);
-      verify(() => logger.success('\n✅ Published Patch!')).called(1);
+      verify(
+        () => codePushClientWrapper.publishPatch(
+          appId: any(named: 'appId'),
+          releaseId: any(named: 'releaseId'),
+          platform: any(named: 'platform'),
+          channelName: any(named: 'channelName'),
+          patchArtifactBundles: any(named: 'patchArtifactBundles'),
+        ),
+      ).called(1);
       expect(exitCode, ExitCode.success.code);
     });
 
@@ -845,7 +853,15 @@ flavors:
         () => runWithOverrides(command.run),
         getCurrentDirectory: () => tempDir,
       );
-      verify(() => logger.success('\n✅ Published Patch!')).called(1);
+      verify(
+        () => codePushClientWrapper.publishPatch(
+          appId: any(named: 'appId'),
+          releaseId: any(named: 'releaseId'),
+          platform: any(named: 'platform'),
+          channelName: any(named: 'channelName'),
+          patchArtifactBundles: any(named: 'patchArtifactBundles'),
+        ),
+      ).called(1);
       expect(exitCode, ExitCode.success.code);
     });
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -835,7 +835,15 @@ Or change your Flutter version and try again using:
           ),
         ),
       ).called(1);
-      verify(() => logger.success('\n✅ Published Patch!')).called(1);
+      verify(
+        () => codePushClientWrapper.publishPatch(
+          appId: any(named: 'appId'),
+          releaseId: any(named: 'releaseId'),
+          platform: any(named: 'platform'),
+          channelName: any(named: 'channelName'),
+          patchArtifactBundles: any(named: 'patchArtifactBundles'),
+        ),
+      ).called(1);
       expect(exitCode, ExitCode.success.code);
     });
 
@@ -878,8 +886,16 @@ flavors:
         () => runWithOverrides(command.run),
         getCurrentDirectory: () => tempDir,
       );
-      verify(() => logger.success('\n✅ Published Patch!')).called(1);
       expect(exitCode, ExitCode.success.code);
+      verify(
+        () => codePushClientWrapper.publishPatch(
+          appId: any(named: 'appId'),
+          releaseId: any(named: 'releaseId'),
+          platform: any(named: 'platform'),
+          channelName: any(named: 'channelName'),
+          patchArtifactBundles: any(named: 'patchArtifactBundles'),
+        ),
+      ).called(1);
     });
 
     test('succeeds when patch is successful using custom base_url', () async {

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
@@ -767,7 +767,15 @@ Please re-run the release command for this version or create a new release.'''),
           ),
         ),
       ).called(1);
-      verify(() => logger.success('\n✅ Published Patch!')).called(1);
+      verify(
+        () => codePushClientWrapper.publishPatch(
+          appId: any(named: 'appId'),
+          releaseId: any(named: 'releaseId'),
+          platform: any(named: 'platform'),
+          channelName: any(named: 'channelName'),
+          patchArtifactBundles: any(named: 'patchArtifactBundles'),
+        ),
+      ).called(1);
       expect(exitCode, ExitCode.success.code);
     });
 


### PR DESCRIPTION
## Description

Adds the patch number to the `shorebird patch` command output.

![Screenshot 2023-09-07 at 11 52 00 AM](https://github.com/shorebirdtech/shorebird/assets/581764/af20ce14-12b9-41f5-805c-c6894fcaaf9f)

Fixes https://github.com/shorebirdtech/shorebird/issues/1212

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
