### PR TITLE
chore(shorebird_cli): highlight missing Android components in doctor

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/doctor_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/doctor_command.dart
@@ -56,7 +56,7 @@ Engine • revision ${shorebirdEnv.shorebirdEngineRevision}''',
     );
 
     if (verbose) {
-      const notDetected = 'not detected';
+      final notDetected = red.wrap('not detected');
       output.writeln('''
 
 Android Toolchain

--- a/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
@@ -134,6 +134,7 @@ Engine • revision $shorebirdEngineRevision
         when(() => argResults['verbose']).thenReturn(true);
         await runWithOverrides(command.run);
 
+        final notDetectedText = red.wrap('not detected');
         verify(
           () => logger.info('''
 
@@ -142,10 +143,10 @@ Flutter • revision ${shorebirdEnv.flutterRevision}
 Engine • revision $shorebirdEngineRevision
 
 Android Toolchain
-  • Android Studio: not detected
-  • Android SDK: not detected
-  • ADB: not detected
-  • JAVA_HOME: not detected'''),
+  • Android Studio: $notDetectedText
+  • Android SDK: $notDetectedText
+  • ADB: $notDetectedText
+  • JAVA_HOME: $notDetectedText'''),
         ).called(1);
       });
 


### PR DESCRIPTION
## Description

Highlight "not detected" Android toolchain components when running `shorebird doctor -v`.

Part of https://github.com/shorebirdtech/shorebird/issues/1213

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
