### PR TITLE
fix(shorebird_cli): ensure system flutter pub get is run even if build fails

### DIFF
--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -477,6 +477,22 @@ ${link(uri: Uri.parse('https://support.google.com/googleplay/android-developer/a
       ).called(1);
     });
 
+    test('runs flutter pub get with system flutter if build fails', () async {
+      when(() => flutterBuildProcessResult.exitCode).thenReturn(1);
+      when(() => flutterBuildProcessResult.stderr).thenReturn('oops');
+
+      await runWithOverrides(command.run);
+
+      verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['--no-version-check', 'pub', 'get', '--offline'],
+          runInShell: any(named: 'runInShell'),
+          useVendedFlutter: false,
+        ),
+      ).called(1);
+    });
+
     test('prints error message if system flutter pub get fails', () async {
       when(() => flutterPubGetProcessResult.exitCode).thenReturn(1);
 


### PR DESCRIPTION
## Description

Wraps `flutter build` commands that use Shorebird's version of flutter in a try/finally that invokes `flutter pub get` in the `finally` block to ensure that `.dart_tool/package_config.json` points to the system version of Flutter whether or not the shorebird build succeeds.

Fixes https://github.com/shorebirdtech/shorebird/issues/1193

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
