### PR TITLE
feat(shorebird_cli): add no-build flag to ios-framework commands

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -25,6 +25,13 @@ of the iOS app that is using this module.''',
         mandatory: true,
       )
       ..addFlag(
+        'no-build',
+        help:
+            'Looks for an existing app.dill instead of running a build command',
+        hide: true,
+        negatable: false,
+      )
+      ..addFlag(
         'force',
         abbr: 'f',
         help: 'Release without confirmation if there are no errors.',
@@ -71,16 +78,16 @@ of the iOS app that is using this module.''',
       );
     }
 
-    final buildProgress = logger.progress('Building iOS framework');
-
-    try {
-      await buildIosFramework();
-    } catch (error) {
-      buildProgress.fail('Failed to build iOS framework: $error');
-      return ExitCode.software.code;
+    if (results['no-build'] != true) {
+      final buildProgress = logger.progress('Building iOS framework');
+      try {
+        await buildIosFramework();
+      } catch (error) {
+        buildProgress.fail('Failed to build iOS framework: $error');
+        return ExitCode.software.code;
+      }
+      buildProgress.complete();
     }
-
-    buildProgress.complete();
 
     final summary = [
       '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('($appId)')}''',


### PR DESCRIPTION
## Description

Adds a `--no-build` flag to the `ios-framework-alpha` release and patch commands to support the add-to-app case described [here](https://docs.flutter.dev/add-to-app/ios/project-setup#option-a---embed-with-cocoapods-and-the-flutter-sdk). Because Xcode builds the Flutter module, Shorebird needs to use the artifacts created by the Xcode archive operation and consume those to create a release or patch.

This flag is hidden for now as this workflow is still in development.

Part of https://github.com/shorebirdtech/shorebird/issues/1198

The full workflow here:

1. Follow the [instructions](https://docs.flutter.dev/add-to-app/ios/project-setup#option-a---embed-with-cocoapods-and-the-flutter-sdk) to set up your Xcode project to consume your Flutter module using cocoapods.
2. Run `/path/to/shorebird/flutter build ios --config-only` to tell Xcode to use Shorebird's Flutter.
3. Create an app archive using the Product -> Archive menu option in Xcode.
4. Run `shorebird release ios-framework-alpha --no-build --release-version X.Y.Z+ABC`
5. Install on the device by following the steps [here](https://developer.apple.com/documentation/xcode/distributing-your-app-to-registered-devices#Install-the-app-on-user-devices)
6. Make dart changes
7. Create a new app archive, following the same process as before.
8. Run `shorebird patch ios-framework-alpha --no-build --release-version X.Y.Z+ABC`
9. Kill and relaunch the app a couple times on the device to see the patch in effect.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
