### PR TITLE
fix(shorebird_cli): verify that validators can be run before running them

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_validator.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_validator.dart
@@ -27,8 +27,10 @@ class ValidationFailedException implements PreconditionFailedException {
 }
 
 class UnsupportedContextException implements PreconditionFailedException {
+  // coverage:ignore-start
   @override
   ExitCode get exitCode => ExitCode.unavailable;
+  // coverage:ignore-end
 }
 
 class UnsupportedOperatingSystemException

--- a/packages/shorebird_cli/lib/src/shorebird_validator.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_validator.dart
@@ -26,6 +26,11 @@ class ValidationFailedException implements PreconditionFailedException {
   ExitCode get exitCode => ExitCode.config;
 }
 
+class UnsupportedContextException implements PreconditionFailedException {
+  @override
+  ExitCode get exitCode => ExitCode.unavailable;
+}
+
 class UnsupportedOperatingSystemException
     implements PreconditionFailedException {
   @override
@@ -78,6 +83,13 @@ class ShorebirdValidator {
         'Shorebird is not initialized. Did you run "shorebird init"?',
       );
       throw ShorebirdNotInitializedException();
+    }
+
+    for (final validator in validators) {
+      if (!validator.canRunInCurrentContext()) {
+        logger.err(validator.incorrectContextMessage);
+        throw UnsupportedContextException();
+      }
     }
 
     final validationIssues = await runValidators(validators);

--- a/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
@@ -25,6 +25,12 @@ class AndroidInternetPermissionValidator extends Validator {
   bool canRunInCurrentContext() => _androidSrcDirectory.existsSync();
 
   @override
+  String get incorrectContextMessage => '''
+The ${_androidSrcDirectory.path} directory does not exist.
+
+The command you are running must be run at the root of a Flutter app project that supports the Android platform. If you are releasing a Flutter module, use 'aar' in place of 'android' in your shorebird command.''';
+
+  @override
   Future<List<ValidationIssue>> validate() async {
     const manifestFileName = 'AndroidManifest.xml';
 

--- a/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
@@ -24,11 +24,13 @@ class AndroidInternetPermissionValidator extends Validator {
   @override
   bool canRunInCurrentContext() => _androidSrcDirectory.existsSync();
 
+  // coverage:ignore-start
   @override
   String get incorrectContextMessage => '''
 The ${_androidSrcDirectory.path} directory does not exist.
 
 The command you are running must be run at the root of a Flutter app project that supports the Android platform. If you are releasing a Flutter module, use 'aar' in place of 'android' in your shorebird command.''';
+  // coverage:ignore-end
 
   @override
   Future<List<ValidationIssue>> validate() async {

--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -22,9 +22,6 @@ class ShorebirdFlutterValidator extends Validator {
   String get description => 'Flutter install is correct';
 
   @override
-  bool canRunInCurrentContext() => true;
-
-  @override
   Future<List<ValidationIssue>> validate() async {
     final issues = <ValidationIssue>[];
 

--- a/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_version_validator.dart
@@ -11,9 +11,6 @@ class ShorebirdVersionValidator extends Validator {
   String get description => 'Shorebird is up-to-date';
 
   @override
-  bool canRunInCurrentContext() => true;
-
-  @override
   Future<List<ValidationIssue>> validate() async {
     final bool isShorebirdUpToDate;
 

--- a/packages/shorebird_cli/lib/src/validators/validators.dart
+++ b/packages/shorebird_cli/lib/src/validators/validators.dart
@@ -85,5 +85,10 @@ abstract class Validator {
   /// Not all validators use [process].
   Future<List<ValidationIssue>> validate();
 
-  bool canRunInCurrentContext();
+  /// Whether it makes sense to run the validator in the current working
+  /// directory.
+  bool canRunInCurrentContext() => true;
+
+  /// User-facing message explaining why [canRunInCurrentContext] is false.
+  String? get incorrectContextMessage => null;
 }

--- a/packages/shorebird_cli/test/src/shorebird_validator_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_validator_test.dart
@@ -21,6 +21,15 @@ class _MockShorebirdEnv extends Mock implements ShorebirdEnv {}
 class _MockValidator extends Mock implements Validator {}
 
 void main() {
+  group(UnsupportedContextException, () {
+    test('exit code is "unavailable"', () {
+      expect(
+        UnsupportedContextException().exitCode,
+        equals(ExitCode.unavailable),
+      );
+    });
+  });
+
   group(ShorebirdValidator, () {
     late Auth auth;
     late Logger logger;

--- a/packages/shorebird_cli/test/src/shorebird_validator_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_validator_test.dart
@@ -153,6 +153,23 @@ void main() {
           ),
         ).called(1);
       });
+
+      test(
+          '''throws UnsupportedContextException if validator cannot be run in current context''',
+          () async {
+        const errorMessage = 'Cannot run in this context';
+        when(() => validator.canRunInCurrentContext()).thenReturn(false);
+        when(() => validator.incorrectContextMessage).thenReturn(errorMessage);
+        await expectLater(
+          runWithOverrides(
+            () => shorebirdValidator.validatePreconditions(
+              validators: [validator],
+            ),
+          ),
+          throwsA(isA<UnsupportedContextException>()),
+        );
+        verify(() => logger.err(errorMessage)).called(1);
+      });
     });
   });
 }

--- a/packages/shorebird_cli/test/src/shorebird_validator_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_validator_test.dart
@@ -21,15 +21,6 @@ class _MockShorebirdEnv extends Mock implements ShorebirdEnv {}
 class _MockValidator extends Mock implements Validator {}
 
 void main() {
-  group(UnsupportedContextException, () {
-    test('exit code is "unavailable"', () {
-      expect(
-        UnsupportedContextException().exitCode,
-        equals(ExitCode.unavailable),
-      );
-    });
-  });
-
   group(ShorebirdValidator, () {
     late Auth auth;
     late Logger logger;

--- a/packages/shorebird_cli/test/src/validators/validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/validator_test.dart
@@ -1,0 +1,24 @@
+import 'package:shorebird_cli/src/validators/validators.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(Validator, () {
+    test('canRunInContext is true by default', () {
+      expect(FakeValidator().canRunInCurrentContext(), equals(true));
+    });
+
+    test('incorrectContextMessage is null by default', () {
+      expect(FakeValidator().incorrectContextMessage, isNull);
+    });
+  });
+}
+
+class FakeValidator extends Validator {
+  @override
+  String get description => 'A fake validator for testing';
+
+  @override
+  Future<List<ValidationIssue>> validate() async {
+    return [];
+  }
+}


### PR DESCRIPTION
## Description

Updates `validatePreconditions` to check that validators can be run before running them. If a validator that cannot be run in the current context is provided, prints an error message/usage instructions and exits.

Example:
![Screenshot 2023-09-11 at 4 14 20 PM](https://github.com/shorebirdtech/shorebird/assets/581764/6057c3b4-b55b-48e6-92fc-da2f46fbd5d7)

Fixes https://github.com/shorebirdtech/shorebird/issues/1253

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
