### PR TITLE
chore(shorebird_cli): hide split-per-abi flag, print warning

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -157,7 +157,11 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
         '--release',
         if (flavor != null) '--flavor=$flavor',
         if (target != null) '--target=$target',
+        // TODO(bryanoltman): reintroduce coverage when we can support this.
+        // See https://github.com/shorebirdtech/shorebird/issues/1141.
+        // coverage:ignore-start
         if (splitPerAbi) '--split-per-abi',
+        // coverage:ignore-end
         ...results.rest,
       ];
 

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -283,6 +283,16 @@ void main() {
       ).called(1);
     });
 
+    test('exits with code unavailable when --split-per-abi is provided',
+        () async {
+      when(() => argResults['artifact']).thenReturn('apk');
+      when(() => argResults['split-per-abi']).thenReturn(true);
+
+      final exitCode = await runWithOverrides(command.run);
+
+      expect(exitCode, ExitCode.unavailable.code);
+    });
+
     test('exits with code 70 when building fails', () async {
       when(() => flutterBuildProcessResult.exitCode).thenReturn(1);
       when(() => flutterBuildProcessResult.stderr).thenReturn('oops');
@@ -414,45 +424,6 @@ ${link(uri: Uri.parse('https://support.google.com/googleplay/android-developer/a
         ),
       ).called(1);
       const buildApkArguments = ['build', 'apk', '--release'];
-      verify(
-        () => shorebirdProcess.run(
-          'flutter',
-          buildApkArguments,
-          runInShell: true,
-        ),
-      ).called(1);
-      expect(exitCode, ExitCode.success.code);
-    });
-
-    test('succeeds when release is successful (with apk + split-per-abi)',
-        () async {
-      when(() => argResults['artifact']).thenReturn('apk');
-      when(() => argResults['split-per-abi']).thenReturn(true);
-      final exitCode = await runWithOverrides(command.run);
-      verify(() => logger.success('\n✅ Published Release!')).called(1);
-      verify(
-        () => codePushClientWrapper.createAndroidReleaseArtifacts(
-          appId: appId,
-          releaseId: release.id,
-          platform: releasePlatform,
-          aabPath: any(named: 'aabPath'),
-          architectures: any(named: 'architectures'),
-        ),
-      ).called(1);
-      verify(
-        () => codePushClientWrapper.updateReleaseStatus(
-          appId: appId,
-          releaseId: release.id,
-          platform: releasePlatform,
-          status: ReleaseStatus.active,
-        ),
-      ).called(1);
-      const buildApkArguments = [
-        'build',
-        'apk',
-        '--release',
-        '--split-per-abi',
-      ];
       verify(
         () => shorebirdProcess.run(
           'flutter',


### PR DESCRIPTION
## Description

This change hides the `split-per-abi` flag from the release android command and prints a warning explaining why we do not currently support this flag.

![Screenshot 2023-09-11 at 5 58 32 PM](https://github.com/shorebirdtech/shorebird/assets/581764/0f38433f-c360-4be0-91e7-d8592deabcd1)

Addresses but does not fix https://github.com/shorebirdtech/shorebird/issues/1141

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
