### PR TITLE
fix(shorebird_cli): provide better error message for missing iOS release

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -136,7 +136,11 @@ class PatchIosCommand extends ShorebirdCommand
       releaseVersion: releaseVersion,
     );
 
-    if (release.platformStatuses[ReleasePlatform.ios] == ReleaseStatus.draft) {
+    if (release.platformStatuses[ReleasePlatform.ios] == null) {
+      logger.err('No iOS release found for $releaseVersion.');
+      return ExitCode.software.code;
+    } else if (release.platformStatuses[ReleasePlatform.ios] ==
+        ReleaseStatus.draft) {
       logger.err('''
 Release $releaseVersion is in an incomplete state. It's possible that the original release was terminated or failed to complete.
 Please re-run the release command for this version or create a new release.''');


### PR DESCRIPTION
## Description

Changes the error message for a missing iOS release from `No artifact found for architecture ipa in release [id]` to `No iOS release found for [version]`.

Fixes https://github.com/shorebirdtech/shorebird/issues/1261

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
