### PR TITLE
feat(shorebird_cli): only list previewable releases for `shorebird preview`

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -190,10 +190,16 @@ Please create a release using "shorebird release" and try again.
     return release;
   }
 
-  Future<List<Release>> getReleases({required String appId}) async {
+  Future<List<Release>> getReleases({
+    required String appId,
+    bool sideloadableOnly = false,
+  }) async {
     final fetchReleasesProgress = logger.progress('Fetching releases');
     try {
-      final releases = await codePushClient.getReleases(appId: appId);
+      final releases = await codePushClient.getReleases(
+        appId: appId,
+        sideloadableOnly: sideloadableOnly,
+      );
       fetchReleasesProgress.complete();
       return releases;
     } catch (error) {

--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -73,7 +73,10 @@ class PreviewCommand extends ShorebirdCommand {
       return ExitCode.success.code;
     }
 
-    final releases = await codePushClientWrapper.getReleases(appId: appId);
+    final releases = await codePushClientWrapper.getReleases(
+      appId: appId,
+      sideloadableOnly: true,
+    );
 
     final releaseVersion = results['release-version'] as String? ??
         await promptForReleaseVersion(releases);
@@ -83,7 +86,9 @@ class PreviewCommand extends ShorebirdCommand {
     );
 
     if (releaseVersion == null || release == null) {
-      logger.info('No releases found');
+      // TODO(bryanoltman): link to FAQ explaining which releases are
+      // previewable.
+      logger.info('No previewable releases found');
       return ExitCode.success.code;
     }
 

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -539,7 +539,31 @@ Please bump your version number and try again.''',
           );
 
           expect(releases, equals([release]));
+
           verify(() => progress.complete()).called(1);
+        });
+
+        test('forwards sideloadableOnly value to codePushClient', () async {
+          when(
+            () => codePushClient.getReleases(
+              appId: any(named: 'appId'),
+              sideloadableOnly: any(named: 'sideloadableOnly'),
+            ),
+          ).thenAnswer((_) async => []);
+
+          await runWithOverrides(
+            () => codePushClientWrapper.getReleases(
+              appId: appId,
+              sideloadableOnly: true,
+            ),
+          );
+
+          verify(
+            () => codePushClient.getReleases(
+              appId: appId,
+              sideloadableOnly: true,
+            ),
+          );
         });
       });
 

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -125,7 +125,10 @@ void main() {
         () => codePushClientWrapper.getApps(),
       ).thenAnswer((_) async => [app]);
       when(
-        () => codePushClientWrapper.getReleases(appId: appId),
+        () => codePushClientWrapper.getReleases(
+          appId: appId,
+          sideloadableOnly: true,
+        ),
       ).thenAnswer((_) async => [release]);
       when(
         () => codePushClientWrapper.getReleaseArtifact(
@@ -172,14 +175,20 @@ void main() {
     test('exits with code 70 when querying for releases fails', () async {
       final exception = Exception('oops');
       when(
-        () => codePushClientWrapper.getReleases(appId: any(named: 'appId')),
+        () => codePushClientWrapper.getReleases(
+          appId: any(named: 'appId'),
+          sideloadableOnly: any(named: 'sideloadableOnly'),
+        ),
       ).thenThrow(exception);
       await expectLater(
         () => runWithOverrides(command.run),
         throwsA(exception),
       );
       verify(
-        () => codePushClientWrapper.getReleases(appId: appId),
+        () => codePushClientWrapper.getReleases(
+          appId: appId,
+          sideloadableOnly: true,
+        ),
       ).called(1);
     });
 
@@ -458,7 +467,10 @@ void main() {
       test('exits early when no releases are found', () async {
         when(() => argResults['release-version']).thenReturn(null);
         when(
-          () => codePushClientWrapper.getReleases(appId: any(named: 'appId')),
+          () => codePushClientWrapper.getReleases(
+            appId: any(named: 'appId'),
+            sideloadableOnly: any(named: 'sideloadableOnly'),
+          ),
         ).thenAnswer((_) async => []);
         final result = await runWithOverrides(command.run);
         expect(result, equals(ExitCode.success.code));
@@ -469,8 +481,13 @@ void main() {
             display: captureAny(named: 'display'),
           ),
         );
-        verify(() => codePushClientWrapper.getReleases(appId: appId)).called(1);
-        verify(() => logger.info('No releases found')).called(1);
+        verify(
+          () => codePushClientWrapper.getReleases(
+            appId: appId,
+            sideloadableOnly: true,
+          ),
+        ).called(1);
+        verify(() => logger.info('No previewable releases found')).called(1);
       });
 
       test(
@@ -494,7 +511,12 @@ void main() {
           ),
         ).captured.single as String Function(Release);
         expect(captured(release), equals(releaseVersion));
-        verify(() => codePushClientWrapper.getReleases(appId: appId)).called(1);
+        verify(
+          () => codePushClientWrapper.getReleases(
+            appId: appId,
+            sideloadableOnly: true,
+          ),
+        ).called(1);
       });
 
       test('forwards deviceId to adb and bundletool', () async {

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -126,8 +126,8 @@ void main() {
       ).thenAnswer((_) async => [app]);
       when(
         () => codePushClientWrapper.getReleases(
-          appId: appId,
-          sideloadableOnly: true,
+          appId: any(named: 'appId'),
+          sideloadableOnly: any(named: 'sideloadableOnly'),
         ),
       ).thenAnswer((_) async => [release]);
       when(

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -445,9 +445,14 @@ class CodePushClient {
   }
 
   /// List all release for the provided [appId].
-  Future<List<Release>> getReleases({required String appId}) async {
+  Future<List<Release>> getReleases({
+    required String appId,
+    bool sideloadableOnly = false,
+  }) async {
     final response = await _httpClient.get(
-      Uri.parse('$_v1/apps/$appId/releases'),
+      Uri.parse(
+        '$_v1/apps/$appId/releases${sideloadableOnly ? '?sideloadable=true' : ''}',
+      ),
     );
 
     if (response.statusCode != HttpStatus.ok) {

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -449,11 +449,18 @@ class CodePushClient {
     required String appId,
     bool sideloadableOnly = false,
   }) async {
-    final response = await _httpClient.get(
-      Uri.parse(
-        '$_v1/apps/$appId/releases${sideloadableOnly ? '?sideloadable=true' : ''}',
-      ),
+    var uri = Uri.parse(
+      '$_v1/apps/$appId/releases',
     );
+    if (sideloadableOnly) {
+      uri = uri.replace(
+        queryParameters: {
+          if (sideloadableOnly) 'sideloadable': 'true',
+        },
+      );
+    }
+
+    final response = await _httpClient.get(uri);
 
     if (response.statusCode != HttpStatus.ok) {
       throw _parseErrorResponse(response.statusCode, response.body);

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -454,9 +454,7 @@ class CodePushClient {
     );
     if (sideloadableOnly) {
       uri = uri.replace(
-        queryParameters: {
-          if (sideloadableOnly) 'sideloadable': 'true',
-        },
+        queryParameters: {'sideloadable': 'true'},
       );
     }
 

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -1786,14 +1786,31 @@ void main() {
     group('getReleases', () {
       const appId = 'test-app-id';
 
-      test('makes the correct request', () async {
-        codePushClient.getReleases(appId: appId).ignore();
-        final request = verify(() => httpClient.send(captureAny()))
-            .captured
-            .single as http.BaseRequest;
-        expect(request.method, equals('GET'));
-        expect(request.url, equals(v1('apps/$appId/releases')));
-        expect(request.hasStandardHeaders, isTrue);
+      group('makes the correct request', () {
+        test('when sideloadableOnly is not specified', () async {
+          codePushClient.getReleases(appId: appId).ignore();
+          final request = verify(() => httpClient.send(captureAny()))
+              .captured
+              .single as http.BaseRequest;
+          expect(request.method, equals('GET'));
+          expect(request.url, equals(v1('apps/$appId/releases')));
+          expect(request.hasStandardHeaders, isTrue);
+        });
+
+        test('when sideloadableOnly is true', () async {
+          codePushClient
+              .getReleases(appId: appId, sideloadableOnly: true)
+              .ignore();
+          final request = verify(() => httpClient.send(captureAny()))
+              .captured
+              .single as http.BaseRequest;
+          expect(request.method, equals('GET'));
+          expect(
+            request.url,
+            equals(v1('apps/$appId/releases?sideloadable=true')),
+          );
+          expect(request.hasStandardHeaders, isTrue);
+        });
       });
 
       test('throws an exception if the http request fails (unknown)', () async {


### PR DESCRIPTION
## Description

Updates the `shorebird preview` release version and platforms list to only include those which can be previewed (releases with Android app bundle artifacts or codesigned iOS Mach-O binaries).

Fixes https://github.com/shorebirdtech/shorebird/issues/981

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
