### PR TITLE
chore(shorebird_cli): add xcarchive upload instructions to `release ios-alpha`

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -217,8 +217,7 @@ ${summary.join('\n')}
       final relativeIpaPath = p.relative(ipaPath);
       logger.info('''
 
-Your next step is to upload the ipa to App Store Connect.
-${lightCyan.wrap(relativeIpaPath)}
+Your next step is to upload your app to App Store Connect.
 
 To upload to the App Store either:
     1. Open ${lightCyan.wrap(relativeArchivePath)} in Xcode and use the "Distribute App" flow.

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -219,7 +219,7 @@ ${summary.join('\n')}
 
 Your next step is to upload your app to App Store Connect.
 
-To upload to the App Store either:
+To upload to the App Store, do one of the following:
     1. Open ${lightCyan.wrap(relativeArchivePath)} in Xcode and use the "Distribute App" flow.
     2. Drag and drop the ${lightCyan.wrap(relativeIpaPath)} bundle into the Apple Transporter macOS app (https://apps.apple.com/us/app/transporter/id1450874784).
     3. Run ${lightCyan.wrap('xcrun altool --upload-app --type ios -f $relativeIpaPath --apiKey your_api_key --apiIssuer your_issuer_id')}.

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -212,6 +212,7 @@ ${summary.join('\n')}
 
     logger.success('\n✅ Published Release!');
 
+    final relativeArchivePath = p.relative(archivePath);
     if (codesign) {
       final relativeIpaPath = p.relative(ipaPath);
       logger.info('''
@@ -220,17 +221,18 @@ Your next step is to upload the ipa to App Store Connect.
 ${lightCyan.wrap(relativeIpaPath)}
 
 To upload to the App Store either:
-    1. Drag and drop the "$relativeIpaPath" bundle into the Apple Transporter macOS app (https://apps.apple.com/us/app/transporter/id1450874784)
-    2. Run ${lightCyan.wrap('xcrun altool --upload-app --type ios -f $relativeIpaPath --apiKey your_api_key --apiIssuer your_issuer_id')}.
+    1. Open ${lightCyan.wrap(relativeArchivePath)} in Xcode and use the "Distribute App" flow.
+    2. Drag and drop the ${lightCyan.wrap(relativeIpaPath)} bundle into the Apple Transporter macOS app (https://apps.apple.com/us/app/transporter/id1450874784).
+    3. Run ${lightCyan.wrap('xcrun altool --upload-app --type ios -f $relativeIpaPath --apiKey your_api_key --apiIssuer your_issuer_id')}.
        See "man altool" for details about how to authenticate with the App Store Connect API key.
 ''');
     } else {
       logger.info('''
 
-Your next step is to submit the archive at ${lightCyan.wrap(archivePath)} to the App Store using Xcode.
+Your next step is to submit the archive at ${lightCyan.wrap(relativeArchivePath)} to the App Store using Xcode.
 
 You can open the archive in Xcode by running:
-    ${lightCyan.wrap('open $archivePath')}
+    ${lightCyan.wrap('open $relativeArchivePath')}
 
 ${styleBold.wrap('Make sure to uncheck "Manage Version and Build Number", or else shorebird will not work.')}
 ''');

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -371,7 +371,6 @@ flutter:
 
         expect(result, equals(ExitCode.success.code));
         final archivePath = p.join(
-          tempDir.path,
           'build',
           'ios',
           'archive',

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -674,7 +674,7 @@ error: exportArchive: No signing certificate "iOS Distribution" found
           any(
             that: stringContainsInOrder(
               [
-                'Your next step is to upload the ipa to App Store Connect.',
+                'Your next step is to upload your app to App Store Connect.',
                 p.join('build', 'ios', 'ipa', 'Runner.ipa'),
               ],
             ),
@@ -747,7 +747,7 @@ flavors:
           any(
             that: stringContainsInOrder(
               [
-                'Your next step is to upload the ipa to App Store Connect.',
+                'Your next step is to upload your app to App Store Connect.',
                 p.join('build', 'ios', 'ipa', 'Runner.ipa'),
               ],
             ),


### PR DESCRIPTION
## Description

Adds a third option to the release instructions (uploading the `.xcarchive` via xcode) to the `shorebird release ios-alpha` success output.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
