### PR TITLE
chore(shorebird_code_push_protocol): make CreateReleaseArtifactRequest canSideload optional

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
@@ -38,7 +38,7 @@ class CreateReleaseArtifactRequest {
 
   /// Whether the artifact can installed and run on a device/emulator as-is.
   @JsonKey(fromJson: _parseStringToBool, toJson: _parseBoolToString)
-  final bool canSideload;
+  final bool? canSideload;
 
   /// The size of the artifact in bytes.
   @JsonKey(fromJson: _parseStringToInt, toJson: _parseIntToString)

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
@@ -48,7 +48,9 @@ class CreateReleaseArtifactRequest {
 
   static String _parseIntToString(dynamic value) => value.toString();
 
-  static bool _parseStringToBool(dynamic value) => value == 'true';
+  // Default to true
+  static bool _parseStringToBool(dynamic value) =>
+      value == null || value == 'true';
 
   static String _parseBoolToString(dynamic value) => value.toString();
 }


### PR DESCRIPTION
## Description

This is for backwards compatibility with older `shorebird_cli` versions

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
