### PR TITLE
feat: add `cutler validate` command

### DIFF
--- a/packages/cutler/lib/checkout.dart
+++ b/packages/cutler/lib/checkout.dart
@@ -110,6 +110,45 @@ class Checkout {
     );
   }
 
+  Version remoteBranch({required String branch, required String remote}) {
+    final output = runCommand(
+      'git',
+      ['ls-remote', '--refs', remote, branch],
+      workingDirectory: workingDirectory,
+    );
+    final hash = output.split('\t').first;
+    final name = output.split('\t').last;
+    return Version(
+      hash: hash,
+      repo: repo,
+      aliases: [name],
+    );
+  }
+
+  Version remoteTag({required String tag, required String remote}) {
+    final output = runCommand(
+      'git',
+      ['ls-remote', '--tags', remote, tag],
+      workingDirectory: workingDirectory,
+    );
+    final hash = output.split('\t').first;
+    final name = output.split('\t').last;
+    return Version(
+      hash: hash,
+      repo: repo,
+      aliases: [name],
+    );
+  }
+
+  bool isAncestor({required String ancestor, required String descendant}) {
+    final output = runCommand(
+      'git',
+      ['merge-base', '--is-ancestor', ancestor, descendant],
+      workingDirectory: workingDirectory,
+    );
+    return output == 'true';
+  }
+
   /// Returns a count of commits between two commits in this repo.
   int countCommits({required String from, required String to}) {
     final output = runCommand(

--- a/packages/cutler/lib/commands/commands.dart
+++ b/packages/cutler/lib/commands/commands.dart
@@ -1,2 +1,3 @@
-export 'versions_command.dart';
 export 'rebase_command.dart';
+export 'validate_command.dart';
+export 'versions_command.dart';

--- a/packages/cutler/lib/commands/validate_command.dart
+++ b/packages/cutler/lib/commands/validate_command.dart
@@ -1,0 +1,76 @@
+import 'package:cutler/checkout.dart';
+import 'package:cutler/commands/base.dart';
+import 'package:cutler/logger.dart';
+import 'package:cutler/model.dart';
+import 'package:cutler/versions.dart';
+import 'package:io/io.dart';
+
+/// Validate that a Shorebird release is consistent with its Flutter release.
+class ValidateCommand extends CutlerCommand {
+  /// Constructs a new [ValidateCommand].
+  ValidateCommand();
+  @override
+  final name = 'validate';
+  @override
+  final description =
+      'Validate that a Shorebird release is consistent with its Flutter '
+      'release.';
+
+  @override
+  int run() {
+    checkouts = Checkouts(config.checkoutsRoot);
+
+    final flutterVersionName = argResults!.rest.first;
+
+    // Given a specific Flutter version code:
+    logger.info('Validating $flutterVersionName');
+
+    // Check that our flutter fork has the expected tag.
+    final origin =
+        checkouts.flutter.remoteTag(tag: flutterVersionName, remote: 'origin');
+    final upstream = checkouts.flutter
+        .remoteTag(tag: flutterVersionName, remote: 'upstream');
+    if (origin != upstream) {
+      logger.err(
+        'Flutter release tag $origin does not match upstream $upstream',
+      );
+      return ExitCode.usage.code;
+    } else {
+      logger.info('Flutter release tag $origin matches upstream $upstream');
+    }
+
+    // Check that the engine has the expected tag?
+
+    final forkpoint = getFlutterVersions(checkouts, flutterVersionName);
+
+    final releaseBranch = 'flutter_release/$flutterVersionName';
+    // Check for flutter_release/$version in all of our forks
+    final forks = [
+      Repo.buildroot,
+      Repo.dart,
+      Repo.engine,
+      Repo.flutter,
+    ];
+    for (final repo in forks) {
+      final checkout = checkouts[repo];
+      final remote =
+          checkout.remoteBranch(branch: releaseBranch, remote: 'origin');
+      logger.info('Found $remote for $repo');
+
+      // Check that the versions at flutter_release/$version include the
+      // expected flutter forkpoint hash.
+      final forkpointVersion = forkpoint[repo];
+      if (!checkout.isAncestor(
+        ancestor: forkpointVersion.hash,
+        descendant: remote.hash,
+      )) {
+        logger.err(
+          'Release branch $releaseBranch for $repo does not include '
+          'forkpoint $forkpointVersion',
+        );
+      }
+    }
+
+    return ExitCode.success.code;
+  }
+}

--- a/packages/cutler/lib/commands/validate_command.dart
+++ b/packages/cutler/lib/commands/validate_command.dart
@@ -4,11 +4,118 @@ import 'package:cutler/logger.dart';
 import 'package:cutler/model.dart';
 import 'package:cutler/versions.dart';
 import 'package:io/io.dart';
+import 'package:version/version.dart' as semver;
+
+/// Check that a tag matches its upstream.
+bool ensureTagMatch(Checkout checkout, String tag) {
+  final origin = checkout.remoteTag(tag: tag, remote: 'origin');
+  final upstream = checkout.remoteTag(tag: tag, remote: 'upstream');
+  final paddedName = checkout.name.padRight(10);
+  if (origin != upstream) {
+    logger.err('❌ $paddedName tag $origin does not match upstream $upstream');
+    return false;
+  }
+  logger.info('✅ $paddedName ${origin.ref} matches upstream $upstream');
+  return true;
+}
+
+/// Check for a flutter_release/$[flutterVersionName] branch in all of our fork
+/// repositories and that our Flutter forkpoint is included in the release
+/// branch.
+bool ensureReleaseBranchesIncludeForkpoint(
+  Checkouts checkouts,
+  String flutterVersionName,
+) {
+  final forkpoint = getFlutterVersions(checkouts, flutterVersionName);
+  final releaseBranch = 'flutter_release/$flutterVersionName';
+  final forks = [
+    Repo.buildroot,
+    Repo.dart,
+    Repo.engine,
+    Repo.flutter,
+  ];
+  for (final repo in forks) {
+    final checkout = checkouts[repo];
+    final remote =
+        checkout.remoteBranch(branch: releaseBranch, remote: 'origin');
+    final paddedName = checkout.name.padRight(10);
+
+    // Check that the versions at flutter_release/$version include the
+    // expected flutter forkpoint hash.
+    final forkpointVersion = forkpoint[repo];
+    if (!checkout.isAncestor(
+      ancestor: forkpointVersion.hash,
+      descendant: remote.hash,
+    )) {
+      logger.err(
+        '❌ $paddedName $releaseBranch does not include '
+        'forkpoint $forkpointVersion',
+      );
+      return false;
+    }
+    logger.info('✅ $paddedName correctly branched');
+  }
+  return true;
+}
+
+/// Validate that a Shorebird release for a given [flutterVersionName]
+/// exists and is consistent with its Flutter release.
+bool validateRelease(Checkouts checkouts, String flutterVersionName) {
+  // Check that our flutter fork has the expected tag.
+  if (!ensureTagMatch(checkouts.flutter, flutterVersionName)) {
+    return false;
+  }
+  // Check that the engine has the expected tag.
+  if (!ensureTagMatch(checkouts.engine, flutterVersionName)) {
+    return false;
+  }
+
+  // Check for flutter_release/$version in all of our forks
+  // and that our flutter forkpoint is included in the release branch.
+  if (!ensureReleaseBranchesIncludeForkpoint(
+    checkouts,
+    flutterVersionName,
+  )) {
+    return false;
+  }
+  return true;
+}
+
+/// Return all Flutter versions that are tagged in the upstream Flutter repo.
+/// Does not include pre-releases.
+/// Returns in descending order (latest release first).
+Iterable<String> allFlutterVersions(Checkout flutter) {
+  final versionTags = flutter.remoteTags(remote: 'upstream');
+  final semvers = <semver.Version>[];
+  for (final tag in versionTags) {
+    // e.g. refs/tags/v1.9.7-hotfix.4
+    final tagName = tag.ref;
+    final versionName = tagName.split('/').last;
+    // ignore old versions
+    if (versionName[0] != '3') {
+      continue;
+    }
+    final version = semver.Version.parse(versionName);
+    logger.info('Found flutter tag $version');
+    if (version.isPreRelease) {
+      continue;
+    }
+    semvers.add(version);
+  }
+  semvers.sort();
+  // Default sort is ascending, we want descending so call reversed.
+  return semvers.reversed.map((version) => version.toString());
+}
 
 /// Validate that a Shorebird release is consistent with its Flutter release.
 class ValidateCommand extends CutlerCommand {
   /// Constructs a new [ValidateCommand].
-  ValidateCommand();
+  ValidateCommand() {
+    argParser.addFlag(
+      'all',
+      help: 'Validate all Flutter releases.',
+    );
+  }
   @override
   final name = 'validate';
   @override
@@ -20,57 +127,25 @@ class ValidateCommand extends CutlerCommand {
   int run() {
     checkouts = Checkouts(config.checkoutsRoot);
 
-    final flutterVersionName = argResults!.rest.first;
+    // If they passed --all, validate all Flutter releases.
+    // Otherwise, validate the versions they passed.
+    final versions = argResults!['all'] as bool
+        ? allFlutterVersions(checkouts.flutter)
+        : argResults!.rest;
 
-    // Given a specific Flutter version code:
-    logger.info('Validating $flutterVersionName');
-
-    // Check that our flutter fork has the expected tag.
-    final origin =
-        checkouts.flutter.remoteTag(tag: flutterVersionName, remote: 'origin');
-    final upstream = checkouts.flutter
-        .remoteTag(tag: flutterVersionName, remote: 'upstream');
-    if (origin != upstream) {
-      logger.err(
-        'Flutter release tag $origin does not match upstream $upstream',
-      );
+    if (versions.isEmpty) {
+      logger
+        ..err('No versions to validate.')
+        ..info(argParser.usage);
       return ExitCode.usage.code;
-    } else {
-      logger.info('Flutter release tag $origin matches upstream $upstream');
     }
 
-    // Check that the engine has the expected tag?
-
-    final forkpoint = getFlutterVersions(checkouts, flutterVersionName);
-
-    final releaseBranch = 'flutter_release/$flutterVersionName';
-    // Check for flutter_release/$version in all of our forks
-    final forks = [
-      Repo.buildroot,
-      Repo.dart,
-      Repo.engine,
-      Repo.flutter,
-    ];
-    for (final repo in forks) {
-      final checkout = checkouts[repo];
-      final remote =
-          checkout.remoteBranch(branch: releaseBranch, remote: 'origin');
-      logger.info('Found $remote for $repo');
-
-      // Check that the versions at flutter_release/$version include the
-      // expected flutter forkpoint hash.
-      final forkpointVersion = forkpoint[repo];
-      if (!checkout.isAncestor(
-        ancestor: forkpointVersion.hash,
-        descendant: remote.hash,
-      )) {
-        logger.err(
-          'Release branch $releaseBranch for $repo does not include '
-          'forkpoint $forkpointVersion',
-        );
+    for (final version in versions) {
+      logger.info('Validating $version');
+      if (!validateRelease(checkouts, version)) {
+        return ExitCode.software.code;
       }
     }
-
     return ExitCode.success.code;
   }
 }

--- a/packages/cutler/lib/cutler.dart
+++ b/packages/cutler/lib/cutler.dart
@@ -15,6 +15,7 @@ class Cutler extends CommandRunner<int> {
   Cutler() : super('cutler', 'A tool for maintaining forks of Flutter.') {
     addCommand(VersionsCommand());
     addCommand(RebaseCommand());
+    addCommand(ValidateCommand());
 
     argParser
       ..addFlag('verbose', abbr: 'v')

--- a/packages/cutler/pubspec.lock
+++ b/packages/cutler/pubspec.lock
@@ -352,6 +352,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  version:
+    dependency: "direct main"
+    description:
+      name: version
+      sha256: "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   very_good_analysis:
     dependency: "direct dev"
     description:

--- a/packages/cutler/pubspec.yaml
+++ b/packages/cutler/pubspec.yaml
@@ -21,3 +21,4 @@ dependencies:
   path: ^1.8.3
   scoped:
     path: ../scoped
+  version: ^3.0.2


### PR DESCRIPTION
Adds a new `validate` command to cutler, that when passed a flutter release version string
validates that Shorebird branches are all set up correctly for that release version.