### PR TITLE
feat(shorebird_cli): print link to troubleshooting page when native changes are detected

### DIFF
--- a/packages/shorebird_cli/lib/src/patch_diff_checker.dart
+++ b/packages/shorebird_cli/lib/src/patch_diff_checker.dart
@@ -97,6 +97,11 @@ class PatchDiffChecker {
           yellow.wrap(
             archiveDiffer.nativeFileSetDiff(contentDiffs).prettyString,
           ),
+        )
+        ..info(
+          yellow.wrap('''
+
+If you don't know why you're seeing this error, visit our troublshooting page at ${link(uri: Uri.parse('https://docs.shorebird.dev/troubleshooting#unexpected-native-changes'))}'''),
         );
 
       if (!force) {

--- a/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
+++ b/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
@@ -154,6 +154,14 @@ void main() {
           verify(
             () => logger.info(yellow.wrap(nativeDiffPrettyString)),
           ).called(1);
+          verify(
+            () => logger.info(
+              any(
+                that:
+                    contains("If you don't know why you're seeing this error"),
+              ),
+            ),
+          ).called(1);
         });
 
         test('prompts user if force is false', () async {


### PR DESCRIPTION
## Description

Prints a link to the section of our troubleshooting page (introduced in https://github.com/shorebirdtech/docs/pull/148) when native changes are detected.

Resolves https://github.com/shorebirdtech/shorebird/issues/1286

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
