### PR TITLE
fix(shorebird_cli): don't provide export options plist if we aren't codesigning

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -195,10 +195,10 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
         'build',
         'ipa',
         '--release',
-        '--export-options-plist=${exportPlistFile.path}',
         if (flavor != null) '--flavor=$flavor',
         if (target != null) '--target=$target',
         if (!codesign) '--no-codesign',
+        if (codesign) '--export-options-plist=${exportPlistFile.path}',
         ...results.rest,
       ];
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -933,6 +933,7 @@ Please re-run the release command for this version or create a new release.'''),
       when(() => argResults['codesign']).thenReturn(false);
       final tempDir = setUpTempDir();
       setUpTempArtifacts(tempDir);
+
       await IOOverrides.runZoned(
         () => runWithOverrides(command.run),
         getCurrentDirectory: () => tempDir,
@@ -945,7 +946,6 @@ Please re-run the release command for this version or create a new release.'''),
           runInShell: any(named: 'runInShell'),
         ),
       ).captured.first as List<String>;
-
       expect(
         capturedArgs
             .whereType<String>()

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io' hide Platform;
 
 import 'package:args/args.dart';
+import 'package:collection/collection.dart';
 import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
@@ -250,6 +251,7 @@ flutter:
       when(() => argResults['dry-run']).thenReturn(false);
       when(() => argResults['force']).thenReturn(false);
       when(() => argResults['release-version']).thenReturn(release.version);
+      when(() => argResults['codesign']).thenReturn(true);
       when(() => argResults.rest).thenReturn([]);
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => auth.client).thenReturn(httpClient);
@@ -925,6 +927,31 @@ Please re-run the release command for this version or create a new release.'''),
           runInShell: true,
         ),
       ).called(1);
+    });
+
+    test('does not provide export options when codesign is false', () async {
+      when(() => argResults['codesign']).thenReturn(false);
+      final tempDir = setUpTempDir();
+      setUpTempArtifacts(tempDir);
+      await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      final capturedArgs = verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          captureAny(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).captured.first as List<String>;
+
+      expect(
+        capturedArgs
+            .whereType<String>()
+            .firstWhereOrNull((arg) => arg.contains('export-options-plist')),
+        isNull,
+      );
     });
 
     test(

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io' hide Platform;
 
 import 'package:args/args.dart';
+import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
@@ -923,6 +924,30 @@ flavors:
       expect(exportOptionsPlist['signingStyle'], 'automatic');
       expect(exportOptionsPlist['uploadBitcode'], isFalse);
       expect(exportOptionsPlist['method'], 'app-store');
+    });
+
+    test('does not provide export options when codesign is false', () async {
+      when(() => argResults['codesign']).thenReturn(false);
+      final tempDir = setUpTempDir();
+
+      await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+
+      final capturedArgs = verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          captureAny(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).captured.first as List<String>;
+      expect(
+        capturedArgs
+            .whereType<String>()
+            .firstWhereOrNull((arg) => arg.contains('export-options-plist')),
+        isNull,
+      );
     });
 
     test('does not prompt if running on CI', () async {


### PR DESCRIPTION
## Description

The use of the ExportOptions.plist does not seem to be documented by Apple in any place I can find, but I don't believe it is relevant if we are performing codesigning ourselves at a later date.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
