### PR TITLE
fix(shorebird_cli): don't check for ipa when generating an unsigned release

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -104,15 +104,6 @@ make smaller updates to your app.
 
     buildProgress.complete();
 
-    // Ensure the ipa was built
-    final String ipaPath;
-    try {
-      ipaPath = getIpaPath();
-    } catch (error) {
-      logger.err('Could not find ipa file: $error');
-      return ExitCode.software.code;
-    }
-
     final archivePath = getXcarchiveDirectory()?.path;
     if (archivePath == null) {
       logger.err('Unable to find .xcarchive directory');
@@ -212,6 +203,15 @@ ${summary.join('\n')}
 
     final relativeArchivePath = p.relative(archivePath);
     if (codesign) {
+      // Ensure the ipa was built
+      final String ipaPath;
+      try {
+        ipaPath = getIpaPath();
+      } catch (error) {
+        logger.err('Could not find ipa file: $error');
+        return ExitCode.software.code;
+      }
+
       final relativeIpaPath = p.relative(ipaPath);
       logger.info('''
 

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -635,9 +635,7 @@ error: exportArchive: No signing certificate "iOS Distribution" found
       );
 
       expect(exitCode, equals(ExitCode.software.code));
-      verify(
-        () => logger.err(any(that: contains('No directory found'))),
-      ).called(1);
+      verify(() => logger.err('Unable to find .xcarchive directory')).called(1);
     });
 
     test('exits with code 70 if ipa build directory does not exist', () async {


### PR DESCRIPTION
## Description

We don't generate an ipa if codesigning is disabled, so only attempt to find an ipa path in that case.

Fixes https://github.com/shorebirdtech/shorebird/issues/1335

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
