### PR TITLE
chore(shorebird_cli): switch to pub_semver package for versions

### DIFF
--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -1,9 +1,9 @@
+import 'package:pub_semver/pub_semver.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
-import 'package:version/version.dart';
 
 class FlutterValidationException implements Exception {
   const FlutterValidationException(this.message);

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -27,13 +27,13 @@ dependencies:
   path: ^1.8.3
   platform: ^3.1.0
   propertylistserialization: ^1.3.0
+  pub_semver: ^2.1.4
   pubspec_parse: ^1.2.2
   scoped:
     path: ../scoped
   shorebird_code_push_client:
     path: ../shorebird_code_push_client
   uuid: ^3.0.7
-  version: ^3.0.2
   xml: ^6.2.2
   yaml: ^3.1.1
   yaml_edit: ^2.1.0


### PR DESCRIPTION
## Description

[`package:pub_semver`](https://pub.dev/packages/pub_semver) is a package created by the Dart team. We're currently using [package:version](https://pub.dev/packages/version), which is from an unknown author. We should use the package published by the Dart team.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
