### PR TITLE
feat(shorebird_cli): add xcodeVersion method to xcodebuild wrapper

### DIFF
--- a/packages/shorebird_cli/test/src/executables/xcodebuild_test.dart
+++ b/packages/shorebird_cli/test/src/executables/xcodebuild_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/process.dart';
@@ -13,6 +14,7 @@ import '../mocks.dart';
 void main() {
   group(XcodeBuild, () {
     late ShorebirdProcess process;
+    late ShorebirdProcessResult processResult;
     late XcodeBuild xcodeBuild;
 
     R runWithOverrides<R>(R Function() body) {
@@ -32,6 +34,7 @@ void main() {
 
     setUp(() {
       process = MockShorebirdProcess();
+      processResult = MockShorebirdProcessResult();
       xcodeBuild = runWithOverrides(XcodeBuild.new);
     });
 
@@ -130,6 +133,98 @@ To add iOS, run "flutter create . --platforms ios"''',
             workingDirectory: p.join(tempDir.path, 'ios'),
           ),
         ).called(1);
+      });
+    });
+
+    group('xcodeVersion', () {
+      late ExitCode exitCode;
+      late String stdout;
+
+      setUp(() {
+        when(() => process.run(XcodeBuild.executable, ['-version']))
+            .thenAnswer((_) async => processResult);
+        when(() => processResult.exitCode).thenAnswer((_) => exitCode.code);
+        when(() => processResult.stdout).thenAnswer((_) => stdout);
+      });
+
+      group('when a non-zero exit code is returned', () {
+        const errorMessage = 'An unexpected error occurred.';
+        setUp(() {
+          stdout = '';
+          exitCode = ExitCode.cantCreate;
+          when(() => processResult.stderr).thenReturn(errorMessage);
+        });
+
+        test('throws a ProcessException', () async {
+          expect(
+            () => runWithOverrides(xcodeBuild.xcodeVersion),
+            throwsA(
+              isA<ProcessException>()
+                  .having((e) => e.message, 'message', errorMessage),
+            ),
+          );
+        });
+      });
+
+      group('when stdout contains unexpected output', () {
+        setUp(() {
+          exitCode = ExitCode.success;
+        });
+
+        test('throws FormatException if output is empty', () async {
+          stdout = '';
+          expect(
+            () => runWithOverrides(xcodeBuild.xcodeVersion),
+            throwsA(
+              isA<FormatException>().having(
+                (e) => e.message,
+                'message',
+                'Could not parse Xcode version from output: "".',
+              ),
+            ),
+          );
+        });
+
+        test('throws FormatException if output does not contain version',
+            () async {
+          stdout = 'unexpected output';
+          expect(
+            () => runWithOverrides(xcodeBuild.xcodeVersion),
+            throwsA(
+              isA<FormatException>().having(
+                (e) => e.message,
+                'message',
+                'Could not parse "output".',
+              ),
+            ),
+          );
+        });
+      });
+
+      group('when stdout contains valid output', () {
+        setUp(() {
+          exitCode = ExitCode.success;
+        });
+
+        test('returns correct version with major, minor, and build numbers',
+            () async {
+          stdout = '''
+Xcode 14.3.1
+Build version 14E300c
+''';
+          final version = await runWithOverrides(xcodeBuild.xcodeVersion);
+          expect(version, Version(14, 3, 1));
+        });
+
+        test('returns correct version with only major and minor numbers',
+            () async {
+          stdout = '''
+Xcode 15.0
+Build version 15A240d
+''';
+          final version = await runWithOverrides(xcodeBuild.xcodeVersion);
+          expect(version, Version(15, 0, 0));
+        });
       });
     });
   });


### PR DESCRIPTION
## Description

Adds the ability to get the currently installed Xcode version using `xcodebuild -version`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
