### PR TITLE
feat(shorebird_cli): add non-strict version parsing function

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/xcodebuild.dart
+++ b/packages/shorebird_cli/lib/src/executables/xcodebuild.dart
@@ -134,6 +134,6 @@ class XcodeBuild {
       return null;
     }
 
-    return VersionParsing.tryParse(versionString, strict: false);
+    return tryParseVersion(versionString, strict: false);
   }
 }

--- a/packages/shorebird_cli/lib/src/executables/xcodebuild.dart
+++ b/packages/shorebird_cli/lib/src/executables/xcodebuild.dart
@@ -131,11 +131,9 @@ class XcodeBuild {
     final lines = LineSplitter.split('${result.stdout}').map((e) => e.trim());
     final versionString = lines.firstOrNull?.split(' ').lastOrNull;
     if (versionString == null) {
-      throw FormatException(
-        'Could not find Xcode version in output: "${result.stdout}".',
-      );
+      return null;
     }
 
-    return VersionParsing.tryParse(versionString);
+    return VersionParsing.tryParse(versionString, strict: false);
   }
 }

--- a/packages/shorebird_cli/lib/src/extensions/version.dart
+++ b/packages/shorebird_cli/lib/src/extensions/version.dart
@@ -1,0 +1,33 @@
+import 'package:pub_semver/pub_semver.dart';
+
+extension VersionParsing on Version {
+  /// Attempts to parse a [versionString] into a [Version] object. If [strict]
+  /// is `false`, and the [versionString] does not contain a patch number, a
+  /// patch number of 0 will be added
+  static Version? tryParse(String versionString, {bool strict = true}) {
+    try {
+      return Version.parse(versionString);
+    } on FormatException {
+      if (strict) {
+        return null;
+      }
+
+      var updatedVersionString = versionString;
+      // [Version.parse] requires a patch number. If we are not in strict mode,
+      // and the version string is of the form "12.0", add a patch number of 0
+      // and try again.
+      final noPatchNumberRegex = RegExp(r'^\d+\.\d+$');
+      if (noPatchNumberRegex.hasMatch(versionString)) {
+        updatedVersionString += '.0';
+      }
+
+      try {
+        return Version.parse(updatedVersionString);
+      } catch (_) {
+        return null;
+      }
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/packages/shorebird_cli/lib/src/extensions/version.dart
+++ b/packages/shorebird_cli/lib/src/extensions/version.dart
@@ -1,28 +1,26 @@
 import 'package:pub_semver/pub_semver.dart';
 
-extension VersionParsing on Version {
-  /// Attempts to parse a [versionString] into a [Version] object. If [strict]
-  /// is `false`, and the [versionString] does not contain a patch number, a
-  /// patch number of 0 will be added
-  static Version? tryParse(String versionString, {bool strict = true}) {
-    try {
-      return Version.parse(versionString);
-    } on FormatException {
-      final noPatchNumberRegex = RegExp(r'^\d+\.\d+$');
-      if (strict || !noPatchNumberRegex.hasMatch(versionString)) {
-        return null;
-      }
+/// Attempts to parse a [versionString] into a [Version] object. If [strict]
+/// is `false`, and the [versionString] does not contain a patch number, a
+/// patch number of 0 will be added
+Version? tryParseVersion(String versionString, {bool strict = true}) {
+  try {
+    return Version.parse(versionString);
+  } on FormatException {
+    final noPatchNumberRegex = RegExp(r'^\d+\.\d+$');
+    if (strict || !noPatchNumberRegex.hasMatch(versionString)) {
+      return null;
+    }
 
-      // [Version.parse] requires a patch number. If we are not in strict mode,
-      // and the version string is of the form "12.0", add a patch number of 0
-      // and try again.
-      try {
-        return Version.parse('$versionString.0');
-      } catch (_) {
-        return null;
-      }
+    // [Version.parse] requires a patch number. If we are not in strict mode,
+    // and the version string is of the form "12.0", add a patch number of 0
+    // and try again.
+    try {
+      return Version.parse('$versionString.0');
     } catch (_) {
       return null;
     }
+  } catch (_) {
+    return null;
   }
 }

--- a/packages/shorebird_cli/lib/src/extensions/version.dart
+++ b/packages/shorebird_cli/lib/src/extensions/version.dart
@@ -8,21 +8,16 @@ extension VersionParsing on Version {
     try {
       return Version.parse(versionString);
     } on FormatException {
-      if (strict) {
+      final noPatchNumberRegex = RegExp(r'^\d+\.\d+$');
+      if (strict || !noPatchNumberRegex.hasMatch(versionString)) {
         return null;
       }
 
-      var updatedVersionString = versionString;
       // [Version.parse] requires a patch number. If we are not in strict mode,
       // and the version string is of the form "12.0", add a patch number of 0
       // and try again.
-      final noPatchNumberRegex = RegExp(r'^\d+\.\d+$');
-      if (noPatchNumberRegex.hasMatch(versionString)) {
-        updatedVersionString += '.0';
-      }
-
       try {
-        return Version.parse(updatedVersionString);
+        return Version.parse('$versionString.0');
       } catch (_) {
         return null;
       }

--- a/packages/shorebird_cli/test/src/executables/xcodebuild_test.dart
+++ b/packages/shorebird_cli/test/src/executables/xcodebuild_test.dart
@@ -171,32 +171,19 @@ To add iOS, run "flutter create . --platforms ios"''',
           exitCode = ExitCode.success;
         });
 
-        test('throws FormatException if output is empty', () async {
+        test('reutrns null if output is empty', () async {
           stdout = '';
           expect(
-            () => runWithOverrides(xcodeBuild.xcodeVersion),
-            throwsA(
-              isA<FormatException>().having(
-                (e) => e.message,
-                'message',
-                'Could not parse Xcode version from output: "".',
-              ),
-            ),
+            await runWithOverrides(xcodeBuild.xcodeVersion),
+            isNull,
           );
         });
 
-        test('throws FormatException if output does not contain version',
-            () async {
+        test('returns null if output does not contain version', () async {
           stdout = 'unexpected output';
           expect(
-            () => runWithOverrides(xcodeBuild.xcodeVersion),
-            throwsA(
-              isA<FormatException>().having(
-                (e) => e.message,
-                'message',
-                'Could not parse "output".',
-              ),
-            ),
+            await runWithOverrides(xcodeBuild.xcodeVersion),
+            isNull,
           );
         });
       });

--- a/packages/shorebird_cli/test/src/extensions/version_test.dart
+++ b/packages/shorebird_cli/test/src/extensions/version_test.dart
@@ -1,0 +1,38 @@
+import 'package:pub_semver/pub_semver.dart';
+import 'package:shorebird_cli/src/extensions/version.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('NonStrictParsing', () {
+    group('with strict mode enabled', () {
+      test('returns a version if the string is a valid semver version', () {
+        expect(VersionParsing.tryParse('1.2.3'), Version(1, 2, 3));
+      });
+
+      test('returns null if string is of the format major.minor', () {
+        expect(VersionParsing.tryParse('1.2'), isNull);
+      });
+
+      test('returns null if string is in an invalid format', () {
+        expect(VersionParsing.tryParse('asdf'), isNull);
+      });
+    });
+
+    group('without strict mode enabled', () {
+      test('returns a version if the string is a valid semver version', () {
+        expect(
+          VersionParsing.tryParse('1.2.3', strict: false),
+          Version(1, 2, 3),
+        );
+      });
+
+      test('returns a version if string is of the format major.minor', () {
+        expect(VersionParsing.tryParse('1.2', strict: false), Version(1, 2, 0));
+      });
+
+      test('returns null if string is in an invalid format', () {
+        expect(VersionParsing.tryParse('asdf', strict: false), isNull);
+      });
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/extensions/version_test.dart
+++ b/packages/shorebird_cli/test/src/extensions/version_test.dart
@@ -3,35 +3,32 @@ import 'package:shorebird_cli/src/extensions/version.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('NonStrictParsing', () {
+  group('tryParseVersion', () {
     group('with strict mode enabled', () {
       test('returns a version if the string is a valid semver version', () {
-        expect(VersionParsing.tryParse('1.2.3'), Version(1, 2, 3));
+        expect(tryParseVersion('1.2.3'), Version(1, 2, 3));
       });
 
       test('returns null if string is of the format major.minor', () {
-        expect(VersionParsing.tryParse('1.2'), isNull);
+        expect(tryParseVersion('1.2'), isNull);
       });
 
       test('returns null if string is in an invalid format', () {
-        expect(VersionParsing.tryParse('asdf'), isNull);
+        expect(tryParseVersion('asdf'), isNull);
       });
     });
 
     group('without strict mode enabled', () {
       test('returns a version if the string is a valid semver version', () {
-        expect(
-          VersionParsing.tryParse('1.2.3', strict: false),
-          Version(1, 2, 3),
-        );
+        expect(tryParseVersion('1.2.3', strict: false), Version(1, 2, 3));
       });
 
       test('returns a version if string is of the format major.minor', () {
-        expect(VersionParsing.tryParse('1.2', strict: false), Version(1, 2, 0));
+        expect(tryParseVersion('1.2', strict: false), Version(1, 2, 0));
       });
 
       test('returns null if string is in an invalid format', () {
-        expect(VersionParsing.tryParse('asdf', strict: false), isNull);
+        expect(tryParseVersion('asdf', strict: false), isNull);
       });
     });
   });


### PR DESCRIPTION
## Description

Adds a `Version` extension to allow non-strict parsing of version numbers (e.g., `2.0`, which is not a valid semver version).

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
