### PR TITLE
feat(shorebird_cli): list detected flavors in shorebird init

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -78,7 +78,16 @@ Please make sure you are running "shorebird init" from the root of your Flutter 
         if (androidFlavors != null) ...androidFlavors,
         if (iosFlavors != null) ...iosFlavors,
       };
-      detectFlavorsProgress.complete();
+      if (productFlavors.isEmpty) {
+        detectFlavorsProgress.complete('No product flavors detected.');
+      } else {
+        detectFlavorsProgress.complete(
+          '${productFlavors.length} product flavors detected:',
+        );
+        for (final flavor in productFlavors) {
+          logger.info('  - $flavor');
+        }
+      }
     } catch (error) {
       detectFlavorsProgress.fail();
       logger.err('Unable to extract product flavors.\n$error');

--- a/packages/shorebird_cli/test/src/commands/init_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/init_command_test.dart
@@ -281,6 +281,8 @@ Please make sure you are running "shorebird init" from the root of your Flutter 
             any(that: contains('app_id: $appId')),
           ),
         ).called(1);
+        verify(() => progress.complete('No product flavors detected.'))
+            .called(1);
         verifyNever(() => xcodeBuild.list(any()));
       });
 
@@ -318,6 +320,10 @@ Please make sure you are running "shorebird init" from the root of your Flutter 
           getCurrentDirectory: () => tempDir,
         );
         expect(exitCode, equals(ExitCode.success.code));
+        verify(() => progress.complete('2 product flavors detected:'))
+            .called(1);
+        verify(() => logger.info('  - internal')).called(1);
+        verify(() => logger.info('  - stable')).called(1);
         verify(
           () => shorebirdYamlFile.writeAsStringSync(
             any(


### PR DESCRIPTION
## Description

Adds a list of detected flavors when running `shorebird init`.

No flavors:
![Screenshot 2023-10-10 at 1 07 32 PM](https://github.com/shorebirdtech/shorebird/assets/581764/543930ed-8797-49a6-b374-7e675e3f3a7f)

With flavors:
![Screenshot 2023-10-10 at 1 07 58 PM](https://github.com/shorebirdtech/shorebird/assets/581764/2eb81948-b268-4d3e-962f-4f5b73ad75c8)


This should help partially mitigate https://github.com/shorebirdtech/shorebird/issues/1379

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
