### PR TITLE
feat(shorebird_cli): copy release aar library out of build dir

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -161,9 +161,8 @@ ${summary.join('\n')}
         packageName: shorebirdEnv.androidPackageName!,
       ),
     );
-    final targetLibraryDirectory = Directory(
-      p.join(Directory.current.path, 'releases', releaseVersion),
-    );
+    final targetLibraryDirectory =
+        Directory(p.join(Directory.current.path, 'release'));
     await copyPath(sourceLibraryDirectory.path, targetLibraryDirectory.path);
 
     final extractAarProgress = logger.progress('Creating artifacts');

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -199,7 +199,7 @@ ${summary.join('\n')}
 
 Your next steps:
 
-1. Add the aar repo to your app's settings.gradle:
+1. Add the aar repo and Shorebird's maven url to your app's settings.gradle:
 
 Note: The maven url needs to be a relative path from your settings.gradle file to the aar library. The code below assumes your Flutter module is in a sibling directory of your Android app.
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:archive/archive_io.dart';
+import 'package:io/io.dart' show copyPath;
 import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
@@ -152,6 +154,18 @@ ${summary.join('\n')}
       );
     }
 
+    // Copy release AAR to a new directory to avoid overwriting with subsequent
+    // patch builds.
+    final sourceLibraryDirectory = Directory(
+      aarLibraryPath(
+        packageName: shorebirdEnv.androidPackageName!,
+      ),
+    );
+    final targetLibraryDirectory = Directory(
+      p.join(Directory.current.path, 'releases', releaseVersion),
+    );
+    await copyPath(sourceLibraryDirectory.path, targetLibraryDirectory.path);
+
     final extractAarProgress = logger.progress('Creating artifacts');
     final extractedAarDir = await extractAar(
       packageName: shorebirdEnv.androidPackageName!,
@@ -183,7 +197,19 @@ ${summary.join('\n')}
       ..success('\n✅ Published Release!')
       ..info('''
 
-Your next step is to add this module as a dependency in your app's build.gradle:
+Your next steps:
+
+1. Add the aar repo to your app's settings.gradle:
+
+Note: The maven url needs to be a relative path from your settings.gradle file to the aar library. The code below assumes your Flutter module is in a sibling directory of your Android app.
+
+${lightCyan.wrap('''
+maven {
+  url '../${p.basename(Directory.current.path)}/${p.relative(targetLibraryDirectory.path)}'
+}
+''')}
+
+2. Add this module as a dependency in your app's build.gradle:
 ${lightCyan.wrap('''
 dependencies {
   // ...

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -204,8 +204,19 @@ Your next steps:
 Note: The maven url needs to be a relative path from your settings.gradle file to the aar library. The code below assumes your Flutter module is in a sibling directory of your Android app.
 
 ${lightCyan.wrap('''
-maven {
-  url '../${p.basename(Directory.current.path)}/${p.relative(targetLibraryDirectory.path)}'
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
++       maven {
++           url '../${p.basename(Directory.current.path)}/${p.relative(targetLibraryDirectory.path)}'
++       }
++       maven {
+-           url 'https://storage.googleapis.com/download.flutter.io'
++           url 'https://download.shorebird.dev/download.flutter.io'
++       }
+    }
 }
 ''')}
 

--- a/packages/shorebird_cli/lib/src/shorebird_artifact_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_artifact_mixin.dart
@@ -6,16 +6,20 @@ import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/logger.dart';
 
 mixin ShorebirdArtifactMixin on ShorebirdCommand {
-  String aarArtifactDirectory({
-    required String packageName,
-    required String buildNumber,
-  }) =>
-      p.joinAll([
+  String aarLibraryPath({required String packageName}) => p.joinAll([
         Directory.current.path,
         'build',
         'host',
         'outputs',
         'repo',
+      ]);
+
+  String aarArtifactDirectory({
+    required String packageName,
+    required String buildNumber,
+  }) =>
+      p.joinAll([
+        aarLibraryPath(packageName: packageName),
         ...packageName.split('.'),
         'flutter_release',
         buildNumber,

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -379,6 +379,19 @@ void main() {
       ).called(1);
     });
 
+    test('copies aar library to a releases folder', () async {
+      final tempDir = setUpTempArtifacts();
+      final exitCode = await IOOverrides.runZoned(
+        () => runWithOverrides(command.run),
+        getCurrentDirectory: () => tempDir,
+      );
+      expect(exitCode, ExitCode.success.code);
+      expect(
+        Directory(p.join(tempDir.path, 'releases', versionName)).existsSync(),
+        isTrue,
+      );
+    });
+
     test('runs flutter pub get with system flutter after successful build',
         () async {
       final tempDir = setUpTempArtifacts();

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -386,10 +386,7 @@ void main() {
         getCurrentDirectory: () => tempDir,
       );
       expect(exitCode, ExitCode.success.code);
-      expect(
-        Directory(p.join(tempDir.path, 'releases', versionName)).existsSync(),
-        isTrue,
-      );
+      expect(Directory(p.join(tempDir.path, 'release')).existsSync(), isTrue);
     });
 
     test('runs flutter pub get with system flutter after successful build',


### PR DESCRIPTION
## Description

Moves the aar library generated by `shorebird release aar` into a separate directory to avoid it being overwritten by subsequent `shorebird patch aar` commands.

Fixes https://github.com/shorebirdtech/shorebird/issues/1349

Updated console output:

![Screenshot 2023-10-10 at 4 33 59 PM](https://github.com/shorebirdtech/shorebird/assets/581764/5d7f6f0a-f62e-41da-a7aa-90734f03725e)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
