### PR TITLE
feat(shorebird_cli): add release-version flag to iOS and Android patch commands

### DIFF
--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -270,7 +270,6 @@ flutter:
       when(() => argResults['staging']).thenReturn(false);
       when(() => argResults['dry-run']).thenReturn(false);
       when(() => argResults['force']).thenReturn(false);
-      when(() => argResults['release-version']).thenReturn(null);
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => auth.client).thenReturn(httpClient);
       when(() => logger.progress(any())).thenReturn(progress);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -549,10 +549,6 @@ Please re-run the release command for this version or create a new release.'''),
     });
 
     group('when release-version option is not provided', () {
-      setUp(() {
-        when(() => argResults['release-version']).thenReturn(null);
-      });
-
       test('extracts release version from app bundle', () async {
         final tempDir = setUpTempDir();
         setUpTempArtifacts(tempDir);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -254,7 +254,6 @@ flutter:
       when(() => argResults['arch']).thenReturn(arch);
       when(() => argResults['dry-run']).thenReturn(false);
       when(() => argResults['force']).thenReturn(false);
-      when(() => argResults['release-version']).thenReturn(null);
       when(() => argResults['codesign']).thenReturn(true);
       when(() => argResults['staging']).thenReturn(false);
       when(() => argResults.rest).thenReturn([]);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -695,10 +695,6 @@ Please re-run the release command for this version or create a new release.'''),
     });
 
     group('when release-version option is not provided', () {
-      setUp(() {
-        when(() => argResults['release-version']).thenReturn(null);
-      });
-
       test('extracts release version from app bundle', () async {
         final tempDir = setUpTempDir();
         setUpTempArtifacts(tempDir);


### PR DESCRIPTION
## Description

Adds the `release-version` flag to `shorebird patch ios-alpha` and `shorebird patch android`. If provided, the CLI will not attempt to read the release version from the patch artifact.

Fixes https://github.com/shorebirdtech/shorebird/issues/1396

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
