### PR TITLE
fix(shorebird_cli): update Android SDK location logic to mimic `flutter_tools`

### DIFF
--- a/packages/shorebird_cli/lib/src/android_sdk.dart
+++ b/packages/shorebird_cli/lib/src/android_sdk.dart
@@ -30,52 +30,84 @@ class AndroidSdk {
   ///   - build-tools/$version/aapt
   ///   - platform-tools/adb
   String? get path {
-    final candidatePaths = <String>[];
-    if (platform.environment.containsKey(kAndroidHome)) {
-      candidatePaths.add(platform.environment[kAndroidHome]!);
-    }
+    final candidatePathLookups = <String? Function()>[
+      () => platform.environment[kAndroidHome],
+      () => platform.environment[kAndroidSdkRoot],
+      _defaultAndroidSdkPath,
+      _androidSdkPathFromAapt,
+      _androidSdkPathFromAdb,
+    ];
 
-    if (platform.environment.containsKey(kAndroidSdkRoot)) {
-      candidatePaths.add(platform.environment[kAndroidSdkRoot]!);
-    }
-
-    final home = platform.isWindows
-        ? platform.environment['USERPROFILE']
-        : platform.environment['HOME'];
-
-    if (home != null) {
-      if (platform.isWindows) {
-        candidatePaths.add(p.join(home, 'AppData', 'Local', 'Android', 'Sdk'));
-      } else if (platform.isLinux) {
-        candidatePaths.add(p.join(home, 'Android', 'Sdk'));
-      } else if (platform.isMacOS) {
-        candidatePaths.add(p.join(home, 'Library', 'Android', 'sdk'));
+    for (final lookup in candidatePathLookups) {
+      final maybePath = lookup();
+      if (maybePath != null && _isValidSdkPath(maybePath)) {
+        return maybePath;
       }
     }
 
-    final maybeAaptPath = osInterface.which('aapt');
-    if (maybeAaptPath != null) {
-      // Resolve path to aapt if it is a symlink.
-      final resolvedAaptPath = File(maybeAaptPath).resolveSymbolicLinksSync();
-      candidatePaths.add(File(resolvedAaptPath).parent.parent.parent.path);
-    }
-
-    final maybeAdbPath = osInterface.which('adb');
-    if (maybeAdbPath != null) {
-      // Resolve path to adb if it is a symlink.
-      final resolvedAdbPath = File(maybeAdbPath).resolveSymbolicLinksSync();
-      candidatePaths.add(File(resolvedAdbPath).parent.parent.path);
-    }
-
-    return candidatePaths.firstWhereOrNull(_isValidSdkPath);
+    return null;
   }
 
+  /// For a path to be a valid Android SDK, it must exist and have either a
+  /// licenses directory or a platform-tools directory. If the SDK only has a
+  /// licenses directory, that indicates that the user has accepted the
+  /// necessary Android licenses and that additional components can be
+  /// downloaded later.
   bool _isValidSdkPath(String path) {
     final directory = Directory(path);
     final licensesDirectory = Directory(p.join(path, 'licenses'));
     final platformToolsDirectory = Directory(p.join(path, 'platform-tools'));
     return directory.existsSync() &&
         (licensesDirectory.existsSync() || platformToolsDirectory.existsSync());
+  }
+
+  /// Returns the default path to the Android SDK if a home directory is defined
+  /// and we're on a recognized platform, or null otherwise.
+  String? _defaultAndroidSdkPath() {
+    final home = platform.isWindows
+        ? platform.environment['USERPROFILE']
+        : platform.environment['HOME'];
+    if (home == null) {
+      return null;
+    }
+
+    if (platform.isWindows) {
+      return p.join(home, 'AppData', 'Local', 'Android', 'Sdk');
+    } else if (platform.isLinux) {
+      return p.join(home, 'Android', 'Sdk');
+    } else if (platform.isMacOS) {
+      return p.join(home, 'Library', 'Android', 'sdk');
+    }
+
+    return null;
+  }
+
+  /// If adb is on the user's path, return the Android SDK that contains it.
+  ///
+  /// In a valid Android SDK, adb is in the platform-tools directory.
+  String? _androidSdkPathFromAdb() {
+    final maybeAdbPath = osInterface.which('adb');
+    if (maybeAdbPath == null) {
+      return null;
+    }
+
+    // Resolve path to adb if it is a symlink.
+    final resolvedAdbPath = File(maybeAdbPath).resolveSymbolicLinksSync();
+    return File(resolvedAdbPath).parent.parent.path;
+  }
+
+  /// If aapt is on the user's path, return the Android SDK that contains it.
+  ///
+  /// In a valid Android SDK, aapt is in the build-tools/$version directory.
+  String? _androidSdkPathFromAapt() {
+    final maybeAaptPath = osInterface.which('aapt');
+    if (maybeAaptPath == null) {
+      return null;
+    }
+
+    // Resolve path to aapt if it is a symlink.
+    final resolvedAaptPath = File(maybeAaptPath).resolveSymbolicLinksSync();
+    return File(resolvedAaptPath).parent.parent.parent.path;
   }
 
   /// The path to the `adb` executable.

--- a/packages/shorebird_cli/lib/src/os/operating_system_interface.dart
+++ b/packages/shorebird_cli/lib/src/os/operating_system_interface.dart
@@ -5,14 +5,11 @@ import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
 
-// TODO(bryanoltman): remove this once os is used.
-// coverage:ignore-start
 /// A reference to a [OperatingSystemInterface] instance.
 final osInterfaceRef = create(OperatingSystemInterface.new);
 
 /// The [OperatingSystemInterface] instance available in the current zone.
 OperatingSystemInterface get osInterface => read(osInterfaceRef);
-// coverage:ignore-end
 
 /// {@template operating_system_interface}
 /// A wrapper around operating system specific functionality.
@@ -46,7 +43,7 @@ class _PosixOperatingSystemInterface implements OperatingSystemInterface {
       return null;
     }
 
-    return result.stdout as String?;
+    return (result.stdout as String?)?.trim();
   }
 }
 

--- a/packages/shorebird_cli/test/src/os/operating_system_interface_test.dart
+++ b/packages/shorebird_cli/test/src/os/operating_system_interface_test.dart
@@ -83,6 +83,25 @@ void main() {
             );
           });
         });
+
+        group('when executable contains leading and trailing newlines', () {
+          const shorebirdPath = '''
+
+
+/path/to/shorebird
+
+''';
+          setUp(() {
+            when(() => processResult.stdout).thenReturn(shorebirdPath);
+          });
+
+          test('returns trimmed path to binary', () {
+            expect(
+              runWithOverrides(() => osInterface.which('shorebird')),
+              equals('/path/to/shorebird'),
+            );
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## Description

Expands the scope of where we look to find a user's Android SDK. List of possible locations taken from https://github.com/flutter/flutter/blob/stable/packages/flutter_tools/lib/src/android/android_sdk.dart

Fixes https://github.com/shorebirdtech/shorebird/issues/1213

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
