### PR TITLE
chore(shorebird_cli): update patch diff warning wording

### DIFF
--- a/packages/shorebird_cli/lib/src/patch_diff_checker.dart
+++ b/packages/shorebird_cli/lib/src/patch_diff_checker.dart
@@ -91,7 +91,7 @@ class PatchDiffChecker {
     if (archiveDiffer.containsPotentiallyBreakingNativeDiffs(contentDiffs)) {
       logger
         ..warn(
-          '''The release artifact contains native changes, which cannot be applied with a patch.''',
+          '''Your app contains native changes, which cannot be applied with a patch.''',
         )
         ..info(
           yellow.wrap(
@@ -118,7 +118,7 @@ If you don't know why you're seeing this error, visit our troublshooting page at
     if (archiveDiffer.containsPotentiallyBreakingAssetDiffs(contentDiffs)) {
       logger
         ..warn(
-          '''The release artifact contains asset changes, which will not be included in the patch.''',
+          '''Your app contains asset changes, which will not be included in the patch.''',
         )
         ..info(
           yellow.wrap(

--- a/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
+++ b/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
@@ -148,7 +148,7 @@ void main() {
 
           verify(
             () => logger.warn(
-              '''The release artifact contains native changes, which cannot be applied with a patch.''',
+              '''Your app contains native changes, which cannot be applied with a patch.''',
             ),
           ).called(1);
           verify(
@@ -249,7 +249,7 @@ void main() {
 
           verify(
             () => logger.warn(
-              '''The release artifact contains asset changes, which will not be included in the patch.''',
+              '''Your app contains asset changes, which will not be included in the patch.''',
             ),
           ).called(1);
           verify(


### PR DESCRIPTION
## Description

Updates the wording of the warning printed to the console when the user attempts to patch with unpatchable changes to make it slightly less confusing ("The release artifact contains…" -> "Your app contains…")

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
