### PR TITLE
feat(shorebird_cli): turn up the verbosity of -v

### DIFF
--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -85,10 +85,7 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
         localEngineSrcPath: topLevelResults['local-engine-src-path'] as String?,
         localEngine: topLevelResults['local-engine'] as String?,
       );
-      final process = ShorebirdProcess(
-        engineConfig: engineConfig,
-        logger: logger,
-      );
+      final process = ShorebirdProcess(engineConfig: engineConfig);
 
       return await runScoped<Future<int?>>(
             () => runCommand(topLevelResults),

--- a/packages/shorebird_cli/lib/src/process.dart
+++ b/packages/shorebird_cli/lib/src/process.dart
@@ -212,7 +212,7 @@ class ShorebirdProcess {
 
   void _logResult(ShorebirdProcessResult result) {
     if (result.exitCode != ExitCode.success.code) {
-      logger.detail('Exit code was ${result.exitCode}');
+      logger.detail('Exited with code ${result.exitCode}');
 
       final stdout = result.stdout as String?;
       if (stdout != null && stdout.isNotEmpty) {

--- a/packages/shorebird_cli/lib/src/process.dart
+++ b/packages/shorebird_cli/lib/src/process.dart
@@ -215,22 +215,22 @@ class ShorebirdProcess {
   void _logResult(ShorebirdProcessResult result) {
     if (result.exitCode != ExitCode.success.code) {
       logger.detail('Exit code was ${result.exitCode}');
-    }
 
-    final stdout = result.stdout as String?;
-    if (stdout != null && stdout.isNotEmpty) {
-      logger.detail('''
+      final stdout = result.stdout as String?;
+      if (stdout != null && stdout.isNotEmpty) {
+        logger.detail('''
 
 stdout:
 $stdout''');
-    }
+      }
 
-    final stderr = result.stderr as String?;
-    if (stderr != null && stderr.isNotEmpty) {
-      logger.detail('''
+      final stderr = result.stderr as String?;
+      if (stderr != null && stderr.isNotEmpty) {
+        logger.detail('''
 
 stderr:
 $stderr''');
+      }
     }
   }
 

--- a/packages/shorebird_cli/lib/src/process.dart
+++ b/packages/shorebird_cli/lib/src/process.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 
 // A reference to a [EngineConfig] instance.
@@ -38,14 +39,11 @@ ShorebirdProcess get process => read(processRef);
 class ShorebirdProcess {
   ShorebirdProcess({
     this.engineConfig = const EngineConfig.empty(),
-    Logger? logger,
     ProcessWrapper? processWrapper, // For mocking ShorebirdProcess.
-  })  : logger = logger ?? Logger(),
-        processWrapper = processWrapper ?? ProcessWrapper();
+  }) : processWrapper = processWrapper ?? ProcessWrapper();
 
   final ProcessWrapper processWrapper;
   final EngineConfig engineConfig;
-  final Logger logger;
 
   Future<ShorebirdProcessResult> run(
     String executable,

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -566,10 +566,7 @@ Please re-run the release command for this version or create a new release.'''),
             () => command.run(),
             values: {
               processRef.overrideWith(
-                () => ShorebirdProcess(
-                  logger: logger,
-                  processWrapper: processWrapper,
-                ),
+                () => ShorebirdProcess(processWrapper: processWrapper),
               ),
             },
           ),

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -239,6 +239,7 @@ void main() {
       when(() => argResults['release-version']).thenReturn(version);
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => auth.client).thenReturn(httpClient);
+      when(() => logger.level).thenReturn(Level.info);
       when(() => logger.progress(any())).thenReturn(progress);
       when(
         () => logger.prompt(any(), defaultValue: any(named: 'defaultValue')),

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
@@ -513,10 +513,7 @@ Please re-run the release command for this version or create a new release.'''),
             () => command.run(),
             values: {
               processRef.overrideWith(
-                () => ShorebirdProcess(
-                  logger: logger,
-                  processWrapper: processWrapper,
-                ),
+                () => ShorebirdProcess(processWrapper: processWrapper),
               ),
             },
           ),

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
@@ -225,6 +225,7 @@ flutter:
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => doctor.iosCommandValidators).thenReturn([flutterValidator]);
       when(flutterValidator.validate).thenAnswer((_) async => []);
+      when(() => logger.level).thenReturn(Level.info);
       when(() => logger.progress(any())).thenReturn(progress);
       when(() => logger.confirm(any())).thenReturn(true);
       when(() => platform.operatingSystem).thenReturn(Platform.macOS);

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
@@ -42,6 +43,10 @@ void main() {
       when(
         () => shorebirdEnv.flutterBinaryFile,
       ).thenReturn(File(p.join('bin', 'cache', 'flutter', 'bin', 'flutter')));
+
+      when(() => runProcessResult.stderr).thenReturn('');
+      when(() => runProcessResult.stdout).thenReturn('');
+      when(() => runProcessResult.exitCode).thenReturn(ExitCode.success.code);
     });
 
     test('ShorebirdProcessResult can be instantiated as a const', () {


### PR DESCRIPTION
## Description

Makes `-v`:

- log stdout and stderr of failed commands
- run `flutter` commands with the `--verbose` flag

This change also refactors `ShorebirdProcess` to use the logger provided by `package:scoped` for consistency and ease of testing.

Part of https://github.com/shorebirdtech/shorebird/issues/1332

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
