### PR TITLE
fix(shorebird_cli): print error message if user attempts to preview iOS on linux or windows

### DIFF
--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' hide Platform;
 
 import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
@@ -15,6 +16,7 @@ import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
@@ -37,6 +39,7 @@ void main() {
     late CodePushClientWrapper codePushClientWrapper;
     late Logger logger;
     late Directory previewDirectory;
+    late Platform platform;
     late Progress progress;
     late Release release;
     late ReleaseArtifact releaseArtifact;
@@ -53,6 +56,7 @@ void main() {
             cacheRef.overrideWith(() => cache),
             codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
             loggerRef.overrideWith(() => logger),
+            platformRef.overrideWith(() => platform),
             shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
           },
         ),
@@ -76,6 +80,7 @@ void main() {
       cache = MockCache();
       codePushClientWrapper = MockCodePushClientWrapper();
       logger = MockLogger();
+      platform = MockPlatform();
       previewDirectory = Directory.systemTemp.createTempSync();
       progress = MockProgress();
       release = MockRelease();
@@ -120,6 +125,10 @@ void main() {
           checkUserIsAuthenticated: any(named: 'checkUserIsAuthenticated'),
         ),
       ).thenAnswer((_) async {});
+
+      when(() => platform.isLinux).thenReturn(false);
+      when(() => platform.isMacOS).thenReturn(false);
+      when(() => platform.isWindows).thenReturn(false);
     });
 
     test('exits when validation fails', () async {
@@ -161,7 +170,7 @@ void main() {
     });
 
     group('android', () {
-      const platform = ReleasePlatform.android;
+      const releasePlatform = ReleasePlatform.android;
       const releaseArtifactUrl = 'https://example.com/release.aab';
       const packageName = 'com.example.app';
 
@@ -171,12 +180,12 @@ void main() {
 
       String aabPath() => p.join(
             previewDirectory.path,
-            '${platform.name}_$releaseVersion.aab',
+            '${releasePlatform.name}_$releaseVersion.aab',
           );
 
       String apksPath() => p.join(
             previewDirectory.path,
-            '${platform.name}_$releaseVersion.apks',
+            '${releasePlatform.name}_$releaseVersion.apks',
           );
 
       R runWithOverrides<R>(R Function() body) {
@@ -193,6 +202,7 @@ void main() {
                 () => codePushClientWrapper,
               ),
               loggerRef.overrideWith(() => logger),
+              platformRef.overrideWith(() => platform),
               shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
             },
           ),
@@ -218,7 +228,7 @@ void main() {
         bundletool = MockBundleTool();
         process = MockProcess();
 
-        when(() => argResults['platform']).thenReturn(platform.name);
+        when(() => argResults['platform']).thenReturn(releasePlatform.name);
         when(
           () => artifactManager.downloadFile(
             any(),
@@ -291,7 +301,7 @@ void main() {
             appId: appId,
             releaseId: releaseId,
             arch: 'aab',
-            platform: platform,
+            platform: releasePlatform,
           ),
         ).called(1);
       });
@@ -489,38 +499,77 @@ void main() {
         verify(() => codePushClientWrapper.getApps()).called(1);
       });
 
-      test('prompts for platforms when platform is not specified', () async {
-        when(
-          () => artifactManager.extractZip(
-            zipFile: any(named: 'zipFile'),
-            outputDirectory: any(named: 'outputDirectory'),
-          ),
-        ).thenAnswer(createShorebirdYaml);
+      group('when platform is not specified', () {
+        setUp(() {
+          when(
+            () => artifactManager.extractZip(
+              zipFile: any(named: 'zipFile'),
+              outputDirectory: any(named: 'outputDirectory'),
+            ),
+          ).thenAnswer(createShorebirdYaml);
 
-        when(() => argResults['platform']).thenReturn(null);
-        when(
-          () => logger.chooseOne<String>(
-            any(),
-            choices: any(named: 'choices'),
-            display: any(named: 'display'),
-          ),
-        ).thenReturn(platform.name);
-        final result = await runWithOverrides(command.run);
-        expect(result, equals(ExitCode.success.code));
-        final platforms = verify(
-          () => logger.chooseOne<String>(
-            any(),
-            choices: captureAny(named: 'choices'),
-            display: any(named: 'display'),
-          ),
-        ).captured.single as List<String>;
-        expect(
-          platforms,
-          equals([
-            ReleasePlatform.android.name,
-            ReleasePlatform.ios.name,
-          ]),
-        );
+          when(() => argResults['platform']).thenReturn(null);
+          when(
+            () => logger.chooseOne<String>(
+              any(),
+              choices: any(named: 'choices'),
+              display: any(named: 'display'),
+            ),
+          ).thenReturn(releasePlatform.name);
+
+          when(() => release.platformStatuses).thenReturn({
+            ReleasePlatform.android: ReleaseStatus.active,
+            ReleasePlatform.ios: ReleaseStatus.active,
+          });
+        });
+
+        group('on macOS', () {
+          setUp(() {
+            when(() => platform.isMacOS).thenReturn(true);
+            command = runWithOverrides(
+              () => PreviewCommand()..testArgResults = argResults,
+            );
+          });
+
+          test('prompts for iOS and Android', () async {
+            final result = await runWithOverrides(command.run);
+            expect(result, equals(ExitCode.success.code));
+            final platforms = verify(
+              () => logger.chooseOne<String>(
+                any(),
+                choices: captureAny(named: 'choices'),
+                display: any(named: 'display'),
+              ),
+            ).captured.single as List<String>;
+            expect(
+              platforms,
+              equals([
+                ReleasePlatform.android.displayName,
+                ReleasePlatform.ios.displayName,
+              ]),
+            );
+          });
+        });
+
+        group('not on non-macOS', () {
+          setUp(() {
+            when(() => platform.isWindows).thenReturn(true);
+          });
+
+          test('does not prompt for platform', () async {
+            final result = await runWithOverrides(command.run);
+            expect(result, equals(ExitCode.success.code));
+            verifyNever(
+              () => logger.chooseOne(any(), choices: any(named: 'choices')),
+            );
+            verify(
+              () => bundletool.buildApks(
+                bundle: any(named: 'bundle'),
+                output: any(named: 'output'),
+              ),
+            ).called(1);
+          });
+        });
       });
 
       test('exits early when no apps are found', () async {
@@ -633,13 +682,13 @@ void main() {
 
     group('ios', () {
       const releaseArtifactUrl = 'https://example.com/runner.app';
-      const platform = ReleasePlatform.ios;
+      const releasePlatform = ReleasePlatform.ios;
       late Devicectl devicectl;
       late IOSDeploy iosDeploy;
 
       String runnerPath() => p.join(
             previewDirectory.path,
-            '${platform.name}_$releaseVersion.app',
+            '${releasePlatform.name}_$releaseVersion.app',
           );
 
       R runWithOverrides<R>(R Function() body) {
@@ -657,6 +706,7 @@ void main() {
               devicectlRef.overrideWith(() => devicectl),
               iosDeployRef.overrideWith(() => iosDeploy),
               loggerRef.overrideWith(() => logger),
+              platformRef.overrideWith(() => platform),
               shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
             },
           ),
@@ -666,7 +716,7 @@ void main() {
       setUp(() {
         devicectl = MockDevicectl();
         iosDeploy = MockIOSDeploy();
-        when(() => argResults['platform']).thenReturn(platform.name);
+        when(() => argResults['platform']).thenReturn(releasePlatform.name);
         when(
           () => artifactManager.downloadFile(
             any(),
@@ -694,7 +744,12 @@ void main() {
             deviceId: any(named: 'deviceId'),
           ),
         ).thenAnswer((_) async => ExitCode.success.code);
+        when(() => release.platformStatuses).thenReturn({
+          ReleasePlatform.android: ReleaseStatus.active,
+          ReleasePlatform.ios: ReleaseStatus.active,
+        });
         when(() => releaseArtifact.url).thenReturn(releaseArtifactUrl);
+        when(() => platform.isMacOS).thenReturn(true);
       });
 
       File setupShorebirdYaml() => File(
@@ -727,7 +782,7 @@ void main() {
             appId: appId,
             releaseId: releaseId,
             arch: 'runner',
-            platform: platform,
+            platform: releasePlatform,
           ),
         ).called(1);
       });

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_platform.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_platform.dart
@@ -1,7 +1,12 @@
 /// A platform to which a Shorebird release can be deployed.
 enum ReleasePlatform {
   // ignore: public_member_api_docs
-  android,
+  android('Android'),
   // ignore: public_member_api_docs
-  ios;
+  ios('iOS');
+
+  const ReleasePlatform(this.displayName);
+
+  /// The display name of the platform.
+  final String displayName;
 }


### PR DESCRIPTION
## Description

Print helpful error instead of failing silently if user tries to preview an unsupported platform (this currently only means "previewing iOS on linux or windows")

Fixes https://github.com/shorebirdtech/shorebird/issues/970

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
