### PR TITLE
fix(shorebird_cli): doctor should ignore non-main AndroidManifest.xml files

### DIFF
--- a/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/android_internet_permission_validator.dart
@@ -4,8 +4,8 @@ import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:xml/xml.dart';
 
-/// Checks that all AndroidManifest.xml files in android/app/src/{flavor}/
-/// contain the INTERNET permission, which is required for Shorebird to work.
+/// Checks that android/app/src/main/AndroidManifest.xml contains the INTERNET
+/// permission, which is required for Shorebird to work.
 ///
 /// See https://github.com/shorebirdtech/shorebird/issues/160.
 class AndroidInternetPermissionValidator extends Validator {
@@ -34,46 +34,30 @@ The command you are running must be run at the root of a Flutter app project tha
 
   @override
   Future<List<ValidationIssue>> validate() async {
-    const manifestFileName = 'AndroidManifest.xml';
-
-    final manifestFiles = _androidSrcDirectory
-        .listSync()
-        .whereType<Directory>()
-        .where(
-          (dir) => dir
-              .listSync()
-              .whereType<File>()
-              .any((file) => p.basename(file.path) == manifestFileName),
-        )
-        .map((e) => p.join(e.path, manifestFileName));
-
-    if (manifestFiles.isEmpty) {
+    final manifestFilePath = p.join(
+      _androidSrcDirectory.path,
+      'main',
+      'AndroidManifest.xml',
+    );
+    final manifestFile = File(manifestFilePath);
+    if (!manifestFile.existsSync()) {
       return [
         ValidationIssue(
           severity: ValidationIssueSeverity.error,
-          message:
-              '''No AndroidManifest.xml files found in ${_androidSrcDirectory.path}''',
+          message: '''No AndroidManifest.xml file found at $manifestFilePath''',
         ),
       ];
     }
 
-    final manifestsWithoutInternetPermission = manifestFiles
-        .where((manifest) => !_androidManifestHasInternetPermission(manifest));
-
-    if (manifestsWithoutInternetPermission.isNotEmpty) {
-      return manifestsWithoutInternetPermission.map(
-        (String manifestPath) {
-          return ValidationIssue(
-            severity: manifestPath.contains(mainAndroidManifestPath)
-                ? ValidationIssueSeverity.error
-                : ValidationIssueSeverity.warning,
-            message:
-                '${p.relative(manifestPath, from: Directory.current.path)} '
-                'is missing the INTERNET permission.',
-            fix: () => _addInternetPermissionToFile(manifestPath),
-          );
-        },
-      ).toList();
+    if (!_androidManifestHasInternetPermission(manifestFilePath)) {
+      return [
+        ValidationIssue(
+          severity: ValidationIssueSeverity.error,
+          message:
+              '$mainAndroidManifestPath is missing the INTERNET permission.',
+          fix: () => _addInternetPermissionToFile(manifestFilePath),
+        ),
+      ];
     }
 
     return [];


### PR DESCRIPTION
## Description

Only check main AndroidManifest.xml for INTERNET permission.

Fixes https://github.com/shorebirdtech/shorebird/issues/1210

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
