### PR TITLE
feat(shorebird_cli): add export-method option to release ios command

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -301,6 +301,10 @@ Either run `flutter pub get` manually, or follow the steps in ${link(uri: Uri.pa
     // The full error text consists of many repeated lines of the format:
     // (newlines added for line length)
     //
+    // [   +1 ms] Encountered error while creating the IPA:
+    // [        ] error: exportArchive: Team "Team" does not have permission to
+    //      create "iOS In House" provisioning profiles.
+    //    error: exportArchive: No profiles for 'com.example.dev' were found
     //    error: exportArchive: No signing certificate "iOS Distribution" found
     //    error: exportArchive: Communication with Apple failed
     //    error: exportArchive: No signing certificate "iOS Distribution" found
@@ -310,7 +314,7 @@ Either run `flutter pub get` manually, or follow the steps in ${link(uri: Uri.pa
     //    error: exportArchive: Communication with Apple failed
     //    error: exportArchive: No signing certificate "iOS Distribution" found
     //    error: exportArchive: Communication with Apple failed
-    final exportArchiveRegex = RegExp(r'^error: exportArchive: (.+)$');
+    final exportArchiveRegex = RegExp(r'error: exportArchive: (.+)$');
 
     return stderr
         .split('\n')

--- a/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
@@ -4,7 +4,6 @@ import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
-import 'package:propertylistserialization/propertylistserialization.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/commands/build/build.dart';
 import 'package:shorebird_cli/src/doctor.dart';
@@ -281,42 +280,6 @@ ${lightCyan.wrap(p.join('build', 'ios', 'archive', 'Runner.xcarchive'))}''',
 ${lightCyan.wrap(p.join('build', 'ios', 'ipa', 'Runner.ipa'))}''',
         ),
       );
-    });
-
-    test('provides appropriate ExportOptions.plist to build ipa command',
-        () async {
-      when(() => buildProcessResult.exitCode).thenReturn(ExitCode.success.code);
-      final tempDir = Directory.systemTemp.createTempSync();
-      final result = await IOOverrides.runZoned(
-        () async => runWithOverrides(command.run),
-        getCurrentDirectory: () => tempDir,
-      );
-
-      expect(result, equals(ExitCode.success.code));
-      expect(exitCode, ExitCode.success.code);
-      final capturedArgs = verify(
-        () => shorebirdProcess.run(
-          'flutter',
-          captureAny(),
-          runInShell: any(named: 'runInShell'),
-        ),
-      ).captured.first as List<String>;
-      final exportOptionsPlistFile = File(
-        capturedArgs
-            .whereType<String>()
-            .firstWhere((arg) => arg.contains('export-options-plist'))
-            .split('=')
-            .last,
-      );
-      expect(exportOptionsPlistFile.existsSync(), isTrue);
-      final exportOptionsPlist =
-          PropertyListSerialization.propertyListWithString(
-        exportOptionsPlistFile.readAsStringSync(),
-      ) as Map<String, Object>;
-      expect(exportOptionsPlist['manageAppVersionAndBuildNumber'], isFalse);
-      expect(exportOptionsPlist['signingStyle'], 'automatic');
-      expect(exportOptionsPlist['uploadBitcode'], isFalse);
-      expect(exportOptionsPlist['method'], 'app-store');
     });
   });
 }

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -7,7 +7,6 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
-import 'package:propertylistserialization/propertylistserialization.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
@@ -1080,42 +1079,6 @@ base_url: $baseUrl''',
         () => runWithOverrides(command.run),
         getCurrentDirectory: () => tempDir,
       );
-    });
-
-    test('provides appropriate ExportOptions.plist to build ipa command',
-        () async {
-      final tempDir = setUpTempDir();
-      setUpTempArtifacts(tempDir);
-
-      final exitCode = await IOOverrides.runZoned(
-        () => runWithOverrides(command.run),
-        getCurrentDirectory: () => tempDir,
-      );
-
-      expect(exitCode, ExitCode.success.code);
-      final capturedArgs = verify(
-        () => shorebirdProcess.run(
-          'flutter',
-          captureAny(),
-          runInShell: any(named: 'runInShell'),
-        ),
-      ).captured.first as List<String>;
-      final exportOptionsPlistFile = File(
-        capturedArgs
-            .whereType<String>()
-            .firstWhere((arg) => arg.contains('export-options-plist'))
-            .split('=')
-            .last,
-      );
-      expect(exportOptionsPlistFile.existsSync(), isTrue);
-      final exportOptionsPlist =
-          PropertyListSerialization.propertyListWithString(
-        exportOptionsPlistFile.readAsStringSync(),
-      ) as Map<String, Object>;
-      expect(exportOptionsPlist['manageAppVersionAndBuildNumber'], isFalse);
-      expect(exportOptionsPlist['signingStyle'], 'automatic');
-      expect(exportOptionsPlist['uploadBitcode'], isFalse);
-      expect(exportOptionsPlist['method'], 'app-store');
     });
 
     test('does not prompt if running on CI', () async {

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:propertylistserialization/propertylistserialization.dart';
 import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
@@ -216,6 +217,12 @@ flutter:
       when(() => argResults['arch']).thenReturn(arch);
       when(() => argResults['codesign']).thenReturn(true);
       when(() => argResults['platform']).thenReturn(releasePlatform);
+      when(() => argResults['export-options-plist']).thenReturn(null);
+      // This is the default value in ReleaseIosCommand.
+      when(() => argResults['export-method']).thenReturn(
+        ExportMethod.appStore.argName,
+      );
+      when(() => argResults.wasParsed('export-method')).thenReturn(false);
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => logger.progress(any())).thenReturn(progress);
       when(() => logger.confirm(any())).thenReturn(true);
@@ -493,6 +500,159 @@ flutter:
             isCodesigned: false,
           ),
         ).called(1);
+      });
+    });
+
+    group('when both export-method and export-options-plist are provided', () {
+      setUp(() {
+        when(() => argResults.wasParsed(exportMethodArgName)).thenReturn(true);
+        when(() => argResults[exportOptionsPlistArgName])
+            .thenReturn('/path/to/export.plist');
+      });
+
+      test('logs error and exits with usage code', () async {
+        final tempDir = setUpTempDir();
+        final result = await IOOverrides.runZoned(
+          () => runWithOverrides(command.run),
+          getCurrentDirectory: () => tempDir,
+        );
+
+        expect(result, equals(ExitCode.usage.code));
+        verify(
+          () => logger.err(
+            'Cannot specify both --export-method and --export-options-plist.',
+          ),
+        ).called(1);
+      });
+    });
+
+    group('when export-method is provided', () {
+      setUp(() {
+        when(() => argResults.wasParsed(exportMethodArgName)).thenReturn(true);
+        when(() => argResults[exportMethodArgName])
+            .thenReturn(ExportMethod.enterprise.argName);
+        when(() => argResults[exportOptionsPlistArgName]).thenReturn(null);
+      });
+
+      test('generates an export options plist with that export method',
+          () async {
+        final tempDir = setUpTempDir();
+        await IOOverrides.runZoned(
+          () => runWithOverrides(command.run),
+          getCurrentDirectory: () => tempDir,
+        );
+
+        final capturedArgs = verify(
+          () => shorebirdProcess.run(
+            'flutter',
+            captureAny(),
+            runInShell: any(named: 'runInShell'),
+          ),
+        ).captured.first as List<String>;
+        final exportOptionsPlistFile = File(
+          capturedArgs
+              .whereType<String>()
+              .firstWhere((arg) => arg.contains(exportOptionsPlistArgName))
+              .split('=')
+              .last,
+        );
+        final exportOptionsPlist = Plist(file: exportOptionsPlistFile);
+        expect(
+          exportOptionsPlist.properties['method'],
+          ExportMethod.enterprise.argName,
+        );
+      });
+    });
+
+    group('when export-options-plist is provided', () {
+      group('when file does not exist', () {
+        setUp(() {
+          when(() => argResults[exportOptionsPlistArgName])
+              .thenReturn('/does/not/exist');
+        });
+
+        test('exits with usage code', () async {
+          final tempDir = setUpTempDir();
+          final result = await IOOverrides.runZoned(
+            () => runWithOverrides(command.run),
+            getCurrentDirectory: () => tempDir,
+          );
+
+          expect(result, equals(ExitCode.usage.code));
+          verify(
+            () => logger.err(
+              'Exception: Export options plist file /does/not/exist does not exist',
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when manageAppVersionAndBuildNumber is not set to false', () {
+        const exportPlistContent = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>
+''';
+
+        test('exits with usage code', () async {
+          final tempDir = setUpTempDir();
+          final exportPlistFile = File(
+            p.join(tempDir.path, 'export.plist'),
+          )..writeAsStringSync(exportPlistContent);
+          when(() => argResults[exportOptionsPlistArgName])
+              .thenReturn(exportPlistFile.path);
+          final result = await IOOverrides.runZoned(
+            () => runWithOverrides(command.run),
+            getCurrentDirectory: () => tempDir,
+          );
+
+          expect(result, equals(ExitCode.usage.code));
+          verify(
+            () => logger.err(
+              '''Exception: Export options plist ${exportPlistFile.path} does not set manageAppVersionAndBuildNumber to false. This is required for shorebird to work.''',
+            ),
+          ).called(1);
+        });
+      });
+    });
+
+    group('when neither export-method nor export-options-plist is provided',
+        () {
+      setUp(() {
+        when(() => argResults.wasParsed(exportMethodArgName)).thenReturn(false);
+        when(() => argResults[exportOptionsPlistArgName]).thenReturn(null);
+      });
+
+      test('generates an export options plist with app-store export method',
+          () async {
+        final tempDir = setUpTempDir();
+        await IOOverrides.runZoned(
+          () => runWithOverrides(command.run),
+          getCurrentDirectory: () => tempDir,
+        );
+
+        final capturedArgs = verify(
+          () => shorebirdProcess.run(
+            'flutter',
+            captureAny(),
+            runInShell: any(named: 'runInShell'),
+          ),
+        ).captured.first as List<String>;
+        final exportOptionsPlistFile = File(
+          capturedArgs
+              .whereType<String>()
+              .firstWhere((arg) => arg.contains(exportOptionsPlistArgName))
+              .split('=')
+              .last,
+        );
+        final exportOptionsPlist = Plist(file: exportOptionsPlistFile);
+        expect(
+          exportOptionsPlist.properties['method'],
+          ExportMethod.appStore.argName,
+        );
       });
     });
 


### PR DESCRIPTION
## Description

Adds ability to specify `--export-method` in `shorebird release ios-alpha` with the same options that are available in the standard Flutter tool. 

This change also

- Updates the stderr output parsing for failed builds to include previously omitted messages, which were being omitted because we ignored lines that had `[   ]` leading characters.
- Removes ExportOptions.plist tests from the patch command, because patch IPAs are never distributed through the app store.
- Removes ExportOptions.plist tests from the `build ios-alpha` command, because this command is hidden and it didn't seem to be worth the effort to add `export-method` and `export-options-plist` support to it.

Fixes https://github.com/shorebirdtech/shorebird/issues/1441

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
