### PR TITLE
fix(shorebird_cli): don't run `flutter pub get` after build if flutter is not installed

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -5,6 +5,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 
@@ -277,6 +278,12 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
   /// https://github.com/shorebirdtech/shorebird/issues/1101 for more info.
   Future<void> _systemFlutterPubGet() async {
     const executable = 'flutter';
+    if (osInterface.which(executable) == null) {
+      // If the user doesn't have Flutter on their PATH, then we can't run
+      // `flutter pub get` with the system Flutter.
+      return;
+    }
+
     final arguments = ['--no-version-check', 'pub', 'get', '--offline'];
 
     final result = await process.run(

--- a/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/commands/build/build.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
@@ -19,6 +20,7 @@ void main() {
 
     late ArgResults argResults;
     late Logger logger;
+    late OperatingSystemInterface operatingSystemInterface;
     late Progress progress;
     late ShorebirdEnv shorebirdEnv;
     late ShorebirdProcess shorebirdProcess;
@@ -32,6 +34,7 @@ void main() {
         body,
         values: {
           loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
           shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
@@ -44,6 +47,7 @@ void main() {
       logger = MockLogger();
       flutterPubGetProcessResult = MockProcessResult();
       buildProcessResult = MockProcessResult();
+      operatingSystemInterface = MockOperatingSystemInterface();
       progress = MockProgress();
       shorebirdEnv = MockShorebirdEnv();
       shorebirdProcess = MockShorebirdProcess();
@@ -73,6 +77,8 @@ void main() {
         return buildProcessResult;
       });
 
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
       when(
         () => shorebirdValidator.validatePreconditions(
           checkUserIsAuthenticated: any(named: 'checkUserIsAuthenticated'),

--- a/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
@@ -8,6 +8,7 @@ import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/commands/build/build.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
@@ -21,6 +22,7 @@ void main() {
     late ArgResults argResults;
     late Doctor doctor;
     late Logger logger;
+    late OperatingSystemInterface operatingSystemInterface;
     late ShorebirdProcessResult flutterPubGetProcessResult;
     late ShorebirdProcessResult buildProcessResult;
     late BuildApkCommand command;
@@ -34,6 +36,7 @@ void main() {
         values: {
           doctorRef.overrideWith(() => doctor),
           loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
         },
@@ -48,6 +51,7 @@ void main() {
       argResults = MockArgResults();
       doctor = MockDoctor();
       logger = MockLogger();
+      operatingSystemInterface = MockOperatingSystemInterface();
       shorebirdProcess = MockShorebirdProcess();
       buildProcessResult = MockProcessResult();
       flutterPubGetProcessResult = MockProcessResult();
@@ -74,6 +78,8 @@ void main() {
       when(() => argResults.rest).thenReturn([]);
       when(() => logger.progress(any())).thenReturn(MockProgress());
       when(() => logger.info(any())).thenReturn(null);
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
       when(
         () => shorebirdValidator.validatePreconditions(
           checkUserIsAuthenticated: any(named: 'checkUserIsAuthenticated'),

--- a/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
@@ -8,6 +8,7 @@ import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/commands/build/build.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
@@ -21,6 +22,7 @@ void main() {
     late ArgResults argResults;
     late Doctor doctor;
     late Logger logger;
+    late OperatingSystemInterface operatingSystemInterface;
     late ShorebirdProcessResult flutterPubGetProcessResult;
     late ShorebirdProcessResult buildProcessResult;
     late BuildAppBundleCommand command;
@@ -35,6 +37,7 @@ void main() {
           doctorRef.overrideWith(() => doctor),
           engineConfigRef.overrideWith(() => const EngineConfig.empty()),
           loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
         },
@@ -49,6 +52,7 @@ void main() {
       argResults = MockArgResults();
       doctor = MockDoctor();
       logger = MockLogger();
+      operatingSystemInterface = MockOperatingSystemInterface();
       buildProcessResult = MockProcessResult();
       flutterPubGetProcessResult = MockProcessResult();
       flutterValidator = MockShorebirdFlutterValidator();
@@ -75,6 +79,8 @@ void main() {
       when(() => argResults.rest).thenReturn([]);
       when(() => logger.progress(any())).thenReturn(MockProgress());
       when(() => logger.info(any())).thenReturn(null);
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
       when(
         () => doctor.androidCommandValidators,
       ).thenReturn([flutterValidator]);

--- a/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
@@ -9,6 +9,7 @@ import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/commands/build/build.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
@@ -22,6 +23,7 @@ void main() {
     late ArgResults argResults;
     late Doctor doctor;
     late Logger logger;
+    late OperatingSystemInterface operatingSystemInterface;
     late ShorebirdProcessResult buildProcessResult;
     late ShorebirdProcessResult flutterPubGetProcessResult;
     late BuildIpaCommand command;
@@ -35,6 +37,7 @@ void main() {
         values: {
           doctorRef.overrideWith(() => doctor),
           loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
         },
@@ -49,6 +52,7 @@ void main() {
       argResults = MockArgResults();
       doctor = MockDoctor();
       logger = MockLogger();
+      operatingSystemInterface = MockOperatingSystemInterface();
       shorebirdProcess = MockShorebirdProcess();
       buildProcessResult = MockProcessResult();
       flutterPubGetProcessResult = MockProcessResult();
@@ -76,6 +80,8 @@ void main() {
       when(() => argResults.rest).thenReturn([]);
       when(() => logger.progress(any())).thenReturn(MockProgress());
       when(() => logger.info(any())).thenReturn(null);
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
       when(() => doctor.iosCommandValidators).thenReturn([flutterValidator]);
       when(
         () => shorebirdValidator.validatePreconditions(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -16,6 +16,7 @@ import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
@@ -85,6 +86,7 @@ void main() {
     late CodePushClientWrapper codePushClientWrapper;
     late Directory shorebirdRoot;
     late Directory flutterDirectory;
+    late OperatingSystemInterface operatingSystemInterface;
     late PatchDiffChecker patchDiffChecker;
     late Platform platform;
     late Progress progress;
@@ -109,6 +111,7 @@ void main() {
           codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           engineConfigRef.overrideWith(() => const EngineConfig.empty()),
           loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
           patchDiffCheckerRef.overrideWith(() => patchDiffChecker),
           platformRef.overrideWith(() => platform),
           processRef.overrideWith(() => shorebirdProcess),
@@ -170,6 +173,7 @@ void main() {
       flutterDirectory = Directory(
         p.join(shorebirdRoot.path, 'bin', 'cache', 'flutter'),
       );
+      operatingSystemInterface = MockOperatingSystemInterface();
       patchDiffChecker = MockPatchDiffChecker();
       platform = MockPlatform();
       progress = MockProgress();
@@ -183,6 +187,8 @@ void main() {
       shorebirdProcess = MockShorebirdProcess();
       shorebirdValidator = MockShorebirdValidator();
 
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
       when(() => platform.environment).thenReturn({});
       when(() => shorebirdEnv.shorebirdRoot).thenReturn(shorebirdRoot);
       when(() => shorebirdEnv.flutterDirectory).thenReturn(flutterDirectory);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -18,6 +18,7 @@ import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
@@ -98,6 +99,7 @@ flutter:
     late Directory shorebirdRoot;
     late Doctor doctor;
     late Java java;
+    late OperatingSystemInterface operatingSystemInterface;
     late PatchDiffChecker patchDiffChecker;
     late Platform platform;
     late Progress progress;
@@ -126,6 +128,7 @@ flutter:
           engineConfigRef.overrideWith(() => const EngineConfig.empty()),
           javaRef.overrideWith(() => java),
           loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
           patchDiffCheckerRef.overrideWith(() => patchDiffChecker),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
           platformRef.overrideWith(() => platform),
@@ -199,6 +202,7 @@ flutter:
       httpClient = MockHttpClient();
       flutterValidator = MockShorebirdFlutterValidator();
       cache = MockCache();
+      operatingSystemInterface = MockOperatingSystemInterface();
       shorebirdEnv = MockShorebirdEnv();
       shorebirdProcess = MockShorebirdProcess();
       shorebirdFlutter = MockShorebirdFlutter();
@@ -347,6 +351,8 @@ flutter:
           validators: any(named: 'validators'),
         ),
       ).thenAnswer((_) async {});
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
       when(
         () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
           localArtifact: any(named: 'localArtifact'),

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -17,6 +17,7 @@ import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
@@ -131,6 +132,7 @@ flutter:
     late IosArchiveDiffer archiveDiffer;
     late Progress progress;
     late Logger logger;
+    late OperatingSystemInterface operatingSystemInterface;
     late PatchDiffChecker patchDiffChecker;
     late Platform platform;
     late ShorebirdProcessResult aotBuildProcessResult;
@@ -152,6 +154,7 @@ flutter:
           codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           doctorRef.overrideWith(() => doctor),
           loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
           patchDiffCheckerRef.overrideWith(() => patchDiffChecker),
           platformRef.overrideWith(() => platform),
           processRef.overrideWith(() => shorebirdProcess),
@@ -244,6 +247,7 @@ flutter:
       flutterBuildProcessResult = MockProcessResult();
       flutterPubGetProcessResult = MockProcessResult();
       httpClient = MockHttpClient();
+      operatingSystemInterface = MockOperatingSystemInterface();
       patchDiffChecker = MockPatchDiffChecker();
       shorebirdEnv = MockShorebirdEnv();
       shorebirdFlutter = MockShorebirdFlutter();
@@ -289,6 +293,8 @@ flutter:
       when(flutterValidator.validate).thenAnswer((_) async => []);
       when(() => logger.confirm(any())).thenReturn(true);
       when(() => logger.progress(any())).thenReturn(progress);
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
       when(() => platform.operatingSystem).thenReturn(Platform.macOS);
       when(() => platform.environment).thenReturn({});
       when(() => platform.script).thenReturn(shorebirdRoot.uri);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
@@ -14,6 +14,7 @@ import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
@@ -83,8 +84,9 @@ flutter:
     late PatchDiffChecker patchDiffChecker;
     late Platform platform;
     late Auth auth;
-    late Progress progress;
+    late OperatingSystemInterface operatingSystemInterface;
     late Logger logger;
+    late Progress progress;
     late ShorebirdProcessResult aotBuildProcessResult;
     late ShorebirdProcessResult flutterBuildProcessResult;
     late ShorebirdProcessResult flutterPubGetProcessResult;
@@ -103,6 +105,7 @@ flutter:
           codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           doctorRef.overrideWith(() => doctor),
           loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
           patchDiffCheckerRef.overrideWith(() => patchDiffChecker),
           platformRef.overrideWith(() => platform),
           processRef.overrideWith(() => shorebirdProcess),
@@ -191,6 +194,7 @@ flutter:
       aotBuildProcessResult = MockProcessResult();
       flutterBuildProcessResult = MockProcessResult();
       flutterPubGetProcessResult = MockProcessResult();
+      operatingSystemInterface = MockOperatingSystemInterface();
       shorebirdEnv = MockShorebirdEnv();
       shorebirdFlutter = MockShorebirdFlutter();
       flutterValidator = MockShorebirdFlutterValidator();
@@ -228,6 +232,8 @@ flutter:
       when(() => logger.level).thenReturn(Level.info);
       when(() => logger.progress(any())).thenReturn(progress);
       when(() => logger.confirm(any())).thenReturn(true);
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
       when(() => platform.operatingSystem).thenReturn(Platform.macOS);
       when(() => shorebirdEnv.getShorebirdYaml()).thenReturn(shorebirdYaml);
       when(() => shorebirdEnv.shorebirdRoot).thenReturn(shorebirdRoot);

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -13,6 +13,7 @@ import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -59,6 +60,7 @@ void main() {
     late CodePushClientWrapper codePushClientWrapper;
     late Directory shorebirdRoot;
     late Java java;
+    late OperatingSystemInterface operatingSystemInterface;
     late Platform platform;
     late Progress progress;
     late Logger logger;
@@ -78,6 +80,7 @@ void main() {
           engineConfigRef.overrideWith(() => const EngineConfig.empty()),
           javaRef.overrideWith(() => java),
           loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
           platformRef.overrideWith(() => platform),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
@@ -129,6 +132,7 @@ void main() {
       auth = MockAuth();
       codePushClientWrapper = MockCodePushClientWrapper();
       java = MockJava();
+      operatingSystemInterface = MockOperatingSystemInterface();
       platform = MockPlatform();
       progress = MockProgress();
       logger = MockLogger();
@@ -146,6 +150,8 @@ void main() {
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => logger.confirm(any())).thenReturn(true);
       when(() => logger.progress(any())).thenReturn(progress);
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
 
       when(() => shorebirdEnv.getShorebirdYaml()).thenReturn(shorebirdYaml);
       when(() => shorebirdEnv.shorebirdRoot).thenReturn(shorebirdRoot);

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -14,6 +14,7 @@ import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -110,6 +111,7 @@ flutter:
     late Auth auth;
     late Progress progress;
     late Logger logger;
+    late OperatingSystemInterface operatingSystemInterface;
     late ShorebirdProcessResult flutterBuildProcessResult;
     late ShorebirdProcessResult flutterPubGetProcessResult;
     late ShorebirdFlutterValidator flutterValidator;
@@ -126,6 +128,7 @@ flutter:
           codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           doctorRef.overrideWith(() => doctor),
           loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
           platformRef.overrideWith(() => platform),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
@@ -184,6 +187,7 @@ flutter:
       platform = MockPlatform();
       shorebirdRoot = Directory.systemTemp.createTempSync();
       auth = MockAuth();
+      operatingSystemInterface = MockOperatingSystemInterface();
       progress = MockProgress();
       logger = MockLogger();
       flutterBuildProcessResult = MockProcessResult();
@@ -222,6 +226,8 @@ flutter:
       when(
         () => logger.prompt(any(), defaultValue: any(named: 'defaultValue')),
       ).thenReturn(version);
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
       when(() => platform.operatingSystem).thenReturn(Platform.macOS);
       when(
         () => flutterBuildProcessResult.exitCode,

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -12,6 +12,7 @@ import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -67,6 +68,7 @@ flutter:
     late Auth auth;
     late Progress progress;
     late Logger logger;
+    late OperatingSystemInterface operatingSystemInterface;
     late ShorebirdProcessResult flutterBuildProcessResult;
     late ShorebirdProcessResult flutterPubGetProcessResult;
     late ShorebirdFlutterValidator flutterValidator;
@@ -83,6 +85,7 @@ flutter:
           codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           doctorRef.overrideWith(() => doctor),
           loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
           platformRef.overrideWith(() => platform),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
@@ -119,6 +122,7 @@ flutter:
       auth = MockAuth();
       progress = MockProgress();
       logger = MockLogger();
+      operatingSystemInterface = MockOperatingSystemInterface();
       flutterBuildProcessResult = MockProcessResult();
       flutterPubGetProcessResult = MockProcessResult();
       flutterValidator = MockShorebirdFlutterValidator();
@@ -156,6 +160,8 @@ flutter:
           .thenReturn(ExitCode.success.code);
       when(() => logger.progress(any())).thenReturn(progress);
       when(() => logger.confirm(any())).thenReturn(true);
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
       when(() => platform.operatingSystem).thenReturn(Platform.macOS);
       when(
         () => codePushClientWrapper.getApp(appId: any(named: 'appId')),


### PR DESCRIPTION
## Description

Checks for the presence of flutter on the user's path before attempting to run `flutter pub get` after a build.

For context: `flutter pub get` is run after a build to reset `.dart_tool/package_config.json` to point to the system flutter install instead of the shorebird flutter install. This value is set when running a flutter build command or flutter pub get.

Fixes https://github.com/shorebirdtech/shorebird/issues/1430

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
