### PR TITLE
fix(shorebird_cli): fix failing test

### DIFF
--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -1697,7 +1697,8 @@ Please bump your version number and try again.''',
 
       Directory setUpTempDir({String? flavor}) {
         final tempDir = Directory.systemTemp.createTempSync();
-        File(p.join(tempDir.path, frameworkPath)).createSync(recursive: true);
+        Directory(p.join(tempDir.path, frameworkPath))
+            .createSync(recursive: true);
         return tempDir;
       }
 


### PR DESCRIPTION
## Description

Creates an xcframework as a directory instead of a file.

Fixes the test failure seen in https://github.com/shorebirdtech/shorebird/actions/runs/6788000286/job/18452058897. 

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
