### PR TITLE
fix(shorebird_cli): only show current adb logs in shorebird preview

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/adb.dart
+++ b/packages/shorebird_cli/lib/src/executables/adb.dart
@@ -67,6 +67,8 @@ class Adb {
     final args = [
       if (deviceId != null) ...['-s', deviceId],
       'logcat',
+      // This arg prevents old logs from being displayed.
+      ...['-T', '1'],
       if (filter != null) ...['-s', filter],
     ];
     return _stream(args.join(' '));

--- a/packages/shorebird_cli/test/src/executables/adb_test.dart
+++ b/packages/shorebird_cli/test/src/executables/adb_test.dart
@@ -202,7 +202,7 @@ void main() {
         });
         final result = await runWithOverrides(() => adb.logcat());
         expect(result, equals(logcatProcess));
-        verify(() => process.start(adbPath, ['logcat'])).called(1);
+        verify(() => process.start(adbPath, ['logcat', '-T', '1'])).called(1);
       });
 
       test('returns correct process (filtered)', () async {
@@ -221,7 +221,7 @@ void main() {
         final result = await runWithOverrides(() => adb.logcat(filter: filter));
         expect(result, equals(logcatProcess));
         verify(
-          () => process.start(adbPath, ['logcat', '-s', filter]),
+          () => process.start(adbPath, ['logcat', '-T', '1', '-s', filter]),
         ).called(1);
       });
 
@@ -234,8 +234,9 @@ void main() {
           fail('Unexpected executable: $executable');
         });
         await runWithOverrides(() => adb.logcat(deviceId: deviceId));
-        verify(() => process.start(adbPath, ['-s', deviceId, 'logcat']))
-            .called(1);
+        verify(
+          () => process.start(adbPath, ['-s', deviceId, 'logcat', '-T', '1']),
+        ).called(1);
       });
     });
   });


### PR DESCRIPTION
## Description

Passes `-T 1` to the invocation of `logcat` to only show logs that were printed after the invocation of logcat.

Fixes https://github.com/shorebirdtech/shorebird/issues/1417

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
