### PR TITLE
fix: include plist path in failure message

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -145,7 +145,9 @@ If this option is not provided, the version number will be determined from the p
       try {
         releaseVersion = plist.versionNumber;
       } catch (error) {
-        logger.err('Failed to determine release version: $error');
+        logger.err(
+          'Failed to determine release version from ${plistFile.path}: $error',
+        );
         return ExitCode.software.code;
       }
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -198,7 +198,9 @@ make smaller updates to your app.
     try {
       releaseVersion = plist.versionNumber;
     } catch (error) {
-      logger.err('Failed to determine release version: $error');
+      logger.err(
+        'Failed to determine release version from ${plistFile.path}: $error',
+      );
       return ExitCode.software.code;
     }
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -720,7 +720,7 @@ Please re-run the release command for this version or create a new release.'''),
         () async {
       final tempDir = setUpTempDir();
       setUpTempArtifacts(tempDir);
-      File(
+      final file = File(
         p.join(
           tempDir.path,
           'build',
@@ -741,7 +741,8 @@ Please re-run the release command for this version or create a new release.'''),
       expect(exitCode, equals(ExitCode.software.code));
       verify(
         () => logger.err(
-          any(that: contains('Failed to determine release version')),
+          'Failed to determine release version from ${file.path}: '
+          'Exception: Could not determine release version',
         ),
       ).called(1);
     });

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -716,10 +716,10 @@ error: exportArchive: No signing certificate "iOS Distribution" found
       ).called(1);
     });
 
-    test('exits with code 70 when release version cannot be determiend',
+    test('exits with code 70 when release version cannot be determined',
         () async {
       final tempDir = setUpTempDir();
-      File(
+      final file = File(
         p.join(
           tempDir.path,
           'build',
@@ -739,7 +739,8 @@ error: exportArchive: No signing certificate "iOS Distribution" found
       expect(exitCode, equals(ExitCode.software.code));
       verify(
         () => logger.err(
-          any(that: contains('Failed to determine release version')),
+          'Failed to determine release version from ${file.path}: '
+          'Exception: Could not determine release version',
         ),
       ).called(1);
     });


### PR DESCRIPTION
This would have helped diagnose a plist parse failure.
Adding it to help with future errors.