### PR TITLE
fix(shorebird_cli): `shorebird init` should not prompt when `--force` or running in CI

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -152,10 +152,14 @@ Please make sure you are running "shorebird init" from the root of your Flutter 
     final String appId;
     Map<String, String>? flavors;
     try {
-      final displayName = logger.prompt(
-        '${lightGreen.wrap('?')} How should we refer to this app?',
-        defaultValue: shorebirdEnv.getPubspecYaml()?.name,
-      );
+      final needsConfirmation = !force && !shorebirdEnv.isRunningOnCI;
+      final pubspecName = shorebirdEnv.getPubspecYaml()!.name;
+      final displayName = needsConfirmation
+          ? logger.prompt(
+              '${lightGreen.wrap('?')} How should we refer to this app?',
+              defaultValue: pubspecName,
+            )
+          : pubspecName;
       final hasNoFlavors = productFlavors.isEmpty;
       final hasSomeFlavors = productFlavors.isNotEmpty &&
           ((androidFlavors?.isEmpty ?? false) ||


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- fix(shorebird_cli): `shorebird init` does not prompt when `--force` or running in CI

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
