### PR TITLE
fix(shorebird_cli): flutter validator should not warn if system Flutter does not exist

### DIFF
--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -15,6 +15,8 @@ class FlutterValidationException implements Exception {
   String toString() => 'FlutterValidationException: $message';
 }
 
+class CommandNotFoundException implements Exception {}
+
 class ShorebirdFlutterValidator extends Validator {
   ShorebirdFlutterValidator();
 
@@ -63,6 +65,8 @@ class ShorebirdFlutterValidator extends Validator {
       pathFlutterVersionString = await _getFlutterVersion(
         useVendedFlutter: false,
       );
+    } on CommandNotFoundException catch (_) {
+      // If there is no system Flutter, we don't throw a validation exception.
     } catch (error) {
       issues.add(
         ValidationIssue(
@@ -117,6 +121,8 @@ This can cause unexpected behavior if you are switching between the tools and th
           ? await shorebirdFlutter.getVersion()
           : await shorebirdFlutter.getSystemVersion();
     } on ProcessException catch (error) {
+      if (error.errorCode == 127) throw CommandNotFoundException();
+
       throw FlutterValidationException(
         'Flutter version check did not complete successfully. ${error.message}',
       );

--- a/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/shorebird_flutter_validator_test.dart
@@ -108,6 +108,21 @@ void main() {
     });
 
     test(
+      'does not warn if system flutter does not exist',
+      () async {
+        when(
+          () => shorebirdFlutter.getSystemVersion(),
+        ).thenThrow(const ProcessException('flutter', ['--version'], '', 127));
+
+        final results = await runWithOverrides(
+          () => validator.validate(),
+        );
+
+        expect(results, isEmpty);
+      },
+    );
+
+    test(
       'does not warn if flutter version and shorebird flutter version have same'
       ' major and minor but different patch versions',
       () async {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- fix(shorebird_cli): flutter validator does not warn if system Flutter does not exist (closes #337)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
