### PR TITLE
feat(shorebird_cli): validate storage.googleapis.com is pingable in doctor

### DIFF
--- a/packages/shorebird_cli/lib/src/doctor.dart
+++ b/packages/shorebird_cli/lib/src/doctor.dart
@@ -27,6 +27,7 @@ class Doctor {
     ShorebirdVersionValidator(),
     ShorebirdFlutterValidator(),
     AndroidInternetPermissionValidator(),
+    StorageAccessValidator(),
   ];
 
   /// Run the provided [validators]. If [applyFixes] is `true`, any validation

--- a/packages/shorebird_cli/lib/src/validators/storage_access_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/storage_access_validator.dart
@@ -1,0 +1,31 @@
+import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/platform.dart';
+import 'package:shorebird_cli/src/process.dart';
+import 'package:shorebird_cli/src/validators/validators.dart';
+
+class StorageAccessValidator extends Validator {
+  @override
+  String get description => 'Has access to storage.googleapis.com';
+
+  @override
+  Future<List<ValidationIssue>> validate() async {
+    final result = await process.run(
+      'ping',
+      [
+        // ping on Windows auto-terminates, but will go on indefinitely on
+        // other linux and mac unless we set a count. 2 was chosen arbitrarily.
+        if (!platform.isWindows) ...['-c', '2'],
+        'https://storage.googleapis.com',
+      ],
+    );
+    if (result.exitCode != ExitCode.success.code) {
+      return [
+        const ValidationIssue(
+          severity: ValidationIssueSeverity.error,
+          message: 'Unable to access storage.googleapis.com',
+        ),
+      ];
+    }
+    return [];
+  }
+}

--- a/packages/shorebird_cli/lib/src/validators/storage_access_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/storage_access_validator.dart
@@ -15,7 +15,7 @@ class StorageAccessValidator extends Validator {
         // ping on Windows auto-terminates, but will go on indefinitely on
         // other linux and mac unless we set a count. 2 was chosen arbitrarily.
         if (!platform.isWindows) ...['-c', '2'],
-        'https://storage.googleapis.com',
+        'storage.googleapis.com',
       ],
     );
     if (result.exitCode != ExitCode.success.code) {

--- a/packages/shorebird_cli/lib/src/validators/storage_access_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/storage_access_validator.dart
@@ -12,9 +12,8 @@ class StorageAccessValidator extends Validator {
     final result = await process.run(
       'ping',
       [
-        // ping on Windows auto-terminates, but will go on indefinitely on
-        // other linux and mac unless we set a count. 2 was chosen arbitrarily.
-        if (!platform.isWindows) ...['-c', '2'],
+        // Execute a single ping.
+        if (platform.isWindows) ...['/n', '1'] else ...['-c', '1'],
         'storage.googleapis.com',
       ],
     );

--- a/packages/shorebird_cli/lib/src/validators/validators.dart
+++ b/packages/shorebird_cli/lib/src/validators/validators.dart
@@ -7,6 +7,7 @@ import 'package:shorebird_cli/src/process.dart';
 export 'android_internet_permission_validator.dart';
 export 'shorebird_flutter_validator.dart';
 export 'shorebird_version_validator.dart';
+export 'storage_access_validator.dart';
 
 /// Severity level of a [ValidationIssue].
 ///

--- a/packages/shorebird_cli/test/src/validators/storage_access_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/storage_access_validator_test.dart
@@ -86,12 +86,12 @@ void main() {
           when(() => platform.isWindows).thenReturn(true);
         });
 
-        test('does not provide count argument', () async {
+        test('provides appropriate count argument', () async {
           await runWithOverrides(validator.validate);
           verify(
             () => process.run(
               'ping',
-              ['storage.googleapis.com'],
+              ['/n', '1', 'storage.googleapis.com'],
             ),
           ).called(1);
         });
@@ -104,12 +104,12 @@ void main() {
           when(() => platform.isWindows).thenReturn(false);
         });
 
-        test('provides count argument', () async {
+        test('provides appropriate count argument', () async {
           await runWithOverrides(validator.validate);
           verify(
             () => process.run(
               'ping',
-              ['-c', '2', 'storage.googleapis.com'],
+              ['-c', '1', 'storage.googleapis.com'],
             ),
           ).called(1);
         });

--- a/packages/shorebird_cli/test/src/validators/storage_access_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/storage_access_validator_test.dart
@@ -38,6 +38,12 @@ void main() {
       when(() => platform.isWindows).thenReturn(false);
     });
 
+    group('description', () {
+      test('has a non-empty description', () {
+        expect(validator.description, isNotEmpty);
+      });
+    });
+
     group('validate', () {
       group('when storage url is accessible', () {
         setUp(() {

--- a/packages/shorebird_cli/test/src/validators/storage_access_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/storage_access_validator_test.dart
@@ -1,0 +1,100 @@
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:platform/platform.dart';
+import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/platform.dart';
+import 'package:shorebird_cli/src/process.dart';
+import 'package:shorebird_cli/src/validators/validators.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group(StorageAccessValidator, () {
+    late Platform platform;
+    late ShorebirdProcess process;
+    late ShorebirdProcessResult pingProcessResult;
+    late StorageAccessValidator validator;
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        () => body(),
+        values: {
+          platformRef.overrideWith(() => platform),
+          processRef.overrideWith(() => process),
+        },
+      );
+    }
+
+    setUp(() {
+      platform = MockPlatform();
+      process = MockShorebirdProcess();
+      pingProcessResult = MockShorebirdProcessResult();
+      validator = StorageAccessValidator();
+
+      when(() => process.run('ping', any())).thenAnswer(
+        (_) async => pingProcessResult,
+      );
+      when(() => platform.isWindows).thenReturn(false);
+    });
+
+    group('validate', () {
+      group('when storage url is accessible', () {
+        setUp(() {
+          when(() => pingProcessResult.exitCode)
+              .thenReturn(ExitCode.success.code);
+        });
+
+        test('returns empty list of validation issues', () async {
+          final results = await runWithOverrides(validator.validate);
+          expect(results, isEmpty);
+        });
+      });
+
+      group('when storage url is inaccessible', () {
+        setUp(() {
+          when(() => pingProcessResult.exitCode)
+              .thenReturn(ExitCode.software.code);
+        });
+
+        test('returns empty list of validation issues', () async {});
+      });
+
+      group('when run on Windows', () {
+        setUp(() {
+          when(() => pingProcessResult.exitCode)
+              .thenReturn(ExitCode.success.code);
+          when(() => platform.isWindows).thenReturn(true);
+        });
+
+        test('does not provide count argument', () async {
+          await runWithOverrides(validator.validate);
+          verify(
+            () => process.run(
+              'ping',
+              ['https://storage.googleapis.com'],
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when run on non-Windows OS', () {
+        setUp(() {
+          when(() => pingProcessResult.exitCode)
+              .thenReturn(ExitCode.success.code);
+          when(() => platform.isWindows).thenReturn(false);
+        });
+
+        test('provides count argument', () async {
+          await runWithOverrides(validator.validate);
+          verify(
+            () => process.run(
+              'ping',
+              ['-c', '2', 'https://storage.googleapis.com'],
+            ),
+          ).called(1);
+        });
+      });
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/validators/storage_access_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/storage_access_validator_test.dart
@@ -91,7 +91,7 @@ void main() {
           verify(
             () => process.run(
               'ping',
-              ['https://storage.googleapis.com'],
+              ['storage.googleapis.com'],
             ),
           ).called(1);
         });
@@ -109,7 +109,7 @@ void main() {
           verify(
             () => process.run(
               'ping',
-              ['-c', '2', 'https://storage.googleapis.com'],
+              ['-c', '2', 'storage.googleapis.com'],
             ),
           ).called(1);
         });

--- a/packages/shorebird_cli/test/src/validators/storage_access_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/storage_access_validator_test.dart
@@ -57,7 +57,20 @@ void main() {
               .thenReturn(ExitCode.software.code);
         });
 
-        test('returns empty list of validation issues', () async {});
+        test('returns validation error', () async {
+          final results = await runWithOverrides(validator.validate);
+          expect(
+            results,
+            equals(
+              [
+                const ValidationIssue(
+                  severity: ValidationIssueSeverity.error,
+                  message: 'Unable to access storage.googleapis.com',
+                ),
+              ],
+            ),
+          );
+        });
       });
 
       group('when run on Windows', () {


### PR DESCRIPTION
## Description

Adds a validator to verify that the user can ping `https://storage.googleapis.com`, which is required to upload release artifacts.

Fixes https://github.com/shorebirdtech/shorebird/issues/1506

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
