### PR TITLE
refactor(shorebird_cli): use scoped http client

### DIFF
--- a/packages/shorebird_cli/bin/shorebird.dart
+++ b/packages/shorebird_cli/bin/shorebird.dart
@@ -11,6 +11,7 @@ import 'package:shorebird_cli/src/command_runner.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/flutter_artifacts.dart';
+import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/os.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
@@ -41,6 +42,7 @@ Future<void> main(List<String> args) async {
         flutterArtifactsRef,
         gitRef,
         gradlewRef,
+        httpClientRef,
         idevicesyslogRef,
         iosDeployRef,
         javaRef,

--- a/packages/shorebird_cli/lib/src/artifact_manager.dart
+++ b/packages/shorebird_cli/lib/src/artifact_manager.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/cache.dart';
+import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/process.dart';
 
 /// A reference to a [ArtifactManager] instance.
@@ -51,7 +52,6 @@ Failed to create diff (exit code ${result.exitCode}).
   /// the path to the downloaded file.
   Future<String> downloadFile(
     Uri uri, {
-    required http.Client httpClient,
     String? outputPath,
   }) async {
     final request = http.Request('GET', uri);

--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -147,9 +147,7 @@ class Auth {
     _loadCredentials();
   }
 
-  static http.Client get _defaultHttpClient => retryingHttpClient(
-        LoggingClient(httpClient: http.Client()),
-      );
+  static http.Client get _defaultHttpClient => httpClient;
 
   final http.Client _httpClient;
   final String _credentialsDir;

--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -48,16 +48,12 @@ final cacheRef = create(Cache.new);
 Cache get cache => read(cacheRef);
 
 class Cache {
-  Cache({
-    http.Client? httpClient,
-    this.extractArchive = _defaultArchiveExtractor,
-  }) : httpClient = httpClient ?? retryingHttpClient(http.Client()) {
+  Cache({this.extractArchive = _defaultArchiveExtractor}) {
     registerArtifact(PatchArtifact(cache: this, platform: platform));
     registerArtifact(BundleToolArtifact(cache: this, platform: platform));
     registerArtifact(AotToolsArtifact(cache: this, platform: platform));
   }
 
-  final http.Client httpClient;
   final ArchiveExtracter extractArchive;
 
   void registerArtifact(CachedArtifact artifact) => _artifacts.add(artifact);
@@ -150,7 +146,7 @@ abstract class CachedArtifact {
     final request = http.Request('GET', Uri.parse(storageUrl));
     final http.StreamedResponse response;
     try {
-      response = await cache.httpClient.send(request);
+      response = await httpClient.send(request);
     } catch (error) {
       throw CacheUpdateFailure(
         '''

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
-import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
@@ -14,7 +13,6 @@ import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/formatters/formatters.dart';
-import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -34,12 +32,9 @@ class PatchAndroidCommand extends ShorebirdCommand
   /// {@macro patch_android_command}
   PatchAndroidCommand({
     HashFunction? hashFn,
-    http.Client? httpClient,
     AndroidArchiveDiffer? archiveDiffer,
   })  : _archiveDiffer = archiveDiffer ?? AndroidArchiveDiffer(),
-        _hashFn = hashFn ?? ((m) => sha256.convert(m).toString()),
-        _httpClient = httpClient ??
-            retryingHttpClient(LoggingClient(httpClient: http.Client())) {
+        _hashFn = hashFn ?? ((m) => sha256.convert(m).toString()) {
     argParser
       ..addOption(
         'target',
@@ -85,7 +80,6 @@ If this option is not provided, the version number will be determined from the p
 
   final ArchiveDiffer _archiveDiffer;
   final HashFunction _hashFn;
-  final http.Client _httpClient;
 
   @override
   Future<int> run() async {
@@ -229,7 +223,6 @@ Current Flutter Revision: $originalFlutterRevision
       try {
         final releaseArtifactPath = await artifactManager.downloadFile(
           Uri.parse(releaseArtifact.value.url),
-          httpClient: _httpClient,
         );
         releaseArtifactPaths[releaseArtifact.key] = releaseArtifactPath;
       } catch (error) {

--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -4,7 +4,6 @@ import 'dart:isolate';
 
 import 'package:archive/archive_io.dart';
 import 'package:collection/collection.dart';
-import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/artifact_manager.dart';
@@ -14,7 +13,6 @@ import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/executables/devicectl/apple_device.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
-import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
@@ -27,10 +25,7 @@ import 'package:yaml_edit/yaml_edit.dart';
 /// {@endtemplate}
 class PreviewCommand extends ShorebirdCommand {
   /// {@macro preview_command}
-  PreviewCommand({
-    http.Client? httpClient,
-  }) : _httpClient = httpClient ??
-            retryingHttpClient(LoggingClient(httpClient: http.Client())) {
+  PreviewCommand() {
     argParser
       ..addOption(
         'device-id',
@@ -70,8 +65,6 @@ class PreviewCommand extends ShorebirdCommand {
           .toList();
     }
   }
-
-  final http.Client _httpClient;
 
   @override
   String get name => 'preview';
@@ -220,7 +213,6 @@ class PreviewCommand extends ShorebirdCommand {
 
         await artifactManager.downloadFile(
           Uri.parse(releaseAabArtifact.url),
-          httpClient: _httpClient,
           outputPath: aabFile.path,
         );
         downloadArtifactProgress.complete();
@@ -325,7 +317,6 @@ class PreviewCommand extends ShorebirdCommand {
 
         final archivePath = await artifactManager.downloadFile(
           Uri.parse(releaseRunnerArtifact.url),
-          httpClient: _httpClient,
         );
         await artifactManager.extractZip(
           zipFile: File(archivePath),

--- a/packages/shorebird_cli/lib/src/http_client/http_client.dart
+++ b/packages/shorebird_cli/lib/src/http_client/http_client.dart
@@ -1,2 +1,17 @@
+import 'package:http/http.dart' as http;
+import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/http_client/logging_client.dart';
+import 'package:shorebird_cli/src/http_client/retrying_client.dart';
+
 export 'logging_client.dart';
 export 'retrying_client.dart';
+
+/// A reference to a [http.Client] instance.
+final httpClientRef = create(
+  () => retryingHttpClient(
+    LoggingClient(httpClient: http.Client()),
+  ),
+);
+
+/// The [http.Client] instance available in the current zone.
+http.Client get httpClient => read(httpClientRef);

--- a/packages/shorebird_cli/lib/src/patch_diff_checker.dart
+++ b/packages/shorebird_cli/lib/src/patch_diff_checker.dart
@@ -27,15 +27,6 @@ PatchDiffChecker get patchDiffChecker => read(patchDiffCheckerRef);
 /// Verifies that a patch can successfully be applied to a release artifact.
 /// {@endtemplate}
 class PatchDiffChecker {
-  /// {@macro patch_verifier}
-  PatchDiffChecker({http.Client? httpClient})
-      // coverage:ignore-start
-      : _httpClient = httpClient ??
-            retryingHttpClient(LoggingClient(httpClient: http.Client()));
-  // coverage:ignore-end
-
-  final http.Client _httpClient;
-
   /// Zips the contents of [localArtifactDirectory] to a temporary file and
   /// forwards to [confirmUnpatchableDiffsIfNecessary].
   Future<void> zipAndConfirmUnpatchableDiffsIfNecessary({
@@ -69,7 +60,7 @@ class PatchDiffChecker {
         logger.progress('Verifying patch can be applied to release');
 
     final request = http.Request('GET', releaseArtifactUrl);
-    final response = await _httpClient.send(request);
+    final response = await httpClient.send(request);
 
     if (response.statusCode != HttpStatus.ok) {
       progress.fail();

--- a/packages/shorebird_cli/test/src/auth/auth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_test.dart
@@ -11,6 +11,7 @@ import 'package:platform/platform.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/command_runner.dart';
+import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -22,7 +23,13 @@ import '../mocks.dart';
 void main() {
   group('scoped', () {
     test('creates instance with default constructor', () {
-      final instance = runScoped(() => auth, values: {authRef});
+      final instance = runScoped(
+        () => auth,
+        values: {
+          authRef,
+          httpClientRef.overrideWith(MockHttpClient.new),
+        },
+      );
       expect(
         instance.credentialsFilePath,
         p.join(applicationConfigHome(executableName), 'credentials.json'),
@@ -65,6 +72,7 @@ void main() {
       return runScoped(
         body,
         values: {
+          httpClientRef.overrideWith(() => httpClient),
           loggerRef.overrideWith(() => logger),
           platformRef.overrideWith(() => platform),
         },

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/cache.dart';
+import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
@@ -28,7 +29,7 @@ class TestCachedArtifact extends CachedArtifact {
 }
 
 void main() {
-  group('Cache', () {
+  group(Cache, () {
     const shorebirdEngineRevision = 'test-revision';
 
     late Directory shorebirdRoot;
@@ -45,6 +46,7 @@ void main() {
         () => body(),
         values: {
           cacheRef.overrideWith(() => cache),
+          httpClientRef.overrideWith(() => httpClient),
           loggerRef.overrideWith(() => logger),
           platformRef.overrideWith(() => platform),
           processRef.overrideWith(() => shorebirdProcess),
@@ -88,7 +90,7 @@ void main() {
         ),
       );
 
-      cache = runWithOverrides(() => Cache(httpClient: httpClient));
+      cache = runWithOverrides(Cache.new);
     });
 
     test('can be instantiated w/out args', () {

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -15,6 +15,7 @@ import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
+import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
@@ -111,6 +112,7 @@ void main() {
           cacheRef.overrideWith(() => cache),
           codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           engineConfigRef.overrideWith(() => const EngineConfig.empty()),
+          httpClientRef.overrideWith(() => httpClient),
           loggerRef.overrideWith(() => logger),
           osInterfaceRef.overrideWith(() => operatingSystemInterface),
           patchDiffCheckerRef.overrideWith(() => patchDiffChecker),
@@ -229,12 +231,8 @@ void main() {
           ..writeAsStringSync('diff');
         return diffPath;
       });
-      when(
-        () => artifactManager.downloadFile(
-          any(),
-          httpClient: any(named: 'httpClient'),
-        ),
-      ).thenAnswer((_) async => '');
+      when(() => artifactManager.downloadFile(any()))
+          .thenAnswer((_) async => '');
       when(
         () => archiveDiffer.changedFiles(any(), any()),
       ).thenReturn(FileSetDiff.empty());
@@ -327,7 +325,6 @@ void main() {
       command = runWithOverrides(
         () => PatchAarCommand(
           archiveDiffer: archiveDiffer,
-          httpClient: httpClient,
           unzipFn: (_, __) async {},
         ),
       )..testArgResults = argResults;
@@ -500,7 +497,6 @@ Please re-run the release command for this version or create a new release.'''),
       when(
         () => artifactManager.downloadFile(
           any(),
-          httpClient: any(named: 'httpClient'),
           outputPath: any(named: 'outputPath'),
         ),
       ).thenThrow(exception);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -17,6 +17,7 @@ import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
+import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
@@ -127,6 +128,7 @@ flutter:
           codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           doctorRef.overrideWith(() => doctor),
           engineConfigRef.overrideWith(() => const EngineConfig.empty()),
+          httpClientRef.overrideWith(() => httpClient),
           javaRef.overrideWith(() => java),
           loggerRef.overrideWith(() => logger),
           osInterfaceRef.overrideWith(() => operatingSystemInterface),
@@ -208,10 +210,7 @@ flutter:
       shorebirdFlutter = MockShorebirdFlutter();
       shorebirdValidator = MockShorebirdValidator();
       command = runWithOverrides(
-        () => PatchAndroidCommand(
-          archiveDiffer: archiveDiffer,
-          httpClient: httpClient,
-        ),
+        () => PatchAndroidCommand(archiveDiffer: archiveDiffer),
       )..testArgResults = argResults;
 
       when(() => shorebirdEnv.getShorebirdYaml()).thenReturn(shorebirdYaml);
@@ -251,12 +250,8 @@ flutter:
           ..writeAsStringSync('diff');
         return diffPath;
       });
-      when(
-        () => artifactManager.downloadFile(
-          any(),
-          httpClient: any(named: 'httpClient'),
-        ),
-      ).thenAnswer((_) async => '');
+      when(() => artifactManager.downloadFile(any()))
+          .thenAnswer((_) async => '');
       when(
         () => archiveDiffer.changedFiles(any(), any()),
       ).thenReturn(FileSetDiff.empty());
@@ -596,7 +591,6 @@ Please re-run the release command for this version or create a new release.'''),
       when(
         () => artifactManager.downloadFile(
           any(),
-          httpClient: any(named: 'httpClient'),
           outputPath: any(named: 'outputPath'),
         ),
       ).thenThrow(exception);

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -16,6 +16,7 @@ import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/executables/devicectl/apple_device.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
+import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
@@ -57,6 +58,7 @@ void main() {
             authRef.overrideWith(() => auth),
             cacheRef.overrideWith(() => cache),
             codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
+            httpClientRef.overrideWith(() => httpClient),
             loggerRef.overrideWith(() => logger),
             platformRef.overrideWith(() => platform),
             shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
@@ -239,6 +241,7 @@ void main() {
               codePushClientWrapperRef.overrideWith(
                 () => codePushClientWrapper,
               ),
+              httpClientRef.overrideWith(() => httpClient),
               loggerRef.overrideWith(() => logger),
               platformRef.overrideWith(() => platform),
               shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
@@ -270,7 +273,6 @@ void main() {
         when(
           () => artifactManager.downloadFile(
             any(),
-            httpClient: any(named: 'httpClient'),
             outputPath: any(named: 'outputPath'),
           ),
         ).thenAnswer((_) async => '');
@@ -354,7 +356,6 @@ void main() {
         when(
           () => artifactManager.downloadFile(
             any(),
-            httpClient: any(named: 'httpClient'),
             outputPath: any(named: 'outputPath'),
           ),
         ).thenThrow(exception);
@@ -709,6 +710,7 @@ void main() {
               codePushClientWrapperRef
                   .overrideWith(() => codePushClientWrapper),
               devicectlRef.overrideWith(() => devicectl),
+              httpClientRef.overrideWith(() => httpClient),
               iosDeployRef.overrideWith(() => iosDeploy),
               loggerRef.overrideWith(() => logger),
               platformRef.overrideWith(() => platform),
@@ -725,10 +727,7 @@ void main() {
         when(() => appleDevice.name).thenReturn('iPhone 12');
         when(() => argResults['platform']).thenReturn(releasePlatform.name);
         when(
-          () => artifactManager.downloadFile(
-            any(),
-            httpClient: any(named: 'httpClient'),
-          ),
+          () => artifactManager.downloadFile(any()),
         ).thenAnswer((_) async => '');
         when(
           () => artifactManager.extractZip(
@@ -798,10 +797,7 @@ void main() {
           () async {
         final exception = Exception('oops');
         when(
-          () => artifactManager.downloadFile(
-            any(),
-            httpClient: any(named: 'httpClient'),
-          ),
+          () => artifactManager.downloadFile(any()),
         ).thenThrow(exception);
         final result = await runWithOverrides(command.run);
         expect(result, equals(ExitCode.software.code));

--- a/packages/shorebird_cli/test/src/http_client/http_client_test.dart
+++ b/packages/shorebird_cli/test/src/http_client/http_client_test.dart
@@ -1,0 +1,16 @@
+import 'package:http/retry.dart';
+import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/http_client/http_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('scoped', () {
+    test('creates instance with default constructor', () {
+      final instance = runScoped(
+        () => httpClient,
+        values: {httpClientRef},
+      );
+      expect(instance, isA<RetryClient>());
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
+++ b/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
@@ -7,6 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
+import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -35,6 +36,7 @@ void main() {
       return runScoped(
         body,
         values: {
+          httpClientRef.overrideWith(() => httpClient),
           loggerRef.overrideWith(() => logger),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
         },
@@ -54,7 +56,7 @@ void main() {
       logger = MockLogger();
       progress = MockProgress();
       shorebirdEnv = MockShorebirdEnv();
-      patchDiffChecker = PatchDiffChecker(httpClient: httpClient);
+      patchDiffChecker = PatchDiffChecker();
 
       when(() => archiveDiffer.changedFiles(any(), any()))
           .thenReturn(FileSetDiff.empty());


### PR DESCRIPTION
## Description

Adds scoped httpClient to avoid having to pass around http clients.

Fixes https://github.com/shorebirdtech/shorebird/issues/1310

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
