### PR TITLE
fix(shorebird_cli): only use shorebird.yaml app_id when no flavors are present

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -85,9 +85,15 @@ class PreviewCommand extends ShorebirdCommand {
       return error.exitCode.code;
     }
 
-    final appId = results['app-id'] as String? ??
-        shorebirdEnv.getShorebirdYaml()?.appId ??
-        await promptForApp();
+    final shorebirdYaml = shorebirdEnv.getShorebirdYaml();
+    final String? appId;
+    if (results.wasParsed('app-id')) {
+      appId = results['app-id'] as String;
+    } else if (shorebirdYaml != null && shorebirdYaml.flavors == null) {
+      appId = shorebirdYaml.appId;
+    } else {
+      appId = await promptForApp();
+    }
 
     if (appId == null) {
       logger.info('No apps found');


### PR DESCRIPTION
## Description

Because each flavor has its own app id, we can only infer an app id to preview from a shorebird.yaml file that doesn't have flavors.

Fixes https://github.com/shorebirdtech/shorebird/issues/1542

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
