### PR TITLE
refactor(shorebird_cli): move artifact download out of patch diff checker

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_manager.dart
+++ b/packages/shorebird_cli/lib/src/artifact_manager.dart
@@ -50,7 +50,7 @@ Failed to create diff (exit code ${result.exitCode}).
 
   /// Downloads the file at the given [uri] to a temporary directory and returns
   /// the path to the downloaded file.
-  Future<String> downloadFile(
+  Future<File> downloadFile(
     Uri uri, {
     String? outputPath,
   }) async {
@@ -76,7 +76,7 @@ Failed to create diff (exit code ${result.exitCode}).
     }
 
     await outFile.openWrite().addStream(response.stream);
-    return outFile.path;
+    return outFile;
   }
 
   /// Extracts the [zipFile] to the [outputDirectory] directory in a separate

--- a/packages/shorebird_cli/lib/src/artifact_manager.dart
+++ b/packages/shorebird_cli/lib/src/artifact_manager.dart
@@ -49,7 +49,7 @@ Failed to create diff (exit code ${result.exitCode}).
   }
 
   /// Downloads the file at the given [uri] to a temporary directory and returns
-  /// the path to the downloaded file.
+  /// the downloaded [File].
   Future<File> downloadFile(
     Uri uri, {
     String? outputPath,

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -209,7 +209,8 @@ Please re-run the release command for this version or create a new release.''');
             buildNumber: buildNumber,
           ),
         ),
-        releaseArtifactUrl: Uri.parse(releaseAarArtifact.url),
+        releaseArtifact: await artifactManager
+            .downloadFile(Uri.parse(releaseAarArtifact.url)),
         archiveDiffer: _archiveDiffer,
         force: force,
       );
@@ -336,10 +337,10 @@ ${summary.join('\n')}
     );
     for (final releaseArtifact in releaseArtifacts.entries) {
       try {
-        final releaseArtifactPath = await artifactManager.downloadFile(
+        final releaseArtifactFile = await artifactManager.downloadFile(
           Uri.parse(releaseArtifact.value.url),
         );
-        releaseArtifactPaths[releaseArtifact.key] = releaseArtifactPath;
+        releaseArtifactPaths[releaseArtifact.key] = releaseArtifactFile.path;
       } catch (error) {
         downloadReleaseArtifactProgress.fail('$error');
         rethrow;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -221,10 +221,10 @@ Current Flutter Revision: $originalFlutterRevision
     );
     for (final releaseArtifact in releaseArtifacts.entries) {
       try {
-        final releaseArtifactPath = await artifactManager.downloadFile(
+        final releaseArtifactFile = await artifactManager.downloadFile(
           Uri.parse(releaseArtifact.value.url),
         );
-        releaseArtifactPaths[releaseArtifact.key] = releaseArtifactPath;
+        releaseArtifactPaths[releaseArtifact.key] = releaseArtifactFile.path;
       } catch (error) {
         downloadReleaseArtifactProgress.fail('$error');
         return ExitCode.software.code;
@@ -236,7 +236,9 @@ Current Flutter Revision: $originalFlutterRevision
     try {
       await patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
         localArtifact: File(bundlePath),
-        releaseArtifactUrl: Uri.parse(releaseAabArtifact.url),
+        releaseArtifact: await artifactManager.downloadFile(
+          Uri.parse(releaseAabArtifact.url),
+        ),
         archiveDiffer: _archiveDiffer,
         force: force,
       );

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -6,6 +6,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
+import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
@@ -215,10 +216,14 @@ Current Flutter Revision: $originalFlutterRevision
       platform: ReleasePlatform.ios,
     );
 
+    final releaseArtifactFile = await artifactManager.downloadFile(
+      Uri.parse(releaseArtifact.url),
+    );
+
     try {
       await patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
         localArtifactDirectory: Directory(archivePath),
-        releaseArtifactUrl: Uri.parse(releaseArtifact.url),
+        releaseArtifact: releaseArtifactFile,
         archiveDiffer: _archiveDiffer,
         force: force,
       );

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
@@ -7,6 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
+import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
@@ -181,7 +182,8 @@ Please re-run the release command for this version or create a new release.''');
     try {
       await patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
         localArtifactDirectory: Directory(getAppXcframeworkPath()),
-        releaseArtifactUrl: Uri.parse(releaseArtifact.url),
+        releaseArtifact:
+            await artifactManager.downloadFile(Uri.parse(releaseArtifact.url)),
         archiveDiffer: _archiveDiffer,
         force: force,
       );

--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -324,11 +324,11 @@ class PreviewCommand extends ShorebirdCommand {
           platform: platform,
         );
 
-        final archivePath = await artifactManager.downloadFile(
+        final archiveFile = await artifactManager.downloadFile(
           Uri.parse(releaseRunnerArtifact.url),
         );
         await artifactManager.extractZip(
-          zipFile: File(archivePath),
+          zipFile: archiveFile,
           outputDirectory: runnerDirectory,
         );
         downloadArtifactProgress.complete();

--- a/packages/shorebird_cli/lib/src/patch_diff_checker.dart
+++ b/packages/shorebird_cli/lib/src/patch_diff_checker.dart
@@ -1,12 +1,9 @@
 import 'dart:io';
 
-import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
-import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive/archive.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
-import 'package:shorebird_cli/src/http_client/http_client.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 
@@ -31,7 +28,7 @@ class PatchDiffChecker {
   /// forwards to [confirmUnpatchableDiffsIfNecessary].
   Future<void> zipAndConfirmUnpatchableDiffsIfNecessary({
     required Directory localArtifactDirectory,
-    required Uri releaseArtifactUrl,
+    required File releaseArtifact,
     required ArchiveDiffer archiveDiffer,
     required bool force,
   }) async {
@@ -41,37 +38,22 @@ class PatchDiffChecker {
 
     return confirmUnpatchableDiffsIfNecessary(
       localArtifact: zippedFile,
-      releaseArtifactUrl: releaseArtifactUrl,
+      releaseArtifact: releaseArtifact,
       archiveDiffer: archiveDiffer,
       force: force,
     );
   }
 
-  /// Downloads the release artifact at [releaseArtifactUrl] and checks for
-  /// differences that could cause issues when applying the patch represented by
-  /// [localArtifact].
+  /// Checks for differences that could cause issues when applying the
+  /// [localArtifact] patch to the [releaseArtifact].
   Future<void> confirmUnpatchableDiffsIfNecessary({
     required File localArtifact,
-    required Uri releaseArtifactUrl,
+    required File releaseArtifact,
     required ArchiveDiffer archiveDiffer,
     required bool force,
   }) async {
     final progress =
         logger.progress('Verifying patch can be applied to release');
-
-    final request = http.Request('GET', releaseArtifactUrl);
-    final response = await httpClient.send(request);
-
-    if (response.statusCode != HttpStatus.ok) {
-      progress.fail();
-      throw Exception(
-        '''Failed to download release artifact: ${response.statusCode} ${response.reasonPhrase}''',
-      );
-    }
-
-    final tempDir = await Directory.systemTemp.createTemp();
-    final releaseArtifact = File(p.join(tempDir.path, 'release.artifact'));
-    await releaseArtifact.openWrite().addStream(response.stream);
 
     final contentDiffs = archiveDiffer.changedFiles(
       releaseArtifact.path,

--- a/packages/shorebird_cli/test/src/artifact_manager_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_manager_test.dart
@@ -150,29 +150,26 @@ void main() {
       });
 
       test('returns path to file when download succeeds', () async {
-        final result = runWithOverrides(
+        final result = await runWithOverrides(
           () async => artifactManager.downloadFile(
             Uri.parse('https://example.com'),
           ),
         );
 
-        await expectLater(
-          result,
-          completion(endsWith('artifact')),
-        );
+        expect(result.path, endsWith('artifact'));
       });
 
       test('returns provided output path when specified', () async {
         final tempDir = Directory.systemTemp.createTempSync();
         final outFile = File(p.join(tempDir.path, 'file.out'));
-        final result = runWithOverrides(
+        final result = await runWithOverrides(
           () async => artifactManager.downloadFile(
             Uri.parse('https://example.com'),
             outputPath: outFile.path,
           ),
         );
 
-        await expectLater(result, completion(outFile.path));
+        expect(result.path, equals(outFile.path));
       });
     });
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -79,6 +79,7 @@ void main() {
       createdAt: DateTime(2023),
       updatedAt: DateTime(2023),
     );
+    final releaseArtifactFile = File('release.artifact');
 
     late AndroidArchiveDiffer archiveDiffer;
     late ArgResults argResults;
@@ -232,7 +233,7 @@ void main() {
         return diffPath;
       });
       when(() => artifactManager.downloadFile(any()))
-          .thenAnswer((_) async => '');
+          .thenAnswer((_) async => releaseArtifactFile);
       when(
         () => archiveDiffer.changedFiles(any(), any()),
       ).thenReturn(FileSetDiff.empty());
@@ -316,7 +317,7 @@ void main() {
       when(
         () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
           localArtifact: any(named: 'localArtifact'),
-          releaseArtifactUrl: any(named: 'releaseArtifactUrl'),
+          releaseArtifact: any(named: 'releaseArtifact'),
           archiveDiffer: archiveDiffer,
           force: any(named: 'force'),
         ),
@@ -619,7 +620,7 @@ Please re-run the release command for this version or create a new release.'''),
       when(
         () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
           localArtifact: any(named: 'localArtifact'),
-          releaseArtifactUrl: any(named: 'releaseArtifactUrl'),
+          releaseArtifact: any(named: 'releaseArtifact'),
           archiveDiffer: archiveDiffer,
           force: any(named: 'force'),
         ),
@@ -632,7 +633,7 @@ Please re-run the release command for this version or create a new release.'''),
       verify(
         () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
           localArtifact: any(named: 'localArtifact'),
-          releaseArtifactUrl: Uri.parse(aarArtifact.url),
+          releaseArtifact: releaseArtifactFile,
           archiveDiffer: archiveDiffer,
           force: false,
         ),
@@ -655,7 +656,7 @@ Please re-run the release command for this version or create a new release.'''),
       when(
         () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
           localArtifact: any(named: 'localArtifact'),
-          releaseArtifactUrl: any(named: 'releaseArtifactUrl'),
+          releaseArtifact: any(named: 'releaseArtifact'),
           archiveDiffer: archiveDiffer,
           force: any(named: 'force'),
         ),
@@ -669,7 +670,7 @@ Please re-run the release command for this version or create a new release.'''),
       verify(
         () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
           localArtifact: any(named: 'localArtifact'),
-          releaseArtifactUrl: Uri.parse(aarArtifact.url),
+          releaseArtifact: releaseArtifactFile,
           archiveDiffer: archiveDiffer,
           force: false,
         ),

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -80,6 +80,7 @@ void main() {
       createdAt: DateTime(2023),
       updatedAt: DateTime(2023),
     );
+    final releaseArtifactFile = File('release.artifact');
     const pubspecYamlContent = '''
 name: example
 version: $version
@@ -251,7 +252,7 @@ flutter:
         return diffPath;
       });
       when(() => artifactManager.downloadFile(any()))
-          .thenAnswer((_) async => '');
+          .thenAnswer((_) async => releaseArtifactFile);
       when(
         () => archiveDiffer.changedFiles(any(), any()),
       ).thenReturn(FileSetDiff.empty());
@@ -354,7 +355,7 @@ flutter:
       when(
         () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
           localArtifact: any(named: 'localArtifact'),
-          releaseArtifactUrl: any(named: 'releaseArtifactUrl'),
+          releaseArtifact: any(named: 'releaseArtifact'),
           archiveDiffer: archiveDiffer,
           force: any(named: 'force'),
         ),
@@ -643,7 +644,7 @@ Please re-run the release command for this version or create a new release.'''),
       when(
         () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
           localArtifact: any(named: 'localArtifact'),
-          releaseArtifactUrl: any(named: 'releaseArtifactUrl'),
+          releaseArtifact: any(named: 'releaseArtifact'),
           archiveDiffer: archiveDiffer,
           force: any(named: 'force'),
         ),
@@ -657,7 +658,7 @@ Please re-run the release command for this version or create a new release.'''),
       verify(
         () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
           localArtifact: any(named: 'localArtifact'),
-          releaseArtifactUrl: Uri.parse(aabArtifact.url),
+          releaseArtifact: releaseArtifactFile,
           archiveDiffer: archiveDiffer,
           force: false,
         ),
@@ -680,7 +681,7 @@ Please re-run the release command for this version or create a new release.'''),
       when(
         () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
           localArtifact: any(named: 'localArtifact'),
-          releaseArtifactUrl: any(named: 'releaseArtifactUrl'),
+          releaseArtifact: any(named: 'releaseArtifact'),
           archiveDiffer: archiveDiffer,
           force: any(named: 'force'),
         ),
@@ -695,7 +696,7 @@ Please re-run the release command for this version or create a new release.'''),
       verify(
         () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
           localArtifact: any(named: 'localArtifact'),
-          releaseArtifactUrl: Uri.parse(aabArtifact.url),
+          releaseArtifact: releaseArtifactFile,
           archiveDiffer: archiveDiffer,
           force: false,
         ),

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
+import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/patch/patch.dart';
@@ -122,10 +123,12 @@ flutter:
     createdAt: DateTime(2023),
     updatedAt: DateTime(2023),
   );
+  final releaseArtifactFile = File('release.artifact');
 
   group(PatchIosCommand, () {
     late ArgResults argResults;
     late AotTools aotTools;
+    late ArtifactManager artifactManager;
     late Auth auth;
     late CodePushClientWrapper codePushClientWrapper;
     late Directory flutterDirectory;
@@ -157,6 +160,7 @@ flutter:
         body,
         values: {
           aotToolsRef.overrideWith(() => aotTools),
+          artifactManagerRef.overrideWith(() => artifactManager),
           authRef.overrideWith(() => auth),
           codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           doctorRef.overrideWith(() => doctor),
@@ -245,6 +249,7 @@ flutter:
 
     setUp(() {
       argResults = MockArgResults();
+      artifactManager = MockArtifactManager();
       aotTools = MockAotTools();
       auth = MockAuth();
       codePushClientWrapper = MockCodePushClientWrapper();
@@ -309,6 +314,8 @@ flutter:
           workingDirectory: any(named: 'workingDirectory'),
         ),
       ).thenAnswer((_) async {});
+      when(() => artifactManager.downloadFile(any()))
+          .thenAnswer((_) async => releaseArtifactFile);
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => auth.client).thenReturn(httpClient);
       when(
@@ -408,7 +415,7 @@ flutter:
       when(
         () => patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
           localArtifactDirectory: any(named: 'localArtifactDirectory'),
-          releaseArtifactUrl: any(named: 'releaseArtifactUrl'),
+          releaseArtifact: any(named: 'releaseArtifact'),
           archiveDiffer: archiveDiffer,
           force: any(named: 'force'),
         ),
@@ -811,7 +818,7 @@ Please re-run the release command for this version or create a new release.'''),
       when(
         () => patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
           localArtifactDirectory: any(named: 'localArtifactDirectory'),
-          releaseArtifactUrl: any(named: 'releaseArtifactUrl'),
+          releaseArtifact: any(named: 'releaseArtifact'),
           archiveDiffer: archiveDiffer,
           force: any(named: 'force'),
         ),
@@ -825,7 +832,7 @@ Please re-run the release command for this version or create a new release.'''),
       verify(
         () => patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
           localArtifactDirectory: any(named: 'localArtifactDirectory'),
-          releaseArtifactUrl: Uri.parse(ipaArtifact.url),
+          releaseArtifact: releaseArtifactFile,
           archiveDiffer: archiveDiffer,
           force: false,
         ),
@@ -848,7 +855,7 @@ Please re-run the release command for this version or create a new release.'''),
       when(
         () => patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
           localArtifactDirectory: any(named: 'localArtifactDirectory'),
-          releaseArtifactUrl: any(named: 'releaseArtifactUrl'),
+          releaseArtifact: any(named: 'releaseArtifact'),
           archiveDiffer: archiveDiffer,
           force: any(named: 'force'),
         ),
@@ -862,7 +869,7 @@ Please re-run the release command for this version or create a new release.'''),
       verify(
         () => patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
           localArtifactDirectory: any(named: 'localArtifactDirectory'),
-          releaseArtifactUrl: Uri.parse(ipaArtifact.url),
+          releaseArtifact: releaseArtifactFile,
           archiveDiffer: archiveDiffer,
           force: false,
         ),

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -283,7 +283,7 @@ void main() {
             any(),
             outputPath: any(named: 'outputPath'),
           ),
-        ).thenAnswer((_) async => '');
+        ).thenAnswer((_) async => File(''));
         when(
           () => artifactManager.extractZip(
             zipFile: any(named: 'zipFile'),
@@ -788,7 +788,7 @@ void main() {
         when(() => argResults['platform']).thenReturn(releasePlatform.name);
         when(
           () => artifactManager.downloadFile(any()),
-        ).thenAnswer((_) async => '');
+        ).thenAnswer((_) async => File(''));
         when(
           () => artifactManager.extractZip(
             zipFile: any(named: 'zipFile'),

--- a/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
+++ b/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
@@ -21,7 +21,7 @@ void main() {
     const assetsDiffPrettyString = 'assets diff pretty string';
     const nativeDiffPrettyString = 'native diff pretty string';
     final localArtifact = File('local.artifact');
-    final releaseArtifactUrl = Uri.parse('https://example.com');
+    final releaseArtifact = File('release.artifact');
 
     late ArchiveDiffer archiveDiffer;
     late FileSetDiff assetsFileSetDiff;
@@ -95,7 +95,7 @@ void main() {
         await runWithOverrides(
           () => patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
             localArtifactDirectory: localArtifactDirectory,
-            releaseArtifactUrl: releaseArtifactUrl,
+            releaseArtifact: releaseArtifact,
             archiveDiffer: archiveDiffer,
             force: false,
           ),
@@ -106,31 +106,6 @@ void main() {
     });
 
     group('confirmUnpatchableDiffsIfNecessary', () {
-      test('throws Exception when release artifact fails to download',
-          () async {
-        when(() => httpClient.send(any())).thenAnswer(
-          (_) async => http.StreamedResponse(
-            const Stream.empty(),
-            HttpStatus.internalServerError,
-            reasonPhrase: 'Internal Server Error',
-          ),
-        );
-
-        await expectLater(
-          runWithOverrides(
-            () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-              localArtifact: localArtifact,
-              releaseArtifactUrl: releaseArtifactUrl,
-              archiveDiffer: archiveDiffer,
-              force: false,
-            ),
-          ),
-          throwsA(isA<Exception>()),
-        );
-
-        verify(() => progress.fail()).called(1);
-      });
-
       group('when native diffs are detected', () {
         setUp(() {
           when(
@@ -142,7 +117,7 @@ void main() {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
               localArtifact: localArtifact,
-              releaseArtifactUrl: releaseArtifactUrl,
+              releaseArtifact: releaseArtifact,
               archiveDiffer: archiveDiffer,
               force: false,
             ),
@@ -170,7 +145,7 @@ void main() {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
               localArtifact: localArtifact,
-              releaseArtifactUrl: releaseArtifactUrl,
+              releaseArtifact: releaseArtifact,
               archiveDiffer: archiveDiffer,
               force: false,
             ),
@@ -183,7 +158,7 @@ void main() {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
               localArtifact: localArtifact,
-              releaseArtifactUrl: releaseArtifactUrl,
+              releaseArtifact: releaseArtifact,
               archiveDiffer: archiveDiffer,
               force: true,
             ),
@@ -200,7 +175,7 @@ void main() {
             runWithOverrides(
               () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
                 localArtifact: localArtifact,
-                releaseArtifactUrl: releaseArtifactUrl,
+                releaseArtifact: releaseArtifact,
                 archiveDiffer: archiveDiffer,
                 force: false,
               ),
@@ -220,7 +195,7 @@ void main() {
             () => runWithOverrides(
               () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
                 localArtifact: localArtifact,
-                releaseArtifactUrl: releaseArtifactUrl,
+                releaseArtifact: releaseArtifact,
                 archiveDiffer: archiveDiffer,
                 force: false,
               ),
@@ -243,7 +218,7 @@ void main() {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
               localArtifact: localArtifact,
-              releaseArtifactUrl: releaseArtifactUrl,
+              releaseArtifact: releaseArtifact,
               archiveDiffer: archiveDiffer,
               force: false,
             ),
@@ -263,7 +238,7 @@ void main() {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
               localArtifact: localArtifact,
-              releaseArtifactUrl: releaseArtifactUrl,
+              releaseArtifact: releaseArtifact,
               archiveDiffer: archiveDiffer,
               force: false,
             ),
@@ -276,7 +251,7 @@ void main() {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
               localArtifact: localArtifact,
-              releaseArtifactUrl: releaseArtifactUrl,
+              releaseArtifact: releaseArtifact,
               archiveDiffer: archiveDiffer,
               force: true,
             ),
@@ -293,7 +268,7 @@ void main() {
             runWithOverrides(
               () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
                 localArtifact: localArtifact,
-                releaseArtifactUrl: releaseArtifactUrl,
+                releaseArtifact: releaseArtifact,
                 archiveDiffer: archiveDiffer,
                 force: false,
               ),
@@ -311,7 +286,7 @@ void main() {
             () => runWithOverrides(
               () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
                 localArtifact: localArtifact,
-                releaseArtifactUrl: releaseArtifactUrl,
+                releaseArtifact: releaseArtifact,
                 archiveDiffer: archiveDiffer,
                 force: false,
               ),
@@ -329,7 +304,7 @@ void main() {
           runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
               localArtifact: localArtifact,
-              releaseArtifactUrl: releaseArtifactUrl,
+              releaseArtifact: releaseArtifact,
               archiveDiffer: archiveDiffer,
               force: false,
             ),


### PR DESCRIPTION
## Description

This refactor updates the `PatchDiffChecker` to accept a `File` instead of a url, moving the responsibility of downloading release artifacts out of `PatchDiffChecker` and into the `ArtifactManager`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
