### PR TITLE
fix(shorebird_cli): use release mach-o artifact instead of patch mach-o artifact as base for linking

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' hide Platform;
+import 'dart:isolate';
 
 import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
@@ -216,14 +217,49 @@ Current Flutter Revision: $originalFlutterRevision
       platform: ReleasePlatform.ios,
     );
 
-    final releaseArtifactFile = await artifactManager.downloadFile(
-      Uri.parse(releaseArtifact.url),
+    final downloadProgress = logger.progress('Downloading release artifact');
+    final File releaseArtifactZipFile;
+    try {
+      releaseArtifactZipFile = await artifactManager.downloadFile(
+        Uri.parse(releaseArtifact.url),
+      );
+      if (!releaseArtifactZipFile.existsSync()) {
+        throw Exception('Failed to download release artifact');
+      }
+    } catch (error) {
+      downloadProgress.fail('$error');
+      return ExitCode.software.code;
+    }
+    downloadProgress.complete();
+
+    final extractZip = artifactManager.extractZip;
+    final unzipProgress = logger.progress('Extracting release artifact');
+    final releaseXcarchivePath = await Isolate.run(() async {
+      final tempDir = Directory.systemTemp.createTempSync();
+      await extractZip(
+        zipFile: releaseArtifactZipFile,
+        outputDirectory: tempDir,
+      );
+      return tempDir.path;
+    });
+    unzipProgress.complete();
+
+    final releaseArtifactFile = File(
+      p.join(
+        releaseXcarchivePath,
+        'Products',
+        'Applications',
+        'Runner.app',
+        'Frameworks',
+        'App.framework',
+        'App',
+      ),
     );
 
     try {
       await patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
         localArtifactDirectory: Directory(archivePath),
-        releaseArtifact: releaseArtifactFile,
+        releaseArtifact: releaseArtifactZipFile,
         archiveDiffer: _archiveDiffer,
         force: force,
       );
@@ -348,18 +384,6 @@ ${summary.join('\n')}
     logger.warn(
       '--use-linker is an experimental feature and may not work as expected.',
     );
-
-    final appDirectory = getAppDirectory();
-
-    if (appDirectory == null) {
-      logger.err('Unable to find .app directory within .xcarchive.');
-      return ExitCode.software.code;
-    }
-
-    if (!releaseArtifact.existsSync()) {
-      logger.err('Unable to find base AOT file at ${releaseArtifact.path}');
-      return ExitCode.software.code;
-    }
 
     final patch = File(_aotOutputPath);
 

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -235,7 +235,7 @@ Current Flutter Revision: $originalFlutterRevision
     }
 
     if (useLinker) {
-      final exitCode = await _runLinker();
+      final exitCode = await _runLinker(releaseArtifact: releaseArtifactFile);
       if (exitCode != ExitCode.success.code) return exitCode;
     }
 
@@ -344,7 +344,7 @@ ${summary.join('\n')}
     buildProgress.complete();
   }
 
-  Future<int> _runLinker() async {
+  Future<int> _runLinker({required File releaseArtifact}) async {
     logger.warn(
       '--use-linker is an experimental feature and may not work as expected.',
     );
@@ -356,17 +356,8 @@ ${summary.join('\n')}
       return ExitCode.software.code;
     }
 
-    final base = File(
-      p.join(
-        appDirectory.path,
-        'Frameworks',
-        'App.framework',
-        'App',
-      ),
-    );
-
-    if (!base.existsSync()) {
-      logger.err('Unable to find base AOT file at ${base.path}');
+    if (!releaseArtifact.existsSync()) {
+      logger.err('Unable to find base AOT file at ${releaseArtifact.path}');
       return ExitCode.software.code;
     }
 
@@ -391,7 +382,7 @@ ${summary.join('\n')}
     final linkProgress = logger.progress('Linking AOT files');
     try {
       await aotTools.link(
-        base: base.path,
+        base: releaseArtifact.path,
         patch: patch.path,
         analyzeSnapshot: analyzeSnapshot.path,
         workingDirectory: _buildDirectory,

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -232,30 +232,6 @@ Current Flutter Revision: $originalFlutterRevision
     }
     downloadProgress.complete();
 
-    final extractZip = artifactManager.extractZip;
-    final unzipProgress = logger.progress('Extracting release artifact');
-    final releaseXcarchivePath = await Isolate.run(() async {
-      final tempDir = Directory.systemTemp.createTempSync();
-      await extractZip(
-        zipFile: releaseArtifactZipFile,
-        outputDirectory: tempDir,
-      );
-      return tempDir.path;
-    });
-    unzipProgress.complete();
-
-    final releaseArtifactFile = File(
-      p.join(
-        releaseXcarchivePath,
-        'Products',
-        'Applications',
-        'Runner.app',
-        'Frameworks',
-        'App.framework',
-        'App',
-      ),
-    );
-
     try {
       await patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
         localArtifactDirectory: Directory(archivePath),
@@ -271,6 +247,29 @@ Current Flutter Revision: $originalFlutterRevision
     }
 
     if (useLinker) {
+      final extractZip = artifactManager.extractZip;
+      final unzipProgress = logger.progress('Extracting release artifact');
+      final releaseXcarchivePath = await Isolate.run(() async {
+        final tempDir = Directory.systemTemp.createTempSync();
+        await extractZip(
+          zipFile: releaseArtifactZipFile,
+          outputDirectory: tempDir,
+        );
+        return tempDir.path;
+      });
+      unzipProgress.complete();
+
+      final releaseArtifactFile = File(
+        p.join(
+          releaseXcarchivePath,
+          'Products',
+          'Applications',
+          'Runner.app',
+          'Frameworks',
+          'App.framework',
+          'App',
+        ),
+      );
       final exitCode = await _runLinker(releaseArtifact: releaseArtifactFile);
       if (exitCode != ExitCode.success.code) return exitCode;
     }

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -320,6 +320,12 @@ flutter:
       ).thenAnswer((_) async {});
       when(() => artifactManager.downloadFile(any()))
           .thenAnswer((_) async => releaseArtifactFile);
+      when(
+        () => artifactManager.extractZip(
+          zipFile: any(named: 'zipFile'),
+          outputDirectory: any(named: 'outputDirectory'),
+        ),
+      ).thenAnswer((_) async {});
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => auth.client).thenReturn(httpClient);
       when(
@@ -852,6 +858,20 @@ Please re-run the release command for this version or create a new release.'''),
       );
     });
 
+    test('exits with code 70 if release artifact fails to download', () async {
+      setUpProjectRoot();
+      setUpProjectRootArtifacts();
+
+      releaseArtifactFile.deleteSync();
+
+      final exitCode = await runWithOverrides(command.run);
+
+      expect(exitCode, equals(ExitCode.software.code));
+      verify(
+        () => progress.fail('Exception: Failed to download release artifact'),
+      ).called(1);
+    });
+
     test(
         '''exits with code 70 if zipAndConfirmUnpatchableDiffsIfNecessary throws UnpatchableChangeException''',
         () async {
@@ -901,47 +921,6 @@ Please re-run the release command for this version or create a new release.'''),
         verify(
           () => logger.warn(
             '''--use-linker is an experimental feature and may not work as expected.''',
-          ),
-        ).called(1);
-      });
-
-      test('exits with code 70 if appDirectory is not found', () async {
-        setUpProjectRoot();
-        setUpProjectRootArtifacts();
-
-        File(
-          p.join(
-            projectRoot.path,
-            'build',
-            'ios',
-            'archive',
-            'Runner.xcarchive',
-            'Products',
-            'Applications',
-            'Runner.app',
-          ),
-        ).deleteSync(recursive: true);
-
-        final exitCode = await runWithOverrides(command.run);
-
-        expect(exitCode, equals(ExitCode.software.code));
-        verify(
-          () => logger.err('Unable to find .app directory within .xcarchive.'),
-        ).called(1);
-      });
-
-      test('exits with code 70 if base app is not found', () async {
-        setUpProjectRoot();
-        setUpProjectRootArtifacts();
-
-        releaseArtifactFile.deleteSync();
-
-        final exitCode = await runWithOverrides(command.run);
-
-        expect(exitCode, equals(ExitCode.software.code));
-        verify(
-          () => logger.err(
-            'Unable to find base AOT file at ${releaseArtifactFile.path}',
           ),
         ).called(1);
       });

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 import '../mocks.dart';
 
 void main() {
-  group('AotTools', () {
+  group(AotTools, () {
     late Cache cache;
     late ShorebirdProcess process;
     late Directory workingDirectory;


### PR DESCRIPTION
## Description

`shorebird patch ios-alpha --use-linker` is currently linking an AOT snapshot produced from a patch build against the patch mach-o binary. This change fixes this, to make `shorebird patch ios-alpha --use-linker` download the release artifact and use that as a base for linking.

An example invocation of the link command with this change:

```
dart /Users/bryanoltman/shorebirdtech/dart-sdk/sdk/pkg/aot_tools/bin/aot_tools.dart link --debug --base=/var/folders/vn/04w25hyn3cg8436mp3qhhv8m0000gn/T/1ZzqC0/Products/Applications/Runner.app/Frameworks/App.framework/App --patch=/Users/bryanoltman/Documents/sandbox/new_app/build/out.aot --analyze-snapshot=/Users/bryanoltman/shorebirdtech/engine/src/out/ios_release/clang_x64/analyze_snapshot_arm64
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
