### PR TITLE
fix: respect --local-engine in gen_snapshot and analyze_snaphot paths

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
@@ -120,7 +120,7 @@ class ShorebirdLocalEngineArtifacts implements ShorebirdArtifacts {
       p.join(
         engineConfig.localEngineSrcPath!,
         'out',
-        'ios_release',
+        engineConfig.localEngine,
         'clang_x64',
         'analyze_snapshot_arm64',
       ),
@@ -146,7 +146,7 @@ class ShorebirdLocalEngineArtifacts implements ShorebirdArtifacts {
       p.join(
         engineConfig.localEngineSrcPath!,
         'out',
-        'ios_release',
+        engineConfig.localEngine,
         'clang_x64',
         'gen_snapshot_arm64',
       ),

--- a/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
@@ -100,6 +100,7 @@ void main() {
 
   group(ShorebirdLocalEngineArtifacts, () {
     late String localEngineSrcPath;
+    late String localEngine;
     late EngineConfig engineConfig;
     late ShorebirdLocalEngineArtifacts artifacts;
 
@@ -114,12 +115,16 @@ void main() {
 
     setUp(() {
       localEngineSrcPath = 'local_engine_src_path';
+      localEngine = 'local_engine';
       engineConfig = MockEngineConfig();
       artifacts = const ShorebirdLocalEngineArtifacts();
 
       when(
         () => engineConfig.localEngineSrcPath,
       ).thenReturn(localEngineSrcPath);
+      when(
+        () => engineConfig.localEngine,
+      ).thenReturn(localEngine);
     });
 
     group('getArtifactPath', () {
@@ -155,7 +160,7 @@ void main() {
             p.join(
               localEngineSrcPath,
               'out',
-              'ios_release',
+              localEngine,
               'clang_x64',
               'gen_snapshot_arm64',
             ),
@@ -174,7 +179,7 @@ void main() {
             p.join(
               localEngineSrcPath,
               'out',
-              'ios_release',
+              localEngine,
               'clang_x64',
               'analyze_snapshot_arm64',
             ),


### PR DESCRIPTION
Previously we were always assuming ios_release which broke when
trying to test with ios_release_unopt.