### PR TITLE
feat: enable linker by default

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -205,6 +205,14 @@ class AotToolsArtifact extends CachedArtifact {
   bool get required => false;
 
   @override
+  Directory get location => Directory(
+        p.join(
+          cache.getArtifactDirectory(name).path,
+          shorebirdEnv.shorebirdEngineRevision,
+        ),
+      );
+
+  @override
   String get storageUrl {
     var artifactName = 'aot-tools-';
     if (platform.isMacOS) {

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -18,6 +18,7 @@ import 'package:shorebird_cli/src/formatters/file_size_formatter.dart';
 import 'package:shorebird_cli/src/ios.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
+import 'package:shorebird_cli/src/process.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -286,7 +287,8 @@ Current Flutter Revision: $originalFlutterRevision
     }
 
     final useLinker =
-        !preLinkerFlutterRevisions.contains(release.flutterRevision);
+        !preLinkerFlutterRevisions.contains(release.flutterRevision) &&
+            engineConfig.localEngine == null;
     if (useLinker) {
       final extractZip = artifactManager.extractZip;
       final unzipProgress = logger.progress('Extracting release artifact');

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -77,8 +77,8 @@ If this option is not provided, the version number will be determined from the p
         help: 'Whether to publish the patch to the staging environment.',
       )
       ..addFlag(
-        'use-linker',
-        negatable: false,
+        'mix',
+        defaultsTo: true,
         hide: true,
         help: 'Whether to use the new linker when building the patch.',
       );
@@ -112,7 +112,7 @@ If this option is not provided, the version number will be determined from the p
     final force = results['force'] == true;
     final dryRun = results['dry-run'] == true;
     final isStaging = results['staging'] == true;
-    final useLinker = results['use-linker'] == true;
+    final useLinker = results['mix'] == true;
 
     if (force && dryRun) {
       logger.err('Cannot use both --force and --dry-run.');
@@ -380,10 +380,6 @@ ${summary.join('\n')}
   }
 
   Future<int> _runLinker({required File releaseArtifact}) async {
-    logger.warn(
-      '--use-linker is an experimental feature and may not work as expected.',
-    );
-
     final patch = File(_aotOutputPath);
 
     if (!patch.existsSync()) {

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -26,6 +26,52 @@ import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
+/// Revisions of Flutter that were released before the linker was enabled.
+const preLinkerFlutterRevisions = <String>{
+  '45d609090a2313d47a4e657d449ff25710abc853',
+  '0b0086ffa92c25c22f50cbadc3851054f08a9cd8',
+  'a3d5f7c614aa1cc4d6cb1506e74fd1c81678e68e',
+  'b7ad8d5759c4889ea323948fe589c69a39c26135',
+  '49b602f7fae8f5bcd8de9547f31928058cbd768e',
+  '6116674ab0d6449104f9f342d96cef0abe30a9a1',
+  'ba444de6ceb9313320a70563d7b6203344e0cd87',
+  '0671f4f9fb2589055d64537e03d7733448b3488b',
+  '1cf1fef6a503672b919a4390ed61320daac07139',
+  '5de12cedfe6002b79183bc59af04561a98c8aa82',
+  '9486b6431e6c808c4e131f134b5d88017b3c32ab',
+  '2e05c41803943a1e81360ae97c75a229c1fb55ef',
+  '0e2d280277cf9f60f7ba802a59f9fd187ffdd050',
+  '628a3eba4e0aba5e6f92c87b320f3c99afb85e61',
+  '3612c8dc659dd7866578b19396efcb63cad71bef',
+  'd84d466eacbeb47d6e81e960c22c6fdfe5a3917d',
+  '8576da53c568d904f464b8aeac105c8790285d32',
+  'd93eb3686c60b626691c8020d7353ea22a0f5ea2',
+  '39df2792f537b1fc62a9c668a6990f585bd91456',
+  '03e895ee09dfbb9c18681d103f4b27671ff65429',
+  'b9b23902966504a9778f4c07e3a3487fa84dcb2a',
+  '02454bae6bf3bef150171c9ce299279e8b875b2e',
+  '8861a600668dbc4d9ca131f5158871bc0523f428',
+  'ef4b661ddc0c71b738432ae59c6bc573e917854b',
+  '47db6d73cfe3227129a510445dd82c45c2dbe347',
+  '7b63f1bac9879c2b00f02bc8d404ffc4c7f24ca2',
+  '012153de178d4a51cd6f9adc792ad63ae3cfb1b3',
+  '83305b5088e6fe327fb3334a73ff190828d85713',
+  '225beb5302e2f03603a775d23be11d96ae253ab1',
+  '402424409c29c28ed69e14cbb39f0a7424a47e16',
+  'b27620fa7dca89c742c12b1277571f7a0d6a9740',
+  '447487a4d2f1a73376e82c61e708f75e315cdaa5',
+  'c0e52af9097e779671591ea105031920f24da4d5',
+  '211d78f6d673fdc6f728217c8f999827c040cd23',
+  'efce3391b9c729e2899e4e1383df718c4445c3ae',
+  '0f62afa7ad2eaa2fa44ff28278d6c6eaf81f327e',
+  '0fc414cbc33ee017ad509671009e8b242539ea16',
+  '6b9b5ff45af7a1ef864038dd7d0c32b620b357c6',
+  '7cd77f78a51576652edc337817152abf4217a257',
+  '5567fb431a2ddbb70c05ff7cd8fcd58bb91f2dbc',
+  '914d5b5fcacc794fd0319f2928ceb514e1e0da33',
+  'e744c831b8355bcb9f3b541d42431d9145eea677',
+};
+
 /// {@template patch_ios_command}
 /// `shorebird patch ios-alpha` command.
 /// {@endtemplate}
@@ -75,12 +121,6 @@ If this option is not provided, the version number will be determined from the p
         'staging',
         negatable: false,
         help: 'Whether to publish the patch to the staging environment.',
-      )
-      ..addFlag(
-        'mix',
-        defaultsTo: true,
-        hide: true,
-        help: 'Whether to use the new linker when building the patch.',
       );
   }
 
@@ -112,7 +152,6 @@ If this option is not provided, the version number will be determined from the p
     final force = results['force'] == true;
     final dryRun = results['dry-run'] == true;
     final isStaging = results['staging'] == true;
-    final useLinker = results['mix'] == true;
 
     if (force && dryRun) {
       logger.err('Cannot use both --force and --dry-run.');
@@ -246,6 +285,8 @@ Current Flutter Revision: $originalFlutterRevision
       return ExitCode.software.code;
     }
 
+    final useLinker =
+        !preLinkerFlutterRevisions.contains(release.flutterRevision);
     if (useLinker) {
       final extractZip = artifactManager.extractZip;
       final unzipProgress = logger.progress('Extracting release artifact');
@@ -271,7 +312,9 @@ Current Flutter Revision: $originalFlutterRevision
         ),
       );
       final exitCode = await _runLinker(releaseArtifact: releaseArtifactFile);
-      if (exitCode != ExitCode.success.code) return exitCode;
+      if (exitCode != ExitCode.success.code) {
+        return exitCode;
+      }
     }
 
     if (dryRun) {

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -311,7 +311,23 @@ Current Flutter Revision: $originalFlutterRevision
           'App',
         ),
       );
-      final exitCode = await _runLinker(releaseArtifact: releaseArtifactFile);
+
+      // Because aot-tools is versioned with the engine, we need to use the
+      // original Flutter revision to link the patch. We have already switched
+      // to and from the release's Flutter revision before and could
+      // theoretically have just stayed on that revision until after _runLinker,
+      // but this approach makes it less likely that we will leave the user on
+      // a different version of Flutter than they started with if something
+      // goes wrong.
+      if (release.flutterRevision != originalFlutterRevision) {
+        await shorebirdFlutter.useRevision(revision: release.flutterRevision);
+      }
+      final exitCode = await _runLinker(
+        releaseArtifact: releaseArtifactFile,
+      );
+      if (release.flutterRevision != originalFlutterRevision) {
+        await shorebirdFlutter.useRevision(revision: originalFlutterRevision);
+      }
       if (exitCode != ExitCode.success.code) {
         return exitCode;
       }

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -286,9 +286,8 @@ Current Flutter Revision: $originalFlutterRevision
       return ExitCode.software.code;
     }
 
-    final useLinker =
-        !preLinkerFlutterRevisions.contains(release.flutterRevision) &&
-            engineConfig.localEngine == null;
+    final useLinker = engineConfig.localEngine == null &&
+        !preLinkerFlutterRevisions.contains(release.flutterRevision);
     if (useLinker) {
       final extractZip = artifactManager.extractZip;
       final unzipProgress = logger.progress('Extracting release artifact');

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -22,6 +22,8 @@ class AotTools {
       artifact: ShorebirdArtifact.aotTools,
     );
 
+    // This enables us to run Dart scripts directly, as is needed when running
+    // with a local engine.
     if (p.extension(executable) == '.dart') {
       return process.run(
         shorebirdEnv.dartBinaryFile.path,

--- a/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
@@ -76,6 +76,7 @@ class ShorebirdCachedArtifacts implements ShorebirdArtifacts {
     return File(
       p.join(
         cache.getArtifactDirectory(executableName).path,
+        shorebirdEnv.shorebirdEngineRevision,
         executableName,
       ),
     );

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -308,7 +308,7 @@ flutter:
       when(() => argResults['force']).thenReturn(false);
       when(() => argResults['codesign']).thenReturn(true);
       when(() => argResults['staging']).thenReturn(false);
-      when(() => argResults['use-linker']).thenReturn(false);
+      when(() => argResults['mix']).thenReturn(false);
       when(() => argResults.rest).thenReturn([]);
       when(
         () => aotTools.link(
@@ -909,20 +909,9 @@ Please re-run the release command for this version or create a new release.'''),
       );
     });
 
-    group('when --use-linker', () {
+    group('when --mix', () {
       setUp(() {
-        when(() => argResults['use-linker']).thenReturn(true);
-      });
-
-      test('logs warning', () async {
-        setUpProjectRoot();
-        setUpProjectRootArtifacts();
-        await runWithOverrides(command.run);
-        verify(
-          () => logger.warn(
-            '''--use-linker is an experimental feature and may not work as expected.''',
-          ),
-        ).called(1);
+        when(() => argResults['mix']).thenReturn(true);
       });
 
       test('exits with code 70 if patch AOT file is not found', () async {

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -785,6 +785,7 @@ void main() {
         iosDeploy = MockIOSDeploy();
 
         when(() => appleDevice.name).thenReturn('iPhone 12');
+        when(() => appleDevice.udid).thenReturn('12345678-1234567890ABCDEF');
         when(() => argResults['platform']).thenReturn(releasePlatform.name);
         when(
           () => artifactManager.downloadFile(any()),

--- a/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
@@ -52,7 +52,9 @@ void main() {
               artifact: ShorebirdArtifact.aotTools,
             ),
           ),
-          equals(p.join(artifactDirectory.path, 'aot-tools')),
+          equals(
+            p.join(artifactDirectory.path, 'engine-revision', 'aot-tools'),
+          ),
         );
       });
 

--- a/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
@@ -40,6 +40,8 @@ void main() {
         () => cache.getArtifactDirectory(any()),
       ).thenReturn(artifactDirectory);
       when(() => shorebirdEnv.flutterDirectory).thenReturn(flutterDirectory);
+      when(() => shorebirdEnv.shorebirdEngineRevision)
+          .thenReturn('engine-revision');
     });
 
     group('getArtifactPath', () {


### PR DESCRIPTION
This renames --use-linker to --mix and makes it on by default.

This isn't quite complete though as it needs to check which
version of Flutter the release you're patching used and 'mix' or
not depending on the version.  Old versions shouldn't mix, all new
versions should.
