### PR TITLE
chore(shorebird_cli): add `isNullOrEmpty` extension to `String?`

### DIFF
--- a/packages/shorebird_cli/lib/src/extensions/string.dart
+++ b/packages/shorebird_cli/lib/src/extensions/string.dart
@@ -1,0 +1,4 @@
+extension NullOrEmtpy on String? {
+  /// Returns `true` if this string is null or empty.
+  bool get isNullOrEmpty => this == null || this!.isEmpty;
+}

--- a/packages/shorebird_cli/test/src/extensions/string_test.dart
+++ b/packages/shorebird_cli/test/src/extensions/string_test.dart
@@ -1,0 +1,10 @@
+import 'package:shorebird_cli/src/extensions/string.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('IsNullOrEmpty', () async {
+    expect(null.isNullOrEmpty, true);
+    expect(''.isNullOrEmpty, true);
+    expect('test'.isNullOrEmpty, false);
+  });
+}


### PR DESCRIPTION
## Description

Adds `isNullOrEmpty` as a convenience for `str == null || str.isEmpty`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
