### PR TITLE
fix(shorebird_cli): Improve JDK lookup and handle empty JAVA_HOME

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/bundletool.dart
+++ b/packages/shorebird_cli/lib/src/executables/bundletool.dart
@@ -3,6 +3,7 @@ import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/android_sdk.dart';
 import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/executables/java.dart';
+import 'package:shorebird_cli/src/extensions/string.dart';
 import 'package:shorebird_cli/src/process.dart';
 
 /// A reference to a [Bundletool] instance.
@@ -25,8 +26,8 @@ class Bundletool {
       javaExecutable,
       ['-jar', bundletool, ...command],
       environment: {
-        if (androidSdkPath != null) 'ANDROID_HOME': androidSdkPath,
-        if (javaHome != null) 'JAVA_HOME': javaHome,
+        if (!androidSdkPath.isNullOrEmpty) 'ANDROID_HOME': androidSdkPath!,
+        if (!javaHome.isNullOrEmpty) 'JAVA_HOME': javaHome!,
       },
     );
   }

--- a/packages/shorebird_cli/lib/src/executables/gradlew.dart
+++ b/packages/shorebird_cli/lib/src/executables/gradlew.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
+import 'package:shorebird_cli/src/extensions/string.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/process.dart';
 
@@ -77,7 +78,7 @@ class Gradlew {
       runInShell: true,
       workingDirectory: p.dirname(executablePath),
       environment: {
-        if (javaHome != null) 'JAVA_HOME': javaHome,
+        if (!javaHome.isNullOrEmpty) 'JAVA_HOME': javaHome!,
       },
     );
 

--- a/packages/shorebird_cli/lib/src/executables/java.dart
+++ b/packages/shorebird_cli/lib/src/executables/java.dart
@@ -5,10 +5,8 @@ import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/android_studio.dart';
 import 'package:shorebird_cli/src/extensions/string.dart';
-import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/os.dart';
 import 'package:shorebird_cli/src/platform.dart';
-import 'package:shorebird_cli/src/process.dart';
 
 /// A reference to a [Java] instance.
 final javaRef = create(Java.new);
@@ -18,20 +16,7 @@ Java get java => read(javaRef);
 
 /// A wrapper around all java related functionality.
 class Java {
-  /// Returns the path to the java executable.
-  String? get executable {
-    if (!platform.isWindows) return 'java';
-
-    final javaHome = home;
-    if (javaHome == null) return null;
-    return p.join(javaHome, 'bin', 'java.exe');
-  }
-
-  /// Returns the path to the java executable relative to the Java home dir.
-  String get _javaExecutable =>
-      platform.isWindows ? p.join('bin', 'java.exe') : 'java';
-
-  /// Returns the path to the user's JDK, if one is found.
+  /// Returns the path to the user's Java executable, if one is found.
   ///
   /// Our goal is to match the behavior of the flutter tool. As per the docs at
   /// https://github.com/flutter/flutter/blob/stable/packages/flutter_tools/lib/src/android/java.dart#L45-L54,
@@ -40,62 +25,34 @@ class Java {
   /// 1. The runtime environment bundled with Android Studio;
   /// 2. The runtime environment found in the JAVA_HOME env variable, if set; or
   /// 3. The java binary found on PATH.
+  String? get executable {
+    if (home.isNullOrEmpty) {
+      return osInterface.which('java');
+    }
+
+    return p.join(home!, _javaExecutablePath);
+  }
+
+  /// Returns a path to the user's JDK. If one is not found, returns `null`.
+  ///
+  /// This first looks for the Java bundled with Android Studio, then the
+  /// JAVA_HOME environment variable.
   String? get home {
-    if (_isValidJava(_androidStudioJavaPath)) {
-      print('using bundled java at $_androidStudioJavaPath');
+    if (!_androidStudioJavaPath.isNullOrEmpty) {
       return _androidStudioJavaPath;
     }
 
     final environmentJava = platform.environment['JAVA_HOME'];
-    if (_isValidJava(environmentJava)) {
-      print('using java found in JAVA_HOME at $environmentJava');
+    if (!environmentJava.isNullOrEmpty) {
       return environmentJava;
     }
-
-    final pathJava = osInterface.which('java');
-    if (!pathJava.isNullOrEmpty && _javaVersionOutput(pathJava!) != null) {
-      print('using java found on PATH at $pathJava');
-      return pathJava;
-    }
-
-    print('no java found');
 
     return null;
   }
 
-  bool _isValidJava(String? javaHomePath) {
-    if (javaHomePath.isNullOrEmpty) {
-      return false;
-    }
-
-    final fullPath = p.join(javaHomePath!, _javaExecutable);
-    final version = _javaVersionOutput(fullPath);
-    return !version.isNullOrEmpty;
-  }
-
-  String? _javaVersionOutput(String executablePath) {
-    final ShorebirdProcessResult result;
-    try {
-      result = process.runSync(executablePath, ['-version'], runInShell: true);
-    } catch (e) {
-      logger.detail('Error running java -version: $e');
-      return null;
-    }
-
-    if (result.exitCode != 0) {
-      return null;
-    }
-
-    final stdout = result.stdout as String?;
-    final stderr = result.stderr as String?;
-
-    if (!stdout.isNullOrEmpty) {
-      return stdout;
-    }
-
-    // Windows java -version output goes to stderr.
-    return stderr;
-  }
+  /// Returns the path to the java executable relative to the Java home dir.
+  String get _javaExecutablePath =>
+      p.join('bin', platform.isWindows ? 'java.exe' : 'java');
 
   String? get _androidStudioJavaPath {
     final androidStudioPath = androidStudio.path;

--- a/packages/shorebird_cli/lib/src/executables/java.dart
+++ b/packages/shorebird_cli/lib/src/executables/java.dart
@@ -4,8 +4,11 @@ import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/android_studio.dart';
+import 'package:shorebird_cli/src/extensions/string.dart';
+import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/os.dart';
 import 'package:shorebird_cli/src/platform.dart';
+import 'package:shorebird_cli/src/process.dart';
 
 /// A reference to a [Java] instance.
 final javaRef = create(Java.new);
@@ -24,19 +27,75 @@ class Java {
     return p.join(javaHome, 'bin', 'java.exe');
   }
 
+  /// Returns the path to the java executable relative to the Java home dir.
+  String get _javaExecutable =>
+      platform.isWindows ? p.join('bin', 'java.exe') : 'java';
+
   /// Returns the path to the user's JDK, if one is found.
   ///
   /// Our goal is to match the behavior of the flutter tool. As per the docs at
   /// https://github.com/flutter/flutter/blob/stable/packages/flutter_tools/lib/src/android/java.dart#L45-L54,
   /// we search for Java in the following places, in order:
   ///
-  /// 1. the runtime environment bundled with Android Studio;
-  /// 2. the runtime environment found in the JAVA_HOME env variable, if set; or
-  /// 3. the java binary found on PATH.
-  String? get home =>
-      _androidStudioJavaPath ??
-      platform.environment['JAVA_HOME'] ??
-      osInterface.which('java');
+  /// 1. The runtime environment bundled with Android Studio;
+  /// 2. The runtime environment found in the JAVA_HOME env variable, if set; or
+  /// 3. The java binary found on PATH.
+  String? get home {
+    if (_isValidJava(_androidStudioJavaPath)) {
+      print('using bundled java at $_androidStudioJavaPath');
+      return _androidStudioJavaPath;
+    }
+
+    final environmentJava = platform.environment['JAVA_HOME'];
+    if (_isValidJava(environmentJava)) {
+      print('using java found in JAVA_HOME at $environmentJava');
+      return environmentJava;
+    }
+
+    final pathJava = osInterface.which('java');
+    if (!pathJava.isNullOrEmpty && _javaVersionOutput(pathJava!) != null) {
+      print('using java found on PATH at $pathJava');
+      return pathJava;
+    }
+
+    print('no java found');
+
+    return null;
+  }
+
+  bool _isValidJava(String? javaHomePath) {
+    if (javaHomePath.isNullOrEmpty) {
+      return false;
+    }
+
+    final fullPath = p.join(javaHomePath!, _javaExecutable);
+    final version = _javaVersionOutput(fullPath);
+    return !version.isNullOrEmpty;
+  }
+
+  String? _javaVersionOutput(String executablePath) {
+    final ShorebirdProcessResult result;
+    try {
+      result = process.runSync(executablePath, ['-version'], runInShell: true);
+    } catch (e) {
+      logger.detail('Error running java -version: $e');
+      return null;
+    }
+
+    if (result.exitCode != 0) {
+      return null;
+    }
+
+    final stdout = result.stdout as String?;
+    final stderr = result.stderr as String?;
+
+    if (!stdout.isNullOrEmpty) {
+      return stdout;
+    }
+
+    // Windows java -version output goes to stderr.
+    return stderr;
+  }
 
   String? get _androidStudioJavaPath {
     final androidStudioPath = androidStudio.path;

--- a/packages/shorebird_cli/test/src/executables/java_test.dart
+++ b/packages/shorebird_cli/test/src/executables/java_test.dart
@@ -80,6 +80,19 @@ void main() {
           );
         });
       });
+
+      group('when no jdk is found', () {
+        setUp(() {
+          when(() => osInterface.which('java')).thenReturn('/bin/java');
+        });
+
+        test('returns java found on path', () async {
+          expect(
+            runWithOverrides(() => java.executable),
+            equals('/bin/java'),
+          );
+        });
+      });
     });
 
     group('home', () {

--- a/packages/shorebird_cli/test/src/executables/java_test.dart
+++ b/packages/shorebird_cli/test/src/executables/java_test.dart
@@ -53,7 +53,6 @@ void main() {
     group('executable', () {
       group('when on Windows', () {
         const javaHome = r'C:\Program Files\Java\jdk-11.0.1';
-
         setUp(() {
           when(() => platform.isWindows).thenReturn(true);
           when(() => platform.environment).thenReturn({'JAVA_HOME': javaHome});
@@ -69,13 +68,15 @@ void main() {
 
       group('when on a non-Windows OS', () {
         setUp(() {
+          const javaHome = '/path/to/jdk';
           when(() => platform.isWindows).thenReturn(false);
+          when(() => platform.environment).thenReturn({'JAVA_HOME': javaHome});
         });
 
         test('returns correct executable on non-windows', () async {
           expect(
             runWithOverrides(() => java.executable),
-            equals('java'),
+            equals('/path/to/jdk/bin/java'),
           );
         });
       });
@@ -210,17 +211,9 @@ void main() {
         });
 
         group('when JAVA_HOME is not set', () {
-          group("when java is on the user's path", () {
-            const javaPath = '/path/to/java';
-            setUp(() {
-              when(() => osInterface.which('java')).thenReturn(javaPath);
-            });
-
+          group('returns null', () {
             test('returns path to java', () {
-              expect(
-                runWithOverrides(() => java.home),
-                equals('/path/to/java'),
-              );
+              expect(runWithOverrides(() => java.home), isNull);
             });
           });
 


### PR DESCRIPTION
## Description

1. Updates Java home (JDK) lookup to not include `which java` (this is a path to a java executable, not a jdk)
2. Treats empty JAVA_HOME as effectively unset.

Fixes https://github.com/shorebirdtech/shorebird/issues/1577

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
