### PR TITLE
fix(shorebird_cli): properly determine android studio path on Windows

### DIFF
--- a/packages/shorebird_cli/lib/src/android_studio.dart
+++ b/packages/shorebird_cli/lib/src/android_studio.dart
@@ -2,7 +2,11 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/extensions/string.dart';
+import 'package:shorebird_cli/src/extensions/version.dart';
+import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 
 /// A reference to a [AndroidStudio] instance.
@@ -15,41 +19,101 @@ AndroidStudio get androidStudio => read(androidStudioRef);
 class AndroidStudio {
   /// The path to the Android Studio installation.
   String? get path {
-    final home = platform.environment['HOME'] ?? '~';
     if (platform.isMacOS) {
-      final candidateLocations = [
-        p.join(home, 'Applications', 'Android Studio.app', 'Contents'),
-        p.join('/', 'Applications', 'Android Studio.app', 'Contents'),
-      ];
-      return candidateLocations.firstWhereOrNull(
-        (location) => Directory(location).existsSync(),
-      );
-    }
-
-    if (platform.isWindows) {
-      final programFiles = platform.environment['PROGRAMFILES']!;
-      final programFilesx86 = platform.environment['PROGRAMFILES(X86)']!;
-      final candidateLocations = [
-        p.join(programFiles, 'Android', 'Android Studio'),
-        p.join(programFilesx86, 'Android', 'Android Studio'),
-      ];
-      return candidateLocations.firstWhereOrNull(
-        (location) => Directory(location).existsSync(),
-      );
-    }
-
-    if (platform.isLinux) {
-      final candidateLocations = [
-        p.join('/', 'snap', 'bin', 'android-studio'),
-        p.join('/', 'opt', 'android-studio'),
-        p.join(home, '.AndroidStudio'),
-        p.join(home, '.cache', 'Google', 'AndroidStudio'),
-      ];
-      return candidateLocations.firstWhereOrNull((location) {
-        return Directory(location).existsSync();
-      });
+      return _macOsPath;
+    } else if (platform.isWindows) {
+      return _windowsPath;
+    } else if (platform.isLinux) {
+      return _linuxPath;
     }
 
     return null;
+  }
+
+  String? get _windowsPath {
+    final localAppData = platform.environment['LOCALAPPDATA'];
+    if (!localAppData.isNullOrEmpty) {
+      final cacheDir = Directory(p.join(localAppData!, 'Google'));
+      if (cacheDir.existsSync()) {
+        // This directory should contain, among other things,
+        // AndroidStudioYYYY.N entries, where YYYY is the year and N is the
+        // version number. Within these directories, there should be a .home
+        // file that contains the path to the Android Studio installation. We
+        // want to find the directory with the highest version number that
+        // points to a valid installation and return that.
+        final studioRegex = RegExp(r'AndroidStudio(\d+\.\d+)');
+        final matchingDirectories = cacheDir
+            .listSync()
+            .whereType<Directory>()
+            .where((dir) => studioRegex.hasMatch(dir.path));
+        Version? highestVersion;
+        final androidStudioVersionsToPaths = <Version, String>{};
+        for (final directory in matchingDirectories) {
+          final directoryName = p.basename(directory.path);
+          final versionMatch = studioRegex.firstMatch(directoryName)!.group(1);
+          final version = tryParseVersion(versionMatch!, strict: false);
+          if (version == null) {
+            logger.detail('Unable to parse version from $directoryName');
+            continue;
+          }
+
+          final homeFile = File(p.join(directory.path, '.home'));
+          if (!homeFile.existsSync()) {
+            continue;
+          }
+
+          final String androidStudioPath;
+          try {
+            androidStudioPath = homeFile.readAsStringSync();
+          } catch (e) {
+            logger.detail('Unable to read $homeFile: $e');
+            continue;
+          }
+
+          if (Directory(androidStudioPath).existsSync()) {
+            androidStudioVersionsToPaths[version] = androidStudioPath;
+            if (highestVersion == null || version > highestVersion) {
+              highestVersion = version;
+            }
+          }
+        }
+
+        return androidStudioVersionsToPaths[highestVersion];
+      }
+    }
+
+    final programFiles = platform.environment['PROGRAMFILES']!;
+    final programFilesx86 = platform.environment['PROGRAMFILES(X86)']!;
+    final candidateLocations = [
+      p.join(programFiles, 'Android', 'Android Studio'),
+      p.join(programFilesx86, 'Android', 'Android Studio'),
+    ];
+    return candidateLocations.firstWhereOrNull(
+      (location) => Directory(location).existsSync(),
+    );
+  }
+
+  String? get _linuxPath {
+    final home = platform.environment['HOME'] ?? '~';
+    final candidateLocations = [
+      p.join('/', 'snap', 'bin', 'android-studio'),
+      p.join('/', 'opt', 'android-studio'),
+      p.join(home, '.AndroidStudio'),
+      p.join(home, '.cache', 'Google', 'AndroidStudio'),
+    ];
+    return candidateLocations.firstWhereOrNull((location) {
+      return Directory(location).existsSync();
+    });
+  }
+
+  String? get _macOsPath {
+    final home = platform.environment['HOME'] ?? '~';
+    final candidateLocations = [
+      p.join(home, 'Applications', 'Android Studio.app', 'Contents'),
+      p.join('/', 'Applications', 'Android Studio.app', 'Contents'),
+    ];
+    return candidateLocations.firstWhereOrNull(
+      (location) => Directory(location).existsSync(),
+    );
   }
 }

--- a/packages/shorebird_cli/lib/src/android_studio.dart
+++ b/packages/shorebird_cli/lib/src/android_studio.dart
@@ -6,7 +6,6 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/extensions/string.dart';
 import 'package:shorebird_cli/src/extensions/version.dart';
-import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 
 /// A reference to a [AndroidStudio] instance.

--- a/packages/shorebird_cli/lib/src/android_studio.dart
+++ b/packages/shorebird_cli/lib/src/android_studio.dart
@@ -40,18 +40,19 @@ class AndroidStudio {
         // file that contains the path to the Android Studio installation. We
         // want to find the directory with the highest version number that
         // points to a valid installation and return that.
-        final studioRegex = RegExp(r'AndroidStudio(\d+\.\d+)');
+        final androidStudioRegex = RegExp(r'AndroidStudio(\d+\.\d+)');
         final matchingDirectories = cacheDir
             .listSync()
             .whereType<Directory>()
-            .where((dir) => studioRegex.hasMatch(dir.path));
+            .where((dir) => androidStudioRegex.hasMatch(dir.path));
         Version? highestVersion;
         final androidStudioVersionsToPaths = <Version, String>{};
         for (final directory in matchingDirectories) {
           final directoryName = p.basename(directory.path);
           // Because we've already performed this match above, we can safely
           // assume that this will match.
-          final versionMatch = studioRegex.firstMatch(directoryName)!.group(1);
+          final versionMatch =
+              androidStudioRegex.firstMatch(directoryName)!.group(1);
           final version = tryParseVersion(versionMatch!, strict: false)!;
 
           final homeFile = File(p.join(directory.path, '.home'));

--- a/packages/shorebird_cli/lib/src/android_studio.dart
+++ b/packages/shorebird_cli/lib/src/android_studio.dart
@@ -50,26 +50,17 @@ class AndroidStudio {
         final androidStudioVersionsToPaths = <Version, String>{};
         for (final directory in matchingDirectories) {
           final directoryName = p.basename(directory.path);
+          // Because we've already performed this match above, we can safely
+          // assume that this will match.
           final versionMatch = studioRegex.firstMatch(directoryName)!.group(1);
-          final version = tryParseVersion(versionMatch!, strict: false);
-          if (version == null) {
-            logger.detail('Unable to parse version from $directoryName');
-            continue;
-          }
+          final version = tryParseVersion(versionMatch!, strict: false)!;
 
           final homeFile = File(p.join(directory.path, '.home'));
           if (!homeFile.existsSync()) {
             continue;
           }
 
-          final String androidStudioPath;
-          try {
-            androidStudioPath = homeFile.readAsStringSync();
-          } catch (e) {
-            logger.detail('Unable to read $homeFile: $e');
-            continue;
-          }
-
+          final androidStudioPath = homeFile.readAsStringSync();
           if (Directory(androidStudioPath).existsSync()) {
             androidStudioVersionsToPaths[version] = androidStudioPath;
             if (highestVersion == null || version > highestVersion) {

--- a/packages/shorebird_cli/test/src/android_studio_test.dart
+++ b/packages/shorebird_cli/test/src/android_studio_test.dart
@@ -36,57 +36,130 @@ void main() {
     });
 
     group('path', () {
-      test('returns correct path on windows', () async {
-        final tempDir = setUpAppTempDir();
-        final androidStudioDir = Directory(
-          p.join(tempDir.path, 'Android', 'Android Studio'),
-        )..createSync(recursive: true);
-        when(() => platform.isWindows).thenReturn(true);
-        when(() => platform.isMacOS).thenReturn(false);
-        when(() => platform.isLinux).thenReturn(false);
-        when(() => platform.environment).thenReturn({
-          'PROGRAMFILES': tempDir.path,
-          'PROGRAMFILES(X86)': tempDir.path,
+      group('on Windows', () {
+        setUp(() {
+          when(() => platform.isWindows).thenReturn(true);
+          when(() => platform.isMacOS).thenReturn(false);
+          when(() => platform.isLinux).thenReturn(false);
         });
-        await expectLater(
-          runWithOverrides(() => androidStudio.path),
-          equals(androidStudioDir.path),
-        );
+
+        group('when LocalAppData has a value', () {
+          final androidStudioVersions = [
+            'AndroidStudio',
+            'AndroidStudio4.0',
+            'AndroidStudio4.1',
+            'AndroidStudio4.2',
+            'AndroidStudio4.3',
+          ];
+
+          Directory setUpLocalAppData() {
+            final tempDir = setUpAppTempDir();
+            final googleDir = Directory(
+              p.join(tempDir.path, 'Google'),
+            )..createSync(recursive: true);
+
+            for (final version in androidStudioVersions) {
+              final androidStudioDir = Directory(
+                p.join(googleDir.path, version),
+              )..createSync(recursive: true);
+
+              final installPath = p.join(tempDir.path, 'bin', version);
+              if (version != androidStudioVersions.last) {
+                // The last version should not have a .home file to test the
+                // case where our highest versioned directory does not point to
+                // a valid installation.
+                Directory(installPath).createSync(recursive: true);
+              }
+
+              if (version != androidStudioVersions.first) {
+                // Test the case where an Android Studio directory doesn't have
+                // a .home file.
+
+                File(
+                  p.join(androidStudioDir.path, '.home'),
+                )
+                  ..createSync(recursive: true)
+                  ..writeAsStringSync(installPath);
+              }
+            }
+
+            return tempDir;
+          }
+
+          test('returns correct path', () async {
+            final appDataDir = setUpLocalAppData();
+            when(() => platform.environment).thenReturn(
+              {'LOCALAPPDATA': appDataDir.path},
+            );
+
+            await expectLater(
+              runWithOverrides(() => androidStudio.path),
+              equals(p.join(appDataDir.path, 'bin', 'AndroidStudio4.2')),
+            );
+          });
+        });
+
+        group('when Local App Data has no value', () {
+          test('returns correct path', () async {
+            final tempDir = setUpAppTempDir();
+            final androidStudioDir = Directory(
+              p.join(tempDir.path, 'Android', 'Android Studio'),
+            )..createSync(recursive: true);
+            when(() => platform.environment).thenReturn({
+              'PROGRAMFILES': tempDir.path,
+              'PROGRAMFILES(X86)': tempDir.path,
+            });
+            await expectLater(
+              runWithOverrides(() => androidStudio.path),
+              equals(androidStudioDir.path),
+            );
+          });
+        });
       });
 
-      test('returns correct path on MacOS', () async {
-        final tempDir = setUpAppTempDir();
-        final androidStudioDir = Directory(
-          p.join(
-            tempDir.path,
-            'Applications',
-            'Android Studio.app',
-            'Contents',
-          ),
-        )..createSync(recursive: true);
-        when(() => platform.isWindows).thenReturn(false);
-        when(() => platform.isMacOS).thenReturn(true);
-        when(() => platform.isLinux).thenReturn(false);
-        when(() => platform.environment).thenReturn({'HOME': tempDir.path});
-        await expectLater(
-          runWithOverrides(() => androidStudio.path),
-          equals(androidStudioDir.path),
-        );
+      group('on MacOS', () {
+        setUp(() {
+          when(() => platform.isWindows).thenReturn(false);
+          when(() => platform.isMacOS).thenReturn(true);
+          when(() => platform.isLinux).thenReturn(false);
+        });
+
+        test('returns correct path', () async {
+          final tempDir = setUpAppTempDir();
+          final androidStudioDir = Directory(
+            p.join(
+              tempDir.path,
+              'Applications',
+              'Android Studio.app',
+              'Contents',
+            ),
+          )..createSync(recursive: true);
+          when(() => platform.environment).thenReturn({'HOME': tempDir.path});
+          await expectLater(
+            runWithOverrides(() => androidStudio.path),
+            equals(androidStudioDir.path),
+          );
+        });
       });
 
-      test('returns correct path on Linux', () async {
-        final tempDir = setUpAppTempDir();
-        final androidStudioDir = Directory(
-          p.join(tempDir.path, '.AndroidStudio'),
-        )..createSync(recursive: true);
-        when(() => platform.isWindows).thenReturn(false);
-        when(() => platform.isMacOS).thenReturn(false);
-        when(() => platform.isLinux).thenReturn(true);
-        when(() => platform.environment).thenReturn({'HOME': tempDir.path});
-        await expectLater(
-          runWithOverrides(() => androidStudio.path),
-          equals(androidStudioDir.path),
-        );
+      group('on Linux', () {
+        setUp(() {
+          when(() => platform.isWindows).thenReturn(false);
+          when(() => platform.isMacOS).thenReturn(false);
+          when(() => platform.isLinux).thenReturn(true);
+        });
+
+        test('returns correct path', () async {
+          final tempDir = setUpAppTempDir();
+          final androidStudioDir = Directory(
+            p.join(tempDir.path, '.AndroidStudio'),
+          )..createSync(recursive: true);
+          when(() => platform.environment).thenReturn({'HOME': tempDir.path});
+          await expectLater(
+            runWithOverrides(() => androidStudio.path),
+            equals(androidStudioDir.path),
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
## Description

Following the example of the `flutter` tool, look in the user's LocalAppData directory for an Android Studio folder that points to a valid install.

Fixes https://github.com/shorebirdtech/shorebird/issues/1578

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
