### PR TITLE
fix(shorebird_cli): preview should only use available platforms

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -131,7 +131,7 @@ class PreviewCommand extends ShorebirdCommand {
 
     final ReleasePlatform releasePlatform;
     if (availablePlatforms.length == 1) {
-      releasePlatform = release.activePlatforms.first;
+      releasePlatform = availablePlatforms.first;
     } else if (results['platform'] != null) {
       releasePlatform =
           ReleasePlatform.values.byName(results['platform'] as String);


### PR DESCRIPTION
## Description

When selecting platform for preview, use available platforms, not all platforms.

Fixes https://github.com/shorebirdtech/shorebird/issues/1561

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
