### PR TITLE
fix(shorebird_cli): use aot-tools.dill for linking if available

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -137,12 +137,14 @@ abstract class CachedArtifact {
 
   String get storageUrl;
 
-  String get executable;
+  String get fileName;
+
+  bool get isExecutable;
 
   bool get required => true;
 
   Future<void> extractArtifact(http.ByteStream stream, String outputPath) {
-    final file = File(p.join(outputPath, executable))
+    final file = File(p.join(outputPath, fileName))
       ..createSync(recursive: true);
     return stream.pipe(file.openWrite());
   }
@@ -180,10 +182,10 @@ allowed to access $storageUrl.''',
 
     await extractArtifact(response.stream, location.path);
 
-    if (!platform.isWindows) {
+    if (!platform.isWindows && isExecutable) {
       final result = await process.start(
         'chmod',
-        ['+x', p.join(location.path, executable)],
+        ['+x', p.join(location.path, fileName)],
       );
       await result.exitCode;
     }
@@ -199,7 +201,10 @@ class AotToolsArtifact extends CachedArtifact {
   // Not technically an executable, but this is where the file should end up and
   // is how it will be consumed.
   @override
-  String get executable => 'aot-tools.dill';
+  String get fileName => 'aot-tools.dill';
+
+  @override
+  bool get isExecutable => false;
 
   /// The aot-tools are only available for revisions that support mixed-mode.
   @override
@@ -225,7 +230,10 @@ class PatchArtifact extends CachedArtifact {
   String get name => 'patch';
 
   @override
-  String get executable => 'patch';
+  String get fileName => 'patch';
+
+  @override
+  bool get isExecutable => true;
 
   @override
   Future<void> extractArtifact(
@@ -260,7 +268,10 @@ class BundleToolArtifact extends CachedArtifact {
   String get name => 'bundletool.jar';
 
   @override
-  String get executable => 'bundletool.jar';
+  String get fileName => 'bundletool.jar';
+
+  @override
+  bool get isExecutable => false;
 
   @override
   String get storageUrl {

--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -198,8 +198,6 @@ class AotToolsArtifact extends CachedArtifact {
   @override
   String get name => 'aot-tools';
 
-  // Not technically an executable, but this is where the file should end up and
-  // is how it will be consumed.
   @override
   String get fileName => 'aot-tools.dill';
 

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -1,4 +1,3 @@
-import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/process.dart';
@@ -18,22 +17,18 @@ class AotTools {
     String? workingDirectory,
   }) async {
     await cache.updateAll();
-    final executable = shorebirdArtifacts.getArtifactPath(
+
+    // This will be a path to either a kernel (.dill) file or a Dart script if
+    // we're running with a local engine.
+    final artifactPath = shorebirdArtifacts.getArtifactPath(
       artifact: ShorebirdArtifact.aotTools,
     );
 
-    // This enables us to run Dart scripts directly, as is needed when running
-    // with a local engine.
-    final ext = p.extension(executable);
-    if (ext == '.dart' || ext == '.dill') {
-      return process.run(
-        shorebirdEnv.dartBinaryFile.path,
-        [executable, ...command],
-        workingDirectory: workingDirectory,
-      );
-    }
-
-    return process.run(executable, command, workingDirectory: workingDirectory);
+    return process.run(
+      shorebirdEnv.dartBinaryFile.path,
+      [artifactPath, ...command],
+      workingDirectory: workingDirectory,
+    );
   }
 
   /// Generate a link vmcode file from two AOT snapshots.

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -24,7 +24,8 @@ class AotTools {
 
     // This enables us to run Dart scripts directly, as is needed when running
     // with a local engine.
-    if (p.extension(executable) == '.dart') {
+    final ext = p.extension(executable);
+    if (ext == '.dart' || ext == '.dill') {
       return process.run(
         shorebirdEnv.dartBinaryFile.path,
         [executable, ...command],

--- a/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
@@ -13,7 +13,7 @@ enum ShorebirdArtifact {
   /// The analyze_snapshot executable.
   analyzeSnapshot,
 
-  /// The aot_tools kernel (.dill file).
+  /// The aot_tools executable or kernel file.
   aotTools,
 
   /// The gen_snapshot executable.

--- a/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
@@ -13,7 +13,7 @@ enum ShorebirdArtifact {
   /// The analyze_snapshot executable.
   analyzeSnapshot,
 
-  /// The aot_tools executable.
+  /// The aot_tools kernel (.dill file).
   aotTools,
 
   /// The gen_snapshot executable.
@@ -73,6 +73,19 @@ class ShorebirdCachedArtifacts implements ShorebirdArtifacts {
 
   File get _aotToolsFile {
     const executableName = 'aot-tools';
+    final kernelFile = File(
+      p.join(
+        cache.getArtifactDirectory(executableName).path,
+        shorebirdEnv.shorebirdEngineRevision,
+        '$executableName.dill',
+      ),
+    );
+    if (kernelFile.existsSync()) {
+      return kernelFile;
+    }
+
+    // We shipped aot-tools as an executable in the past, so we return that if
+    // no kernel file is found.
     return File(
       p.join(
         cache.getArtifactDirectory(executableName).path,

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -25,7 +25,10 @@ class TestCachedArtifact extends CachedArtifact {
   String get name => 'test';
 
   @override
-  String get executable => 'test';
+  String get fileName => 'test';
+
+  @override
+  bool get isExecutable => true;
 
   @override
   String get storageUrl => 'test-url';

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -25,6 +25,9 @@ class TestCachedArtifact extends CachedArtifact {
   String get name => 'test';
 
   @override
+  String get executable => 'test';
+
+  @override
   String get storageUrl => 'test-url';
 }
 
@@ -142,18 +145,6 @@ void main() {
       });
     });
 
-    group('CachedArtifact', () {
-      late CachedArtifact artifact;
-
-      setUp(() {
-        artifact = TestCachedArtifact(cache: cache, platform: platform);
-      });
-
-      test('has empty executables by default', () {
-        expect(artifact.executables, isEmpty);
-      });
-    });
-
     group('clear', () {
       test('deletes the cache directory', () async {
         final shorebirdCacheDirectory = runWithOverrides(
@@ -217,7 +208,7 @@ void main() {
             (invocation) async {
               final request =
                   invocation.positionalArguments.first as http.BaseRequest;
-              if (request.url.path.endsWith('aot-tools-darwin-x64')) {
+              if (request.url.path.endsWith('aot-tools.dill')) {
                 return http.StreamedResponse(
                   const Stream.empty(),
                   HttpStatus.notFound,

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -701,7 +701,8 @@ Please re-run the release command for this version or create a new release.'''),
       // Verify that we switch back to the original revision once we're done.
       verifyInOrder([
         () => shorebirdFlutter.useRevision(
-            revision: preLinkerRelease.flutterRevision),
+              revision: preLinkerRelease.flutterRevision,
+            ),
         () => shorebirdFlutter.useRevision(revision: otherRevision),
       ]);
 

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -99,7 +99,7 @@ void main() {
           ).thenReturn(aotToolsPath);
         });
 
-        test('completes when linking exits with code 0', () async {
+        test('links and exits with code 0', () async {
           when(
             () => process.run(
               any(),
@@ -139,7 +139,59 @@ void main() {
         });
       });
 
-      group('when using local aot_tools', () {
+      group('when aot-tools is a kernel file', () {
+        const aotToolsPath = 'aot_tools.dill';
+
+        setUp(() {
+          when(
+            () => shorebirdArtifacts.getArtifactPath(
+              artifact: ShorebirdArtifact.aotTools,
+            ),
+          ).thenReturn(aotToolsPath);
+        });
+
+        test('links and exits with code 0', () async {
+          when(
+            () => process.run(
+              any(),
+              any(),
+              workingDirectory: any(named: 'workingDirectory'),
+            ),
+          ).thenAnswer(
+            (_) async => const ShorebirdProcessResult(
+              exitCode: 0,
+              stdout: '',
+              stderr: '',
+            ),
+          );
+          await expectLater(
+            runWithOverrides(
+              () => aotTools.link(
+                base: base,
+                patch: patch,
+                analyzeSnapshot: analyzeSnapshot,
+                workingDirectory: workingDirectory.path,
+              ),
+            ),
+            completes,
+          );
+          verify(
+            () => process.run(
+              dartBinaryFile.path,
+              [
+                aotToolsPath,
+                'link',
+                '--base=$base',
+                '--patch=$patch',
+                '--analyze-snapshot=$analyzeSnapshot',
+              ],
+              workingDirectory: any(named: 'workingDirectory'),
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when aot_tools is a dart file', () {
         const aotToolsPath = 'aot_tools.dart';
 
         setUp(() {
@@ -150,7 +202,7 @@ void main() {
           ).thenReturn(aotToolsPath);
         });
 
-        test('completes when linking exits with code 0', () async {
+        test('links and exits with code 0', () async {
           when(
             () => process.run(
               any(),

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -88,57 +88,6 @@ void main() {
         );
       });
 
-      group('when using cached aot tools', () {
-        const aotToolsPath = 'aot-tools';
-
-        setUp(() {
-          when(
-            () => shorebirdArtifacts.getArtifactPath(
-              artifact: ShorebirdArtifact.aotTools,
-            ),
-          ).thenReturn(aotToolsPath);
-        });
-
-        test('links and exits with code 0', () async {
-          when(
-            () => process.run(
-              any(),
-              any(),
-              workingDirectory: any(named: 'workingDirectory'),
-            ),
-          ).thenAnswer(
-            (_) async => const ShorebirdProcessResult(
-              exitCode: 0,
-              stdout: '',
-              stderr: '',
-            ),
-          );
-          await expectLater(
-            runWithOverrides(
-              () => aotTools.link(
-                base: base,
-                patch: patch,
-                analyzeSnapshot: analyzeSnapshot,
-                workingDirectory: workingDirectory.path,
-              ),
-            ),
-            completes,
-          );
-          verify(
-            () => process.run(
-              any(that: endsWith('aot-tools')),
-              [
-                'link',
-                '--base=$base',
-                '--patch=$patch',
-                '--analyze-snapshot=$analyzeSnapshot',
-              ],
-              workingDirectory: any(named: 'workingDirectory'),
-            ),
-          ).called(1);
-        });
-      });
-
       group('when aot-tools is a kernel file', () {
         const aotToolsPath = 'aot_tools.dill';
 

--- a/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
@@ -52,16 +52,21 @@ void main() {
       group('aot-tools', () {
         const aotToolsKernel = 'aot-tools.dill';
         const aotToolsExe = 'aot-tools';
-        final aotToolsKernelPath = p.join(
-          artifactDirectory.path,
-          engineRevision,
-          aotToolsKernel,
-        );
-        final aotToolsExePath = p.join(
-          artifactDirectory.path,
-          engineRevision,
-          aotToolsExe,
-        );
+        late String aotToolsKernelPath;
+        late String aotToolsExePath;
+
+        setUp(() {
+          aotToolsKernelPath = p.join(
+            artifactDirectory.path,
+            engineRevision,
+            aotToolsKernel,
+          );
+          aotToolsExePath = p.join(
+            artifactDirectory.path,
+            engineRevision,
+            aotToolsExe,
+          );
+        });
 
         group('when kernel and executable are present', () {
           setUp(() {

--- a/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
@@ -13,6 +13,7 @@ import 'mocks.dart';
 
 void main() {
   group(ShorebirdCachedArtifacts, () {
+    const engineRevision = 'engine-revision';
     late Cache cache;
     late Directory flutterDirectory;
     late Directory artifactDirectory;
@@ -31,8 +32,11 @@ void main() {
 
     setUp(() {
       cache = MockCache();
-      flutterDirectory = Directory('flutter');
-      artifactDirectory = Directory('artifacts');
+      final tmpDir = Directory.systemTemp.createTempSync();
+      flutterDirectory = Directory(p.join(tmpDir.path, 'flutter'))
+        ..createSync(recursive: true);
+      artifactDirectory = Directory(p.join(tmpDir.path, 'artifacts'))
+        ..createSync(recursive: true);
       shorebirdEnv = MockShorebirdEnv();
       artifacts = const ShorebirdCachedArtifacts();
 
@@ -41,21 +45,58 @@ void main() {
       ).thenReturn(artifactDirectory);
       when(() => shorebirdEnv.flutterDirectory).thenReturn(flutterDirectory);
       when(() => shorebirdEnv.shorebirdEngineRevision)
-          .thenReturn('engine-revision');
+          .thenReturn(engineRevision);
     });
 
     group('getArtifactPath', () {
-      test('returns correct path for aot tools', () {
-        expect(
-          runWithOverrides(
-            () => artifacts.getArtifactPath(
-              artifact: ShorebirdArtifact.aotTools,
-            ),
-          ),
-          equals(
-            p.join(artifactDirectory.path, 'engine-revision', 'aot-tools'),
-          ),
+      group('aot-tools', () {
+        const aotToolsKernel = 'aot-tools.dill';
+        const aotToolsExe = 'aot-tools';
+        final aotToolsKernelPath = p.join(
+          artifactDirectory.path,
+          engineRevision,
+          aotToolsKernel,
         );
+        final aotToolsExePath = p.join(
+          artifactDirectory.path,
+          engineRevision,
+          aotToolsExe,
+        );
+
+        group('when kernel and executable are present', () {
+          setUp(() {
+            File(aotToolsKernelPath).createSync(recursive: true);
+            File(aotToolsExePath).createSync(recursive: true);
+          });
+
+          test('returns path to kernel file', () async {
+            expect(
+              runWithOverrides(
+                () => artifacts.getArtifactPath(
+                  artifact: ShorebirdArtifact.aotTools,
+                ),
+              ),
+              equals(aotToolsKernelPath),
+            );
+          });
+        });
+
+        group('when only executable is present', () {
+          setUp(() {
+            File(aotToolsExePath).createSync(recursive: true);
+          });
+
+          test('returns path to executable file', () {
+            expect(
+              runWithOverrides(
+                () => artifacts.getArtifactPath(
+                  artifact: ShorebirdArtifact.aotTools,
+                ),
+              ),
+              equals(aotToolsExePath),
+            );
+          });
+        });
       });
 
       test('returns correct path for gen_snapshot', () {


### PR DESCRIPTION
## Description

Because the precompiled `aot-tools` executable will only work on architectures that match the `dart` executable used to build it, and because we build dart on arm64 macs, the `aot-tools` executable does not work on x64 macs. This change looks for an aot-tools kernel file (`.dill`) and uses the `dart` packaged with shorebird's flutter (which was used to produce the kernel file) to run it.

Fixes https://github.com/shorebirdtech/shorebird/issues/1595

Related to but not dependent on https://github.com/shorebirdtech/_build_engine/pull/56

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
