### PR TITLE
fix(shorebird_cli): use temp file when setting preview channel

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -476,7 +476,9 @@ class PreviewCommand extends ShorebirdCommand {
       // Which does NOT create entries in the zip archive for directories.
       // It's important to do this because bundletool expects the
       // .aab not to contain any directories.
-      final encoder = ZipFileEncoder()..create(aabFile.path);
+      final aabFileName = p.basename(aabFile.path);
+      final tmpAabFile = File(p.join(tempDir.path, aabFileName));
+      final encoder = ZipFileEncoder()..create(tmpAabFile.path);
       for (final file in Directory(outputPath).listSync(recursive: true)) {
         if (file is File) {
           await encoder.addFile(
@@ -486,6 +488,9 @@ class PreviewCommand extends ShorebirdCommand {
         }
       }
       encoder.close();
+
+      // Replace the existing preview artifact with the updated one.
+      tmpAabFile.copySync(aabFile.path);
       tempDir.deleteSync(recursive: true);
     });
   }

--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -476,8 +476,7 @@ class PreviewCommand extends ShorebirdCommand {
       // Which does NOT create entries in the zip archive for directories.
       // It's important to do this because bundletool expects the
       // .aab not to contain any directories.
-      final aabFileName = p.basename(aabFile.path);
-      final tmpAabFile = File(p.join(tempDir.path, aabFileName));
+      final tmpAabFile = File(p.join(tempDir.path, p.basename(aabFile.path)));
       final encoder = ZipFileEncoder()..create(tmpAabFile.path);
       for (final file in Directory(outputPath).listSync(recursive: true)) {
         if (file is File) {


### PR DESCRIPTION
## Description

This change updates the `preview` command to re-zip the release aab to a temp directory before using it to avoid corrupting the existing artifact if the zip operation is interrupted. Not totally sure how to programmatically test this, but I've verified that it works locally. 

Fixes https://github.com/shorebirdtech/shorebird/issues/1584

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
