### PR TITLE
fix: old aot_tools binaries do not work

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
@@ -211,7 +211,7 @@ Please re-run the release command for this version or create a new release.''');
       return ExitCode.software.code;
     }
 
-    // TODO use linker if available
+    // TODO(bryanoltman): use linker if available
 
     final File patchFile;
     if (await aotTools.isGeneratePatchDiffBaseSupported()) {

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -81,8 +81,11 @@ class AotTools {
     // "Unrecognized flags: dump_blobs"
     final result = await _exec(
       [
+        // TODO(eseidel): add a --help, or --version or some other way to
+        // get a non-zero exit code without needing to pass in a path to a
+        // snapshot.  This shows up during verbose mode and is confusing.
         'dump_blobs',
-        '--analyze-snapshot=nonexistent_analzye_snapshot',
+        '--analyze-snapshot=nonexistent_analyze_snapshot',
         '--output=out',
         '--snapshot=nonexistent_snapshot',
       ],

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -28,9 +28,21 @@ class AotTools {
       artifact: ShorebirdArtifact.aotTools,
     );
 
+    // Fallback behavior for older versions of shorebird where aot-tools was
+    // distributed as an executable.
+    final extension = p.extension(artifactPath);
+    if (extension != '.dill' && extension != '.dart') {
+      return process.run(
+        artifactPath,
+        command,
+        workingDirectory: workingDirectory,
+      );
+    }
+
+    // local engine versions use .dart and we distribute aot-tools as a .dill
     return process.run(
       shorebirdEnv.dartBinaryFile.path,
-      [artifactPath, ...command],
+      ['run', artifactPath, ...command],
       workingDirectory: workingDirectory,
     );
   }

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -293,10 +293,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: d4872660c46d929f6b8a9ef4e7a7eff7e49bbf0c4ec3f385ee32df5119175139
+      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   http_multi_server:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -254,18 +254,22 @@ void main() {
 
           await expectLater(runWithOverrides(cache.updateAll), completes);
 
-          final request = verify(() => httpClient.send(captureAny()))
+          final requests = verify(() => httpClient.send(captureAny()))
               .captured
-              .first as http.BaseRequest;
+              .cast<http.BaseRequest>()
+              .map((r) => r.url)
+              .toList();
 
-          expect(
-            request.url,
-            equals(
-              Uri.parse(
-                '${cache.storageBaseUrl}/${cache.storageBucket}/shorebird/$shorebirdEngineRevision/patch-darwin-x64.zip',
-              ),
-            ),
-          );
+          String perEngine(String name) =>
+              '${cache.storageBaseUrl}/${cache.storageBucket}/shorebird/$shorebirdEngineRevision/$name';
+
+          final expected = [
+            perEngine('patch-darwin-x64.zip'),
+            'https://github.com/google/bundletool/releases/download/1.15.6/bundletool-all-1.15.6.jar',
+            perEngine('aot-tools.dill'),
+          ].map(Uri.parse).toList();
+
+          expect(requests, equals(expected));
         });
 
         test('pull correct artifact for Windows', () async {
@@ -275,18 +279,22 @@ void main() {
 
           await expectLater(runWithOverrides(cache.updateAll), completes);
 
-          final request = verify(() => httpClient.send(captureAny()))
+          final requests = verify(() => httpClient.send(captureAny()))
               .captured
-              .first as http.BaseRequest;
+              .cast<http.BaseRequest>()
+              .map((r) => r.url)
+              .toList();
 
-          expect(
-            request.url,
-            equals(
-              Uri.parse(
-                '${cache.storageBaseUrl}/${cache.storageBucket}/shorebird/$shorebirdEngineRevision/patch-windows-x64.zip',
-              ),
-            ),
-          );
+          String perEngine(String name) =>
+              '${cache.storageBaseUrl}/${cache.storageBucket}/shorebird/$shorebirdEngineRevision/$name';
+
+          final expected = [
+            perEngine('patch-windows-x64.zip'),
+            'https://github.com/google/bundletool/releases/download/1.15.6/bundletool-all-1.15.6.jar',
+            perEngine('aot-tools.dill'),
+          ].map(Uri.parse).toList();
+
+          expect(requests, equals(expected));
         });
 
         test('pull correct artifact for Linux', () async {
@@ -296,17 +304,22 @@ void main() {
 
           await expectLater(runWithOverrides(cache.updateAll), completes);
 
-          final request = verify(() => httpClient.send(captureAny()))
+          final requests = verify(() => httpClient.send(captureAny()))
               .captured
-              .first as http.BaseRequest;
-          expect(
-            request.url,
-            equals(
-              Uri.parse(
-                '${cache.storageBaseUrl}/${cache.storageBucket}/shorebird/$shorebirdEngineRevision/patch-linux-x64.zip',
-              ),
-            ),
-          );
+              .cast<http.BaseRequest>()
+              .map((r) => r.url)
+              .toList();
+
+          String perEngine(String name) =>
+              '${cache.storageBaseUrl}/${cache.storageBucket}/shorebird/$shorebirdEngineRevision/$name';
+
+          final expected = [
+            perEngine('patch-linux-x64.zip'),
+            'https://github.com/google/bundletool/releases/download/1.15.6/bundletool-all-1.15.6.jar',
+            perEngine('aot-tools.dill'),
+          ].map(Uri.parse).toList();
+
+          expect(requests, equals(expected));
         });
       });
     });

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -25,9 +25,6 @@ class TestCachedArtifact extends CachedArtifact {
   String get name => 'test';
 
   @override
-  String get fileName => 'test';
-
-  @override
   bool get isExecutable => true;
 
   @override
@@ -230,7 +227,7 @@ void main() {
           );
           verify(
             () => logger.detail(
-              '''[cache] optional artifact: "aot-tools" was not found, skipping...''',
+              '''[cache] optional artifact: "aot-tools.dill" was not found, skipping...''',
             ),
           ).called(1);
         });

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -208,7 +208,8 @@ void main() {
             (invocation) async {
               final request =
                   invocation.positionalArguments.first as http.BaseRequest;
-              if (request.url.path.endsWith('aot-tools.dill')) {
+              final fileName = p.basename(request.url.path);
+              if (fileName.startsWith('aot-tools')) {
                 return http.StreamedResponse(
                   const Stream.empty(),
                   HttpStatus.notFound,
@@ -228,6 +229,11 @@ void main() {
           verify(
             () => logger.detail(
               '''[cache] optional artifact: "aot-tools.dill" was not found, skipping...''',
+            ),
+          ).called(1);
+          verify(
+            () => logger.detail(
+              '''[cache] optional artifact: "aot-tools" was not found, skipping...''',
             ),
           ).called(1);
         });

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -95,6 +95,59 @@ void main() {
         );
       });
 
+      group('when aot-tools is an executable', () {
+        const aotToolsPath = 'aot_tools';
+
+        setUp(() {
+          when(
+            () => shorebirdArtifacts.getArtifactPath(
+              artifact: ShorebirdArtifact.aotTools,
+            ),
+          ).thenReturn(aotToolsPath);
+        });
+
+        test('links and exits with code 0', () async {
+          when(
+            () => process.run(
+              aotToolsPath,
+              any(),
+              workingDirectory: any(named: 'workingDirectory'),
+            ),
+          ).thenAnswer(
+            (_) async => const ShorebirdProcessResult(
+              exitCode: 0,
+              stdout: '',
+              stderr: '',
+            ),
+          );
+          await expectLater(
+            runWithOverrides(
+              () => aotTools.link(
+                base: base,
+                patch: patch,
+                analyzeSnapshot: analyzeSnapshot,
+                workingDirectory: workingDirectory.path,
+                outputPath: outputPath,
+              ),
+            ),
+            completes,
+          );
+          verify(
+            () => process.run(
+              aotToolsPath,
+              [
+                'link',
+                '--base=$base',
+                '--patch=$patch',
+                '--analyze-snapshot=$analyzeSnapshot',
+                '--output=$outputPath',
+              ],
+              workingDirectory: any(named: 'workingDirectory'),
+            ),
+          ).called(1);
+        });
+      });
+
       group('when aot-tools is a kernel file', () {
         const aotToolsPath = 'aot_tools.dill';
 

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -62,7 +62,7 @@ void main() {
           () => shorebirdArtifacts.getArtifactPath(
             artifact: ShorebirdArtifact.aotTools,
           ),
-        ).thenReturn('aot-tools');
+        ).thenReturn('aot-tools.dill');
         when(
           () => process.run(
             dartBinaryFile.path,
@@ -136,6 +136,7 @@ void main() {
             () => process.run(
               dartBinaryFile.path,
               [
+                'run',
                 aotToolsPath,
                 'link',
                 '--base=$base',
@@ -190,6 +191,7 @@ void main() {
             () => process.run(
               dartBinaryFile.path,
               [
+                'run',
                 aotToolsPath,
                 'link',
                 '--base=$base',


### PR DESCRIPTION
We try to execute them as dart scripts rather than running them
directly.  While I was in here I cleaned up a typo and removed
fileName in favor of name.

Fixes https://github.com/shorebirdtech/shorebird/issues/1644.
