### PR TITLE
fix(shorebird_cli): look after -- separator for target and flavor

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -106,8 +106,8 @@ If this option is not provided, the version number will be determined from the p
     await cache.updateAll();
 
     const platform = ReleasePlatform.android;
-    final flavor = results.findOption('flavor');
-    final target = results.findOption('target');
+    final flavor = results.findOption('flavor', argParser: argParser);
+    final target = results.findOption('target', argParser: argParser);
 
     final shorebirdYaml = shorebirdEnv.getShorebirdYaml()!;
     final appId = shorebirdYaml.getAppId(flavor: flavor);

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -12,6 +12,7 @@ import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/doctor.dart';
+import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/formatters/formatters.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
@@ -105,8 +106,8 @@ If this option is not provided, the version number will be determined from the p
     await cache.updateAll();
 
     const platform = ReleasePlatform.android;
-    final flavor = results['flavor'] as String?;
-    final target = results['target'] as String?;
+    final flavor = results.findOption('flavor');
+    final target = results.findOption('target');
 
     final shorebirdYaml = shorebirdEnv.getShorebirdYaml()!;
     final appId = shorebirdYaml.getAppId(flavor: flavor);

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -163,8 +163,8 @@ If this option is not provided, the version number will be determined from the p
 
     const arch = 'aarch64';
     const releasePlatform = ReleasePlatform.ios;
-    final flavor = results.findOption('flavor');
-    final target = results.findOption('target');
+    final flavor = results.findOption('flavor', argParser: argParser);
+    final target = results.findOption('target', argParser: argParser);
 
     final shorebirdYaml = shorebirdEnv.getShorebirdYaml()!;
     final appId = shorebirdYaml.getAppId(flavor: flavor);

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -6,6 +6,7 @@ import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
 import 'package:shorebird_cli/src/doctor.dart';
+import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -80,8 +81,8 @@ make smaller updates to your app.
     }
 
     const platform = ReleasePlatform.android;
-    final flavor = results['flavor'] as String?;
-    final target = results['target'] as String?;
+    final flavor = results.findOption('flavor');
+    final target = results.findOption('target');
     final generateApk = results['artifact'] as String == 'apk';
     final splitApk = results['split-per-abi'] == true;
     if (generateApk && splitApk) {

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -81,8 +81,8 @@ make smaller updates to your app.
     }
 
     const platform = ReleasePlatform.android;
-    final flavor = results.findOption('flavor');
-    final target = results.findOption('target');
+    final flavor = results.findOption('flavor', argParser: argParser);
+    final target = results.findOption('target', argParser: argParser);
     final generateApk = results['artifact'] as String == 'apk';
     final splitApk = results['split-per-abi'] == true;
     if (generateApk && splitApk) {

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -8,6 +8,7 @@ import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
+import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/ios.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
@@ -152,8 +153,8 @@ make smaller updates to your app.
     }
 
     const releasePlatform = ReleasePlatform.ios;
-    final flavor = results['flavor'] as String?;
-    final target = results['target'] as String?;
+    final flavor = results.findOption('flavor');
+    final target = results.findOption('target');
     final shorebirdYaml = shorebirdEnv.getShorebirdYaml()!;
     final appId = shorebirdYaml.getAppId(flavor: flavor);
     final app = await codePushClientWrapper.getApp(appId: appId);

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -153,8 +153,8 @@ make smaller updates to your app.
     }
 
     const releasePlatform = ReleasePlatform.ios;
-    final flavor = results.findOption('flavor');
-    final target = results.findOption('target');
+    final flavor = results.findOption('flavor', argParser: argParser);
+    final target = results.findOption('target', argParser: argParser);
     final shorebirdYaml = shorebirdEnv.getShorebirdYaml()!;
     final appId = shorebirdYaml.getAppId(flavor: flavor);
     final app = await codePushClientWrapper.getApp(appId: appId);

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -2,7 +2,10 @@ import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 
 extension OptionFinder on ArgResults {
-  String? findOption(String name) {
+  String? findOption(
+    String name, {
+    required ArgParser argParser,
+  }) {
     if (wasParsed(name)) {
       return this[name] as String?;
     }
@@ -10,9 +13,27 @@ extension OptionFinder on ArgResults {
     // We would ideally check for abbrevations here as well, but ArgResults
     // doesn't expose its parser (which we could use to get the list of
     // [Options] being parsed) or an abbrevations map.
-    final flagStart = '--$name=';
-    return rest
-        .firstWhereOrNull((extra) => extra.startsWith(flagStart))
-        ?.substring(flagStart.length);
+    final abbr = argParser.options.values
+        .firstWhereOrNull((option) => option.name == name)
+        ?.abbr;
+
+    final flagsToCheck = [
+      '--$name',
+      if (abbr != null) '-$abbr',
+    ];
+
+    for (var i = 0; i < rest.length; i++) {
+      for (final flag in flagsToCheck) {
+        if (rest[i] == flag && i + 1 < rest.length) {
+          return rest[i + 1];
+        }
+        final flagEqualsStart = '$flag=';
+        if (rest[i].startsWith(flagEqualsStart)) {
+          return rest[i].substring(flagEqualsStart.length);
+        }
+      }
+    }
+
+    return null;
   }
 }

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -1,0 +1,15 @@
+import 'package:args/args.dart';
+import 'package:collection/collection.dart';
+
+extension OptionFinder on ArgResults {
+  String? findOption(String name) {
+    if (wasParsed(name)) {
+      return this[name] as String?;
+    }
+
+    final flagStart = '--$name=';
+    return rest
+        .firstWhereOrNull((extra) => extra.startsWith(flagStart))
+        ?.substring(flagStart.length);
+  }
+}

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -2,6 +2,8 @@ import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 
 extension OptionFinder on ArgResults {
+  /// // Detects flags even when passed to underlying commands via a `--`
+  /// separator.
   String? findOption(
     String name, {
     required ArgParser argParser,

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -7,6 +7,9 @@ extension OptionFinder on ArgResults {
       return this[name] as String?;
     }
 
+    // We would ideally check for abbrevations here as well, but ArgResults
+    // doesn't expose its parser (which we could use to get the list of
+    // [Options] being parsed) or an abbrevations map.
     final flagStart = '--$name=';
     return rest
         .firstWhereOrNull((extra) => extra.startsWith(flagStart))

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -269,11 +269,12 @@ flutter:
       when(
         () => archiveDiffer.containsPotentiallyBreakingNativeDiffs(any()),
       ).thenReturn(false);
-      when(() => argResults.rest).thenReturn([]);
       when(() => argResults['arch']).thenReturn(arch);
       when(() => argResults['staging']).thenReturn(false);
       when(() => argResults['dry-run']).thenReturn(false);
       when(() => argResults['force']).thenReturn(false);
+      when(() => argResults.rest).thenReturn([]);
+      when(() => argResults.wasParsed(any())).thenReturn(true);
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => auth.client).thenReturn(httpClient);
       when(() => logger.progress(any())).thenReturn(progress);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -325,6 +325,7 @@ flutter:
       when(() => argResults['codesign']).thenReturn(true);
       when(() => argResults['staging']).thenReturn(false);
       when(() => argResults.rest).thenReturn([]);
+      when(() => argResults.wasParsed(any())).thenReturn(true);
       when(
         () => aotTools.link(
           base: any(named: 'base'),

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -163,10 +163,11 @@ void main() {
         ),
       ).thenAnswer((_) async => flutterBuildProcessResult);
 
-      when(() => argResults.rest).thenReturn([]);
       when(() => argResults['arch']).thenReturn(arch);
       when(() => argResults['platform']).thenReturn(releasePlatform);
       when(() => argResults['artifact']).thenReturn('aab');
+      when(() => argResults.rest).thenReturn([]);
+      when(() => argResults.wasParsed(any())).thenReturn(true);
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => auth.client).thenReturn(httpClient);
       when(() => cache.updateAll()).thenAnswer((_) async => {});

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -228,7 +228,6 @@ flutter:
           runInShell: any(named: 'runInShell'),
         ),
       ).thenAnswer((_) async => flutterBuildProcessResult);
-      when(() => argResults.rest).thenReturn([]);
       when(() => argResults['arch']).thenReturn(arch);
       when(() => argResults['codesign']).thenReturn(true);
       when(() => argResults['platform']).thenReturn(releasePlatform);
@@ -237,6 +236,8 @@ flutter:
       when(() => argResults['export-method']).thenReturn(
         ExportMethod.appStore.argName,
       );
+      when(() => argResults.rest).thenReturn([]);
+      when(() => argResults.wasParsed(any())).thenReturn(true);
       when(() => argResults.wasParsed('export-method')).thenReturn(false);
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => logger.progress(any())).thenReturn(progress);

--- a/packages/shorebird_cli/test/src/extensions/arg_results_test.dart
+++ b/packages/shorebird_cli/test/src/extensions/arg_results_test.dart
@@ -8,7 +8,7 @@ void main() {
 
     setUp(() {
       argParser = ArgParser()
-        ..addOption('foo')
+        ..addOption('foo', abbr: 'f')
         ..addOption('bar');
     });
 
@@ -17,15 +17,10 @@ void main() {
         test('returns value', () {
           final args = ['--foo=value'];
           final argResults = argParser.parse(args);
-          expect(argResults.findOption('foo'), equals('value'));
-        });
-      });
-
-      group('when option is in rest', () {
-        test('returns value', () {
-          final args = ['--bar=baz', '--', '--foo=value'];
-          final argResults = argParser.parse(args);
-          expect(argResults.findOption('foo'), equals('value'));
+          expect(
+            argResults.findOption('foo', argParser: argParser),
+            equals('value'),
+          );
         });
       });
 
@@ -33,7 +28,56 @@ void main() {
         test('returns null', () {
           final args = ['--bar=value'];
           final argResults = argParser.parse(args);
-          expect(argResults.findOption('foo'), isNull);
+          expect(
+            argResults.findOption('foo', argParser: argParser),
+            isNull,
+          );
+        });
+      });
+
+      group('when option is in rest', () {
+        group('when option is passed with full name and equals', () {
+          test('returns value', () {
+            final args = ['--', '--foo=value'];
+            final argResults = argParser.parse(args);
+            expect(
+              argResults.findOption('foo', argParser: argParser),
+              equals('value'),
+            );
+          });
+        });
+
+        group('when option is passed with full name and space', () {
+          test('returns value', () {
+            final args = ['--', '--foo', 'value', '--bar', 'value2'];
+            final argResults = argParser.parse(args);
+            expect(
+              argResults.findOption('foo', argParser: argParser),
+              equals('value'),
+            );
+          });
+        });
+
+        group('when option is passed with abbreviation and equals', () {
+          test('returns value', () {
+            final args = ['--', '-f=value'];
+            final argResults = argParser.parse(args);
+            expect(
+              argResults.findOption('foo', argParser: argParser),
+              equals('value'),
+            );
+          });
+        });
+
+        group('when option is passed with abbreviation and space', () {
+          test('returns value', () {
+            final args = ['--', '-f', 'value'];
+            final argResults = argParser.parse(args);
+            expect(
+              argResults.findOption('foo', argParser: argParser),
+              equals('value'),
+            );
+          });
         });
       });
     });

--- a/packages/shorebird_cli/test/src/extensions/arg_results_test.dart
+++ b/packages/shorebird_cli/test/src/extensions/arg_results_test.dart
@@ -1,0 +1,41 @@
+import 'package:args/args.dart';
+import 'package:shorebird_cli/src/extensions/arg_results.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OptionFinder', () {
+    late ArgParser argParser;
+
+    setUp(() {
+      argParser = ArgParser()
+        ..addOption('foo')
+        ..addOption('bar');
+    });
+
+    group('findOption', () {
+      group('when option is passed directly', () {
+        test('returns value', () {
+          final args = ['--foo=value'];
+          final argResults = argParser.parse(args);
+          expect(argResults.findOption('foo'), equals('value'));
+        });
+      });
+
+      group('when option is in rest', () {
+        test('returns value', () {
+          final args = ['--bar=baz', '--', '--foo=value'];
+          final argResults = argParser.parse(args);
+          expect(argResults.findOption('foo'), equals('value'));
+        });
+      });
+
+      group('when option is missing', () {
+        test('returns null', () {
+          final args = ['--bar=value'];
+          final argResults = argParser.parse(args);
+          expect(argResults.findOption('foo'), isNull);
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

Updates patch and release commands to look for `target` and `flavor` parameters passed as part of `rest` (i.e., after the `--` arguments separator).

Fixes https://github.com/shorebirdtech/shorebird/issues/1654

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
