### PR TITLE
fix(shorebird_cli): don't access aotTools if useLinker is false

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -346,7 +346,7 @@ Current Flutter Revision: $originalFlutterRevision
 
     final patchBuildFile = File(useLinker ? _vmcodeOutputPath : _aotOutputPath);
     final File patchFile;
-    if (await aotTools.isGeneratePatchDiffBaseSupported()) {
+    if (useLinker && await aotTools.isGeneratePatchDiffBaseSupported()) {
       final patchBaseProgress = logger.progress('Generating patch diff base');
       final analyzeSnapshotPath = shorebirdArtifacts.getArtifactPath(
         artifact: ShorebirdArtifact.analyzeSnapshot,

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -1111,6 +1111,13 @@ Please re-run the release command for this version or create a new release.'''),
         setUpProjectRoot();
         setUpProjectRootArtifacts();
 
+        when(
+          () => codePushClientWrapper.getRelease(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+          ),
+        ).thenAnswer((_) async => postLinkerRelease);
+
         when(() => aotTools.isGeneratePatchDiffBaseSupported())
             .thenAnswer((_) async => true);
         when(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -1117,7 +1117,6 @@ Please re-run the release command for this version or create a new release.'''),
             releaseVersion: any(named: 'releaseVersion'),
           ),
         ).thenAnswer((_) async => postLinkerRelease);
-
         when(() => aotTools.isGeneratePatchDiffBaseSupported())
             .thenAnswer((_) async => true);
         when(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -998,6 +998,7 @@ Please re-run the release command for this version or create a new release.'''),
             outputPath: any(named: 'outputPath'),
           ),
         );
+        verifyNever(() => aotTools.isGeneratePatchDiffBaseSupported());
       });
     });
 


### PR DESCRIPTION
## Description

We should never use aotTools if we are on a pre-linker Flutter rev.

Fixes https://github.com/shorebirdtech/shorebird/issues/1658

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
