### PR TITLE
fix(shorebird_cli): use help to determine whether dump_blobs is available

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -79,20 +79,8 @@ class AotTools {
     // the error message will contain something like: "Snapshot file does not
     // exist". If the flag is not supported, the error message will contain
     // "Unrecognized flags: dump_blobs"
-    final result = await _exec(
-      [
-        // TODO(eseidel): add a --help, or --version or some other way to
-        // get a non-zero exit code without needing to pass in a path to a
-        // snapshot.  This shows up during verbose mode and is confusing.
-        'dump_blobs',
-        '--analyze-snapshot=nonexistent_analyze_snapshot',
-        '--output=out',
-        '--snapshot=nonexistent_snapshot',
-      ],
-    );
-    return !result.stderr
-        .toString()
-        .contains('Could not find a command named "dump_blobs"');
+    final result = await _exec(['--help']);
+    return result.stdout.toString().contains('dump_blobs');
   }
 
   /// Uses the analyze_snapshot executable to write the data and isolate

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/cache.dart';
@@ -260,7 +261,7 @@ void main() {
     });
 
     group('isGeneratePatchDiffBaseSupported', () {
-      var stderr = '';
+      var stdout = '';
       setUp(() {
         when(
           () => process.run(
@@ -269,14 +270,30 @@ void main() {
             workingDirectory: any(named: 'workingDirectory'),
           ),
         ).thenAnswer(
-          (_) async =>
-              ShorebirdProcessResult(exitCode: 1, stdout: '', stderr: stderr),
+          (_) async => ShorebirdProcessResult(
+            exitCode: ExitCode.success.code,
+            stdout: stdout,
+            stderr: '',
+          ),
         );
       });
 
       group('when dump_blobs flag is not recognized', () {
         setUp(() {
-          stderr = 'Could not find a command named "dump_blobs"';
+          stdout = '''
+Dart equivalent of bintools
+
+Usage: aot_tools <command> [arguments]
+
+Global options:
+-h, --help       Print this usage information.
+-v, --verbose    Noisy logging.
+
+Available commands:
+  link   Link two aot snapshots.
+
+Run "aot_tools help <command>" for more information about a command.
+''';
         });
 
         test('returns false', () async {
@@ -289,7 +306,22 @@ void main() {
 
       group('when dump_blobs is recognized', () {
         setUp(() {
-          stderr = 'Invalid snapshot';
+          stdout = '''
+Dart equivalent of bintools
+
+Usage: aot_tools <command> [arguments]
+
+Global options:
+-h, --help            Print this usage information.
+-v, --[no-]verbose    Noisy logging.
+
+Available commands:
+  dump_blobs              Reads the isolate and vm snapshot data from an aot snapshot file, concatenates them, and writes them to the specified out path.
+  dump_linker_overrides   Statically analyzes dart code and dumps the overrides to the specified output path.
+  link                    Link two aot snapshots.
+
+Run "aot_tools help <command>" for more information about a command.
+''';
         });
 
         test('returns true', () async {


### PR DESCRIPTION
## Description

This is a cleaner and more robust way to determine whether the dump_blobs command is available in aot_tools.

Fixes https://github.com/shorebirdtech/shorebird/issues/1668

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
