### PR TITLE
feat(shorebird_cli): when using `-v`, include all process output

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -191,24 +191,22 @@ class ShorebirdProcess {
   }
 
   void _logResult(ShorebirdProcessResult result) {
-    if (result.exitCode != ExitCode.success.code) {
-      logger.detail('Exited with code ${result.exitCode}');
+    logger.detail('Exited with code ${result.exitCode}');
 
-      final stdout = result.stdout as String?;
-      if (stdout != null && stdout.isNotEmpty) {
-        logger.detail('''
+    final stdout = result.stdout as String?;
+    if (stdout != null && stdout.isNotEmpty) {
+      logger.detail('''
 
 stdout:
 $stdout''');
-      }
+    }
 
-      final stderr = result.stderr as String?;
-      if (stderr != null && stderr.isNotEmpty) {
-        logger.detail('''
+    final stderr = result.stderr as String?;
+    if (stderr != null && stderr.isNotEmpty) {
+      logger.detail('''
 
 stderr:
 $stderr''');
-      }
     }
   }
 

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -247,6 +247,25 @@ void main() {
           ).called(1);
         });
 
+        group('when result has 0 exit code', () {
+          setUp(() {
+            when(() => runProcessResult.exitCode).thenReturn(0);
+            when(() => runProcessResult.stdout).thenReturn('out');
+            when(() => runProcessResult.stderr).thenReturn('err');
+          });
+
+          test('logs stdout and stderr if present', () async {
+            await runWithOverrides(() => shorebirdProcess.run('flutter', []));
+
+            verify(
+              () => logger.detail(any(that: contains('stdout'))),
+            ).called(1);
+            verify(
+              () => logger.detail(any(that: contains('stderr'))),
+            ).called(1);
+          });
+        });
+
         group('when result has non-zero exit code', () {
           setUp(() {
             when(() => runProcessResult.exitCode).thenReturn(1);
@@ -257,10 +276,12 @@ void main() {
           test('logs stdout and stderr if present', () async {
             await runWithOverrides(() => shorebirdProcess.run('flutter', []));
 
-            verify(() => logger.detail(any(that: contains('stdout'))))
-                .called(1);
-            verify(() => logger.detail(any(that: contains('stderr'))))
-                .called(1);
+            verify(
+              () => logger.detail(any(that: contains('stdout'))),
+            ).called(1);
+            verify(
+              () => logger.detail(any(that: contains('stderr'))),
+            ).called(1);
           });
         });
       });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- fix(shorebird_cli): when using `-v`, include all process output

Previously we would only show the process output if the process exited with a non-zero exit code. This change makes it so when `--verbose` is enabled, all process logs are always shown.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
