### PR TITLE
fix: update iOS warning to say "beta" and only show on patching.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 This section contains past updates we've sent to customers via Discord.
 
+## 0.24.1 (January 31, 2024)
+
+* iOS release builds now run at full speed.  iOS patches remain slower than releases.
+
+📚 Release notes can be found at https://github.com/shorebirdtech/shorebird/releases/tag/v0.24.1
+
 ## 0.24.0 (January 30, 2024)
 
 This is our last planned release before iOS beta.  We believe iOS is stable

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -9,7 +9,6 @@ import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
-import 'package:shorebird_cli/src/ios.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -119,8 +118,6 @@ make smaller updates to your app.
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;
     }
-
-    showiOSStatusWarning();
 
     final codesign = results['codesign'] == true;
     if (!codesign) {

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -5,7 +5,6 @@ import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
-import 'package:shorebird_cli/src/ios.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -52,8 +51,6 @@ of the iOS app that is using this module.''',
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;
     }
-
-    showiOSStatusWarning();
 
     const releasePlatform = ReleasePlatform.ios;
     final releaseVersion = results['release-version'] as String;

--- a/packages/shorebird_cli/lib/src/ios.dart
+++ b/packages/shorebird_cli/lib/src/ios.dart
@@ -3,7 +3,9 @@ import 'package:shorebird_cli/src/logger.dart';
 
 void showiOSStatusWarning() {
   final url = link(
-    uri: Uri.parse('https://docs.shorebird.dev/status#ios-alpha'),
+    uri: Uri.parse('https://docs.shorebird.dev/status'),
   );
-  logger.warn('iOS support is alpha. See $url for more information.');
+  logger
+    ..warn('iOS support is beta. Some apps may run slower after patching.')
+    ..info('See $url for more information.');
 }

--- a/packages/shorebird_cli/lib/src/version.dart
+++ b/packages/shorebird_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.24.0';
+const packageVersion = '0.24.1';

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_cli
 description: Command-line tool to interact with Shorebird's services.
-version: 0.24.0
+version: 0.24.1
 repository: https://github.com/shorebirdtech/shorebird
 
 publish_to: none


### PR DESCRIPTION
Also updated release notes and version for 0.24.1.
