### PR TITLE
fix(shorebird_cli): fix export-method parsing in release ios command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -125,8 +125,9 @@ make smaller updates to your app.
         return ExitCode.usage.code;
       }
     } else if (results.wasParsed(exportMethodArgName)) {
-      final exportMethod =
-          ExportMethod.values.byName(results[exportMethodArgName] as String);
+      final exportMethod = ExportMethod.values.firstWhere(
+        (element) => element.argName == results[exportMethodArgName] as String,
+      );
       exportOptionsPlist = createExportOptionsPlist(exportMethod: exportMethod);
     } else {
       exportOptionsPlist = null;

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -405,10 +405,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -405,10 +405,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -536,7 +536,7 @@ flutter:
       setUp(() {
         when(() => argResults.wasParsed(exportMethodArgName)).thenReturn(true);
         when(() => argResults[exportMethodArgName])
-            .thenReturn(ExportMethod.enterprise.argName);
+            .thenReturn(ExportMethod.adHoc.argName);
         when(() => argResults[exportOptionsPlistArgName]).thenReturn(null);
       });
 
@@ -562,7 +562,7 @@ flutter:
         final exportOptionsPlist = Plist(file: exportOptionsPlistFile);
         expect(
           exportOptionsPlist.properties['method'],
-          ExportMethod.enterprise.argName,
+          ExportMethod.adHoc.argName,
         );
       });
     });


### PR DESCRIPTION
## Description

This was previously checking `export-method` for enum name instead of arg name (so `adHoc` was expected instead of `ad-hoc`.

Fixes https://github.com/shorebirdtech/shorebird/issues/1708.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
