### PR TITLE
fix(shorebird_cli): disallow obfuscation for iOS releases

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -99,7 +99,10 @@ make smaller updates to your app.
     if (results.rest.contains('--obfuscate')) {
       // Obfuscated releases break patching, so we don't support them.
       // See https://github.com/shorebirdtech/shorebird/issues/1619
-      logger.err('Shorebird does not currently support obfuscation on iOS.');
+      logger
+        ..err('Shorebird does not currently support obfuscation on iOS.')
+        ..info(
+            '''We hope to support obfuscation in the future. We are tracking this work at ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/1619'))}.''');
       return ExitCode.usage.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -96,6 +96,13 @@ make smaller updates to your app.
       return e.exitCode.code;
     }
 
+    if (results.rest.contains('--obfuscate')) {
+      // Obfuscated releases break patching, so we don't support them.
+      // See https://github.com/shorebirdtech/shorebird/issues/1619
+      logger.err('Shorebird does not currently support obfuscation on iOS.');
+      return ExitCode.usage.code;
+    }
+
     final codesign = results['codesign'] == true;
     if (!codesign) {
       logger

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -343,6 +343,22 @@ flutter:
       ).called(1);
     });
 
+    group('when obfuscate flag is passed', () {
+      setUp(() {
+        when(() => argResults.rest).thenReturn(['--obfuscate']);
+      });
+
+      test('prints error and exits with usage code', () async {
+        final exitCode = await runWithOverrides(command.run);
+
+        expect(exitCode, equals(ExitCode.usage.code));
+        verify(
+          () => logger
+              .err('Shorebird does not currently support obfuscation on iOS.'),
+        ).called(1);
+      });
+    });
+
     group('when codesign is disabled', () {
       setUp(() {
         when(() => argResults['codesign']).thenReturn(false);


### PR DESCRIPTION
## Description

Print a warning and exit if the `--obfuscate` flag is passed used with the release ios command (i.e., `shorebird release ios -- --obfuscate --split-debug-info=./build/app/outputs/symbols`).

Releases built with obfuscation will fail to patch. In my testing, non-obfuscated releases can be patched with obfuscated patches, but we may want to consider adding a warning if a user passes the `--obfuscate` flag to `shorebird patch ios`, as this won't help them in any way and will probably prevent us from linking anything.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
