### PR TITLE
feat(shorebird_cli): add `--flutter-version` to `shorebird release` commands

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_use_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_use_command.dart
@@ -21,6 +21,13 @@ class FlutterVersionsUseCommand extends ShorebirdCommand {
 
   @override
   Future<int> run() async {
+    logger.warn(
+      '''
+This command has been deprecated and will be removed in the next major version.
+Please use: "shorebird release <target> --flutter-version <version>" instead.
+''',
+    );
+
     if (results.rest.isEmpty) {
       logger.err(
         '''

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -43,6 +43,10 @@ class ReleaseAndroidCommand extends ShorebirdCommand
           'apk': 'Android Package Kit',
         },
       )
+      ..addOption(
+        'flutter-version',
+        help: 'The Flutter version to use when building the app (e.g: 3.16.3).',
+      )
       ..addFlag(
         'split-per-abi',
         help: 'Whether to split the APKs per ABIs. '
@@ -85,6 +89,8 @@ make smaller updates to your app.
     final target = results.findOption('target', argParser: argParser);
     final generateApk = results['artifact'] as String == 'apk';
     final splitApk = results['split-per-abi'] == true;
+    final flutterVersion = results['flutter-version'] as String?;
+
     if (generateApk && splitApk) {
       logger
         ..err(
@@ -100,17 +106,66 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
       return ExitCode.unavailable.code;
     }
 
-    final buildProgress = logger.progress('Building release');
+    var flutterRevision = shorebirdEnv.flutterRevision;
+    if (flutterVersion != null) {
+      final String? revision;
+      try {
+        revision = await shorebirdFlutter.getRevisionForVersion(
+          flutterVersion,
+        );
+      } catch (error) {
+        logger.err(
+          '''
+Unable to determine revision for Flutter version: $flutterVersion.
+$error''',
+        );
+        return ExitCode.software.code;
+      }
+
+      if (revision == null) {
+        final openIssueLink = link(
+          uri: Uri.parse(
+            'https://github.com/shorebirdtech/shorebird/issues/new?assignees=&labels=feature&projects=&template=feature_request.md&title=feat%3A+',
+          ),
+          message: 'open an issue',
+        );
+        logger.err('''
+Version $flutterVersion not found. Please $openIssueLink to request a new version.
+Use `shorebird flutter versions list` to list available versions.
+''');
+        return ExitCode.software.code;
+      }
+
+      flutterRevision = revision;
+    }
+
+    final originalFlutterRevision = shorebirdEnv.flutterRevision;
+    final switchFlutterRevision = flutterRevision != originalFlutterRevision;
+
+    if (switchFlutterRevision) {
+      await shorebirdFlutter.useRevision(revision: flutterRevision);
+    }
+
+    final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
+
+    final buildProgress = logger.progress(
+      'Building release with Flutter $flutterVersionString',
+    );
+
     try {
       await buildAppBundle(flavor: flavor, target: target);
       if (generateApk) {
         await buildApk(flavor: flavor, target: target);
       }
-      buildProgress.complete();
     } on ProcessException catch (error) {
       buildProgress.fail('Failed to build: ${error.message}');
       return ExitCode.software.code;
+    } finally {
+      if (switchFlutterRevision) {
+        await shorebirdFlutter.useRevision(revision: originalFlutterRevision);
+      }
     }
+    buildProgress.complete();
 
     final projectRoot = shorebirdEnv.getShorebirdProjectRoot()!;
     final shorebirdYaml = shorebirdEnv.getShorebirdYaml()!;
@@ -162,14 +217,13 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
       );
     }
 
-    final flutterVersion = await shorebirdFlutter.getVersionAndRevision();
     final archNames = architectures.keys.map((arch) => arch.name);
     final summary = [
       '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('(${app.appId})')}''',
       if (flavor != null) '🍧 Flavor: ${lightCyan.wrap(flavor)}',
       '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
       '''🕹️  Platform: ${lightCyan.wrap(platform.name)} ${lightCyan.wrap('(${archNames.join(', ')})')}''',
-      '🐦 Flutter Version: ${lightCyan.wrap(flutterVersion)}',
+      '🐦 Flutter Version: ${lightCyan.wrap(flutterVersionString)}',
     ];
 
     logger.info('''

--- a/packages/shorebird_cli/test/src/commands/flutter/versions/flutter_versions_use_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/flutter/versions/flutter_versions_use_command_test.dart
@@ -56,6 +56,18 @@ void main() {
       expect(command.description, equals('Use a different Flutter version.'));
     });
 
+    test('logs deprecation warning', () async {
+      await runWithOverrides(command.run);
+      verify(
+        () => logger.warn(
+          '''
+This command has been deprecated and will be removed in the next major version.
+Please use: "shorebird release <target> --flutter-version <version>" instead.
+''',
+        ),
+      ).called(1);
+    });
+
     test('exits with code 64 when no version is specified', () async {
       when(() => argResults.rest).thenReturn([]);
       await expectLater(

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -285,6 +285,77 @@ void main() {
       expect(result, ExitCode.config.code);
     });
 
+    group('when flutter-version is provided', () {
+      const flutterVersion = '3.16.3';
+      setUp(() {
+        when(() => argResults['flutter-version']).thenReturn(flutterVersion);
+      });
+
+      group('when unable to determine flutter revision', () {
+        final exception = Exception('oops');
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenThrow(exception);
+        });
+
+        test('exits with code 70', () async {
+          final exitCode = await runWithOverrides(command.run);
+          expect(exitCode, equals(ExitCode.software.code));
+          verify(
+            () => logger.err(
+              '''
+Unable to determine revision for Flutter version: $flutterVersion.
+$exception''',
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when flutter version is not supported', () {
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenAnswer((_) async => null);
+        });
+
+        test('exits with code 70', () async {
+          final exitCode = await runWithOverrides(command.run);
+          expect(exitCode, equals(ExitCode.software.code));
+          verify(
+            () => logger.err(
+              any(that: contains('Version $flutterVersion not found.')),
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when flutter version is supported', () {
+        const revision = '771d07b2cf';
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenAnswer((_) async => revision);
+          when(
+            () => shorebirdFlutter.useRevision(
+              revision: any(named: 'revision'),
+            ),
+          ).thenAnswer((_) async {});
+        });
+
+        test(
+            'uses specified flutter version to build '
+            'and reverts to original flutter version', () async {
+          setUpProjectRootArtifacts();
+          await runWithOverrides(command.run);
+          verifyInOrder([
+            () => shorebirdFlutter.useRevision(revision: revision),
+            () => shorebirdFlutter.useRevision(revision: flutterRevision),
+          ]);
+        });
+      });
+    });
+
     test('exits with code 70 when building aar fails', () async {
       when(() => flutterBuildProcessResult.exitCode).thenReturn(1);
       when(() => flutterBuildProcessResult.stderr).thenReturn('oops');

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -287,6 +287,76 @@ void main() {
       expect(exitCode, ExitCode.unavailable.code);
     });
 
+    group('when flutter-version is provided', () {
+      const flutterVersion = '3.16.3';
+      setUp(() {
+        when(() => argResults['flutter-version']).thenReturn(flutterVersion);
+      });
+
+      group('when unable to determine flutter revision', () {
+        final exception = Exception('oops');
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenThrow(exception);
+        });
+
+        test('exits with code 70', () async {
+          final exitCode = await runWithOverrides(command.run);
+          expect(exitCode, equals(ExitCode.software.code));
+          verify(
+            () => logger.err(
+              '''
+Unable to determine revision for Flutter version: $flutterVersion.
+$exception''',
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when flutter version is not supported', () {
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenAnswer((_) async => null);
+        });
+
+        test('exits with code 70', () async {
+          final exitCode = await runWithOverrides(command.run);
+          expect(exitCode, equals(ExitCode.software.code));
+          verify(
+            () => logger.err(
+              any(that: contains('Version $flutterVersion not found.')),
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when flutter version is supported', () {
+        const revision = '771d07b2cf';
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenAnswer((_) async => revision);
+          when(
+            () => shorebirdFlutter.useRevision(
+              revision: any(named: 'revision'),
+            ),
+          ).thenAnswer((_) async {});
+        });
+
+        test(
+            'uses specified flutter version to build '
+            'and reverts to original flutter version', () async {
+          await runWithOverrides(command.run);
+          verifyInOrder([
+            () => shorebirdFlutter.useRevision(revision: revision),
+            () => shorebirdFlutter.useRevision(revision: flutterRevision),
+          ]);
+        });
+      });
+    });
+
     test('exits with code 70 when building fails', () async {
       when(() => flutterBuildProcessResult.exitCode).thenReturn(1);
       when(() => flutterBuildProcessResult.stderr).thenReturn('oops');

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -667,6 +667,76 @@ flutter:
       });
     });
 
+    group('when flutter-version is provided', () {
+      const flutterVersion = '3.16.3';
+      setUp(() {
+        when(() => argResults['flutter-version']).thenReturn(flutterVersion);
+      });
+
+      group('when unable to determine flutter revision', () {
+        final exception = Exception('oops');
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenThrow(exception);
+        });
+
+        test('exits with code 70', () async {
+          final exitCode = await runWithOverrides(command.run);
+          expect(exitCode, equals(ExitCode.software.code));
+          verify(
+            () => logger.err(
+              '''
+Unable to determine revision for Flutter version: $flutterVersion.
+$exception''',
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when flutter version is not supported', () {
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenAnswer((_) async => null);
+        });
+
+        test('exits with code 70', () async {
+          final exitCode = await runWithOverrides(command.run);
+          expect(exitCode, equals(ExitCode.software.code));
+          verify(
+            () => logger.err(
+              any(that: contains('Version $flutterVersion not found.')),
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when flutter version is supported', () {
+        const revision = '771d07b2cf';
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenAnswer((_) async => revision);
+          when(
+            () => shorebirdFlutter.useRevision(
+              revision: any(named: 'revision'),
+            ),
+          ).thenAnswer((_) async {});
+        });
+
+        test(
+            'uses specified flutter version to build '
+            'and reverts to original flutter version', () async {
+          await runWithOverrides(command.run);
+          verifyInOrder([
+            () => shorebirdFlutter.useRevision(revision: revision),
+            () => shorebirdFlutter.useRevision(revision: flutterRevision),
+          ]);
+        });
+      });
+    });
+
     test('exits with code 70 when build fails with non-zero exit code',
         () async {
       when(() => flutterBuildProcessResult.exitCode).thenReturn(1);

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -257,6 +257,76 @@ flutter:
       ).called(1);
     });
 
+    group('when flutter-version is provided', () {
+      const flutterVersion = '3.16.3';
+      setUp(() {
+        when(() => argResults['flutter-version']).thenReturn(flutterVersion);
+      });
+
+      group('when unable to determine flutter revision', () {
+        final exception = Exception('oops');
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenThrow(exception);
+        });
+
+        test('exits with code 70', () async {
+          final exitCode = await runWithOverrides(command.run);
+          expect(exitCode, equals(ExitCode.software.code));
+          verify(
+            () => logger.err(
+              '''
+Unable to determine revision for Flutter version: $flutterVersion.
+$exception''',
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when flutter version is not supported', () {
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenAnswer((_) async => null);
+        });
+
+        test('exits with code 70', () async {
+          final exitCode = await runWithOverrides(command.run);
+          expect(exitCode, equals(ExitCode.software.code));
+          verify(
+            () => logger.err(
+              any(that: contains('Version $flutterVersion not found.')),
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when flutter version is supported', () {
+        const revision = '771d07b2cf';
+        setUp(() {
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenAnswer((_) async => revision);
+          when(
+            () => shorebirdFlutter.useRevision(
+              revision: any(named: 'revision'),
+            ),
+          ).thenAnswer((_) async {});
+        });
+
+        test(
+            'uses specified flutter version to build '
+            'and reverts to original flutter version', () async {
+          await runWithOverrides(command.run);
+          verifyInOrder([
+            () => shorebirdFlutter.useRevision(revision: revision),
+            () => shorebirdFlutter.useRevision(revision: flutterRevision),
+          ]);
+        });
+      });
+    });
+
     test('exits with code 70 when build fails with non-zero exit code',
         () async {
       when(() => flutterBuildProcessResult.exitCode).thenReturn(1);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- closes #1687 
  - to limit the scope of the changes, I did not refactor the release commands to share more code but will do so in a subsequent set of PRs since that will be more involved.

Sample Usage:

```
shorebird release android --flutter-version 3.16.9
Updating Flutter...
HEAD is now at 771d07b2 chore: roll engine to e898854017610e9803e97d0847cc84c7da6822e0
Shorebird Engine • revision e898854017610e9803e97d0847cc84c7da6822e0
Flutter 3.16.10-0.0.pre.22 • channel [user-branch] • unknown source
Framework • revision 771d07b2cf (5 days ago) • 2024-02-07 15:24:25 -0800
Engine • revision e898854017
Tools • Dart 3.2.6 • DevTools 2.28.5
Building Shorebird...
Resolving dependencies... (1.0s)
Got dependencies.
✓ Building release with Flutter 3.16.9 (771d07b2cf) (2.5s)
✓ Fetching apps (0.5s)
✓ Detecting release version (5.5s)
✓ Fetching releases (84ms)

🚀 Ready to create a new release!

📱 App: flutter_sandbox (cc700ca4-70b0-4d57-b97c-19dd8a1ac9e4)
📦 Release Version: 0.1.0+1
🕹️  Platform: android (arm64, arm32, x86_64)
🐦 Flutter Version: 3.16.9 (771d07b2cf)

Would you like to continue? (y/N) 
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
