### PR TITLE
fix(shorebird_cli): improve iOS preview logging when no device is found

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -368,7 +368,7 @@ class PreviewCommand extends ShorebirdCommand {
       final shouldUseDeviceCtl = deviceForLaunch != null;
       final progressCompleteMessage = deviceForLaunch != null
           ? 'Using device ${deviceForLaunch.name}'
-          : null;
+          : '''No iOS 17+ device found, looking for devices running iOS 16 or lower''';
       deviceLocateProgress.complete(progressCompleteMessage);
 
       final int installExitCode;

--- a/packages/shorebird_cli/lib/src/executables/ios_deploy.dart
+++ b/packages/shorebird_cli/lib/src/executables/ios_deploy.dart
@@ -62,6 +62,12 @@ class IOSDeploy {
   // (lldb) Process 1234 resuming
   static final _lldbProcessResuming = RegExp(r'Process \d+ resuming');
 
+  /// [....] Waiting for device to connect
+  static final _preConnectProgressUpdate = RegExp(r'\[\.+\] (.*)');
+
+  /// [  0%] Downloading package
+  static final _postConnectProgressUpdate = RegExp(r'\[\s+\d+\%\]');
+
   // Send signal to stop (pause) the app. Used before a backtrace dump.
   static const String _signalStop = 'process signal SIGSTOP';
 
@@ -250,7 +256,10 @@ Or run on an iOS simulator without code signing
           if (line.contains('Copying') && line.endsWith('to device')) {
             final abbreviatedLine = line.replaceFirst('$bundlePath/', '');
             launchProgress.update(abbreviatedLine);
-          } else if (line.startsWith(RegExp(r'\[\s+\d+\%\]'))) {
+          } else if (_preConnectProgressUpdate.hasMatch(line)) {
+            final match = _preConnectProgressUpdate.firstMatch(line)!;
+            launchProgress.update(match.group(1)!);
+          } else if (_postConnectProgressUpdate.hasMatch(line)) {
             launchProgress.update(line);
           } else {
             logger.detail(line);

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -1091,6 +1091,11 @@ channel: ${track.channel}
           await runWithOverrides(command.run);
 
           verify(
+            () => progress.complete(
+              '''No iOS 17+ device found, looking for devices running iOS 16 or lower''',
+            ),
+          ).called(1);
+          verify(
             () => iosDeploy.installAndLaunchApp(
               bundlePath: runnerPath(),
               deviceId: 'not-a-device-id',

--- a/packages/shorebird_cli/test/src/executables/ios_deploy_test.dart
+++ b/packages/shorebird_cli/test/src/executables/ios_deploy_test.dart
@@ -269,6 +269,20 @@ void main() {
             bundlePath,
           ]),
         ).called(1);
+
+        // Removes leading [...] from lines that start with [...]
+        verify(
+          () => progress.update(
+            """Using 82b15a4a69ad47c74fe3e71b62a6a6e2842efe25 (D22AP, iPhone X, iphoneos, arm64, 16.3.1, 20D67) a.k.a. 'Felix’s iPhone'.""",
+          ),
+        ).called(1);
+
+        // Does not remove leading [  x%] from lines that start with [  x%]
+        verify(
+          () => progress.update(
+            '''[  7%] Copying /Users/felix/Development/github.com/shorebirdtech/_shorebird/shorebird/bin/cache/previews/b3be02c7-97a8-4135-be71-814cc43d096e/ios_1.0.4+7.app/Base.lproj/Main.storyboardc/BYZ-38-t0r-view-8bC-Xf-vdC.nib to device''',
+          ),
+        ).called(1);
       });
 
       test('kills process on sigint', () async {


### PR DESCRIPTION
## Description

When no iOS device is connected for preview, our logs would previously show something similar to:

```
✓ Locating device for run
⠼ Starting app...
```

And would sit at this state while ios-deploy waited for a device to be connected.

This change updates the behavior to print:

```
✓ No iOS 17+ device found, looking for devices running iOS 16 or lower (1.1s)
⠏ Waiting for iOS device to be connected... (2.2s)
```

Fixes https://github.com/shorebirdtech/shorebird/issues/1711

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
