### PR TITLE
chore: change User.authProvider to User.jwtIssuer

### DIFF
--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -361,7 +361,7 @@ extension OauthValues on oauth2.AuthProvider {
       case MicrosoftAuthProvider:
         return oauth2.ClientId(
           /// Shorebird CLI's OAuth 2.0 identifier for Azure/Entra.
-          'e389e829-42b2-47ab-8868-581475f90313',
+          '0ff83897-ec85-4642-a250-48d5f595137c',
         );
     }
 

--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -22,13 +22,13 @@ final authRef = create(Auth.new);
 Auth get auth => read(authRef);
 
 /// Matches 'https://accounts.google.com' exactly.
-final googleJwtIssuerRegexp = RegExp(r'https:\/\/accounts\.google\.com');
+final googleJwtIssuerRegexp = RegExp(r'^https:\/\/accounts\.google\.com$');
 
 /// Matches lines like
 /// https://login.microsoftonline.com/{tenant-id}/v2.0/.well-known/openid-configuration
 /// Captures the tenant ID as a group.
 final microsoftJwtIssuerRegexp = RegExp(
-  r'https:\/\/login\.microsoftonline\.com\/([\w-]+)\/v2\.0',
+  r'^https:\/\/login\.microsoftonline\.com\/([\w-]+)\/v2\.0$',
 );
 
 typedef ObtainAccessCredentials = Future<oauth2.AccessCredentials> Function(

--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -21,15 +21,13 @@ final authRef = create(Auth.new);
 // The [Auth] instance available in the current zone.
 Auth get auth => read(authRef);
 
-/// Matches 'https://accounts.google.com' exactly.
-final googleJwtIssuerRegexp = RegExp(r'^https:\/\/accounts\.google\.com$');
+/// The JWT issuer field for Google-issued JWTs.
+const googleJwtIssuer = 'https://accounts.google.com';
 
-/// Matches lines like
-/// https://login.microsoftonline.com/{tenant-id}/v2.0/.well-known/openid-configuration
-/// Captures the tenant ID as a group.
-final microsoftJwtIssuerRegexp = RegExp(
-  r'^https:\/\/login\.microsoftonline\.com\/([\w-]+)\/v2\.0$',
-);
+/// Microsoft-issued JWTs are of the form
+/// https://login.microsoftonline.com/{tenant-id}/v2.0. We don't care about the
+/// tenant ID, so we just match the prefix.
+const microsoftJwtIssuerPrefix = 'https://login.microsoftonline.com/';
 
 typedef ObtainAccessCredentials = Future<oauth2.AccessCredentials> Function(
   oauth2.AuthProvider authProvider,
@@ -330,9 +328,9 @@ class UserNotFoundException implements Exception {
 
 extension OauthAuthProvider on Jwt {
   oauth2.AuthProvider get authProvider {
-    if (googleJwtIssuerRegexp.hasMatch(payload.iss)) {
+    if (payload.iss == googleJwtIssuer) {
       return oauth2.GoogleAuthProvider();
-    } else if (microsoftJwtIssuerRegexp.hasMatch(payload.iss)) {
+    } else if (payload.iss.startsWith(microsoftJwtIssuerPrefix)) {
       return MicrosoftAuthProvider();
     }
 

--- a/packages/shorebird_cli/test/src/auth/auth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_test.dart
@@ -30,6 +30,10 @@ class FakeProvider extends oauth2.AuthProvider {
   Uri get tokenEndpoint => Uri.https('example.com');
 }
 
+const googleJwtIssuer = 'https://accounts.google.com';
+const microsoftJwtIssuer =
+    'https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0';
+
 void main() {
   group('scoped', () {
     test('creates instance with default constructor', () {
@@ -98,8 +102,7 @@ void main() {
     group('authProvider', () {
       group('when issuer is login.microsoft.online', () {
         setUp(() {
-          when(() => payload.iss)
-              .thenReturn('https://login.microsoftonline.com');
+          when(() => payload.iss).thenReturn(microsoftJwtIssuer);
         });
 
         test('returns AuthProvider.microsoft', () {
@@ -109,7 +112,7 @@ void main() {
 
       group('when issuer is accounts.google.com', () {
         setUp(() {
-          when(() => payload.iss).thenReturn('https://accounts.google.com');
+          when(() => payload.iss).thenReturn(googleJwtIssuer);
         });
 
         test('returns AuthProvider.google', () {
@@ -142,7 +145,11 @@ void main() {
     const idToken =
         '''eyJhbGciOiJIUzI1NiIsImtpZCI6IjEyMzQiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiI1MjMzMDIyMzMyOTMtZWlhNWFudG0wdGd2ZWsyNDB0NDZvcmN0a3RpYWJyZWsuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI1MjMzMDIyMzMyOTMtZWlhNWFudG0wdGd2ZWsyNDB0NDZvcmN0a3RpYWJyZWsuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMjM0NSIsImhkIjoic2hvcmViaXJkLmRldiIsImVtYWlsIjoidGVzdEBlbWFpbC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaWF0IjoxMjM0LCJleHAiOjY3ODl9.MYbITALvKsGYTYjw1o7AQ0ObkqRWVBSr9cFYJrvA46g''';
     const email = 'test@email.com';
-    const user = User(id: 42, email: email, authProvider: AuthProvider.google);
+    const user = User(
+      id: 42,
+      email: email,
+      jwtIssuer: googleJwtIssuer,
+    );
     const refreshToken = '';
     const scopes = <String>[];
     final googleAuthProvider = GoogleAuthProvider();

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -92,7 +92,7 @@ void main() {
       const user = User(
         id: 123,
         email: 'tester@shorebird.dev',
-        authProvider: AuthProvider.google,
+        jwtIssuer: 'https://accounts.google.com',
       );
 
       test('makes the correct request', () async {
@@ -1114,7 +1114,8 @@ void main() {
         id: 1,
         email: 'tester@shorebird.dev',
         displayName: userName,
-        authProvider: AuthProvider.microsoft,
+        jwtIssuer:
+            'https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0',
       );
 
       test('makes the correct request', () async {

--- a/packages/shorebird_code_push_protocol/lib/src/models/user.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/user.dart
@@ -1,5 +1,4 @@
 import 'package:json_annotation/json_annotation.dart';
-import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 
 part 'user.g.dart';
 

--- a/packages/shorebird_code_push_protocol/lib/src/models/user.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/user.dart
@@ -12,7 +12,7 @@ class User {
   const User({
     required this.id,
     required this.email,
-    required this.authProvider,
+    required this.jwtIssuer,
     this.hasActiveSubscription = false,
     this.displayName,
     this.stripeCustomerId,
@@ -39,6 +39,6 @@ class User {
   /// The user's Stripe customer ID, if they have one.
   final String? stripeCustomerId;
 
-  /// The SSO provider used to create the user.
-  final AuthProvider authProvider;
+  /// The JWT issuer used to create the user.
+  final String jwtIssuer;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/user.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/user.g.dart
@@ -15,8 +15,7 @@ User _$UserFromJson(Map<String, dynamic> json) => $checkedCreate(
         final val = User(
           id: $checkedConvert('id', (v) => v as int),
           email: $checkedConvert('email', (v) => v as String),
-          authProvider: $checkedConvert(
-              'auth_provider', (v) => $enumDecode(_$AuthProviderEnumMap, v)),
+          jwtIssuer: $checkedConvert('jwt_issuer', (v) => v as String),
           hasActiveSubscription: $checkedConvert(
               'has_active_subscription', (v) => v as bool? ?? false),
           displayName: $checkedConvert('display_name', (v) => v as String?),
@@ -26,7 +25,7 @@ User _$UserFromJson(Map<String, dynamic> json) => $checkedCreate(
         return val;
       },
       fieldKeyMap: const {
-        'authProvider': 'auth_provider',
+        'jwtIssuer': 'jwt_issuer',
         'hasActiveSubscription': 'has_active_subscription',
         'displayName': 'display_name',
         'stripeCustomerId': 'stripe_customer_id'
@@ -39,10 +38,5 @@ Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
       'display_name': instance.displayName,
       'has_active_subscription': instance.hasActiveSubscription,
       'stripe_customer_id': instance.stripeCustomerId,
-      'auth_provider': _$AuthProviderEnumMap[instance.authProvider]!,
+      'jwt_issuer': instance.jwtIssuer,
     };
-
-const _$AuthProviderEnumMap = {
-  AuthProvider.google: 'google',
-  AuthProvider.microsoft: 'microsoft',
-};

--- a/packages/shorebird_code_push_protocol/test/src/models/user_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/user_test.dart
@@ -9,7 +9,7 @@ void main() {
         email: 'test@shorebird.dev',
         stripeCustomerId: 'test-customer-id',
         displayName: 'Test User',
-        authProvider: AuthProvider.google,
+        jwtIssuer: 'https://accounts.google.com',
       );
       expect(
         User.fromJson(user.toJson()).toJson(),


### PR DESCRIPTION
## Description

Because JWT issuers can vary between Azure tenants, we're recording the full issuer instead of simply that it was Microsoft.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
