### PR TITLE
fix(shorebird_cli): check for authed user before prompting for provider

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/login_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/login_command.dart
@@ -27,6 +27,15 @@ class LoginCommand extends ShorebirdCommand {
 
   @override
   Future<int> run() async {
+    if (auth.isAuthenticated) {
+      logger
+        ..info('You are already logged in as <${auth.email}>.')
+        ..info(
+          'Run ${lightCyan.wrap('shorebird logout')} to log out and try again.',
+        );
+      return ExitCode.success.code;
+    }
+
     final api.AuthProvider provider;
     if (results.wasParsed('provider')) {
       provider = api.AuthProvider.values.byName(results['provider'] as String);
@@ -40,13 +49,6 @@ class LoginCommand extends ShorebirdCommand {
 
     try {
       await auth.login(provider, prompt: prompt);
-    } on UserAlreadyLoggedInException catch (error) {
-      logger
-        ..info('You are already logged in as <${error.email}>.')
-        ..info(
-          'Run ${lightCyan.wrap('shorebird logout')} to log out and try again.',
-        );
-      return ExitCode.success.code;
     } on UserNotFoundException catch (error) {
       final consoleUri = Uri.https('console.shorebird.dev');
       logger


### PR DESCRIPTION
## Description

Exit asap if the user is already logged in (don't prompt them for platform).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
