### PR TITLE
fix(shorebird_cli): lower minimum Dart version required by googleapis_auth

### DIFF
--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -292,10 +292,11 @@ packages:
   googleapis_auth:
     dependency: "direct main"
     description:
-      name: googleapis_auth
-      sha256: cafc46446574fd42826aa4cd4d623c94482598fda0a5a5649bf2781bcbc09258
-      url: "https://pub.dev"
-    source: hosted
+      path: googleapis_auth
+      ref: "shorebird/dev"
+      resolved-ref: "98f25a9f746ec438029fced875e4b44f35a244ad"
+      url: "https://github.com/shorebirdtech/googleapis.dart.git"
+    source: git
     version: "1.5.0"
   graphs:
     dependency: transitive

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -17,7 +17,11 @@ dependencies:
   cli_util: ^0.4.0
   collection: ^1.17.1
   crypto: ^3.0.2
-  googleapis_auth: ^1.5.0
+  googleapis_auth:
+    git:
+      url: https://github.com/shorebirdtech/googleapis.dart.git
+      path: googleapis_auth
+      ref: shorebird/dev
   http: ^1.0.0
   intl: ^0.19.0
   io: ^1.0.4


### PR DESCRIPTION
[That didn't last long, did it?](https://github.com/shorebirdtech/shorebird/pull/1760)

Updates `shorebird_cli` to use [our fork of googleapis_auth](https://github.com/shorebirdtech/googleapis.dart/tree/shorebird/dev), which has had the dart version constraints changed to match `shorebird_cli`'s 
