### PR TITLE
feat(shorebird_code_push_protocol): add wasForced, hasAssetChanges, andHasNativeChanges to CreatePatchRequest

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_request.dart
@@ -8,7 +8,12 @@ part 'create_patch_request.g.dart';
 @JsonSerializable()
 class CreatePatchRequest {
   /// {@macro create_patch_request}
-  const CreatePatchRequest({required this.releaseId});
+  const CreatePatchRequest({
+    required this.releaseId,
+    required this.wasForced,
+    required this.hasAssetChanges,
+    required this.hasNativeChanges,
+  });
 
   /// Converts a Map<String, dynamic> to a [CreatePatchRequest]
   factory CreatePatchRequest.fromJson(Map<String, dynamic> json) =>
@@ -19,4 +24,13 @@ class CreatePatchRequest {
 
   /// The ID of the release.
   final int releaseId;
+
+  /// Whether the user used the --force flag when authoring this patch.
+  final bool? wasForced;
+
+  /// Whether the patch's assets were not the same as those of the release
+  final bool? hasAssetChanges;
+
+  /// Whether the patch's native code is different than that of the release.
+  final bool? hasNativeChanges;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_request.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_request.g.dart
@@ -15,13 +15,26 @@ CreatePatchRequest _$CreatePatchRequestFromJson(Map<String, dynamic> json) =>
       ($checkedConvert) {
         final val = CreatePatchRequest(
           releaseId: $checkedConvert('release_id', (v) => v as int),
+          wasForced: $checkedConvert('was_forced', (v) => v as bool?),
+          hasAssetChanges:
+              $checkedConvert('has_asset_changes', (v) => v as bool?),
+          hasNativeChanges:
+              $checkedConvert('has_native_changes', (v) => v as bool?),
         );
         return val;
       },
-      fieldKeyMap: const {'releaseId': 'release_id'},
+      fieldKeyMap: const {
+        'releaseId': 'release_id',
+        'wasForced': 'was_forced',
+        'hasAssetChanges': 'has_asset_changes',
+        'hasNativeChanges': 'has_native_changes'
+      },
     );
 
 Map<String, dynamic> _$CreatePatchRequestToJson(CreatePatchRequest instance) =>
     <String, dynamic>{
       'release_id': instance.releaseId,
+      'was_forced': instance.wasForced,
+      'has_asset_changes': instance.hasAssetChanges,
+      'has_native_changes': instance.hasNativeChanges,
     };

--- a/packages/shorebird_code_push_protocol/test/src/messages/create_patch/create_patch_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/create_patch/create_patch_request_test.dart
@@ -4,7 +4,12 @@ import 'package:test/test.dart';
 void main() {
   group(CreatePatchRequest, () {
     test('can be (de)serialized', () {
-      const request = CreatePatchRequest(releaseId: 1234);
+      const request = CreatePatchRequest(
+        releaseId: 1234,
+        wasForced: true,
+        hasAssetChanges: true,
+        hasNativeChanges: false,
+      );
       expect(
         CreatePatchRequest.fromJson(request.toJson()).toJson(),
         equals(request.toJson()),


### PR DESCRIPTION
## Description

Adds fields to `CreatePatchRequest` that will help us better understand patches and more quickly diagnose problems with them.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
