### PR TITLE
fix: only build patch artifacts once if release version is specified and flutter version is not current

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -208,7 +208,6 @@ Current Flutter Revision: $originalFlutterRevision
       // Flutter (i.e., if the release version was provided as an argument and
       // we didn't need to build the patch to determine the release version),
       // build it now.
-
       final buildProgress = logger.progress('Building patch');
       try {
         await buildAppBundle(flavor: flavor, target: target);

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -216,6 +216,7 @@ Current Flutter Revision: $originalFlutterRevision
         buildProgress.fail('Failed to build: ${error.message}');
         return ExitCode.software.code;
       }
+      hasBuiltWithLatestFlutter = true;
     }
 
     final releaseArtifacts = await codePushClientWrapper.getReleaseArtifacts(

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -218,6 +218,7 @@ Current Flutter Revision: $currentFlutterRevision
       } catch (_) {
         return ExitCode.software.code;
       }
+      hasBuiltWithLatestFlutter = true;
     }
 
     final archivePath = getXcarchiveDirectory()?.path;

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -477,6 +477,37 @@ Please re-run the release command for this version or create a new release.'''),
     });
 
     test(
+        '''only builds once if release-version is specified and release uses different flutter revision''',
+        () async {
+      const otherRevision = 'other-revision';
+      when(() => shorebirdEnv.flutterRevision).thenReturn(otherRevision);
+      when(() => argResults['release-version']).thenReturn(version);
+
+      setUpProjectRoot();
+      setUpProjectRootArtifacts();
+      final exitCode = await runWithOverrides(command.run);
+      expect(exitCode, ExitCode.success.code);
+
+      verify(
+        () => shorebirdFlutter.useRevision(revision: release.flutterRevision),
+      ).called(1);
+      verify(
+        () => shorebirdProcess.run(
+          'flutter',
+          [
+            'build',
+            'appbundle',
+            '--release',
+          ],
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).called(1);
+      verify(
+        () => shorebirdFlutter.useRevision(revision: otherRevision),
+      ).called(1);
+    });
+
+    test(
         '''switches to release flutter revision when shorebird flutter revision does not match''',
         () async {
       const otherRevision = 'other-revision';

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -732,41 +732,6 @@ Please re-run the release command for this version or create a new release.'''),
     });
 
     test(
-        '''only builds once if release-version is specified and release uses different flutter revision''',
-        () async {
-      const otherRevision = 'other-revision';
-      when(() => shorebirdEnv.flutterRevision).thenReturn(otherRevision);
-      when(() => argResults['release-version'])
-          .thenReturn(preLinkerRelease.version);
-
-      setUpProjectRoot();
-      setUpProjectRootArtifacts();
-      final exitCode = await runWithOverrides(command.run);
-      expect(exitCode, ExitCode.success.code);
-
-      verify(
-        () => shorebirdFlutter.useRevision(
-            revision: preLinkerRelease.flutterRevision),
-      ).called(1);
-      verify(
-        () => shorebirdProcess.run(
-          'flutter',
-          any(
-            that: containsAll([
-              'build',
-              'ipa',
-              '--release',
-            ]),
-          ),
-          runInShell: any(named: 'runInShell'),
-        ),
-      ).called(1);
-      verify(
-        () => shorebirdFlutter.useRevision(revision: otherRevision),
-      ).called(1);
-    });
-
-    test(
         '''switches to release flutter revision when shorebird flutter revision does not match''',
         () async {
       const otherRevision = 'other-revision';
@@ -838,6 +803,48 @@ Please re-run the release command for this version or create a new release.'''),
             appId: appId,
             releaseVersion: customReleaseVersion,
           ),
+        ).called(1);
+      });
+
+      test('exits with code 70 if build fails', () async {
+        when(() => flutterBuildProcessResult.exitCode).thenReturn(1);
+        when(() => flutterBuildProcessResult.stderr).thenReturn('oops');
+
+        setUpProjectRoot();
+        setUpProjectRootArtifacts();
+        final exitCode = await runWithOverrides(command.run);
+        expect(exitCode, ExitCode.software.code);
+      });
+
+      test('only builds once if release uses different flutter revision',
+          () async {
+        const otherRevision = 'other-revision';
+        when(() => shorebirdEnv.flutterRevision).thenReturn(otherRevision);
+
+        setUpProjectRoot();
+        setUpProjectRootArtifacts();
+        final exitCode = await runWithOverrides(command.run);
+        expect(exitCode, ExitCode.success.code);
+
+        verify(
+          () => shorebirdFlutter.useRevision(
+              revision: preLinkerRelease.flutterRevision),
+        ).called(1);
+        verify(
+          () => shorebirdProcess.run(
+            'flutter',
+            any(
+              that: containsAll([
+                'build',
+                'ipa',
+                '--release',
+              ]),
+            ),
+            runInShell: any(named: 'runInShell'),
+          ),
+        ).called(1);
+        verify(
+          () => shorebirdFlutter.useRevision(revision: otherRevision),
         ).called(1);
       });
     });

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -806,6 +806,23 @@ Please re-run the release command for this version or create a new release.'''),
         ).called(1);
       });
 
+      test('exits with code 70 if xcarchive is not found', () async {
+        setUpProjectRoot();
+        setUpProjectRootArtifacts();
+        Directory(
+          p.join(projectRoot.path, 'build'),
+        ).deleteSync(recursive: true);
+
+        final exitCode = await runWithOverrides(command.run);
+
+        expect(exitCode, equals(ExitCode.software.code));
+        verify(
+          () => logger.err(
+            any(that: contains('Unable to find .xcarchive directory')),
+          ),
+        ).called(1);
+      });
+
       test('exits with code 70 if build fails', () async {
         when(() => flutterBuildProcessResult.exitCode).thenReturn(1);
         when(() => flutterBuildProcessResult.stderr).thenReturn('oops');


### PR DESCRIPTION
## Description

Updates `patch ios` and `patch android` commands to use the `release-version` parameter (if specified) instead of always building the patch artifact to determine the release version.

Fixes https://github.com/shorebirdtech/shorebird/issues/1784

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
