### PR TITLE
refactor(shorebird_cli): consolidate flutter version switching logic in patch commands

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -8,6 +8,8 @@ import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 
 enum Arch {
@@ -117,100 +119,117 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
     return allAndroidArchitectures;
   }
 
-  Future<void> buildAppBundle({String? flavor, String? target}) async {
-    return _runShorebirdBuildCommand(() async {
-      const executable = 'flutter';
-      final arguments = [
-        'build',
-        'appbundle',
-        '--release',
-        if (flavor != null) '--flavor=$flavor',
-        if (target != null) '--target=$target',
-        ...results.rest,
-      ];
+  Future<void> buildAppBundle({
+    String? flavor,
+    String? target,
+    String? flutterRevision,
+  }) async {
+    return _runShorebirdBuildCommand(
+      flutterRevision: flutterRevision,
+      command: () async {
+        const executable = 'flutter';
+        final arguments = [
+          'build',
+          'appbundle',
+          '--release',
+          if (flavor != null) '--flavor=$flavor',
+          if (target != null) '--target=$target',
+          ...results.rest,
+        ];
 
-      final result = await process.run(
-        executable,
-        arguments,
-        runInShell: true,
-      );
-
-      if (result.exitCode != ExitCode.success.code) {
-        throw ProcessException(
-          'flutter',
+        final result = await process.run(
+          executable,
           arguments,
-          result.stderr.toString(),
-          result.exitCode,
+          runInShell: true,
         );
-      }
-    });
+
+        if (result.exitCode != ExitCode.success.code) {
+          throw ProcessException(
+            'flutter',
+            arguments,
+            result.stderr.toString(),
+            result.exitCode,
+          );
+        }
+      },
+    );
   }
 
-  Future<void> buildAar({required String buildNumber}) async {
-    return _runShorebirdBuildCommand(() async {
-      const executable = 'flutter';
-      final arguments = [
-        'build',
-        'aar',
-        '--no-debug',
-        '--no-profile',
-        '--build-number=$buildNumber',
-        ...results.rest,
-      ];
+  Future<void> buildAar({
+    required String buildNumber,
+    String? flutterRevision,
+  }) async {
+    return _runShorebirdBuildCommand(
+      flutterRevision: flutterRevision,
+      command: () async {
+        const executable = 'flutter';
+        final arguments = [
+          'build',
+          'aar',
+          '--no-debug',
+          '--no-profile',
+          '--build-number=$buildNumber',
+          ...results.rest,
+        ];
 
-      final result = await process.run(
-        executable,
-        arguments,
-        runInShell: true,
-      );
-
-      if (result.exitCode != ExitCode.success.code) {
-        throw ProcessException(
-          'flutter',
+        final result = await process.run(
+          executable,
           arguments,
-          result.stderr.toString(),
-          result.exitCode,
+          runInShell: true,
         );
-      }
-    });
+
+        if (result.exitCode != ExitCode.success.code) {
+          throw ProcessException(
+            'flutter',
+            arguments,
+            result.stderr.toString(),
+            result.exitCode,
+          );
+        }
+      },
+    );
   }
 
   Future<void> buildApk({
     String? flavor,
     String? target,
     bool splitPerAbi = false,
+    String? flutterRevision,
   }) async {
-    return _runShorebirdBuildCommand(() async {
-      const executable = 'flutter';
-      final arguments = [
-        'build',
-        'apk',
-        '--release',
-        if (flavor != null) '--flavor=$flavor',
-        if (target != null) '--target=$target',
-        // TODO(bryanoltman): reintroduce coverage when we can support this.
-        // See https://github.com/shorebirdtech/shorebird/issues/1141.
-        // coverage:ignore-start
-        if (splitPerAbi) '--split-per-abi',
-        // coverage:ignore-end
-        ...results.rest,
-      ];
+    return _runShorebirdBuildCommand(
+      flutterRevision: flutterRevision,
+      command: () async {
+        const executable = 'flutter';
+        final arguments = [
+          'build',
+          'apk',
+          '--release',
+          if (flavor != null) '--flavor=$flavor',
+          if (target != null) '--target=$target',
+          // TODO(bryanoltman): reintroduce coverage when we can support this.
+          // See https://github.com/shorebirdtech/shorebird/issues/1141.
+          // coverage:ignore-start
+          if (splitPerAbi) '--split-per-abi',
+          // coverage:ignore-end
+          ...results.rest,
+        ];
 
-      final result = await process.run(
-        executable,
-        arguments,
-        runInShell: true,
-      );
-
-      if (result.exitCode != ExitCode.success.code) {
-        throw ProcessException(
-          'flutter',
+        final result = await process.run(
+          executable,
           arguments,
-          result.stderr.toString(),
-          result.exitCode,
+          runInShell: true,
         );
-      }
-    });
+
+        if (result.exitCode != ExitCode.success.code) {
+          throw ProcessException(
+            'flutter',
+            arguments,
+            result.stderr.toString(),
+            result.exitCode,
+          );
+        }
+      },
+    );
   }
 
   /// Calls `flutter build ipa`. If [codesign] is false, this will only build
@@ -220,46 +239,50 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
     File? exportOptionsPlist,
     String? flavor,
     String? target,
+    String? flutterRevision,
   }) async {
-    return _runShorebirdBuildCommand(() async {
-      const executable = 'flutter';
-      final arguments = [
-        'build',
-        'ipa',
-        '--release',
-        if (flavor != null) '--flavor=$flavor',
-        if (target != null) '--target=$target',
-        if (!codesign) '--no-codesign',
-        if (codesign)
-          '''--export-options-plist=${(exportOptionsPlist ?? createExportOptionsPlist()).path}''',
-        ...results.rest,
-      ];
+    return _runShorebirdBuildCommand(
+      flutterRevision: flutterRevision,
+      command: () async {
+        const executable = 'flutter';
+        final arguments = [
+          'build',
+          'ipa',
+          '--release',
+          if (flavor != null) '--flavor=$flavor',
+          if (target != null) '--target=$target',
+          if (!codesign) '--no-codesign',
+          if (codesign)
+            '''--export-options-plist=${(exportOptionsPlist ?? createExportOptionsPlist()).path}''',
+          ...results.rest,
+        ];
 
-      final result = await process.run(
-        executable,
-        arguments,
-        runInShell: true,
-      );
-
-      if (result.exitCode != ExitCode.success.code) {
-        throw ProcessException(
-          'flutter',
+        final result = await process.run(
+          executable,
           arguments,
-          result.stderr.toString(),
-          result.exitCode,
-        );
-      }
-
-      if (result.stderr
-          .toString()
-          .contains('Encountered error while creating the IPA')) {
-        final errorMessage = _failedToCreateIpaErrorMessage(
-          stderr: result.stderr.toString(),
+          runInShell: true,
         );
 
-        throw BuildException(errorMessage);
-      }
-    });
+        if (result.exitCode != ExitCode.success.code) {
+          throw ProcessException(
+            'flutter',
+            arguments,
+            result.stderr.toString(),
+            result.exitCode,
+          );
+        }
+
+        if (result.stderr
+            .toString()
+            .contains('Encountered error while creating the IPA')) {
+          final errorMessage = _failedToCreateIpaErrorMessage(
+            stderr: result.stderr.toString(),
+          );
+
+          throw BuildException(errorMessage);
+        }
+      },
+    );
   }
 
   /// Creates an ExportOptions.plist file, which is used to tell xcodebuild to
@@ -297,42 +320,67 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
   }
 
   /// Builds a release iOS framework (.xcframework) for the current project.
-  Future<void> buildIosFramework() async {
-    return _runShorebirdBuildCommand(() async {
-      const executable = 'flutter';
-      final arguments = [
-        'build',
-        'ios-framework',
-        '--no-debug',
-        '--no-profile',
-        ...results.rest,
-      ];
+  Future<void> buildIosFramework({String? flutterRevision}) async {
+    return _runShorebirdBuildCommand(
+      flutterRevision: flutterRevision,
+      command: () async {
+        const executable = 'flutter';
+        final arguments = [
+          'build',
+          'ios-framework',
+          '--no-debug',
+          '--no-profile',
+          ...results.rest,
+        ];
 
-      final result = await process.run(
-        executable,
-        arguments,
-        runInShell: true,
-      );
-
-      if (result.exitCode != ExitCode.success.code) {
-        throw ProcessException(
-          'flutter',
+        final result = await process.run(
+          executable,
           arguments,
-          result.stderr.toString(),
-          result.exitCode,
+          runInShell: true,
         );
-      }
-    });
+
+        if (result.exitCode != ExitCode.success.code) {
+          throw ProcessException(
+            'flutter',
+            arguments,
+            result.stderr.toString(),
+            result.exitCode,
+          );
+        }
+      },
+    );
   }
 
   /// A wrapper around [command] (which runs a `flutter build` command with
   /// Shorebird's fork of Flutter) with a try/finally that runs
   /// `flutter pub get` with the system installation of Flutter to reset
   /// `.dart_tool/package_config.json` to the system Flutter.
-  Future<void> _runShorebirdBuildCommand(ShorebirdBuildCommand command) async {
+  Future<void> _runShorebirdBuildCommand({
+    required ShorebirdBuildCommand command,
+    String? flutterRevision,
+  }) async {
+    final currentFlutterRevision = shorebirdEnv.flutterRevision;
+    flutterRevision ??= currentFlutterRevision;
+
     try {
+      if (currentFlutterRevision != flutterRevision) {
+        final flutterVersionProgress = logger.progress(
+          'Switching to Flutter revision $flutterRevision',
+        );
+        await shorebirdFlutter.useRevision(revision: flutterRevision);
+        flutterVersionProgress.complete();
+      }
+
       await command();
     } finally {
+      if (currentFlutterRevision != flutterRevision) {
+        final flutterVersionProgress = logger.progress(
+          '''Switching back to original Flutter revision $currentFlutterRevision''',
+        );
+        await shorebirdFlutter.useRevision(revision: currentFlutterRevision);
+        flutterVersionProgress.complete();
+      }
+
       await _systemFlutterPubGet();
     }
   }

--- a/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
@@ -89,6 +89,7 @@ void main() {
       when(
         () => shorebirdEnv.androidPackageName,
       ).thenReturn(androidPackageName);
+      when(() => shorebirdEnv.flutterRevision).thenReturn('1234');
 
       command = runWithOverrides(BuildAarCommand.new)
         ..testArgResults = argResults;

--- a/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
@@ -7,6 +7,7 @@ import 'package:shorebird_cli/src/commands/build/build.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
@@ -24,6 +25,7 @@ void main() {
     late ShorebirdProcessResult flutterPubGetProcessResult;
     late ShorebirdProcessResult buildProcessResult;
     late BuildApkCommand command;
+    late ShorebirdEnv shorebirdEnv;
     late ShorebirdFlutterValidator flutterValidator;
     late ShorebirdProcess shorebirdProcess;
     late ShorebirdValidator shorebirdValidator;
@@ -36,6 +38,7 @@ void main() {
           loggerRef.overrideWith(() => logger),
           osInterfaceRef.overrideWith(() => operatingSystemInterface),
           processRef.overrideWith(() => shorebirdProcess),
+          shorebirdEnvRef.overrideWith(() => shorebirdEnv),
           shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
         },
       );
@@ -54,6 +57,7 @@ void main() {
       buildProcessResult = MockProcessResult();
       flutterPubGetProcessResult = MockProcessResult();
       flutterValidator = MockShorebirdFlutterValidator();
+      shorebirdEnv = MockShorebirdEnv();
       shorebirdValidator = MockShorebirdValidator();
 
       when(
@@ -78,6 +82,8 @@ void main() {
       when(() => logger.info(any())).thenReturn(null);
       when(() => operatingSystemInterface.which('flutter'))
           .thenReturn('/path/to/flutter');
+      when(() => shorebirdEnv.flutterRevision).thenReturn('1234');
+
       when(
         () => shorebirdValidator.validatePreconditions(
           checkUserIsAuthenticated: any(named: 'checkUserIsAuthenticated'),

--- a/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
@@ -8,6 +8,7 @@ import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
@@ -25,6 +26,7 @@ void main() {
     late ShorebirdProcessResult flutterPubGetProcessResult;
     late ShorebirdProcessResult buildProcessResult;
     late BuildAppBundleCommand command;
+    late ShorebirdEnv shorebirdEnv;
     late ShorebirdFlutterValidator flutterValidator;
     late ShorebirdProcess shorebirdProcess;
     late ShorebirdValidator shorebirdValidator;
@@ -38,6 +40,7 @@ void main() {
           loggerRef.overrideWith(() => logger),
           osInterfaceRef.overrideWith(() => operatingSystemInterface),
           processRef.overrideWith(() => shorebirdProcess),
+          shorebirdEnvRef.overrideWith(() => shorebirdEnv),
           shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
         },
       );
@@ -55,6 +58,7 @@ void main() {
       buildProcessResult = MockProcessResult();
       flutterPubGetProcessResult = MockProcessResult();
       flutterValidator = MockShorebirdFlutterValidator();
+      shorebirdEnv = MockShorebirdEnv();
       shorebirdProcess = MockShorebirdProcess();
       shorebirdValidator = MockShorebirdValidator();
 
@@ -83,6 +87,7 @@ void main() {
       when(
         () => doctor.androidCommandValidators,
       ).thenReturn([flutterValidator]);
+      when(() => shorebirdEnv.flutterRevision).thenReturn('1234');
       when(
         () => shorebirdValidator.validatePreconditions(
           checkUserIsAuthenticated: any(named: 'checkUserIsAuthenticated'),

--- a/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
@@ -7,6 +7,7 @@ import 'package:shorebird_cli/src/commands/build/build.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
@@ -24,6 +25,7 @@ void main() {
     late ShorebirdProcessResult buildProcessResult;
     late ShorebirdProcessResult flutterPubGetProcessResult;
     late BuildIpaCommand command;
+    late ShorebirdEnv shorebirdEnv;
     late ShorebirdFlutterValidator flutterValidator;
     late ShorebirdProcess shorebirdProcess;
     late ShorebirdValidator shorebirdValidator;
@@ -36,6 +38,7 @@ void main() {
           loggerRef.overrideWith(() => logger),
           osInterfaceRef.overrideWith(() => operatingSystemInterface),
           processRef.overrideWith(() => shorebirdProcess),
+          shorebirdEnvRef.overrideWith(() => shorebirdEnv),
           shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
         },
       );
@@ -54,6 +57,7 @@ void main() {
       buildProcessResult = MockProcessResult();
       flutterPubGetProcessResult = MockProcessResult();
       flutterValidator = MockShorebirdFlutterValidator();
+      shorebirdEnv = MockShorebirdEnv();
       shorebirdValidator = MockShorebirdValidator();
 
       when(
@@ -80,6 +84,7 @@ void main() {
       when(() => operatingSystemInterface.which('flutter'))
           .thenReturn('/path/to/flutter');
       when(() => doctor.iosCommandValidators).thenReturn([flutterValidator]);
+      when(() => shorebirdEnv.flutterRevision).thenReturn('1234');
       when(
         () => shorebirdValidator.validatePreconditions(
           checkUserIsAuthenticated: any(named: 'checkUserIsAuthenticated'),


### PR DESCRIPTION
## Description

Moves flutter version switching into the shared ShorebirdBuildMixin to reduce repeated code in our various patch commands.

Cleanup after https://github.com/shorebirdtech/shorebird/pull/1785

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
