### PR TITLE
fix(shorebird_cli): report correct flutter rev when creating release

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -105,7 +105,7 @@ make smaller updates to your app.
       );
     }
 
-    var flutterRevision = shorebirdEnv.flutterRevision;
+    var flutterRevisionForRelease = shorebirdEnv.flutterRevision;
     if (flutterVersion != null) {
       final String? revision;
       try {
@@ -135,14 +135,15 @@ Use `shorebird flutter versions list` to list available versions.
         return ExitCode.software.code;
       }
 
-      flutterRevision = revision;
+      flutterRevisionForRelease = revision;
     }
 
     final originalFlutterRevision = shorebirdEnv.flutterRevision;
-    final switchFlutterRevision = flutterRevision != originalFlutterRevision;
+    final switchFlutterRevision =
+        flutterRevisionForRelease != originalFlutterRevision;
 
     if (switchFlutterRevision) {
-      await shorebirdFlutter.useRevision(revision: flutterRevision);
+      await shorebirdFlutter.useRevision(revision: flutterRevisionForRelease);
     }
 
     final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
@@ -202,7 +203,7 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
-        flutterRevision: flutterRevision,
+        flutterRevision: flutterRevisionForRelease,
         platform: platform,
       );
     }

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -203,6 +203,8 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
+        // Intentionally not using shorebirdEnv.flutterRevision here because
+        // the revision may have changed for the build.
         flutterRevision: flutterRevisionForRelease,
         platform: platform,
       );

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -202,7 +202,7 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
-        flutterRevision: shorebirdEnv.flutterRevision,
+        flutterRevision: flutterRevision,
         platform: platform,
       );
     }

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -106,7 +106,7 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
       return ExitCode.unavailable.code;
     }
 
-    var flutterRevision = shorebirdEnv.flutterRevision;
+    var flutterRevisionForRelease = shorebirdEnv.flutterRevision;
     if (flutterVersion != null) {
       final String? revision;
       try {
@@ -136,14 +136,15 @@ Use `shorebird flutter versions list` to list available versions.
         return ExitCode.software.code;
       }
 
-      flutterRevision = revision;
+      flutterRevisionForRelease = revision;
     }
 
     final originalFlutterRevision = shorebirdEnv.flutterRevision;
-    final switchFlutterRevision = flutterRevision != originalFlutterRevision;
+    final switchFlutterRevision =
+        flutterRevisionForRelease != originalFlutterRevision;
 
     if (switchFlutterRevision) {
-      await shorebirdFlutter.useRevision(revision: flutterRevision);
+      await shorebirdFlutter.useRevision(revision: flutterRevisionForRelease);
     }
 
     final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
@@ -257,7 +258,7 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
-        flutterRevision: flutterRevision,
+        flutterRevision: flutterRevisionForRelease,
         platform: platform,
       );
     }

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -258,6 +258,8 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
+        // Intentionally not using shorebirdEnv.flutterRevision here because
+        // the revision may have changed for the build.
         flutterRevision: flutterRevisionForRelease,
         platform: platform,
       );

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -257,7 +257,7 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
-        flutterRevision: shorebirdEnv.flutterRevision,
+        flutterRevision: flutterRevision,
         platform: platform,
       );
     }

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -159,7 +159,7 @@ make smaller updates to your app.
     final appId = shorebirdYaml.getAppId(flavor: flavor);
     final app = await codePushClientWrapper.getApp(appId: appId);
 
-    var flutterRevision = shorebirdEnv.flutterRevision;
+    var flutterRevisionForRelease = shorebirdEnv.flutterRevision;
     if (flutterVersion != null) {
       final String? revision;
       try {
@@ -189,14 +189,15 @@ Use `shorebird flutter versions list` to list available versions.
         return ExitCode.software.code;
       }
 
-      flutterRevision = revision;
+      flutterRevisionForRelease = revision;
     }
 
     final originalFlutterRevision = shorebirdEnv.flutterRevision;
-    final switchFlutterRevision = flutterRevision != originalFlutterRevision;
+    final switchFlutterRevision =
+        flutterRevisionForRelease != originalFlutterRevision;
 
     if (switchFlutterRevision) {
-      await shorebirdFlutter.useRevision(revision: flutterRevision);
+      await shorebirdFlutter.useRevision(revision: flutterRevisionForRelease);
     }
 
     final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
@@ -308,7 +309,7 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
-        flutterRevision: flutterRevision,
+        flutterRevision: flutterRevisionForRelease,
         platform: releasePlatform,
       );
     }

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -308,7 +308,7 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
-        flutterRevision: shorebirdEnv.flutterRevision,
+        flutterRevision: flutterRevision,
         platform: releasePlatform,
       );
     }

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -309,6 +309,8 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
+        // Intentionally not using shorebirdEnv.flutterRevision here because
+        // the revision may have changed for the build.
         flutterRevision: flutterRevisionForRelease,
         platform: releasePlatform,
       );

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -172,7 +172,7 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
-        flutterRevision: shorebirdEnv.flutterRevision,
+        flutterRevision: flutterRevision,
         platform: releasePlatform,
       );
     }

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -173,6 +173,8 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
+        // Intentionally not using shorebirdEnv.flutterRevision here because
+        // the revision may have changed for the build.
         flutterRevision: flutterRevisionForRelease,
         platform: releasePlatform,
       );

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -81,7 +81,7 @@ of the iOS app that is using this module.''',
       );
     }
 
-    var flutterRevision = shorebirdEnv.flutterRevision;
+    var flutterRevisionForRelease = shorebirdEnv.flutterRevision;
     if (flutterVersion != null) {
       final String? revision;
       try {
@@ -111,14 +111,15 @@ Use `shorebird flutter versions list` to list available versions.
         return ExitCode.software.code;
       }
 
-      flutterRevision = revision;
+      flutterRevisionForRelease = revision;
     }
 
     final originalFlutterRevision = shorebirdEnv.flutterRevision;
-    final switchFlutterRevision = flutterRevision != originalFlutterRevision;
+    final switchFlutterRevision =
+        flutterRevisionForRelease != originalFlutterRevision;
 
     if (switchFlutterRevision) {
-      await shorebirdFlutter.useRevision(revision: flutterRevision);
+      await shorebirdFlutter.useRevision(revision: flutterRevisionForRelease);
     }
 
     final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
@@ -172,7 +173,7 @@ ${summary.join('\n')}
       release = await codePushClientWrapper.createRelease(
         appId: appId,
         version: releaseVersion,
-        flutterRevision: flutterRevision,
+        flutterRevision: flutterRevisionForRelease,
         platform: releasePlatform,
       );
     }

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -151,7 +151,7 @@ void main() {
 
       when(() => auth.client).thenReturn(httpClient);
       when(() => argResults['build-number']).thenReturn(buildNumber);
-      when(() => argResults['release-version']).thenReturn(versionName);
+      when(() => argResults['release-version']).thenReturn(version);
       when(() => argResults.rest).thenReturn([]);
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => logger.confirm(any())).thenReturn(true);
@@ -352,6 +352,14 @@ $exception''',
             () => shorebirdFlutter.useRevision(revision: revision),
             () => shorebirdFlutter.useRevision(revision: flutterRevision),
           ]);
+          verify(
+            () => codePushClientWrapper.createRelease(
+              appId: appId,
+              version: version,
+              flutterRevision: revision,
+              platform: releasePlatform,
+            ),
+          ).called(1);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -353,6 +353,14 @@ $exception''',
             () => shorebirdFlutter.useRevision(revision: revision),
             () => shorebirdFlutter.useRevision(revision: flutterRevision),
           ]);
+          verify(
+            () => codePushClientWrapper.createRelease(
+              appId: appId,
+              version: version,
+              flutterRevision: revision,
+              platform: releasePlatform,
+            ),
+          ).called(1);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -715,6 +715,7 @@ $exception''',
       group('when flutter version is supported', () {
         const revision = '771d07b2cf';
         setUp(() {
+          setUpProjectRoot();
           when(
             () => shorebirdFlutter.getRevisionForVersion(any()),
           ).thenAnswer((_) async => revision);
@@ -733,6 +734,14 @@ $exception''',
             () => shorebirdFlutter.useRevision(revision: revision),
             () => shorebirdFlutter.useRevision(revision: flutterRevision),
           ]);
+          verify(
+            () => codePushClientWrapper.createRelease(
+              appId: appId,
+              version: version,
+              flutterRevision: revision,
+              platform: releasePlatform,
+            ),
+          ).called(1);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -323,6 +323,14 @@ $exception''',
             () => shorebirdFlutter.useRevision(revision: revision),
             () => shorebirdFlutter.useRevision(revision: flutterRevision),
           ]);
+          verify(
+            () => codePushClientWrapper.createRelease(
+              appId: appId,
+              version: version,
+              flutterRevision: revision,
+              platform: releasePlatform,
+            ),
+          ).called(1);
         });
       });
     });


### PR DESCRIPTION
## Description

Fixes a bug where we would record the incorrect Flutter revision for releases created with the non-default Flutter revision.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
