### PR TITLE
chore(shorebird_cli): update .xcframework used by release ios-framework for signing

### DIFF
--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -106,6 +106,20 @@ flutter:
       File(
         p.join(projectRoot.path, 'shorebird.yaml'),
       ).writeAsStringSync('app_id: $appId');
+      // Create an xcframework in the release directory to simulate running this
+      // command a subsequent time.
+      Directory(p.join(projectRoot.path, 'release', 'Flutter.xcframework'))
+          .createSync(recursive: true);
+      Directory(
+        p.join(
+          projectRoot.path,
+          'build',
+          'ios',
+          'framework',
+          'Release',
+          'Flutter.xcframework',
+        ),
+      ).createSync(recursive: true);
     }
 
     setUpAll(() {
@@ -316,9 +330,12 @@ $exception''',
         });
 
         test(
-            'uses specified flutter version to build '
-            'and reverts to original flutter version', () async {
+            '''uses specified flutter version to build and reverts to original flutter version''',
+            () async {
+          setUpProjectRoot();
+
           await runWithOverrides(command.run);
+
           verifyInOrder([
             () => shorebirdFlutter.useRevision(revision: revision),
             () => shorebirdFlutter.useRevision(revision: flutterRevision),
@@ -425,9 +442,10 @@ $exception''',
           any(
             that: stringContainsInOrder(
               [
-                'Your next step is to include the .xcframework files in',
-                p.join('build', 'ios', 'framework', 'Release'),
-                'in your iOS app.',
+                'Your next step is to add the .xcframework files found in',
+                'release',
+                'to your iOS app.',
+                '''Embed the App.xcframework and ShorebirdFlutter.framework in your Xcode project''',
               ],
             ),
           ),
@@ -440,7 +458,7 @@ $exception''',
           appFrameworkPath: any(
             named: 'appFrameworkPath',
             that: endsWith(
-              p.join('build', 'ios', 'framework', 'Release', 'App.xcframework'),
+              p.join('release', 'App.xcframework'),
             ),
           ),
         ),


### PR DESCRIPTION
## Description

Updates `release ios-framework` command to:

1. Move .xcframework files to `release` directory to avoid overwriting them with subsequent `patch ios-framework` commands. This matches what `release aab` does, and will allow users to repeatedly launch from Xcode with the release xcarchive and more easily test patching.
2. Rename Flutter.xcframework to ShorebirdFlutter.xcframework to avoid the `“Flutter.xcframework” is not signed with the expected identity and may have been compromised.` error in Xcode.

<img width="564" alt="Screenshot 2024-03-13 at 8 22 30 PM" src="https://github.com/shorebirdtech/shorebird/assets/581764/f3fabb98-fa46-4bbb-a69b-99a428a81283">

Related docs PR: https://github.com/shorebirdtech/docs/pull/191

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
