### PR TITLE
fix(shorebird_cli): run all release and patch commands with a scoped shorebirdEnv

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_use_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_use_command.dart
@@ -47,15 +47,9 @@ Usage: shorebird flutter versions use <version>''');
 
     final version = results.rest.first;
     if (_shaRegExp.hasMatch(version)) {
-      final installRevisionProgress = logger.progress(
-        'Installing Flutter $version',
-      );
       try {
         await shorebirdFlutter.useRevision(revision: version);
-        installRevisionProgress.complete();
-      } catch (error) {
-        installRevisionProgress.fail('Failed to install Flutter $version.');
-        logger.err('$error');
+      } catch (_) {
         return ExitCode.software.code;
       }
 
@@ -88,15 +82,9 @@ Use `shorebird flutter versions list` to list available versions.''');
       return ExitCode.software.code;
     }
 
-    final installRevisionProgress = logger.progress(
-      'Installing Flutter $version',
-    );
     try {
       await shorebirdFlutter.useVersion(version: version);
-      installRevisionProgress.complete();
-    } catch (error) {
-      installRevisionProgress.fail('Failed to install Flutter $version.');
-      logger.err('$error');
+    } catch (_) {
       return ExitCode.software.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -20,6 +20,7 @@ import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
@@ -159,9 +160,16 @@ Please re-run the release command for this version or create a new release.''');
       return ExitCode.software.code;
     }
 
+    final flutterInstallProgress = logger.progress(
+      'Installing Flutter ${release.flutterRevision}',
+    );
+    await shorebirdFlutter.installRevision(revision: release.flutterRevision);
+    flutterInstallProgress.complete();
+
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: release.flutterRevision,
     );
+
     return await runScoped(
       () async {
         final buildNumber = results['build-number'] as String;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -160,11 +160,11 @@ Please re-run the release command for this version or create a new release.''');
       return ExitCode.software.code;
     }
 
-    final flutterInstallProgress = logger.progress(
-      'Installing Flutter ${release.flutterRevision}',
-    );
-    await shorebirdFlutter.installRevision(revision: release.flutterRevision);
-    flutterInstallProgress.complete();
+    try {
+      await shorebirdFlutter.installRevision(revision: release.flutterRevision);
+    } catch (_) {
+      return ExitCode.software.code;
+    }
 
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: release.flutterRevision,

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
+import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/cache.dart';
@@ -158,105 +159,113 @@ Please re-run the release command for this version or create a new release.''');
       return ExitCode.software.code;
     }
 
-    final buildNumber = results['build-number'] as String;
-    final buildProgress = logger.progress('Building patch');
-    try {
-      await buildAar(
-        buildNumber: buildNumber,
-        flutterRevision: release.flutterRevision,
-      );
-      buildProgress.complete();
-    } on ProcessException catch (error) {
-      buildProgress.fail('Failed to build: ${error.message}');
-      return ExitCode.software.code;
-    }
-
-    final extractedAarDir = await extractAar(
-      packageName: shorebirdEnv.androidPackageName!,
-      buildNumber: buildNumber,
-      unzipFn: _unzipFn,
+    final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
+      flutterRevisionOverride: release.flutterRevision,
     );
+    return await runScoped(
+      () async {
+        final buildNumber = results['build-number'] as String;
+        final buildProgress = logger.progress('Building patch');
+        try {
+          await buildAar(buildNumber: buildNumber);
+          buildProgress.complete();
+        } on ProcessException catch (error) {
+          buildProgress.fail('Failed to build: ${error.message}');
+          return ExitCode.software.code;
+        }
 
-    final DiffStatus diffStatus;
-    try {
-      diffStatus = await patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-        localArtifact: File(
-          aarArtifactPath(
-            packageName: shorebirdEnv.androidPackageName!,
-            buildNumber: buildNumber,
-          ),
-        ),
-        releaseArtifact: await artifactManager
-            .downloadFile(Uri.parse(releaseAarArtifact.url)),
-        archiveDiffer: _archiveDiffer,
-        force: force,
-      );
-    } on UserCancelledException {
-      return ExitCode.success.code;
-    } on UnpatchableChangeException {
-      logger.info('Exiting.');
-      return ExitCode.software.code;
-    }
+        final extractedAarDir = await extractAar(
+          packageName: shorebirdEnv.androidPackageName!,
+          buildNumber: buildNumber,
+          unzipFn: _unzipFn,
+        );
 
-    final patchArtifactBundles = await _createPatchArtifacts(
-      releaseArtifactPaths: releaseArtifactPaths,
-      extractedAarDirectory: extractedAarDir,
-    );
-    if (patchArtifactBundles == null) {
-      return ExitCode.software.code;
-    }
+        final DiffStatus diffStatus;
+        try {
+          diffStatus =
+              await patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+            localArtifact: File(
+              aarArtifactPath(
+                packageName: shorebirdEnv.androidPackageName!,
+                buildNumber: buildNumber,
+              ),
+            ),
+            releaseArtifact: await artifactManager
+                .downloadFile(Uri.parse(releaseAarArtifact.url)),
+            archiveDiffer: _archiveDiffer,
+            force: force,
+          );
+        } on UserCancelledException {
+          return ExitCode.success.code;
+        } on UnpatchableChangeException {
+          logger.info('Exiting.');
+          return ExitCode.software.code;
+        }
 
-    final archMetadata = patchArtifactBundles.keys.map((arch) {
-      final name = arch.name;
-      final size = formatBytes(patchArtifactBundles[arch]!.size);
-      return '$name ($size)';
-    });
+        final patchArtifactBundles = await _createPatchArtifacts(
+          releaseArtifactPaths: releaseArtifactPaths,
+          extractedAarDirectory: extractedAarDir,
+        );
+        if (patchArtifactBundles == null) {
+          return ExitCode.software.code;
+        }
 
-    if (dryRun) {
-      logger
-        ..info('No issues detected.')
-        ..info('The server may enforce additional checks.');
-      return ExitCode.success.code;
-    }
+        final archMetadata = patchArtifactBundles.keys.map((arch) {
+          final name = arch.name;
+          final size = formatBytes(patchArtifactBundles[arch]!.size);
+          return '$name ($size)';
+        });
 
-    final summary = [
-      '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('(${app.appId})')}''',
-      '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
-      '''🕹️  Platform: ${lightCyan.wrap(platform.name)} ${lightCyan.wrap('[${archMetadata.join(', ')}]')}''',
-      '🟢 Track: ${lightCyan.wrap('Production')}',
-    ];
+        if (dryRun) {
+          logger
+            ..info('No issues detected.')
+            ..info('The server may enforce additional checks.');
+          return ExitCode.success.code;
+        }
 
-    logger.info(
-      '''
+        final summary = [
+          '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('(${app.appId})')}''',
+          '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
+          '''🕹️  Platform: ${lightCyan.wrap(platform.name)} ${lightCyan.wrap('[${archMetadata.join(', ')}]')}''',
+          '🟢 Track: ${lightCyan.wrap('Production')}',
+        ];
+
+        logger.info(
+          '''
 
 ${styleBold.wrap(lightGreen.wrap('🚀 Ready to publish a new patch!'))}
 
 ${summary.join('\n')}
 ''',
-    );
+        );
 
-    final needsConfirmation = !force && !shorebirdEnv.isRunningOnCI;
-    if (needsConfirmation) {
-      final confirm = logger.confirm('Would you like to continue?');
+        final needsConfirmation = !force && !shorebirdEnv.isRunningOnCI;
+        if (needsConfirmation) {
+          final confirm = logger.confirm('Would you like to continue?');
 
-      if (!confirm) {
-        logger.info('Aborting.');
+          if (!confirm) {
+            logger.info('Aborting.');
+            return ExitCode.success.code;
+          }
+        }
+
+        await codePushClientWrapper.publishPatch(
+          appId: appId,
+          releaseId: release.id,
+          wasForced: force,
+          hasAssetChanges: diffStatus.hasAssetChanges,
+          hasNativeChanges: diffStatus.hasNativeChanges,
+          platform: platform,
+          track: DeploymentTrack.production,
+          patchArtifactBundles: patchArtifactBundles,
+        );
+
         return ExitCode.success.code;
-      }
-    }
-
-    await codePushClientWrapper.publishPatch(
-      appId: appId,
-      releaseId: release.id,
-      wasForced: force,
-      hasAssetChanges: diffStatus.hasAssetChanges,
-      hasNativeChanges: diffStatus.hasNativeChanges,
-      platform: platform,
-      track: DeploymentTrack.production,
-      patchArtifactBundles: patchArtifactBundles,
+      },
+      values: {
+        shorebirdEnvRef.overrideWith(() => releaseFlutterShorebirdEnv),
+      },
     );
-
-    return ExitCode.success.code;
   }
 
   Future<String?> _promptForReleaseVersion(List<Release> releases) async {

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -185,11 +185,11 @@ Current Flutter Revision: $currentFlutterRevision
 ''');
     }
 
-    final flutterInstallProgress = logger.progress(
-      'Installing Flutter ${release.flutterRevision}',
-    );
-    await shorebirdFlutter.installRevision(revision: release.flutterRevision);
-    flutterInstallProgress.complete();
+    try {
+      await shorebirdFlutter.installRevision(revision: release.flutterRevision);
+    } catch (_) {
+      return ExitCode.software.code;
+    }
 
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: release.flutterRevision,

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -19,6 +19,7 @@ import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_release_version_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -183,6 +184,12 @@ Release Flutter Revision: ${release.flutterRevision}
 Current Flutter Revision: $currentFlutterRevision
 ''');
     }
+
+    final flutterInstallProgress = logger.progress(
+      'Installing Flutter ${release.flutterRevision}',
+    );
+    await shorebirdFlutter.installRevision(revision: release.flutterRevision);
+    flutterInstallProgress.complete();
 
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: release.flutterRevision,

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io' hide Platform;
-import 'dart:isolate';
 
 import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
@@ -245,16 +244,14 @@ Current Flutter Revision: $currentFlutterRevision
           return ExitCode.software.code;
         }
 
-        final extractZip = artifactManager.extractZip;
         final unzipProgress = logger.progress('Extracting release artifact');
-        final releaseXcarchivePath = await Isolate.run(() async {
-          final tempDir = Directory.systemTemp.createTempSync();
-          await extractZip(
-            zipFile: releaseArtifactZipFile,
-            outputDirectory: tempDir,
-          );
-          return tempDir.path;
-        });
+        final tempDir = Directory.systemTemp.createTempSync();
+        await artifactManager.extractZip(
+          zipFile: releaseArtifactZipFile,
+          outputDirectory: tempDir,
+        );
+        final releaseXcarchivePath = tempDir.path;
+
         unzipProgress.complete();
         final appDirectory = getAppDirectory(
           xcarchiveDirectory: Directory(releaseXcarchivePath),

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -25,6 +25,7 @@ import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
@@ -178,9 +179,16 @@ Current Flutter Revision: $currentFlutterRevision
       );
     }
 
+    final flutterInstallProgress = logger.progress(
+      'Installing Flutter ${release.flutterRevision}',
+    );
+    await shorebirdFlutter.installRevision(revision: release.flutterRevision);
+    flutterInstallProgress.complete();
+
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: release.flutterRevision,
     );
+
     return await runScoped(
       () async {
         if (!hasBuiltWithActiveFlutter ||

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -178,11 +178,11 @@ Current Flutter Revision: $currentFlutterRevision
       );
     }
 
-    final flutterInstallProgress = logger.progress(
-      'Installing Flutter ${release.flutterRevision}',
-    );
-    await shorebirdFlutter.installRevision(revision: release.flutterRevision);
-    flutterInstallProgress.complete();
+    try {
+      await shorebirdFlutter.installRevision(revision: release.flutterRevision);
+    } catch (_) {
+      return ExitCode.software.code;
+    }
 
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: release.flutterRevision,

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -6,6 +6,7 @@ import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
+import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -24,7 +25,6 @@ import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
-import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
@@ -178,203 +178,202 @@ Current Flutter Revision: $currentFlutterRevision
       );
     }
 
-    if (!hasBuiltWithActiveFlutter ||
-        release.flutterRevision != currentFlutterRevision) {
-      try {
-        await _buildPatch(
-          flavor: flavor,
-          target: target,
-          flutterRevision: release.flutterRevision,
-        );
-      } catch (_) {
-        return ExitCode.software.code;
-      }
-    }
-
-    final archivePath = getXcarchiveDirectory()?.path;
-    if (archivePath == null) {
-      logger.err('Unable to find .xcarchive directory');
-      return ExitCode.software.code;
-    }
-
-    final releaseArtifact = await codePushClientWrapper.getReleaseArtifact(
-      appId: appId,
-      releaseId: release.id,
-      arch: 'xcarchive',
-      platform: ReleasePlatform.ios,
+    final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
+      flutterRevisionOverride: release.flutterRevision,
     );
+    return await runScoped(
+      () async {
+        if (!hasBuiltWithActiveFlutter ||
+            release.flutterRevision != currentFlutterRevision) {
+          try {
+            await _buildPatch(flavor: flavor, target: target);
+          } catch (_) {
+            return ExitCode.software.code;
+          }
+        }
 
-    final downloadProgress = logger.progress('Downloading release artifact');
-    final File releaseArtifactZipFile;
-    try {
-      releaseArtifactZipFile = await artifactManager.downloadFile(
-        Uri.parse(releaseArtifact.url),
-      );
-      if (!releaseArtifactZipFile.existsSync()) {
-        throw Exception('Failed to download release artifact');
-      }
-    } catch (error) {
-      downloadProgress.fail('$error');
-      return ExitCode.software.code;
-    }
-    downloadProgress.complete();
+        final archivePath = getXcarchiveDirectory()?.path;
+        if (archivePath == null) {
+          logger.err('Unable to find .xcarchive directory');
+          return ExitCode.software.code;
+        }
 
-    final DiffStatus diffStatus;
-    try {
-      diffStatus =
-          await patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
-        localArtifactDirectory: Directory(archivePath),
-        releaseArtifact: releaseArtifactZipFile,
-        archiveDiffer: _archiveDiffer,
-        force: force,
-      );
-    } on UserCancelledException {
-      return ExitCode.success.code;
-    } on UnpatchableChangeException {
-      logger.info('Exiting.');
-      return ExitCode.software.code;
-    }
-
-    final extractZip = artifactManager.extractZip;
-    final unzipProgress = logger.progress('Extracting release artifact');
-    final releaseXcarchivePath = await Isolate.run(() async {
-      final tempDir = Directory.systemTemp.createTempSync();
-      await extractZip(
-        zipFile: releaseArtifactZipFile,
-        outputDirectory: tempDir,
-      );
-      return tempDir.path;
-    });
-    unzipProgress.complete();
-    final appDirectory =
-        getAppDirectory(xcarchiveDirectory: Directory(releaseXcarchivePath));
-    if (appDirectory == null) {
-      logger.err('Unable to find release artifact .app directory');
-      return ExitCode.software.code;
-    }
-    final releaseArtifactFile = File(
-      p.join(
-        appDirectory.path,
-        'Frameworks',
-        'App.framework',
-        'App',
-      ),
-    );
-
-    final useLinker = engineConfig.localEngine != null ||
-        !preLinkerFlutterRevisions.contains(release.flutterRevision);
-    if (useLinker) {
-      // Because aot-tools is versioned with the engine, we need to use the
-      // original Flutter revision to link the patch. We have already switched
-      // to and from the release's Flutter revision before and could
-      // theoretically have just stayed on that revision until after _runLinker,
-      // but this approach makes it less likely that we will leave the user on
-      // a different version of Flutter than they started with if something
-      // goes wrong.
-      if (release.flutterRevision != currentFlutterRevision) {
-        await shorebirdFlutter.useRevision(revision: release.flutterRevision);
-      }
-      final exitCode = await _runLinker(
-        releaseArtifact: releaseArtifactFile,
-      );
-      if (release.flutterRevision != currentFlutterRevision) {
-        await shorebirdFlutter.useRevision(revision: currentFlutterRevision);
-      }
-      if (exitCode != ExitCode.success.code) {
-        return exitCode;
-      }
-    }
-
-    if (dryRun) {
-      logger
-        ..info('No issues detected.')
-        ..info('The server may enforce additional checks.');
-      return ExitCode.success.code;
-    }
-
-    final patchBuildFile = File(useLinker ? _vmcodeOutputPath : _aotOutputPath);
-    final File patchFile;
-    if (useLinker && await aotTools.isGeneratePatchDiffBaseSupported()) {
-      final patchBaseProgress = logger.progress('Generating patch diff base');
-      final analyzeSnapshotPath = shorebirdArtifacts.getArtifactPath(
-        artifact: ShorebirdArtifact.analyzeSnapshot,
-      );
-
-      final File patchBaseFile;
-      try {
-        // If the aot_tools executable supports the dump_blobs command, we
-        // can generate a stable diff base and use that to create a patch.
-        patchBaseFile = await aotTools.generatePatchDiffBase(
-          analyzeSnapshotPath: analyzeSnapshotPath,
-          releaseSnapshot: releaseArtifactFile,
+        final releaseArtifact = await codePushClientWrapper.getReleaseArtifact(
+          appId: appId,
+          releaseId: release.id,
+          arch: 'xcarchive',
+          platform: ReleasePlatform.ios,
         );
-        patchBaseProgress.complete();
-      } catch (error) {
-        patchBaseProgress.fail('$error');
-        return ExitCode.software.code;
-      }
 
-      patchFile = File(
-        await artifactManager.createDiff(
-          releaseArtifactPath: patchBaseFile.path,
-          patchArtifactPath: patchBuildFile.path,
-        ),
-      );
-    } else {
-      patchFile = patchBuildFile;
-    }
+        final downloadProgress =
+            logger.progress('Downloading release artifact');
+        final File releaseArtifactZipFile;
+        try {
+          releaseArtifactZipFile = await artifactManager.downloadFile(
+            Uri.parse(releaseArtifact.url),
+          );
+          if (!releaseArtifactZipFile.existsSync()) {
+            throw Exception('Failed to download release artifact');
+          }
+        } catch (error) {
+          downloadProgress.fail('$error');
+          return ExitCode.software.code;
+        }
+        downloadProgress.complete();
 
-    final patchFileSize = patchFile.statSync().size;
+        final DiffStatus diffStatus;
+        try {
+          diffStatus =
+              await patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
+            localArtifactDirectory: Directory(archivePath),
+            releaseArtifact: releaseArtifactZipFile,
+            archiveDiffer: _archiveDiffer,
+            force: force,
+          );
+        } on UserCancelledException {
+          return ExitCode.success.code;
+        } on UnpatchableChangeException {
+          logger.info('Exiting.');
+          return ExitCode.software.code;
+        }
 
-    final summary = [
-      '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('($appId)')}''',
-      if (flavor != null) '🍧 Flavor: ${lightCyan.wrap(flavor)}',
-      '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
-      '''🕹️  Platform: ${lightCyan.wrap(releasePlatform.name)} ${lightCyan.wrap('[$arch (${formatBytes(patchFileSize)})]')}''',
-      if (isStaging)
-        '🟠 Track: ${lightCyan.wrap('Staging')}'
-      else
-        '🟢 Track: ${lightCyan.wrap('Production')}',
-    ];
+        final extractZip = artifactManager.extractZip;
+        final unzipProgress = logger.progress('Extracting release artifact');
+        final releaseXcarchivePath = await Isolate.run(() async {
+          final tempDir = Directory.systemTemp.createTempSync();
+          await extractZip(
+            zipFile: releaseArtifactZipFile,
+            outputDirectory: tempDir,
+          );
+          return tempDir.path;
+        });
+        unzipProgress.complete();
+        final appDirectory = getAppDirectory(
+          xcarchiveDirectory: Directory(releaseXcarchivePath),
+        );
+        if (appDirectory == null) {
+          logger.err('Unable to find release artifact .app directory');
+          return ExitCode.software.code;
+        }
+        final releaseArtifactFile = File(
+          p.join(
+            appDirectory.path,
+            'Frameworks',
+            'App.framework',
+            'App',
+          ),
+        );
 
-    logger.info(
-      '''
+        final useLinker = engineConfig.localEngine != null ||
+            !preLinkerFlutterRevisions.contains(release.flutterRevision);
+        if (useLinker) {
+          final exitCode = await _runLinker(
+            releaseArtifact: releaseArtifactFile,
+          );
+
+          if (exitCode != ExitCode.success.code) {
+            return exitCode;
+          }
+        }
+
+        if (dryRun) {
+          logger
+            ..info('No issues detected.')
+            ..info('The server may enforce additional checks.');
+          return ExitCode.success.code;
+        }
+
+        final patchBuildFile =
+            File(useLinker ? _vmcodeOutputPath : _aotOutputPath);
+        final File patchFile;
+        if (useLinker && await aotTools.isGeneratePatchDiffBaseSupported()) {
+          final patchBaseProgress =
+              logger.progress('Generating patch diff base');
+          final analyzeSnapshotPath = shorebirdArtifacts.getArtifactPath(
+            artifact: ShorebirdArtifact.analyzeSnapshot,
+          );
+
+          final File patchBaseFile;
+          try {
+            // If the aot_tools executable supports the dump_blobs command, we
+            // can generate a stable diff base and use that to create a patch.
+            patchBaseFile = await aotTools.generatePatchDiffBase(
+              analyzeSnapshotPath: analyzeSnapshotPath,
+              releaseSnapshot: releaseArtifactFile,
+            );
+            patchBaseProgress.complete();
+          } catch (error) {
+            patchBaseProgress.fail('$error');
+            return ExitCode.software.code;
+          }
+
+          patchFile = File(
+            await artifactManager.createDiff(
+              releaseArtifactPath: patchBaseFile.path,
+              patchArtifactPath: patchBuildFile.path,
+            ),
+          );
+        } else {
+          patchFile = patchBuildFile;
+        }
+
+        final patchFileSize = patchFile.statSync().size;
+
+        final summary = [
+          '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('($appId)')}''',
+          if (flavor != null) '🍧 Flavor: ${lightCyan.wrap(flavor)}',
+          '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
+          '''🕹️  Platform: ${lightCyan.wrap(releasePlatform.name)} ${lightCyan.wrap('[$arch (${formatBytes(patchFileSize)})]')}''',
+          if (isStaging)
+            '🟠 Track: ${lightCyan.wrap('Staging')}'
+          else
+            '🟢 Track: ${lightCyan.wrap('Production')}',
+        ];
+
+        logger.info(
+          '''
 
 ${styleBold.wrap(lightGreen.wrap('🚀 Ready to publish a new patch!'))}
 
 ${summary.join('\n')}
 ''',
-    );
+        );
 
-    final needsConfirmation = !force && !shorebirdEnv.isRunningOnCI;
-    if (needsConfirmation) {
-      final confirm = logger.confirm('Would you like to continue?');
+        final needsConfirmation = !force && !shorebirdEnv.isRunningOnCI;
+        if (needsConfirmation) {
+          final confirm = logger.confirm('Would you like to continue?');
 
-      if (!confirm) {
-        logger.info('Aborting.');
+          if (!confirm) {
+            logger.info('Aborting.');
+            return ExitCode.success.code;
+          }
+        }
+
+        await codePushClientWrapper.publishPatch(
+          appId: appId,
+          releaseId: release.id,
+          wasForced: force,
+          hasAssetChanges: diffStatus.hasAssetChanges,
+          hasNativeChanges: diffStatus.hasNativeChanges,
+          platform: releasePlatform,
+          track:
+              isStaging ? DeploymentTrack.staging : DeploymentTrack.production,
+          patchArtifactBundles: {
+            Arch.arm64: PatchArtifactBundle(
+              arch: arch,
+              path: patchFile.path,
+              hash: _hashFn(patchBuildFile.readAsBytesSync()),
+              size: patchFileSize,
+            ),
+          },
+        );
+
         return ExitCode.success.code;
-      }
-    }
-
-    await codePushClientWrapper.publishPatch(
-      appId: appId,
-      releaseId: release.id,
-      wasForced: force,
-      hasAssetChanges: diffStatus.hasAssetChanges,
-      hasNativeChanges: diffStatus.hasNativeChanges,
-      platform: releasePlatform,
-      track: isStaging ? DeploymentTrack.staging : DeploymentTrack.production,
-      patchArtifactBundles: {
-        Arch.arm64: PatchArtifactBundle(
-          arch: arch,
-          path: patchFile.path,
-          hash: _hashFn(patchBuildFile.readAsBytesSync()),
-          size: patchFileSize,
-        ),
+      },
+      values: {
+        shorebirdEnvRef.overrideWith(() => releaseFlutterShorebirdEnv),
       },
     );
-
-    return ExitCode.success.code;
   }
 
   String get _buildDirectory => p.join(
@@ -418,7 +417,6 @@ ${summary.join('\n')}
   Future<void> _buildPatch({
     required String? flavor,
     required String? target,
-    String? flutterRevision,
   }) async {
     final shouldCodesign = results['codesign'] == true;
     final buildProgress = logger.progress('Building patch');
@@ -429,7 +427,6 @@ ${summary.join('\n')}
         codesign: shouldCodesign,
         flavor: flavor,
         target: target,
-        flutterRevision: flutterRevision,
       );
     } on ProcessException catch (error) {
       buildProgress.fail('Failed to build: ${error.message}');

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
@@ -137,6 +137,12 @@ Please re-run the release command for this version or create a new release.''');
       return ExitCode.software.code;
     }
 
+    final flutterInstallProgress = logger.progress(
+      'Installing Flutter ${release.flutterRevision}',
+    );
+    await shorebirdFlutter.installRevision(revision: release.flutterRevision);
+    flutterInstallProgress.complete();
+
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: release.flutterRevision,
     );

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
@@ -1,5 +1,4 @@
 import 'dart:io' hide Platform;
-import 'dart:isolate';
 
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
@@ -234,29 +233,13 @@ Please re-run the release command for this version or create a new release.''');
           ),
         );
 
-        final currentFlutterRevision = shorebirdEnv.flutterRevision;
         final useLinker = engineConfig.localEngine != null ||
             !preLinkerFlutterRevisions.contains(release.flutterRevision);
         if (useLinker) {
-          // Because aot-tools is versioned with the engine, we need to use the
-          // original Flutter revision to link the patch. We have already switched
-          // to and from the release's Flutter revision before and could
-          // theoretically have just stayed on that revision until after _runLinker,
-          // but this approach makes it less likely that we will leave the user on
-          // a different version of Flutter than they started with if something
-          // goes wrong.
-          if (release.flutterRevision != currentFlutterRevision) {
-            await shorebirdFlutter.useRevision(
-                revision: release.flutterRevision);
-          }
           final exitCode = await _runLinker(
             aotSnapshot: aotSnapshotFile,
             releaseArtifact: releaseArtifactFile,
           );
-          if (release.flutterRevision != currentFlutterRevision) {
-            await shorebirdFlutter.useRevision(
-                revision: currentFlutterRevision);
-          }
           if (exitCode != ExitCode.success.code) {
             return exitCode;
           }

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
@@ -6,6 +6,7 @@ import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
+import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -136,205 +137,220 @@ Please re-run the release command for this version or create a new release.''');
       return ExitCode.software.code;
     }
 
-    final buildProgress = logger.progress('Building patch');
-    try {
-      await buildIosFramework(flutterRevision: release.flutterRevision);
-      buildProgress.complete();
-    } on ProcessException catch (error) {
-      buildProgress.fail('Failed to build: ${error.message}');
-      return ExitCode.software.code;
-    }
-
-    final File aotSnapshotFile;
-    try {
-      final newestDillFile = newestAppDill();
-      aotSnapshotFile = await buildElfAotSnapshot(
-        appDillPath: newestDillFile.path,
-        outFilePath: p.join(
-          shorebirdEnv.getShorebirdProjectRoot()!.path,
-          'build',
-          'out.aot',
-        ),
-      );
-    } catch (error) {
-      buildProgress.fail('$error');
-      return ExitCode.software.code;
-    }
-
-    buildProgress.complete();
-
-    final releaseArtifact = await codePushClientWrapper.getReleaseArtifact(
-      appId: appId,
-      releaseId: release.id,
-      arch: 'xcframework',
-      platform: ReleasePlatform.ios,
+    final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
+      flutterRevisionOverride: release.flutterRevision,
     );
 
-    final downloadProgress = logger.progress('Downloading release artifact');
-    final File releaseArtifactZipFile;
-    try {
-      releaseArtifactZipFile = await artifactManager.downloadFile(
-        Uri.parse(releaseArtifact.url),
-      );
-      if (!releaseArtifactZipFile.existsSync()) {
-        throw Exception('Failed to download release artifact');
-      }
-    } catch (error) {
-      downloadProgress.fail('$error');
-      return ExitCode.software.code;
-    }
-    downloadProgress.complete();
+    return await runScoped(
+      () async {
+        final buildProgress = logger.progress('Building patch');
+        try {
+          await buildIosFramework();
+          buildProgress.complete();
+        } on ProcessException catch (error) {
+          buildProgress.fail('Failed to build: ${error.message}');
+          return ExitCode.software.code;
+        }
 
-    final DiffStatus diffStatus;
-    try {
-      diffStatus =
-          await patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
-        localArtifactDirectory: Directory(getAppXcframeworkPath()),
-        releaseArtifact: releaseArtifactZipFile,
-        archiveDiffer: _archiveDiffer,
-        force: force,
-      );
-    } on UserCancelledException {
-      return ExitCode.success.code;
-    } on UnpatchableChangeException {
-      logger.info('Exiting.');
-      return ExitCode.software.code;
-    }
+        final File aotSnapshotFile;
+        try {
+          final newestDillFile = newestAppDill();
+          aotSnapshotFile = await buildElfAotSnapshot(
+            appDillPath: newestDillFile.path,
+            outFilePath: p.join(
+              shorebirdEnv.getShorebirdProjectRoot()!.path,
+              'build',
+              'out.aot',
+            ),
+          );
+        } catch (error) {
+          buildProgress.fail('$error');
+          return ExitCode.software.code;
+        }
 
-    final extractZip = artifactManager.extractZip;
-    final unzipProgress = logger.progress('Extracting release artifact');
-    final releaseXcframeworkPath = await Isolate.run(() async {
-      final tempDir = Directory.systemTemp.createTempSync();
-      await extractZip(
-        zipFile: releaseArtifactZipFile,
-        outputDirectory: tempDir,
-      );
-      return tempDir.path;
-    });
+        buildProgress.complete();
 
-    unzipProgress
-        .complete('Extracted release artifact to $releaseXcframeworkPath');
-    final releaseArtifactFile = File(
-      p.join(
-        releaseXcframeworkPath,
-        'ios-arm64',
-        'App.framework',
-        'App',
-      ),
-    );
-
-    final currentFlutterRevision = shorebirdEnv.flutterRevision;
-    final useLinker = engineConfig.localEngine != null ||
-        !preLinkerFlutterRevisions.contains(release.flutterRevision);
-    if (useLinker) {
-      // Because aot-tools is versioned with the engine, we need to use the
-      // original Flutter revision to link the patch. We have already switched
-      // to and from the release's Flutter revision before and could
-      // theoretically have just stayed on that revision until after _runLinker,
-      // but this approach makes it less likely that we will leave the user on
-      // a different version of Flutter than they started with if something
-      // goes wrong.
-      if (release.flutterRevision != currentFlutterRevision) {
-        await shorebirdFlutter.useRevision(revision: release.flutterRevision);
-      }
-      final exitCode = await _runLinker(
-        aotSnapshot: aotSnapshotFile,
-        releaseArtifact: releaseArtifactFile,
-      );
-      if (release.flutterRevision != currentFlutterRevision) {
-        await shorebirdFlutter.useRevision(revision: currentFlutterRevision);
-      }
-      if (exitCode != ExitCode.success.code) {
-        return exitCode;
-      }
-    }
-
-    final patchBuildFile =
-        useLinker ? File(_vmcodeOutputPath) : aotSnapshotFile;
-    final File patchFile;
-    if (await aotTools.isGeneratePatchDiffBaseSupported()) {
-      final patchBaseProgress = logger.progress('Generating patch diff base');
-      final analyzeSnapshotPath = shorebirdArtifacts.getArtifactPath(
-        artifact: ShorebirdArtifact.analyzeSnapshot,
-      );
-
-      final File patchBaseFile;
-      try {
-        // If the aot_tools executable supports the dump_blobs command, we
-        // can generate a stable diff base and use that to create a patch.
-        patchBaseFile = await aotTools.generatePatchDiffBase(
-          analyzeSnapshotPath: analyzeSnapshotPath,
-          releaseSnapshot: releaseArtifactFile,
+        final releaseArtifact = await codePushClientWrapper.getReleaseArtifact(
+          appId: appId,
+          releaseId: release.id,
+          arch: 'xcframework',
+          platform: ReleasePlatform.ios,
         );
-        patchBaseProgress.complete();
-      } catch (error) {
-        patchBaseProgress.fail('$error');
-        return ExitCode.software.code;
-      }
 
-      patchFile = File(
-        await artifactManager.createDiff(
-          releaseArtifactPath: patchBaseFile.path,
-          patchArtifactPath: patchBuildFile.path,
-        ),
-      );
-    } else {
-      patchFile = patchBuildFile;
-    }
+        final downloadProgress =
+            logger.progress('Downloading release artifact');
+        final File releaseArtifactZipFile;
+        try {
+          releaseArtifactZipFile = await artifactManager.downloadFile(
+            Uri.parse(releaseArtifact.url),
+          );
+          if (!releaseArtifactZipFile.existsSync()) {
+            throw Exception('Failed to download release artifact');
+          }
+        } catch (error) {
+          downloadProgress.fail('$error');
+          return ExitCode.software.code;
+        }
+        downloadProgress.complete();
 
-    if (dryRun) {
-      logger
-        ..info('No issues detected.')
-        ..info('The server may enforce additional checks.');
-      return ExitCode.success.code;
-    }
+        final DiffStatus diffStatus;
+        try {
+          diffStatus =
+              await patchDiffChecker.zipAndConfirmUnpatchableDiffsIfNecessary(
+            localArtifactDirectory: Directory(getAppXcframeworkPath()),
+            releaseArtifact: releaseArtifactZipFile,
+            archiveDiffer: _archiveDiffer,
+            force: force,
+          );
+        } on UserCancelledException {
+          return ExitCode.success.code;
+        } on UnpatchableChangeException {
+          logger.info('Exiting.');
+          return ExitCode.software.code;
+        }
 
-    final patchFileSize = patchFile.statSync().size;
-    final summary = [
-      '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('($appId)')}''',
-      '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
-      '''🕹️  Platform: ${lightCyan.wrap(releasePlatform.name)} ${lightCyan.wrap('[$arch (${formatBytes(patchFileSize)})]')}''',
-      '🟢 Track: ${lightCyan.wrap('Production')}',
-    ];
+        final extractZip = artifactManager.extractZip;
+        final unzipProgress = logger.progress('Extracting release artifact');
+        final releaseXcframeworkPath = await Isolate.run(() async {
+          final tempDir = Directory.systemTemp.createTempSync();
+          await extractZip(
+            zipFile: releaseArtifactZipFile,
+            outputDirectory: tempDir,
+          );
+          return tempDir.path;
+        });
 
-    logger.info(
-      '''
+        unzipProgress
+            .complete('Extracted release artifact to $releaseXcframeworkPath');
+        final releaseArtifactFile = File(
+          p.join(
+            releaseXcframeworkPath,
+            'ios-arm64',
+            'App.framework',
+            'App',
+          ),
+        );
+
+        final currentFlutterRevision = shorebirdEnv.flutterRevision;
+        final useLinker = engineConfig.localEngine != null ||
+            !preLinkerFlutterRevisions.contains(release.flutterRevision);
+        if (useLinker) {
+          // Because aot-tools is versioned with the engine, we need to use the
+          // original Flutter revision to link the patch. We have already switched
+          // to and from the release's Flutter revision before and could
+          // theoretically have just stayed on that revision until after _runLinker,
+          // but this approach makes it less likely that we will leave the user on
+          // a different version of Flutter than they started with if something
+          // goes wrong.
+          if (release.flutterRevision != currentFlutterRevision) {
+            await shorebirdFlutter.useRevision(
+                revision: release.flutterRevision);
+          }
+          final exitCode = await _runLinker(
+            aotSnapshot: aotSnapshotFile,
+            releaseArtifact: releaseArtifactFile,
+          );
+          if (release.flutterRevision != currentFlutterRevision) {
+            await shorebirdFlutter.useRevision(
+                revision: currentFlutterRevision);
+          }
+          if (exitCode != ExitCode.success.code) {
+            return exitCode;
+          }
+        }
+
+        final patchBuildFile =
+            useLinker ? File(_vmcodeOutputPath) : aotSnapshotFile;
+        final File patchFile;
+        if (await aotTools.isGeneratePatchDiffBaseSupported()) {
+          final patchBaseProgress =
+              logger.progress('Generating patch diff base');
+          final analyzeSnapshotPath = shorebirdArtifacts.getArtifactPath(
+            artifact: ShorebirdArtifact.analyzeSnapshot,
+          );
+
+          final File patchBaseFile;
+          try {
+            // If the aot_tools executable supports the dump_blobs command, we
+            // can generate a stable diff base and use that to create a patch.
+            patchBaseFile = await aotTools.generatePatchDiffBase(
+              analyzeSnapshotPath: analyzeSnapshotPath,
+              releaseSnapshot: releaseArtifactFile,
+            );
+            patchBaseProgress.complete();
+          } catch (error) {
+            patchBaseProgress.fail('$error');
+            return ExitCode.software.code;
+          }
+
+          patchFile = File(
+            await artifactManager.createDiff(
+              releaseArtifactPath: patchBaseFile.path,
+              patchArtifactPath: patchBuildFile.path,
+            ),
+          );
+        } else {
+          patchFile = patchBuildFile;
+        }
+
+        if (dryRun) {
+          logger
+            ..info('No issues detected.')
+            ..info('The server may enforce additional checks.');
+          return ExitCode.success.code;
+        }
+
+        final patchFileSize = patchFile.statSync().size;
+        final summary = [
+          '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('($appId)')}''',
+          '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
+          '''🕹️  Platform: ${lightCyan.wrap(releasePlatform.name)} ${lightCyan.wrap('[$arch (${formatBytes(patchFileSize)})]')}''',
+          '🟢 Track: ${lightCyan.wrap('Production')}',
+        ];
+
+        logger.info(
+          '''
 
 ${styleBold.wrap(lightGreen.wrap('🚀 Ready to publish a new patch!'))}
 
 ${summary.join('\n')}
 ''',
-    );
+        );
 
-    final needsConfirmation = !force && !shorebirdEnv.isRunningOnCI;
-    if (needsConfirmation) {
-      final confirm = logger.confirm('Would you like to continue?');
+        final needsConfirmation = !force && !shorebirdEnv.isRunningOnCI;
+        if (needsConfirmation) {
+          final confirm = logger.confirm('Would you like to continue?');
 
-      if (!confirm) {
-        logger.info('Aborting.');
+          if (!confirm) {
+            logger.info('Aborting.');
+            return ExitCode.success.code;
+          }
+        }
+
+        await codePushClientWrapper.publishPatch(
+          appId: appId,
+          releaseId: release.id,
+          wasForced: force,
+          hasAssetChanges: diffStatus.hasAssetChanges,
+          hasNativeChanges: diffStatus.hasNativeChanges,
+          platform: releasePlatform,
+          track: DeploymentTrack.production,
+          patchArtifactBundles: {
+            Arch.arm64: PatchArtifactBundle(
+              arch: arch,
+              path: patchFile.path,
+              hash: _hashFn(patchBuildFile.readAsBytesSync()),
+              size: patchFileSize,
+            ),
+          },
+        );
+
         return ExitCode.success.code;
-      }
-    }
-
-    await codePushClientWrapper.publishPatch(
-      appId: appId,
-      releaseId: release.id,
-      wasForced: force,
-      hasAssetChanges: diffStatus.hasAssetChanges,
-      hasNativeChanges: diffStatus.hasNativeChanges,
-      platform: releasePlatform,
-      track: DeploymentTrack.production,
-      patchArtifactBundles: {
-        Arch.arm64: PatchArtifactBundle(
-          arch: arch,
-          path: patchFile.path,
-          hash: _hashFn(patchBuildFile.readAsBytesSync()),
-          size: patchFileSize,
-        ),
+      },
+      values: {
+        shorebirdEnvRef.overrideWith(() => releaseFlutterShorebirdEnv),
       },
     );
-
-    return ExitCode.success.code;
   }
 
   Future<String?> _promptForReleaseVersion(List<Release> releases) async {

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
@@ -136,11 +136,11 @@ Please re-run the release command for this version or create a new release.''');
       return ExitCode.software.code;
     }
 
-    final flutterInstallProgress = logger.progress(
-      'Installing Flutter ${release.flutterRevision}',
-    );
-    await shorebirdFlutter.installRevision(revision: release.flutterRevision);
-    flutterInstallProgress.complete();
+    try {
+      await shorebirdFlutter.installRevision(revision: release.flutterRevision);
+    } catch (_) {
+      return ExitCode.software.code;
+    }
 
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: release.flutterRevision,

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
@@ -215,16 +215,13 @@ Please re-run the release command for this version or create a new release.''');
           return ExitCode.software.code;
         }
 
-        final extractZip = artifactManager.extractZip;
         final unzipProgress = logger.progress('Extracting release artifact');
-        final releaseXcframeworkPath = await Isolate.run(() async {
-          final tempDir = Directory.systemTemp.createTempSync();
-          await extractZip(
-            zipFile: releaseArtifactZipFile,
-            outputDirectory: tempDir,
-          );
-          return tempDir.path;
-        });
+        final tempDir = Directory.systemTemp.createTempSync();
+        await artifactManager.extractZip(
+          zipFile: releaseArtifactZipFile,
+          outputDirectory: tempDir,
+        );
+        final releaseXcframeworkPath = tempDir.path;
 
         unzipProgress
             .complete('Extracted release artifact to $releaseXcframeworkPath');

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -139,11 +139,13 @@ Use `shorebird flutter versions list` to list available versions.
       flutterRevisionForRelease = revision;
     }
 
-    final flutterInstallProgress = logger.progress(
-      'Installing Flutter $flutterRevisionForRelease',
-    );
-    await shorebirdFlutter.installRevision(revision: flutterRevisionForRelease);
-    flutterInstallProgress.complete();
+    try {
+      await shorebirdFlutter.installRevision(
+        revision: flutterRevisionForRelease,
+      );
+    } catch (_) {
+      return ExitCode.software.code;
+    }
 
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: flutterRevisionForRelease,

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -139,6 +139,12 @@ Use `shorebird flutter versions list` to list available versions.
       flutterRevisionForRelease = revision;
     }
 
+    final flutterInstallProgress = logger.progress(
+      'Installing Flutter $flutterRevisionForRelease',
+    );
+    await shorebirdFlutter.installRevision(revision: flutterRevisionForRelease);
+    flutterInstallProgress.complete();
+
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: flutterRevisionForRelease,
     );

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -5,6 +5,7 @@ import 'package:archive/archive_io.dart';
 import 'package:io/io.dart' show copyPath;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
+import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/config/config.dart';
@@ -138,116 +139,112 @@ Use `shorebird flutter versions list` to list available versions.
       flutterRevisionForRelease = revision;
     }
 
-    final originalFlutterRevision = shorebirdEnv.flutterRevision;
-    final switchFlutterRevision =
-        flutterRevisionForRelease != originalFlutterRevision;
-
-    if (switchFlutterRevision) {
-      await shorebirdFlutter.useRevision(revision: flutterRevisionForRelease);
-    }
-
-    final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
-
-    final buildProgress = logger.progress(
-      'Building release with Flutter $flutterVersionString',
+    final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
+      flutterRevisionOverride: flutterRevisionForRelease,
     );
 
-    try {
-      await buildAar(buildNumber: buildNumber);
-    } on ProcessException catch (error) {
-      buildProgress.fail('Failed to build: ${error.message}');
-      return ExitCode.software.code;
-    } finally {
-      if (switchFlutterRevision) {
-        await shorebirdFlutter.useRevision(revision: originalFlutterRevision);
-      }
-    }
-    buildProgress.complete();
+    return await runScoped(
+      () async {
+        final flutterVersionString =
+            await shorebirdFlutter.getVersionAndRevision();
 
-    final archNames = architectures.keys.map((arch) => arch.name);
-    final summary = [
-      '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('(${app.appId})')}''',
-      '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
-      '''🕹️  Platform: ${lightCyan.wrap(platform.name)} ${lightCyan.wrap('(${archNames.join(', ')})')}''',
-      '🐦 Flutter Version: ${lightCyan.wrap(flutterVersionString)}',
-    ];
+        final buildProgress = logger.progress(
+          'Building release with Flutter $flutterVersionString',
+        );
 
-    logger.info('''
+        try {
+          await buildAar(buildNumber: buildNumber);
+        } on ProcessException catch (error) {
+          buildProgress.fail('Failed to build: ${error.message}');
+          return ExitCode.software.code;
+        }
+        buildProgress.complete();
+
+        final archNames = architectures.keys.map((arch) => arch.name);
+        final summary = [
+          '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('(${app.appId})')}''',
+          '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
+          '''🕹️  Platform: ${lightCyan.wrap(platform.name)} ${lightCyan.wrap('(${archNames.join(', ')})')}''',
+          '🐦 Flutter Version: ${lightCyan.wrap(flutterVersionString)}',
+        ];
+
+        logger.info('''
 
 ${styleBold.wrap(lightGreen.wrap('🚀 Ready to create a new release!'))}
 
 ${summary.join('\n')}
 ''');
 
-    final force = results['force'] == true;
-    final needConfirmation = !force;
-    if (needConfirmation) {
-      final confirm = logger.confirm('Would you like to continue?');
+        final force = results['force'] == true;
+        final needConfirmation = !force;
+        if (needConfirmation) {
+          final confirm = logger.confirm('Would you like to continue?');
 
-      if (!confirm) {
-        logger.info('Aborting.');
-        return ExitCode.success.code;
-      }
-    }
+          if (!confirm) {
+            logger.info('Aborting.');
+            return ExitCode.success.code;
+          }
+        }
 
-    final Release release;
-    if (existingRelease != null) {
-      release = existingRelease;
-      await codePushClientWrapper.updateReleaseStatus(
-        appId: appId,
-        releaseId: release.id,
-        platform: platform,
-        status: ReleaseStatus.draft,
-      );
-    } else {
-      release = await codePushClientWrapper.createRelease(
-        appId: appId,
-        version: releaseVersion,
-        // Intentionally not using shorebirdEnv.flutterRevision here because
-        // the revision may have changed for the build.
-        flutterRevision: flutterRevisionForRelease,
-        platform: platform,
-      );
-    }
+        final Release release;
+        if (existingRelease != null) {
+          release = existingRelease;
+          await codePushClientWrapper.updateReleaseStatus(
+            appId: appId,
+            releaseId: release.id,
+            platform: platform,
+            status: ReleaseStatus.draft,
+          );
+        } else {
+          release = await codePushClientWrapper.createRelease(
+            appId: appId,
+            version: releaseVersion,
+            flutterRevision: shorebirdEnv.flutterRevision,
+            platform: platform,
+          );
+        }
 
-    // Copy release AAR to a new directory to avoid overwriting with subsequent
-    // patch builds.
-    final sourceLibraryDirectory = Directory(aarLibraryPath);
-    final targetLibraryDirectory = Directory(
-      p.join(shorebirdEnv.getShorebirdProjectRoot()!.path, 'release'),
-    );
-    await copyPath(sourceLibraryDirectory.path, targetLibraryDirectory.path);
+        // Copy release AAR to a new directory to avoid overwriting with
+        // subsequent patch builds.
+        final sourceLibraryDirectory = Directory(aarLibraryPath);
+        final targetLibraryDirectory = Directory(
+          p.join(shorebirdEnv.getShorebirdProjectRoot()!.path, 'release'),
+        );
+        await copyPath(
+          sourceLibraryDirectory.path,
+          targetLibraryDirectory.path,
+        );
 
-    final extractAarProgress = logger.progress('Creating artifacts');
-    final extractedAarDir = await extractAar(
-      packageName: shorebirdEnv.androidPackageName!,
-      buildNumber: buildNumber,
-      unzipFn: _unzipFn,
-    );
-    extractAarProgress.complete();
+        final extractAarProgress = logger.progress('Creating artifacts');
+        final extractedAarDir = await extractAar(
+          packageName: shorebirdEnv.androidPackageName!,
+          buildNumber: buildNumber,
+          unzipFn: _unzipFn,
+        );
+        extractAarProgress.complete();
 
-    await codePushClientWrapper.createAndroidArchiveReleaseArtifacts(
-      appId: app.appId,
-      releaseId: release.id,
-      platform: platform,
-      aarPath: aarArtifactPath(
-        packageName: shorebirdEnv.androidPackageName!,
-        buildNumber: buildNumber,
-      ),
-      extractedAarDir: extractedAarDir,
-      architectures: architectures,
-    );
+        await codePushClientWrapper.createAndroidArchiveReleaseArtifacts(
+          appId: app.appId,
+          releaseId: release.id,
+          platform: platform,
+          aarPath: aarArtifactPath(
+            packageName: shorebirdEnv.androidPackageName!,
+            buildNumber: buildNumber,
+          ),
+          extractedAarDir: extractedAarDir,
+          architectures: architectures,
+        );
 
-    await codePushClientWrapper.updateReleaseStatus(
-      appId: app.appId,
-      releaseId: release.id,
-      platform: platform,
-      status: ReleaseStatus.active,
-    );
+        await codePushClientWrapper.updateReleaseStatus(
+          appId: app.appId,
+          releaseId: release.id,
+          platform: platform,
+          status: ReleaseStatus.active,
+        );
 
-    logger
-      ..success('\n✅ Published Release ${release.version}!')
-      ..info('''
+        logger
+          ..success('\n✅ Published Release ${release.version}!')
+          ..info('''
 
 Your next steps:
 
@@ -281,6 +278,11 @@ dependencies {
 }''')}
 ''');
 
-    return ExitCode.success.code;
+        return ExitCode.success.code;
+      },
+      values: {
+        shorebirdEnvRef.overrideWith(() => releaseFlutterShorebirdEnv),
+      },
+    );
   }
 }

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -140,6 +140,12 @@ Use `shorebird flutter versions list` to list available versions.
       flutterRevisionForRelease = revision;
     }
 
+    final flutterInstallProgress = logger.progress(
+      'Installing Flutter $flutterRevisionForRelease',
+    );
+    await shorebirdFlutter.installRevision(revision: flutterRevisionForRelease);
+    flutterInstallProgress.complete();
+
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: flutterRevisionForRelease,
     );

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -140,11 +140,13 @@ Use `shorebird flutter versions list` to list available versions.
       flutterRevisionForRelease = revision;
     }
 
-    final flutterInstallProgress = logger.progress(
-      'Installing Flutter $flutterRevisionForRelease',
-    );
-    await shorebirdFlutter.installRevision(revision: flutterRevisionForRelease);
-    flutterInstallProgress.complete();
+    try {
+      await shorebirdFlutter.installRevision(
+        revision: flutterRevisionForRelease,
+      );
+    } catch (_) {
+      return ExitCode.software.code;
+    }
 
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: flutterRevisionForRelease,

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -191,7 +191,10 @@ Use `shorebird flutter versions list` to list available versions.
         );
         final bundlePath = flavor != null
             ? p.join(
-                bundleDirPath, '${flavor}Release', 'app-$flavor-release.aab')
+                bundleDirPath,
+                '${flavor}Release',
+                'app-$flavor-release.aab',
+              )
             : p.join(bundleDirPath, 'release', 'app-release.aab');
         final apkPath = flavor != null
             ? p.join(apkDirPath, flavor, 'release', 'app-$flavor-release.apk')

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -193,11 +193,13 @@ Use `shorebird flutter versions list` to list available versions.
       flutterRevisionForRelease = revision;
     }
 
-    final flutterInstallProgress = logger.progress(
-      'Installing Flutter $flutterRevisionForRelease',
-    );
-    await shorebirdFlutter.installRevision(revision: flutterRevisionForRelease);
-    flutterInstallProgress.complete();
+    try {
+      await shorebirdFlutter.installRevision(
+        revision: flutterRevisionForRelease,
+      );
+    } catch (_) {
+      return ExitCode.software.code;
+    }
 
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: flutterRevisionForRelease,

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -193,6 +193,12 @@ Use `shorebird flutter versions list` to list available versions.
       flutterRevisionForRelease = revision;
     }
 
+    final flutterInstallProgress = logger.progress(
+      'Installing Flutter $flutterRevisionForRelease',
+    );
+    await shorebirdFlutter.installRevision(revision: flutterRevisionForRelease);
+    flutterInstallProgress.complete();
+
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: flutterRevisionForRelease,
     );

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -3,6 +3,7 @@ import 'dart:io' hide Platform;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
+import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
@@ -192,160 +193,154 @@ Use `shorebird flutter versions list` to list available versions.
       flutterRevisionForRelease = revision;
     }
 
-    final originalFlutterRevision = shorebirdEnv.flutterRevision;
-    final switchFlutterRevision =
-        flutterRevisionForRelease != originalFlutterRevision;
-
-    if (switchFlutterRevision) {
-      await shorebirdFlutter.useRevision(revision: flutterRevisionForRelease);
-    }
-
-    final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
-
-    final buildProgress = logger.progress(
-      'Building release with Flutter $flutterVersionString',
+    final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
+      flutterRevisionOverride: flutterRevisionForRelease,
     );
 
-    try {
-      await buildIpa(
-        codesign: codesign,
-        exportOptionsPlist: exportOptionsPlist,
-        flavor: flavor,
-        target: target,
-      );
-    } on ProcessException catch (error) {
-      buildProgress.fail('Failed to build: ${error.message}');
-      return ExitCode.software.code;
-    } on BuildException catch (error) {
-      buildProgress.fail('Failed to build');
-      logger.err(error.message);
-      return ExitCode.software.code;
-    } finally {
-      if (switchFlutterRevision) {
-        await shorebirdFlutter.useRevision(revision: originalFlutterRevision);
-      }
-    }
+    return await runScoped(
+      () async {
+        final flutterVersionString =
+            await shorebirdFlutter.getVersionAndRevision();
 
-    buildProgress.complete();
+        final buildProgress = logger.progress(
+          'Building release with Flutter $flutterVersionString',
+        );
 
-    final archiveDirectory = getXcarchiveDirectory();
-    if (archiveDirectory == null) {
-      logger.err('Unable to find .xcarchive directory');
-      return ExitCode.software.code;
-    }
-    final archivePath = archiveDirectory.path;
+        try {
+          await buildIpa(
+            codesign: codesign,
+            exportOptionsPlist: exportOptionsPlist,
+            flavor: flavor,
+            target: target,
+          );
+        } on ProcessException catch (error) {
+          buildProgress.fail('Failed to build: ${error.message}');
+          return ExitCode.software.code;
+        } on BuildException catch (error) {
+          buildProgress.fail('Failed to build');
+          logger.err(error.message);
+          return ExitCode.software.code;
+        }
 
-    final appDirectory = getAppDirectory(xcarchiveDirectory: archiveDirectory);
-    if (appDirectory == null) {
-      logger.err('Unable to find .app directory');
-      return ExitCode.software.code;
-    }
-    final runnerPath = appDirectory.path;
+        buildProgress.complete();
 
-    final plistFile = File(p.join(archivePath, 'Info.plist'));
-    if (!plistFile.existsSync()) {
-      logger.err('No Info.plist file found at ${plistFile.path}.');
-      return ExitCode.software.code;
-    }
+        final archiveDirectory = getXcarchiveDirectory();
+        if (archiveDirectory == null) {
+          logger.err('Unable to find .xcarchive directory');
+          return ExitCode.software.code;
+        }
+        final archivePath = archiveDirectory.path;
 
-    final plist = Plist(file: plistFile);
-    final String releaseVersion;
-    try {
-      releaseVersion = plist.versionNumber;
-    } catch (error) {
-      logger.err(
-        'Failed to determine release version from ${plistFile.path}: $error',
-      );
-      return ExitCode.software.code;
-    }
+        final appDirectory =
+            getAppDirectory(xcarchiveDirectory: archiveDirectory);
+        if (appDirectory == null) {
+          logger.err('Unable to find .app directory');
+          return ExitCode.software.code;
+        }
+        final runnerPath = appDirectory.path;
 
-    final existingRelease = await codePushClientWrapper.maybeGetRelease(
-      appId: appId,
-      releaseVersion: releaseVersion,
-    );
-    if (existingRelease != null) {
-      codePushClientWrapper.ensureReleaseIsNotActive(
-        release: existingRelease,
-        platform: releasePlatform,
-      );
-    }
+        final plistFile = File(p.join(archivePath, 'Info.plist'));
+        if (!plistFile.existsSync()) {
+          logger.err('No Info.plist file found at ${plistFile.path}.');
+          return ExitCode.software.code;
+        }
 
-    final summary = [
-      '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('($appId)')}''',
-      if (flavor != null) '🍧 Flavor: ${lightCyan.wrap(flavor)}',
-      '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
-      '''🕹️  Platform: ${lightCyan.wrap(releasePlatform.name)}''',
-      '🐦 Flutter Version: ${lightCyan.wrap(flutterVersionString)}',
-    ];
+        final plist = Plist(file: plistFile);
+        final String releaseVersion;
+        try {
+          releaseVersion = plist.versionNumber;
+        } catch (error) {
+          logger.err(
+            '''Failed to determine release version from ${plistFile.path}: $error''',
+          );
+          return ExitCode.software.code;
+        }
 
-    logger.info('''
+        final existingRelease = await codePushClientWrapper.maybeGetRelease(
+          appId: appId,
+          releaseVersion: releaseVersion,
+        );
+        if (existingRelease != null) {
+          codePushClientWrapper.ensureReleaseIsNotActive(
+            release: existingRelease,
+            platform: releasePlatform,
+          );
+        }
+
+        final summary = [
+          '''📱 App: ${lightCyan.wrap(app.displayName)} ${lightCyan.wrap('($appId)')}''',
+          if (flavor != null) '🍧 Flavor: ${lightCyan.wrap(flavor)}',
+          '📦 Release Version: ${lightCyan.wrap(releaseVersion)}',
+          '''🕹️  Platform: ${lightCyan.wrap(releasePlatform.name)}''',
+          '🐦 Flutter Version: ${lightCyan.wrap(flutterVersionString)}',
+        ];
+
+        logger.info('''
 
 ${styleBold.wrap(lightGreen.wrap('🚀 Ready to create a new release!'))}
 
 ${summary.join('\n')}
 ''');
 
-    final force = results['force'] == true;
-    final needConfirmation = !force && !shorebirdEnv.isRunningOnCI;
-    if (needConfirmation) {
-      final confirm = logger.confirm('Would you like to continue?');
+        final force = results['force'] == true;
+        final needConfirmation = !force && !shorebirdEnv.isRunningOnCI;
+        if (needConfirmation) {
+          final confirm = logger.confirm('Would you like to continue?');
 
-      if (!confirm) {
-        logger.info('Aborting.');
-        return ExitCode.success.code;
-      }
-    }
+          if (!confirm) {
+            logger.info('Aborting.');
+            return ExitCode.success.code;
+          }
+        }
 
-    final Release release;
-    if (existingRelease != null) {
-      release = existingRelease;
-      await codePushClientWrapper.updateReleaseStatus(
-        appId: appId,
-        releaseId: release.id,
-        platform: releasePlatform,
-        status: ReleaseStatus.draft,
-      );
-    } else {
-      release = await codePushClientWrapper.createRelease(
-        appId: appId,
-        version: releaseVersion,
-        // Intentionally not using shorebirdEnv.flutterRevision here because
-        // the revision may have changed for the build.
-        flutterRevision: flutterRevisionForRelease,
-        platform: releasePlatform,
-      );
-    }
+        final Release release;
+        if (existingRelease != null) {
+          release = existingRelease;
+          await codePushClientWrapper.updateReleaseStatus(
+            appId: appId,
+            releaseId: release.id,
+            platform: releasePlatform,
+            status: ReleaseStatus.draft,
+          );
+        } else {
+          release = await codePushClientWrapper.createRelease(
+            appId: appId,
+            version: releaseVersion,
+            flutterRevision: shorebirdEnv.flutterRevision,
+            platform: releasePlatform,
+          );
+        }
 
-    await codePushClientWrapper.createIosReleaseArtifacts(
-      appId: app.appId,
-      releaseId: release.id,
-      xcarchivePath: archivePath,
-      runnerPath: runnerPath,
-      isCodesigned: codesign,
-    );
+        await codePushClientWrapper.createIosReleaseArtifacts(
+          appId: app.appId,
+          releaseId: release.id,
+          xcarchivePath: archivePath,
+          runnerPath: runnerPath,
+          isCodesigned: codesign,
+        );
 
-    await codePushClientWrapper.updateReleaseStatus(
-      appId: app.appId,
-      releaseId: release.id,
-      platform: releasePlatform,
-      status: ReleaseStatus.active,
-    );
+        await codePushClientWrapper.updateReleaseStatus(
+          appId: app.appId,
+          releaseId: release.id,
+          platform: releasePlatform,
+          status: ReleaseStatus.active,
+        );
 
-    logger.success('\n✅ Published Release ${release.version}!');
+        logger.success('\n✅ Published Release ${release.version}!');
 
-    final relativeArchivePath = p.relative(archivePath);
-    if (codesign) {
-      // Ensure the ipa was built
-      final String ipaPath;
-      try {
-        ipaPath = getIpaPath();
-      } catch (error) {
-        logger.err('Could not find ipa file: $error');
-        return ExitCode.software.code;
-      }
+        final relativeArchivePath = p.relative(archivePath);
+        if (codesign) {
+          // Ensure the ipa was built
+          final String ipaPath;
+          try {
+            ipaPath = getIpaPath();
+          } catch (error) {
+            logger.err('Could not find ipa file: $error');
+            return ExitCode.software.code;
+          }
 
-      final relativeIpaPath = p.relative(ipaPath);
-      logger.info('''
+          final relativeIpaPath = p.relative(ipaPath);
+          logger.info('''
 
 Your next step is to upload your app to App Store Connect.
 
@@ -355,8 +350,8 @@ To upload to the App Store, do one of the following:
     3. Run ${lightCyan.wrap('xcrun altool --upload-app --type ios -f $relativeIpaPath --apiKey your_api_key --apiIssuer your_issuer_id')}.
        See "man altool" for details about how to authenticate with the App Store Connect API key.
 ''');
-    } else {
-      logger.info('''
+        } else {
+          logger.info('''
 
 Your next step is to submit the archive at ${lightCyan.wrap(relativeArchivePath)} to the App Store using Xcode.
 
@@ -365,9 +360,14 @@ You can open the archive in Xcode by running:
 
 ${styleBold.wrap('Make sure to uncheck "Manage Version and Build Number", or else shorebird will not work.')}
 ''');
-    }
+        }
 
-    return ExitCode.success.code;
+        return ExitCode.success.code;
+      },
+      values: {
+        shorebirdEnvRef.overrideWith(() => releaseFlutterShorebirdEnv),
+      },
+    );
   }
 
   /// Verifies that [exportOptionsPlistFile] exists and sets

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -118,6 +118,12 @@ Use `shorebird flutter versions list` to list available versions.
       flutterRevisionForRelease = revision;
     }
 
+    final flutterInstallProgress = logger.progress(
+      'Installing Flutter $flutterRevisionForRelease',
+    );
+    await shorebirdFlutter.installRevision(revision: flutterRevisionForRelease);
+    flutterInstallProgress.complete();
+
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: flutterRevisionForRelease,
     );

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -118,11 +118,13 @@ Use `shorebird flutter versions list` to list available versions.
       flutterRevisionForRelease = revision;
     }
 
-    final flutterInstallProgress = logger.progress(
-      'Installing Flutter $flutterRevisionForRelease',
-    );
-    await shorebirdFlutter.installRevision(revision: flutterRevisionForRelease);
-    flutterInstallProgress.complete();
+    try {
+      await shorebirdFlutter.installRevision(
+        revision: flutterRevisionForRelease,
+      );
+    } catch (_) {
+      return ExitCode.software.code;
+    }
 
     final releaseFlutterShorebirdEnv = shorebirdEnv.copyWith(
       flutterRevisionOverride: flutterRevisionForRelease,

--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:scoped/scoped.dart';

--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:scoped/scoped.dart';
@@ -131,5 +132,16 @@ class Git {
   Future<String> status({required String directory, List<String>? args}) async {
     final result = await git(['status', ...?args], workingDirectory: directory);
     return '${result.stdout}'.trim();
+  }
+
+  /// Runs `git ls-remote --heads` in [directory]. Returns output lines as a
+  /// list of strings. Used to find the HEAD revisions of all branches.
+  Future<List<String>> lsRemoteHeads({Directory? directory}) async {
+    final result = await git(
+      ['ls-remote', '--heads'],
+      workingDirectory: directory?.path,
+    );
+    final stdout = result.stdout as String;
+    return LineSplitter.split(stdout.trim()).toList();
   }
 }

--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -133,15 +133,4 @@ class Git {
     final result = await git(['status', ...?args], workingDirectory: directory);
     return '${result.stdout}'.trim();
   }
-
-  /// Runs `git ls-remote --heads` in [directory]. Returns output lines as a
-  /// list of strings. Used to find the HEAD revisions of all branches.
-  Future<List<String>> lsRemoteHeads({Directory? directory}) async {
-    final result = await git(
-      ['ls-remote', '--heads'],
-      workingDirectory: directory?.path,
-    );
-    final stdout = result.stdout as String;
-    return LineSplitter.split(stdout.trim()).toList();
-  }
 }

--- a/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_build_mixin.dart
@@ -8,8 +8,6 @@ import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
-import 'package:shorebird_cli/src/shorebird_env.dart';
-import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 
 enum Arch {
@@ -119,117 +117,100 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
     return allAndroidArchitectures;
   }
 
-  Future<void> buildAppBundle({
-    String? flavor,
-    String? target,
-    String? flutterRevision,
-  }) async {
-    return _runShorebirdBuildCommand(
-      flutterRevision: flutterRevision,
-      command: () async {
-        const executable = 'flutter';
-        final arguments = [
-          'build',
-          'appbundle',
-          '--release',
-          if (flavor != null) '--flavor=$flavor',
-          if (target != null) '--target=$target',
-          ...results.rest,
-        ];
+  Future<void> buildAppBundle({String? flavor, String? target}) async {
+    return _runShorebirdBuildCommand(() async {
+      const executable = 'flutter';
+      final arguments = [
+        'build',
+        'appbundle',
+        '--release',
+        if (flavor != null) '--flavor=$flavor',
+        if (target != null) '--target=$target',
+        ...results.rest,
+      ];
 
-        final result = await process.run(
-          executable,
+      final result = await process.run(
+        executable,
+        arguments,
+        runInShell: true,
+      );
+
+      if (result.exitCode != ExitCode.success.code) {
+        throw ProcessException(
+          'flutter',
           arguments,
-          runInShell: true,
+          result.stderr.toString(),
+          result.exitCode,
         );
-
-        if (result.exitCode != ExitCode.success.code) {
-          throw ProcessException(
-            'flutter',
-            arguments,
-            result.stderr.toString(),
-            result.exitCode,
-          );
-        }
-      },
-    );
+      }
+    });
   }
 
-  Future<void> buildAar({
-    required String buildNumber,
-    String? flutterRevision,
-  }) async {
-    return _runShorebirdBuildCommand(
-      flutterRevision: flutterRevision,
-      command: () async {
-        const executable = 'flutter';
-        final arguments = [
-          'build',
-          'aar',
-          '--no-debug',
-          '--no-profile',
-          '--build-number=$buildNumber',
-          ...results.rest,
-        ];
+  Future<void> buildAar({required String buildNumber}) async {
+    return _runShorebirdBuildCommand(() async {
+      const executable = 'flutter';
+      final arguments = [
+        'build',
+        'aar',
+        '--no-debug',
+        '--no-profile',
+        '--build-number=$buildNumber',
+        ...results.rest,
+      ];
 
-        final result = await process.run(
-          executable,
+      final result = await process.run(
+        executable,
+        arguments,
+        runInShell: true,
+      );
+
+      if (result.exitCode != ExitCode.success.code) {
+        throw ProcessException(
+          'flutter',
           arguments,
-          runInShell: true,
+          result.stderr.toString(),
+          result.exitCode,
         );
-
-        if (result.exitCode != ExitCode.success.code) {
-          throw ProcessException(
-            'flutter',
-            arguments,
-            result.stderr.toString(),
-            result.exitCode,
-          );
-        }
-      },
-    );
+      }
+    });
   }
 
   Future<void> buildApk({
     String? flavor,
     String? target,
     bool splitPerAbi = false,
-    String? flutterRevision,
   }) async {
-    return _runShorebirdBuildCommand(
-      flutterRevision: flutterRevision,
-      command: () async {
-        const executable = 'flutter';
-        final arguments = [
-          'build',
-          'apk',
-          '--release',
-          if (flavor != null) '--flavor=$flavor',
-          if (target != null) '--target=$target',
-          // TODO(bryanoltman): reintroduce coverage when we can support this.
-          // See https://github.com/shorebirdtech/shorebird/issues/1141.
-          // coverage:ignore-start
-          if (splitPerAbi) '--split-per-abi',
-          // coverage:ignore-end
-          ...results.rest,
-        ];
+    return _runShorebirdBuildCommand(() async {
+      const executable = 'flutter';
+      final arguments = [
+        'build',
+        'apk',
+        '--release',
+        if (flavor != null) '--flavor=$flavor',
+        if (target != null) '--target=$target',
+        // TODO(bryanoltman): reintroduce coverage when we can support this.
+        // See https://github.com/shorebirdtech/shorebird/issues/1141.
+        // coverage:ignore-start
+        if (splitPerAbi) '--split-per-abi',
+        // coverage:ignore-end
+        ...results.rest,
+      ];
 
-        final result = await process.run(
-          executable,
+      final result = await process.run(
+        executable,
+        arguments,
+        runInShell: true,
+      );
+
+      if (result.exitCode != ExitCode.success.code) {
+        throw ProcessException(
+          'flutter',
           arguments,
-          runInShell: true,
+          result.stderr.toString(),
+          result.exitCode,
         );
-
-        if (result.exitCode != ExitCode.success.code) {
-          throw ProcessException(
-            'flutter',
-            arguments,
-            result.stderr.toString(),
-            result.exitCode,
-          );
-        }
-      },
-    );
+      }
+    });
   }
 
   /// Calls `flutter build ipa`. If [codesign] is false, this will only build
@@ -239,50 +220,46 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
     File? exportOptionsPlist,
     String? flavor,
     String? target,
-    String? flutterRevision,
   }) async {
-    return _runShorebirdBuildCommand(
-      flutterRevision: flutterRevision,
-      command: () async {
-        const executable = 'flutter';
-        final arguments = [
-          'build',
-          'ipa',
-          '--release',
-          if (flavor != null) '--flavor=$flavor',
-          if (target != null) '--target=$target',
-          if (!codesign) '--no-codesign',
-          if (codesign)
-            '''--export-options-plist=${(exportOptionsPlist ?? createExportOptionsPlist()).path}''',
-          ...results.rest,
-        ];
+    return _runShorebirdBuildCommand(() async {
+      const executable = 'flutter';
+      final arguments = [
+        'build',
+        'ipa',
+        '--release',
+        if (flavor != null) '--flavor=$flavor',
+        if (target != null) '--target=$target',
+        if (!codesign) '--no-codesign',
+        if (codesign)
+          '''--export-options-plist=${(exportOptionsPlist ?? createExportOptionsPlist()).path}''',
+        ...results.rest,
+      ];
 
-        final result = await process.run(
-          executable,
+      final result = await process.run(
+        executable,
+        arguments,
+        runInShell: true,
+      );
+
+      if (result.exitCode != ExitCode.success.code) {
+        throw ProcessException(
+          'flutter',
           arguments,
-          runInShell: true,
+          result.stderr.toString(),
+          result.exitCode,
+        );
+      }
+
+      if (result.stderr
+          .toString()
+          .contains('Encountered error while creating the IPA')) {
+        final errorMessage = _failedToCreateIpaErrorMessage(
+          stderr: result.stderr.toString(),
         );
 
-        if (result.exitCode != ExitCode.success.code) {
-          throw ProcessException(
-            'flutter',
-            arguments,
-            result.stderr.toString(),
-            result.exitCode,
-          );
-        }
-
-        if (result.stderr
-            .toString()
-            .contains('Encountered error while creating the IPA')) {
-          final errorMessage = _failedToCreateIpaErrorMessage(
-            stderr: result.stderr.toString(),
-          );
-
-          throw BuildException(errorMessage);
-        }
-      },
-    );
+        throw BuildException(errorMessage);
+      }
+    });
   }
 
   /// Creates an ExportOptions.plist file, which is used to tell xcodebuild to
@@ -320,67 +297,42 @@ mixin ShorebirdBuildMixin on ShorebirdCommand {
   }
 
   /// Builds a release iOS framework (.xcframework) for the current project.
-  Future<void> buildIosFramework({String? flutterRevision}) async {
-    return _runShorebirdBuildCommand(
-      flutterRevision: flutterRevision,
-      command: () async {
-        const executable = 'flutter';
-        final arguments = [
-          'build',
-          'ios-framework',
-          '--no-debug',
-          '--no-profile',
-          ...results.rest,
-        ];
+  Future<void> buildIosFramework() async {
+    return _runShorebirdBuildCommand(() async {
+      const executable = 'flutter';
+      final arguments = [
+        'build',
+        'ios-framework',
+        '--no-debug',
+        '--no-profile',
+        ...results.rest,
+      ];
 
-        final result = await process.run(
-          executable,
+      final result = await process.run(
+        executable,
+        arguments,
+        runInShell: true,
+      );
+
+      if (result.exitCode != ExitCode.success.code) {
+        throw ProcessException(
+          'flutter',
           arguments,
-          runInShell: true,
+          result.stderr.toString(),
+          result.exitCode,
         );
-
-        if (result.exitCode != ExitCode.success.code) {
-          throw ProcessException(
-            'flutter',
-            arguments,
-            result.stderr.toString(),
-            result.exitCode,
-          );
-        }
-      },
-    );
+      }
+    });
   }
 
   /// A wrapper around [command] (which runs a `flutter build` command with
   /// Shorebird's fork of Flutter) with a try/finally that runs
   /// `flutter pub get` with the system installation of Flutter to reset
   /// `.dart_tool/package_config.json` to the system Flutter.
-  Future<void> _runShorebirdBuildCommand({
-    required ShorebirdBuildCommand command,
-    String? flutterRevision,
-  }) async {
-    final currentFlutterRevision = shorebirdEnv.flutterRevision;
-    flutterRevision ??= currentFlutterRevision;
-
+  Future<void> _runShorebirdBuildCommand(ShorebirdBuildCommand command) async {
     try {
-      if (currentFlutterRevision != flutterRevision) {
-        final flutterVersionProgress = logger.progress(
-          'Switching to Flutter revision $flutterRevision',
-        );
-        await shorebirdFlutter.useRevision(revision: flutterRevision);
-        flutterVersionProgress.complete();
-      }
-
       await command();
     } finally {
-      if (currentFlutterRevision != flutterRevision) {
-        final flutterVersionProgress = logger.progress(
-          '''Switching back to original Flutter revision $currentFlutterRevision''',
-        );
-        await shorebirdFlutter.useRevision(revision: currentFlutterRevision);
-        flutterVersionProgress.complete();
-      }
-
       await _systemFlutterPubGet();
     }
   }

--- a/packages/shorebird_cli/lib/src/shorebird_env.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_env.dart
@@ -22,6 +22,11 @@ class ShorebirdEnv {
   const ShorebirdEnv({String? flutterRevisionOverride})
       : _flutterRevisionOverride = flutterRevisionOverride;
 
+  ShorebirdEnv copyWith({String? flutterRevisionOverride}) => ShorebirdEnv(
+        flutterRevisionOverride:
+            flutterRevisionOverride ?? _flutterRevisionOverride,
+      );
+
   final String? _flutterRevisionOverride;
 
   /// The root directory of the Shorebird install.

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -37,8 +37,9 @@ class ShorebirdFlutter {
 
     final version = await getVersionString(revision: revision);
 
-    final installProgress =
-        logger.progress('Installing Flutter $version ($revision)');
+    final installProgress = logger.progress(
+      'Installing Flutter $version (${shortRevisionString(revision)})',
+    );
 
     try {
       // Clone the Shorebird Flutter repo into the target directory.
@@ -55,7 +56,7 @@ class ShorebirdFlutter {
       await git.checkout(directory: targetDirectory.path, revision: revision);
     } catch (error) {
       installProgress.fail(
-        'Failed to install Flutter $version ($revision)',
+        'Failed to install Flutter $version (${shortRevisionString(revision)})',
       );
       logger.err('$error');
       rethrow;
@@ -102,6 +103,9 @@ class ShorebirdFlutter {
     return match?.group(1);
   }
 
+  /// Converts a full git revision to a short revision string.
+  String shortRevisionString(String revision) => revision.substring(0, 10);
+
   /// Returns the current Shorebird Flutter version and revision.
   /// Returns unknown if the version check fails.
   Future<String> getVersionAndRevision() async {
@@ -110,7 +114,7 @@ class ShorebirdFlutter {
       version = await getVersionString();
     } catch (_) {}
 
-    return '$version (${shorebirdEnv.flutterRevision.substring(0, 10)})';
+    return '$version (${shortRevisionString(shorebirdEnv.flutterRevision)})';
   }
 
   /// Returns the current Shorebird Flutter version.

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -38,7 +38,7 @@ class ShorebirdFlutter {
     final version = await getVersionString(revision: revision);
 
     final installProgress =
-        logger.progress('Installing Flutter revision $version ($revision)');
+        logger.progress('Installing Flutter $version ($revision)');
 
     try {
       // Clone the Shorebird Flutter repo into the target directory.
@@ -55,7 +55,7 @@ class ShorebirdFlutter {
       await git.checkout(directory: targetDirectory.path, revision: revision);
     } catch (error) {
       installProgress.fail(
-        'Failed to install Flutter revision $version ($revision)',
+        'Failed to install Flutter $version ($revision)',
       );
       logger.err('$error');
       rethrow;

--- a/packages/shorebird_cli/test/src/commands/flutter/versions/flutter_versions_use_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/flutter/versions/flutter_versions_use_command_test.dart
@@ -142,9 +142,6 @@ Use `shorebird flutter versions list` to list available versions.'''),
       verifyInOrder([
         () => logger.progress('Fetching Flutter versions'),
         () => progress.complete(),
-        () => logger.progress('Installing Flutter $version'),
-        () => progress.fail('Failed to install Flutter $version.'),
-        () => logger.err('error'),
       ]);
     });
 
@@ -157,11 +154,6 @@ Use `shorebird flutter versions list` to list available versions.'''),
         runWithOverrides(command.run),
         completion(equals(ExitCode.software.code)),
       );
-      verifyInOrder([
-        () => logger.progress('Installing Flutter $revision'),
-        () => progress.fail('Failed to install Flutter $revision.'),
-        () => logger.err('error'),
-      ]);
     });
 
     test('exits with code 0 when version install succeeds', () async {
@@ -173,9 +165,6 @@ Use `shorebird flutter versions list` to list available versions.'''),
         () => logger.progress('Fetching Flutter versions'),
         () => shorebirdFlutter.getVersions(),
         () => progress.complete(),
-        () => logger.progress('Installing Flutter $version'),
-        () => shorebirdFlutter.useVersion(version: version),
-        () => progress.complete(),
       ]);
     });
 
@@ -185,11 +174,6 @@ Use `shorebird flutter versions list` to list available versions.'''),
         runWithOverrides(command.run),
         completion(equals(ExitCode.success.code)),
       );
-      verifyInOrder([
-        () => logger.progress('Installing Flutter $revision'),
-        () => shorebirdFlutter.useRevision(revision: revision),
-        () => progress.complete(),
-      ]);
     });
   });
 }

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -318,7 +318,9 @@ void main() {
         () => cache.getArtifactDirectory(any()),
       ).thenReturn(Directory.systemTemp.createTempSync());
       when(
-        () => shorebirdFlutter.useRevision(revision: any(named: 'revision')),
+        () => shorebirdFlutter.installRevision(
+          revision: any(named: 'revision'),
+        ),
       ).thenAnswer((_) async {});
       when(
         () => shorebirdValidator.validatePreconditions(
@@ -581,6 +583,11 @@ Please re-run the release command for this version or create a new release.'''),
         ),
       );
 
+      verify(
+        () => shorebirdFlutter.installRevision(
+          revision: release.flutterRevision,
+        ),
+      ).called(1);
       verify(
         () => processWrapper.run(
           flutterFile.path,

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -511,6 +511,29 @@ Please re-run the release command for this version or create a new release.'''),
       expect(exitCode, ExitCode.success.code);
     });
 
+    group('when flutter version install fails', () {
+      setUp(() {
+        when(
+          () => shorebirdFlutter.installRevision(
+            revision: any(named: 'revision'),
+          ),
+        ).thenThrow(Exception('oops'));
+      });
+
+      test('exits with code 70', () async {
+        setUpProjectRootArtifacts();
+
+        final result = await runWithOverrides(command.run);
+
+        expect(result, equals(ExitCode.software.code));
+        verify(
+          () => shorebirdFlutter.installRevision(
+            revision: release.flutterRevision,
+          ),
+        ).called(1);
+      });
+    });
+
     test('exits with code 70 when downloading release artifact fails',
         () async {
       final exception = Exception('oops');

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -681,6 +681,30 @@ Please re-run the release command for this version or create a new release.'''),
       ).called(1);
     });
 
+    group('when flutter version install fails', () {
+      setUp(() {
+        when(
+          () => shorebirdFlutter.installRevision(
+            revision: any(named: 'revision'),
+          ),
+        ).thenThrow(Exception('oops'));
+      });
+
+      test('exits with code 70', () async {
+        setUpProjectRoot();
+        setUpProjectRootArtifacts();
+
+        final result = await runWithOverrides(command.run);
+
+        expect(result, equals(ExitCode.software.code));
+        verify(
+          () => shorebirdFlutter.installRevision(
+            revision: release.flutterRevision,
+          ),
+        ).called(1);
+      });
+    });
+
     test(
         '''exits with code 0 if confirmUnpatchableDiffsIfNecessary throws UserCancelledException''',
         () async {

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -232,8 +232,11 @@ flutter:
       });
       when(() => shorebirdEnv.flutterDirectory).thenReturn(flutterDirectory);
       when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
-      when(() => shorebirdFlutter.useRevision(revision: any(named: 'revision')))
-          .thenAnswer((_) async {});
+      when(
+        () => shorebirdFlutter.installRevision(
+          revision: any(named: 'revision'),
+        ),
+      ).thenAnswer((_) async {});
       when(
         () => shorebirdProcess.run(
           'flutter',
@@ -877,7 +880,14 @@ Please re-run the release command for this version or create a new release.'''),
       });
       setUpProjectRoot();
       setUpProjectRootArtifacts();
+
       final exitCode = await runWithOverrides(command.run);
+
+      verify(
+        () => shorebirdFlutter.installRevision(
+          revision: release.flutterRevision,
+        ),
+      ).called(1);
       verify(
         () => logger.info(
           any(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -220,6 +220,16 @@ flutter:
       when(
         () => shorebirdEnv.getShorebirdProjectRoot(),
       ).thenReturn(projectRoot);
+      when(
+        () => shorebirdEnv.copyWith(
+          flutterRevisionOverride: any(named: 'flutterRevisionOverride'),
+        ),
+      ).thenAnswer((invocation) {
+        when(() => shorebirdEnv.flutterRevision).thenReturn(
+          invocation.namedArguments[#flutterRevisionOverride] as String,
+        );
+        return shorebirdEnv;
+      });
       when(() => shorebirdEnv.flutterDirectory).thenReturn(flutterDirectory);
       when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
       when(() => shorebirdFlutter.useRevision(revision: any(named: 'revision')))
@@ -487,11 +497,6 @@ Please re-run the release command for this version or create a new release.'''),
       final exitCode = await runWithOverrides(command.run);
 
       expect(exitCode, ExitCode.success.code);
-      // Verify that we switch back to the original revision once we're done.
-      verifyInOrder([
-        () => shorebirdFlutter.useRevision(revision: release.flutterRevision),
-        () => shorebirdFlutter.useRevision(revision: otherRevision),
-      ]);
       verify(
         () => logger.info(
           any(
@@ -504,27 +509,6 @@ Please re-run the release command for this version or create a new release.'''),
         ),
       ).called(1);
     });
-
-    test(
-      'exits with code 70 if build fails after switching flutter versions',
-      () async {
-        const otherRevision = 'other-revision';
-        when(() => shorebirdEnv.flutterRevision).thenReturn(otherRevision);
-        when(
-          () => shorebirdFlutter.useRevision(revision: any(named: 'revision')),
-        ).thenAnswer((_) async {
-          // Cause builds to fail after switching flutter versions.
-          when(() => flutterBuildProcessResult.exitCode).thenReturn(1);
-          when(() => flutterBuildProcessResult.stderr).thenReturn('oops');
-        });
-        setUpProjectRoot();
-        setUpProjectRootArtifacts();
-
-        final exitCode = await runWithOverrides(command.run);
-
-        expect(exitCode, equals(ExitCode.software.code));
-      },
-    );
 
     group('when release-version option is provided', () {
       setUp(() {
@@ -554,15 +538,26 @@ Please re-run the release command for this version or create a new release.'''),
           () async {
         const otherRevision = 'other-revision';
         when(() => shorebirdEnv.flutterRevision).thenReturn(otherRevision);
+        when(
+          () => shorebirdProcess.run(
+            'flutter',
+            any(),
+            runInShell: any(named: 'runInShell'),
+          ),
+        ).thenAnswer((_) async {
+          // Ensure we're building with the correct flutter revision.
+          expect(shorebirdEnv.flutterRevision, equals(release.flutterRevision));
+          return flutterBuildProcessResult;
+        });
 
         setUpProjectRoot();
         setUpProjectRootArtifacts();
         final exitCode = await runWithOverrides(command.run);
         expect(exitCode, ExitCode.success.code);
-
         verify(
-          () => shorebirdFlutter.useRevision(revision: release.flutterRevision),
+          () => shorebirdEnv.copyWith(flutterRevisionOverride: flutterRevision),
         ).called(1);
+
         verify(
           () => shorebirdProcess.run(
             'flutter',
@@ -573,9 +568,6 @@ Please re-run the release command for this version or create a new release.'''),
             ],
             runInShell: any(named: 'runInShell'),
           ),
-        ).called(1);
-        verify(
-          () => shorebirdFlutter.useRevision(revision: otherRevision),
         ).called(1);
       });
     });
@@ -872,6 +864,17 @@ Please re-run the release command for this version or create a new release.'''),
     });
 
     test('succeeds when patch is successful (production)', () async {
+      when(
+        () => shorebirdProcess.run(
+          'flutter',
+          any(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).thenAnswer((_) async {
+        // Ensure we're building with the correct flutter revision.
+        expect(shorebirdEnv.flutterRevision, equals(release.flutterRevision));
+        return flutterBuildProcessResult;
+      });
       setUpProjectRoot();
       setUpProjectRootArtifacts();
       final exitCode = await runWithOverrides(command.run);
@@ -953,6 +956,17 @@ Please re-run the release command for this version or create a new release.'''),
       const target = './lib/main_development.dart';
       when(() => argResults['flavor']).thenReturn(flavor);
       when(() => argResults['target']).thenReturn(target);
+      when(
+        () => shorebirdProcess.run(
+          'flutter',
+          any(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).thenAnswer((_) async {
+        // Ensure we're building with the correct flutter revision.
+        expect(shorebirdEnv.flutterRevision, equals(release.flutterRevision));
+        return flutterBuildProcessResult;
+      });
       setUpProjectRoot();
       File(
         p.join(projectRoot.path, 'shorebird.yaml'),

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -442,8 +442,11 @@ flutter:
       when(() => shorebirdEnv.flutterRevision)
           .thenReturn(preLinkerFlutterRevision);
       when(() => shorebirdEnv.isRunningOnCI).thenReturn(false);
-      when(() => shorebirdFlutter.useRevision(revision: any(named: 'revision')))
-          .thenAnswer((_) async {});
+      when(
+        () => shorebirdFlutter.installRevision(
+          revision: any(named: 'revision'),
+        ),
+      ).thenAnswer((_) async {});
       when(
         () => aotBuildProcessResult.exitCode,
       ).thenReturn(ExitCode.success.code);
@@ -804,12 +807,12 @@ Please re-run the release command for this version or create a new release.'''),
       final exitCode = await runWithOverrides(command.run);
 
       expect(exitCode, ExitCode.success.code);
-      verify(
-        () => shorebirdEnv.copyWith(
-          flutterRevisionOverride: preLinkerFlutterRevision,
-        ),
-      ).called(1);
 
+      when(
+        () => shorebirdFlutter.installRevision(
+          revision: any(named: 'revision'),
+        ),
+      ).thenAnswer((_) async {});
       verify(
         () => logger.info(
           any(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -948,6 +948,30 @@ Please re-run the release command for this version or create a new release.'''),
       verify(() => logger.info('Aborting.')).called(1);
     });
 
+    group('when flutter version install fails', () {
+      setUp(() {
+        when(
+          () => shorebirdFlutter.installRevision(
+            revision: any(named: 'revision'),
+          ),
+        ).thenThrow(Exception('oops'));
+      });
+
+      test('exits with code 70', () async {
+        setUpProjectRoot();
+        setUpProjectRootArtifacts();
+
+        final result = await runWithOverrides(command.run);
+
+        expect(result, equals(ExitCode.software.code));
+        verify(
+          () => shorebirdFlutter.installRevision(
+            revision: preLinkerFlutterRevision,
+          ),
+        ).called(1);
+      });
+    });
+
     test('throws error when creating aot snapshot fails', () async {
       const error = 'oops something went wrong';
       when(() => aotBuildProcessResult.exitCode).thenReturn(1);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
@@ -688,6 +688,30 @@ Please re-run the release command for this version or create a new release.'''),
       ).called(1);
     });
 
+    group('when flutter version install fails', () {
+      setUp(() {
+        when(
+          () => shorebirdFlutter.installRevision(
+            revision: any(named: 'revision'),
+          ),
+        ).thenThrow(Exception('oops'));
+      });
+
+      test('exits with code 70', () async {
+        setUpProjectRoot();
+        setUpProjectRootArtifacts();
+
+        final result = await runWithOverrides(command.run);
+
+        expect(result, equals(ExitCode.software.code));
+        verify(
+          () => shorebirdFlutter.installRevision(
+            revision: preLinkerFlutterRevision,
+          ),
+        ).called(1);
+      });
+    });
+
     test('aborts when user opts out', () async {
       when(() => logger.confirm(any())).thenReturn(false);
       setUpProjectRoot();

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
@@ -23,6 +23,7 @@ import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
@@ -116,6 +117,7 @@ flutter:
     late ShorebirdProcessResult flutterBuildProcessResult;
     late ShorebirdProcessResult flutterPubGetProcessResult;
     late ShorebirdEnv shorebirdEnv;
+    late ShorebirdFlutter shorebirdFlutter;
     late ShorebirdFlutterValidator flutterValidator;
     late ShorebirdProcess shorebirdProcess;
     late ShorebirdValidator shorebirdValidator;
@@ -138,6 +140,7 @@ flutter:
           platformRef.overrideWith(() => platform),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
+          shorebirdFlutterRef.overrideWith(() => shorebirdFlutter),
           shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
         },
       );
@@ -242,6 +245,7 @@ flutter:
       flutterPubGetProcessResult = MockProcessResult();
       operatingSystemInterface = MockOperatingSystemInterface();
       shorebirdEnv = MockShorebirdEnv();
+      shorebirdFlutter = MockShorebirdFlutter();
       flutterValidator = MockShorebirdFlutterValidator();
       shorebirdProcess = MockShorebirdProcess();
       shorebirdValidator = MockShorebirdValidator();
@@ -322,6 +326,11 @@ flutter:
           artifact: ShorebirdArtifact.analyzeSnapshot,
         ),
       ).thenReturn(analyzeSnapshotFile.path);
+      when(
+        () => shorebirdFlutter.installRevision(
+          revision: any(named: 'revision'),
+        ),
+      ).thenAnswer((_) async {});
       when(
         () => shorebirdArtifacts.getArtifactPath(
           artifact: ShorebirdArtifact.genSnapshot,
@@ -609,6 +618,11 @@ Please re-run the release command for this version or create a new release.'''),
       final exitCode = await runWithOverrides(command.run);
 
       expect(exitCode, equals(ExitCode.success.code));
+      verify(
+        () => shorebirdFlutter.installRevision(
+          revision: preLinkerFlutterRevision,
+        ),
+      ).called(1);
     });
 
     test(
@@ -646,6 +660,7 @@ Please re-run the release command for this version or create a new release.'''),
 
       setUpProjectRoot();
       setUpProjectRootArtifacts();
+
       await runWithOverrides(
         () => runScoped(
           () => command.run(),
@@ -656,6 +671,12 @@ Please re-run the release command for this version or create a new release.'''),
           },
         ),
       );
+
+      verify(
+        () => shorebirdFlutter.installRevision(
+          revision: preLinkerFlutterRevision,
+        ),
+      ).called(1);
       verify(
         () => processWrapper.run(
           flutterFile.path,

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -380,6 +380,26 @@ $exception''',
             ),
           ).called(1);
         });
+
+        group('when flutter version install fails', () {
+          setUp(() {
+            when(
+              () => shorebirdFlutter.installRevision(
+                revision: any(named: 'revision'),
+              ),
+            ).thenThrow(Exception('oops'));
+          });
+
+          test('exits with code 70', () async {
+            setUpProjectRootArtifacts();
+            final result = await runWithOverrides(command.run);
+
+            expect(result, equals(ExitCode.software.code));
+            verify(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ).called(1);
+          });
+        });
       });
     });
 

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -361,7 +361,7 @@ $exception''',
               any(that: containsAll(['build', 'aar'])),
               runInShell: any(named: 'runInShell'),
             ),
-          ).thenAnswer((invocation) async {
+          ).thenAnswer((_) async {
             // Ensure we're using the correct flutter revision.
             expect(shorebirdEnv.flutterRevision, equals(revision));
             return flutterBuildProcessResult;

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -183,6 +183,11 @@ void main() {
       when(
         () => shorebirdFlutter.getVersionAndRevision(),
       ).thenAnswer((_) async => flutterVersionAndRevision);
+      when(
+        () => shorebirdFlutter.installRevision(
+          revision: any(named: 'revision'),
+        ),
+      ).thenAnswer((_) async => {});
 
       when(
         () => flutterBuildProcessResult.exitCode,
@@ -363,6 +368,9 @@ $exception''',
           });
 
           await runWithOverrides(command.run);
+
+          verify(() => shorebirdFlutter.installRevision(revision: revision))
+              .called(1);
           verify(
             () => codePushClientWrapper.createRelease(
               appId: appId,

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -353,11 +353,6 @@ $exception''',
           when(
             () => shorebirdFlutter.getRevisionForVersion(any()),
           ).thenAnswer((_) async => revision);
-          when(
-            () => shorebirdFlutter.useRevision(
-              revision: any(named: 'revision'),
-            ),
-          ).thenAnswer((_) async {});
         });
 
         test(

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -383,6 +383,25 @@ $exception''',
             ),
           ).called(1);
         });
+
+        group('when flutter version install fails', () {
+          setUp(() {
+            when(
+              () => shorebirdFlutter.installRevision(
+                revision: any(named: 'revision'),
+              ),
+            ).thenThrow(Exception('oops'));
+          });
+
+          test('exits with code 70', () async {
+            final result = await runWithOverrides(command.run);
+
+            expect(result, equals(ExitCode.software.code));
+            verify(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ).called(1);
+          });
+        });
       });
     });
 

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -156,6 +156,11 @@ void main() {
       when(
         () => shorebirdFlutter.getVersionAndRevision(),
       ).thenAnswer((_) async => flutterVersionAndRevision);
+      when(
+        () => shorebirdFlutter.installRevision(
+          revision: any(named: 'revision'),
+        ),
+      ).thenAnswer((_) async => {});
 
       when(
         () => shorebirdProcess.run(
@@ -372,6 +377,8 @@ $exception''',
 
           await runWithOverrides(command.run);
 
+          verify(() => shorebirdFlutter.installRevision(revision: revision))
+              .called(1);
           verify(
             () => codePushClientWrapper.createRelease(
               appId: appId,

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -734,11 +734,6 @@ $exception''',
           when(
             () => shorebirdFlutter.getRevisionForVersion(any()),
           ).thenAnswer((_) async => revision);
-          when(
-            () => shorebirdFlutter.useRevision(
-              revision: any(named: 'revision'),
-            ),
-          ).thenAnswer((_) async {});
         });
 
         test('uses specified flutter version to build', () async {

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -762,6 +762,25 @@ $exception''',
             ),
           ).called(1);
         });
+
+        group('when flutter version install fails', () {
+          setUp(() {
+            when(
+              () => shorebirdFlutter.installRevision(
+                revision: any(named: 'revision'),
+              ),
+            ).thenThrow(Exception('oops'));
+          });
+
+          test('exits with code 70', () async {
+            final result = await runWithOverrides(command.run);
+
+            expect(result, equals(ExitCode.software.code));
+            verify(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ).called(1);
+          });
+        });
       });
     });
 

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -225,6 +225,11 @@ flutter:
         () => shorebirdFlutter.getVersionAndRevision(),
       ).thenAnswer((_) async => flutterVersionAndRevision);
       when(
+        () => shorebirdFlutter.installRevision(
+          revision: any(named: 'revision'),
+        ),
+      ).thenAnswer((_) async => {});
+      when(
         () => shorebirdProcess.run(
           'flutter',
           ['--no-version-check', 'pub', 'get', '--offline'],
@@ -750,6 +755,9 @@ $exception''',
           });
 
           await runWithOverrides(command.run);
+
+          verify(() => shorebirdFlutter.installRevision(revision: revision))
+              .called(1);
           verify(
             () => codePushClientWrapper.createRelease(
               appId: appId,

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -212,6 +212,16 @@ flutter:
       when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
       when(() => shorebirdEnv.isRunningOnCI).thenReturn(false);
       when(
+        () => shorebirdEnv.copyWith(
+          flutterRevisionOverride: any(named: 'flutterRevisionOverride'),
+        ),
+      ).thenAnswer((invocation) {
+        when(() => shorebirdEnv.flutterRevision).thenReturn(
+          invocation.namedArguments[#flutterRevisionOverride] as String,
+        );
+        return shorebirdEnv;
+      });
+      when(
         () => shorebirdFlutter.getVersionAndRevision(),
       ).thenAnswer((_) async => flutterVersionAndRevision);
       when(
@@ -726,14 +736,20 @@ $exception''',
           ).thenAnswer((_) async {});
         });
 
-        test(
-            'uses specified flutter version to build '
-            'and reverts to original flutter version', () async {
+        test('uses specified flutter version to build', () async {
+          when(
+            () => shorebirdProcess.run(
+              'flutter',
+              any(),
+              runInShell: any(named: 'runInShell'),
+            ),
+          ).thenAnswer((_) async {
+            // Ensure we're using the correct flutter version.
+            expect(shorebirdEnv.flutterRevision, equals(revision));
+            return flutterBuildProcessResult;
+          });
+
           await runWithOverrides(command.run);
-          verifyInOrder([
-            () => shorebirdFlutter.useRevision(revision: revision),
-            () => shorebirdFlutter.useRevision(revision: flutterRevision),
-          ]);
           verify(
             () => codePushClientWrapper.createRelease(
               appId: appId,

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -169,6 +169,11 @@ flutter:
         () => shorebirdFlutter.getVersionAndRevision(),
       ).thenAnswer((_) async => flutterVersionAndRevision);
       when(
+        () => shorebirdFlutter.installRevision(
+          revision: any(named: 'revision'),
+        ),
+      ).thenAnswer((_) async => {});
+      when(
         () => shorebirdProcess.run(
           'flutter',
           ['--no-version-check', 'pub', 'get', '--offline'],
@@ -356,6 +361,8 @@ $exception''',
 
           await runWithOverrides(command.run);
 
+          verify(() => shorebirdFlutter.installRevision(revision: revision))
+              .called(1);
           verify(
             () => codePushClientWrapper.createRelease(
               appId: appId,

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -337,11 +337,6 @@ $exception''',
           when(
             () => shorebirdFlutter.getRevisionForVersion(any()),
           ).thenAnswer((_) async => revision);
-          when(
-            () => shorebirdFlutter.useRevision(
-              revision: any(named: 'revision'),
-            ),
-          ).thenAnswer((_) async {});
         });
 
         test('uses specified flutter version build', () async {

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -367,6 +367,26 @@ $exception''',
             ),
           ).called(1);
         });
+
+        group('when flutter version install fails', () {
+          setUp(() {
+            when(
+              () => shorebirdFlutter.installRevision(
+                revision: any(named: 'revision'),
+              ),
+            ).thenThrow(Exception('oops'));
+          });
+
+          test('exits with code 70', () async {
+            setUpProjectRoot();
+            final result = await runWithOverrides(command.run);
+
+            expect(result, equals(ExitCode.software.code));
+            verify(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ).called(1);
+          });
+        });
       });
     });
 

--- a/packages/shorebird_cli/test/src/executables/git_test.dart
+++ b/packages/shorebird_cli/test/src/executables/git_test.dart
@@ -459,6 +459,50 @@ origin/flutter_release/3.10.6''';
           ),
         );
       });
+
+      group('lsRemoteHeads', () {
+        final directory = Directory('repository');
+        const output = '''
+
+origin/flutter_release/3.10.0
+origin/flutter_release/3.10.1
+origin/flutter_release/3.10.2
+origin/flutter_release/3.10.3
+origin/flutter_release/3.10.4
+origin/flutter_release/3.10.5
+origin/flutter_release/3.10.6''';
+        test('executes correct command', () async {
+          when(() => processResult.stdout).thenReturn(output);
+          await expectLater(
+            runWithOverrides(
+              () => git.lsRemoteHeads(directory: directory),
+            ),
+            completion(equals(output.trim().split(Platform.lineTerminator))),
+          );
+          verify(
+            () => process.run(
+              'git',
+              ['ls-remote', '--heads'],
+              workingDirectory: directory.path,
+            ),
+          ).called(1);
+        });
+
+        test('throws ProcessException if process exits with error', () async {
+          const error = 'oops';
+          when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+          when(() => processResult.stderr).thenReturn(error);
+          expect(
+            () => runWithOverrides(
+              () => git.lsRemoteHeads(directory: directory),
+            ),
+            throwsA(
+              isA<ProcessException>()
+                  .having((e) => e.message, 'message', error),
+            ),
+          );
+        });
+      });
     });
   });
 }

--- a/packages/shorebird_cli/test/src/executables/git_test.dart
+++ b/packages/shorebird_cli/test/src/executables/git_test.dart
@@ -459,50 +459,6 @@ origin/flutter_release/3.10.6''';
           ),
         );
       });
-
-      group('lsRemoteHeads', () {
-        final directory = Directory('repository');
-        const output = '''
-
-origin/flutter_release/3.10.0
-origin/flutter_release/3.10.1
-origin/flutter_release/3.10.2
-origin/flutter_release/3.10.3
-origin/flutter_release/3.10.4
-origin/flutter_release/3.10.5
-origin/flutter_release/3.10.6''';
-        test('executes correct command', () async {
-          when(() => processResult.stdout).thenReturn(output);
-          await expectLater(
-            runWithOverrides(
-              () => git.lsRemoteHeads(directory: directory),
-            ),
-            completion(equals(output.trim().split(Platform.lineTerminator))),
-          );
-          verify(
-            () => process.run(
-              'git',
-              ['ls-remote', '--heads'],
-              workingDirectory: directory.path,
-            ),
-          ).called(1);
-        });
-
-        test('throws ProcessException if process exits with error', () async {
-          const error = 'oops';
-          when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
-          when(() => processResult.stderr).thenReturn(error);
-          expect(
-            () => runWithOverrides(
-              () => git.lsRemoteHeads(directory: directory),
-            ),
-            throwsA(
-              isA<ProcessException>()
-                  .having((e) => e.message, 'message', error),
-            ),
-          );
-        });
-      });
     });
   });
 }

--- a/packages/shorebird_cli/test/src/shorebird_env_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_env_test.dart
@@ -47,9 +47,20 @@ void main() {
 
     group('copyWith', () {
       test('creates a new instance with the provided values', () {
-        final newEnv = shorebirdEnv.copyWith(flutterRevisionOverride: 'test');
+        final newEnv = runWithOverrides(
+          () => shorebirdEnv.copyWith(flutterRevisionOverride: 'test'),
+        );
         expect(newEnv, isNot(same(shorebirdEnv)));
         expect(newEnv.flutterRevision, equals('test'));
+      });
+
+      test('uses existing values when not provided', () {
+        final newEnv = runWithOverrides(() => shorebirdEnv.copyWith());
+        expect(newEnv, isNot(same(shorebirdEnv)));
+        expect(
+          runWithOverrides(() => newEnv.flutterRevision),
+          equals(flutterRevision),
+        );
       });
     });
 

--- a/packages/shorebird_cli/test/src/shorebird_env_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_env_test.dart
@@ -45,6 +45,14 @@ void main() {
       when(() => platform.script).thenReturn(platformScript);
     });
 
+    group('copyWith', () {
+      test('creates a new instance with the provided values', () {
+        final newEnv = shorebirdEnv.copyWith(flutterRevisionOverride: 'test');
+        expect(newEnv, isNot(same(shorebirdEnv)));
+        expect(newEnv.flutterRevision, equals('test'));
+      });
+    });
+
     group('getShorebirdYamlFile', () {
       test('returns correct file', () {
         final tempDir = Directory.systemTemp.createTempSync();

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -83,14 +83,6 @@ void main() {
           pattern: any(named: 'pattern'),
         ),
       ).thenAnswer((_) async => 'origin/flutter_release/3.10.6');
-      when(
-        () => git.lsRemoteHeads(directory: any(named: 'directory')),
-      ).thenAnswer(
-        (_) async => [
-          'flutter-revision refs/heads/flutter_release/3.10.6',
-          'test-revision refs/heads/flutter_release/3.10.7',
-        ],
-      );
       when(() => logger.progress(any())).thenReturn(progress);
       when(() => shorebirdEnv.flutterDirectory).thenReturn(flutterDirectory);
       when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
@@ -412,46 +404,6 @@ $revision
       });
     });
 
-    group('getVersionForRevision', () {
-      const output = [
-        '8679396700d040e779463461c7c79ba08d130209	refs/heads/flutter_release/3.19.0',
-        '9d3f4fcf6f9adf1e4951e0b35adde89ca1be5899	refs/heads/flutter_release/3.19.0-0.4.pre',
-        'f6e79dd6ccfd36e5d2b7a289bd37cb5236c7fed7	refs/heads/flutter_release/3.19.1',
-        '5b9d29d67adb059103beefb65710ee3dabae2f85	refs/heads/flutter_release/3.19.2',
-        'a6d1747d7f573b2ba2e2b96db1b76ed2f3f024da	refs/heads/flutter_release/3.19.3',
-        '8dd30c5c027a440d15696d3bc48d01dd47d9aab7	refs/heads/fuchsia_r49',
-        'afda8153fd2d2c32c8495ad008d6c25fa8203df1	refs/heads/fuchsia_r51',
-        '7673108d7eeebd9d1558535ea7a1cf94877a0c4e	refs/heads/fuchsia_r51a',
-      ];
-
-      setUp(() {
-        when(() => git.lsRemoteHeads(directory: any(named: 'directory')))
-            .thenAnswer((_) async => output);
-      });
-
-      test('returns null if revision not found', () async {
-        await expectLater(
-          runWithOverrides(
-            () => shorebirdFlutter.getVersionForRevision('not-a-revision'),
-          ),
-          completion(isNull),
-        );
-        verify(() => git.lsRemoteHeads(directory: flutterDirectory)).called(1);
-      });
-
-      test('returns version if revision is found', () async {
-        await expectLater(
-          runWithOverrides(
-            () => shorebirdFlutter.getVersionForRevision(
-              '5b9d29d67adb059103beefb65710ee3dabae2f85',
-            ),
-          ),
-          completion('3.19.2'),
-        );
-        verify(() => git.lsRemoteHeads(directory: flutterDirectory)).called(1);
-      });
-    });
-
     group('getVersions', () {
       const format = '%(refname:short)';
       const pattern = 'refs/remotes/origin/flutter_release/*';
@@ -601,12 +553,12 @@ origin/flutter_release/3.10.6''';
         ).called(1);
         verify(
           () => logger.progress(
-            'Installing Flutter revision 3.10.7 (test-revision)',
+            'Installing Flutter revision 3.10.6 (test-revision)',
           ),
         ).called(1);
         verify(
           () => progress.fail(
-            'Failed to install Flutter revision 3.10.7 (test-revision)',
+            'Failed to install Flutter revision 3.10.6 (test-revision)',
           ),
         ).called(1);
       });
@@ -620,7 +572,7 @@ origin/flutter_release/3.10.6''';
         );
         verify(
           () => logger.progress(
-            'Installing Flutter revision 3.10.7 (test-revision)',
+            'Installing Flutter revision 3.10.6 (test-revision)',
           ),
         ).called(1);
         verify(() => progress.complete()).called(1);

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -553,12 +553,12 @@ origin/flutter_release/3.10.6''';
         ).called(1);
         verify(
           () => logger.progress(
-            'Installing Flutter revision 3.10.6 (test-revision)',
+            'Installing Flutter 3.10.6 (test-revision)',
           ),
         ).called(1);
         verify(
           () => progress.fail(
-            'Failed to install Flutter revision 3.10.6 (test-revision)',
+            'Failed to install Flutter 3.10.6 (test-revision)',
           ),
         ).called(1);
       });
@@ -572,7 +572,7 @@ origin/flutter_release/3.10.6''';
         );
         verify(
           () => logger.progress(
-            'Installing Flutter revision 3.10.6 (test-revision)',
+            'Installing Flutter 3.10.6 (test-revision)',
           ),
         ).called(1);
         verify(() => progress.complete()).called(1);

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -553,12 +553,12 @@ origin/flutter_release/3.10.6''';
         ).called(1);
         verify(
           () => logger.progress(
-            'Installing Flutter 3.10.6 (test-revision)',
+            'Installing Flutter 3.10.6 (test-revis)',
           ),
         ).called(1);
         verify(
           () => progress.fail(
-            'Failed to install Flutter 3.10.6 (test-revision)',
+            'Failed to install Flutter 3.10.6 (test-revis)',
           ),
         ).called(1);
       });
@@ -572,7 +572,7 @@ origin/flutter_release/3.10.6''';
         );
         verify(
           () => logger.progress(
-            'Installing Flutter 3.10.6 (test-revision)',
+            'Installing Flutter 3.10.6 (test-revis)',
           ),
         ).called(1);
         verify(() => progress.complete()).called(1);


### PR DESCRIPTION
## Description

Updates all patch and release commands to run build operations with a scoped `shorebirdEnv`, which is used to determine the current Flutter revision.

The diff is ugly, but broadly, this change simply creates a new `shorebirdEnv` using `copyWith` once we know which Flutter revision we're using to create the build, and wraps all build operations in `runScoped` with that shorebirdEnv as an override.

Fixes https://github.com/shorebirdtech/shorebird/issues/1794

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
