### PR TITLE
fix(shorebird_cli): check for new android build artifacts location

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -385,7 +385,7 @@ Cannot find release build artifacts.
 Please run `shorebird cache clean` and try again. If the issue persists, please
 file a bug report at https://github.com/shorebirdtech/shorebird/issues/new.
 
-Expected locations are:
+Looked in:
   - build/app/intermediates/stripped_native_libs/stripReleaseDebugSymbols/release/out/lib
   - build/app/intermediates/stripped_native_libs/strip{flavor}ReleaseDebugSymbols/{flavor}Release/out/lib
   - build/app/intermediates/stripped_native_libs/release/out/lib

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive/directory_archive.dart';
+import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/logger.dart';
@@ -369,16 +370,32 @@ Please create a release using "shorebird release" and try again.
     String? flavor,
   }) async {
     final createArtifactProgress = logger.progress('Creating artifacts');
+    final archsDir = ArtifactManager.androidArchsDirectory(
+      projectRoot: Directory(projectRoot),
+      flavor: flavor,
+    );
+
+    if (archsDir == null) {
+      _handleErrorAndExit(
+        Exception('Cannot find patch build artifacts.'),
+        progress: createArtifactProgress,
+        message: '''
+Cannot find release build artifacts.
+
+Please run `shorebird cache clean` and try again. If the issue persists, please
+file a bug report at https://github.com/shorebirdtech/shorebird/issues/new.
+
+Expected locations are:
+  - build/app/intermediates/stripped_native_libs/stripReleaseDebugSymbols/release/out/lib
+  - build/app/intermediates/stripped_native_libs/strip{flavor}ReleaseDebugSymbols/{flavor}Release/out/lib
+  - build/app/intermediates/stripped_native_libs/release/out/lib
+  - build/app/intermediates/stripped_native_libs/{flavor}Release/out/lib''',
+      );
+    }
+
     for (final archMetadata in architectures.values) {
       final artifactPath = p.join(
-        projectRoot,
-        'build',
-        'app',
-        'intermediates',
-        'stripped_native_libs',
-        flavor != null ? '${flavor}Release' : 'release',
-        'out',
-        'lib',
+        archsDir.path,
         archMetadata.path,
         'libapp.so',
       );

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -222,7 +222,7 @@ Current Flutter Revision: $currentFlutterRevision
 Please run `shorebird cache clean` and try again. If the issue persists, please
 file a bug report at https://github.com/shorebirdtech/shorebird/issues/new.
 
-Expected locations are:
+Looked in:
   - build/app/intermediates/stripped_native_libs/stripReleaseDebugSymbols/release/out/lib
   - build/app/intermediates/stripped_native_libs/strip{flavor}ReleaseDebugSymbols/{flavor}Release/out/lib
   - build/app/intermediates/stripped_native_libs/release/out/lib

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -209,6 +209,29 @@ Current Flutter Revision: $currentFlutterRevision
           }
         }
 
+        final patchArchsBuildDir = ArtifactManager.androidArchsDirectory(
+          projectRoot: projectRoot,
+          flavor: flavor,
+        );
+
+        if (patchArchsBuildDir == null) {
+          logger
+            ..err('Cannot find patch build artifacts.')
+            ..info(
+              '''
+Please run `shorebird cache clean` and try again. If the issue persists, please
+file a bug report at https://github.com/shorebirdtech/shorebird/issues/new.
+
+Expected locations are:
+  - build/app/intermediates/stripped_native_libs/stripReleaseDebugSymbols/release/out/lib
+  - build/app/intermediates/stripped_native_libs/strip{flavor}ReleaseDebugSymbols/{flavor}Release/out/lib
+  - build/app/intermediates/stripped_native_libs/release/out/lib
+  - build/app/intermediates/stripped_native_libs/{flavor}Release/out/lib''',
+            );
+
+          return ExitCode.software.code;
+        }
+
         final releaseArtifacts =
             await codePushClientWrapper.getReleaseArtifacts(
           appId: app.appId,
@@ -266,18 +289,10 @@ Current Flutter Revision: $currentFlutterRevision
 
         final patchArtifactBundles = <Arch, PatchArtifactBundle>{};
         final createDiffProgress = logger.progress('Creating artifacts');
-
         for (final releaseArtifactPath in releaseArtifactPaths.entries) {
           final archMetadata = architectures[releaseArtifactPath.key]!;
           final patchArtifactPath = p.join(
-            projectRoot.path,
-            'build',
-            'app',
-            'intermediates',
-            'stripped_native_libs',
-            flavor != null ? '${flavor}Release' : 'release',
-            'out',
-            'lib',
+            patchArchsBuildDir.path,
             archMetadata.path,
             'libapp.so',
           );

--- a/packages/shorebird_cli/test/src/artifact_manager_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_manager_test.dart
@@ -191,5 +191,155 @@ void main() {
         expect(tempDir.listSync(recursive: true), hasLength(146));
       });
     });
+
+    group('androidArchsDirectory', () {
+      late Directory projectRoot;
+      late Directory strippedNativeLibsDirectory;
+
+      setUp(() {
+        projectRoot = Directory.systemTemp.createTempSync();
+        strippedNativeLibsDirectory = Directory(
+          p.join(
+            projectRoot.path,
+            'build',
+            'app',
+            'intermediates',
+            'stripped_native_libs',
+          ),
+        )..createSync(recursive: true);
+      });
+
+      group('without flavor', () {
+        setUp(() {});
+
+        test('returns null if no directories exist at the expected paths', () {
+          final result = ArtifactManager.androidArchsDirectory(
+            projectRoot: projectRoot,
+          );
+
+          expect(result, isNull);
+        });
+
+        test('returns a path containing stripReleaseDebugSymbols if it exists',
+            () {
+          final stripNativeDebugLibsDirectory = Directory(
+            p.join(
+              strippedNativeLibsDirectory.path,
+              'release',
+              'stripReleaseDebugSymbols',
+              'out',
+              'lib',
+            ),
+          )..createSync(recursive: true);
+
+          // Create paths with and without the stripReleaseDebugSymbols
+          // directory to ensure the method returns the correct path when both
+          // exist.
+          Directory(
+            p.join(
+              strippedNativeLibsDirectory.path,
+              'release',
+              'out',
+              'lib',
+            ),
+          ).createSync(recursive: true);
+
+          final result = ArtifactManager.androidArchsDirectory(
+            projectRoot: projectRoot,
+          );
+
+          expect(result, isNotNull);
+          expect(result!.path, equals(stripNativeDebugLibsDirectory.path));
+        });
+
+        test(
+            '''returns a path not containing stripReleaseDebugSymbols no path containing stripReleaseDebugSymbols exists''',
+            () {
+          final noStripReleaseDebugSymbolsPath = Directory(
+            p.join(
+              strippedNativeLibsDirectory.path,
+              'release',
+              'out',
+              'lib',
+            ),
+          )..createSync(recursive: true);
+
+          final result = ArtifactManager.androidArchsDirectory(
+            projectRoot: projectRoot,
+          );
+
+          expect(result, isNotNull);
+          expect(result!.path, equals(noStripReleaseDebugSymbolsPath.path));
+        });
+      });
+
+      group('with a flavor named "internal"', () {
+        const flavor = 'internal';
+
+        test('returns null if no directories exist at the expected paths', () {
+          final result = ArtifactManager.androidArchsDirectory(
+            projectRoot: projectRoot,
+            flavor: flavor,
+          );
+
+          expect(result, isNull);
+        });
+
+        test(
+            '''returns a path containing stripInternalReleaseDebugSymbols if it exists''',
+            () {
+          final stripNativeDebugLibsDirectory = Directory(
+            p.join(
+              strippedNativeLibsDirectory.path,
+              'internalRelease',
+              'stripInternalReleaseDebugSymbols',
+              'out',
+              'lib',
+            ),
+          )..createSync(recursive: true);
+
+          // Create paths with and without the stripReleaseDebugSymbols
+          // directory to ensure the method returns the correct path when both
+          // exist.
+          Directory(
+            p.join(
+              strippedNativeLibsDirectory.path,
+              'internalRelease',
+              'out',
+              'lib',
+            ),
+          ).createSync(recursive: true);
+
+          final result = ArtifactManager.androidArchsDirectory(
+            projectRoot: projectRoot,
+            flavor: flavor,
+          );
+
+          expect(result, isNotNull);
+          expect(result!.path, equals(stripNativeDebugLibsDirectory.path));
+        });
+
+        test(
+            '''returns a path not containing stripInternalReleaseDebugSymbols no path containing stripInternalReleaseDebugSymbols exists''',
+            () {
+          final noStripReleaseDebugSymbolsPath = Directory(
+            p.join(
+              strippedNativeLibsDirectory.path,
+              'internalRelease',
+              'out',
+              'lib',
+            ),
+          )..createSync(recursive: true);
+
+          final result = ArtifactManager.androidArchsDirectory(
+            projectRoot: projectRoot,
+            flavor: flavor,
+          );
+
+          expect(result, isNotNull);
+          expect(result!.path, equals(noStripReleaseDebugSymbolsPath.path));
+        });
+      });
+    });
   });
 }

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -1025,6 +1025,28 @@ Please bump your version number and try again.''',
           ).thenAnswer((_) async {});
         });
 
+        test('exits with code 70 when artifacts cannot be found', () async {
+          await expectLater(
+            () async => runWithOverrides(
+              () async => codePushClientWrapper.createAndroidReleaseArtifacts(
+                appId: app.appId,
+                releaseId: releaseId,
+                platform: releasePlatform,
+                projectRoot: projectRoot.path,
+                aabPath: p.join(projectRoot.path, aabPath),
+                architectures: ShorebirdBuildMixin.allAndroidArchitectures,
+              ),
+            ),
+            exitsWithCode(ExitCode.software),
+          );
+
+          verify(
+            () => progress.fail(
+              any(that: contains('Cannot find release build artifacts')),
+            ),
+          ).called(1);
+        });
+
         test('exits with code 70 when artifact creation fails', () async {
           const error = 'something went wrong';
           when(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -432,6 +432,20 @@ flutter:
       expect(exitCode, equals(ExitCode.software.code));
     });
 
+    test('exits with code 70 when build artifacts cannot be found', () async {
+      final exitCode = await runWithOverrides(command.run);
+
+      expect(exitCode, equals(ExitCode.software.code));
+      verify(() => logger.err('Cannot find patch build artifacts.')).called(1);
+      verify(
+        () => logger.info(
+          any(
+            that: contains('Please run `shorebird cache clean` and try again'),
+          ),
+        ),
+      ).called(1);
+    });
+
     test(
         '''exits with code 70 if release is in draft state for the android platform''',
         () async {


### PR DESCRIPTION
## Description

A newer version of the Android gradle plugin (between 7.3.0 and 8.3.0) changed the output location of the `libapp.so` build artifacts. This change updates to check both the old and new locations, preferring the new location if found. 

Fixes https://github.com/shorebirdtech/shorebird/issues/1798

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
