### PR TITLE
fix(shorebird_cli): add export-options-plist option to patch ios

### DIFF
--- a/packages/shorebird_cli/lib/src/platform/ios.dart
+++ b/packages/shorebird_cli/lib/src/platform/ios.dart
@@ -68,7 +68,10 @@ Ios get ios => read(iosRef);
 class Ios {
   File exportOptionsPlistFromArgs(ArgResults results) {
     final exportPlistArg = results[exportOptionsPlistArgName] as String?;
-    if (exportPlistArg != null && results.wasParsed(exportMethodArgName)) {
+    final exportMethodArgExists = results.options.contains(exportMethodArgName);
+    if (exportPlistArg != null &&
+        exportMethodArgExists &&
+        results.wasParsed(exportMethodArgName)) {
       throw ArgumentError(
         '''Cannot specify both --$exportMethodArgName and --$exportOptionsPlistArgName.''',
       );
@@ -82,7 +85,7 @@ class Ios {
     }
 
     final ExportMethod? exportMethod;
-    if (results.wasParsed(exportMethodArgName)) {
+    if (exportMethodArgExists && results.wasParsed(exportMethodArgName)) {
       exportMethod = ExportMethod.values.firstWhere(
         (element) => element.argName == results[exportMethodArgName] as String,
       );

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -408,7 +408,8 @@ flutter:
       ).thenAnswer((_) async {});
       when(() => doctor.iosCommandValidators).thenReturn([flutterValidator]);
       when(() => engineConfig.localEngine).thenReturn(null);
-      when(() => ios.createExportOptionsPlist()).thenReturn(File('.'));
+      when(() => ios.exportOptionsPlistFromArgs(argResults))
+          .thenReturn(File('.'));
       when(flutterValidator.validate).thenAnswer((_) async => []);
       when(() => logger.confirm(any())).thenReturn(true);
       when(() => logger.progress(any())).thenReturn(progress);
@@ -554,6 +555,21 @@ flutter:
           .called(1);
       verify(() => logger.info(PatchCommand.forceDeprecationExplanation))
           .called(1);
+    });
+
+    group('when exportOptionsPlistFromArgs throws exception', () {
+      setUp(() {
+        when(() => ios.exportOptionsPlistFromArgs(argResults))
+            .thenThrow(ArgumentError('bad args'));
+      });
+
+      test('logs error and exits with usage code', () async {
+        setUpProjectRoot();
+        final exitCode = await runWithOverrides(command.run);
+
+        expect(exitCode, equals(ExitCode.usage.code));
+        verify(() => logger.err('Invalid argument(s): bad args')).called(1);
+      });
     });
 
     test('exits with code 70 when building fails', () async {

--- a/packages/shorebird_cli/test/src/platform/ios_test.dart
+++ b/packages/shorebird_cli/test/src/platform/ios_test.dart
@@ -25,6 +25,10 @@ void main() {
         argResults = MockArgResults();
 
         when(() => argResults.wasParsed(any())).thenReturn(false);
+        when(() => argResults.options).thenReturn([
+          exportMethodArgName,
+          exportOptionsPlistArgName,
+        ]);
       });
 
       group('when both export-method and export-options-plist are provided',
@@ -151,6 +155,18 @@ void main() {
           expect(exportOptionsPlistMap['signingStyle'], 'automatic');
           expect(exportOptionsPlistMap['uploadBitcode'], isFalse);
           expect(exportOptionsPlistMap['method'], 'app-store');
+        });
+      });
+
+      group('when export-method option does not exist', () {
+        setUp(() {
+          when(() => argResults.options)
+              .thenReturn([exportOptionsPlistArgName]);
+        });
+
+        test('does not check whether export-method was parsed', () {
+          ios.exportOptionsPlistFromArgs(argResults);
+          verifyNever(() => argResults.wasParsed(exportMethodArgName));
         });
       });
     });


### PR DESCRIPTION
## Description

Adds `--export-options-plist` to the `patch ios` command for consistency with the `release ios` command.

Fixes https://github.com/shorebirdtech/shorebird/issues/1754

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
