### PR TITLE
fix(shorebird_cli): detect Azure pipeline CI environment

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_env.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_env.dart
@@ -230,5 +230,9 @@ class ShorebirdEnv {
 
       // https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
       ||
-      platform.environment.containsKey('GITHUB_ACTIONS');
+      platform.environment.containsKey('GITHUB_ACTIONS')
+
+      // https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+      ||
+      platform.environment.containsKey('TF_BUILD');
 }

--- a/packages/shorebird_cli/test/src/shorebird_env_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_env_test.dart
@@ -607,6 +607,11 @@ base_url: https://example.com''');
         expect(runWithOverrides(() => shorebirdEnv.isRunningOnCI), isTrue);
       });
 
+      test('returns true if TF_BUILD is set', () {
+        when(() => platform.environment).thenReturn({'TF_BUILD': 'True'});
+        expect(runWithOverrides(() => shorebirdEnv.isRunningOnCI), isTrue);
+      });
+
       test('returns false if no relevant environment variables are set', () {
         when(() => platform.environment).thenReturn({});
         expect(runWithOverrides(() => shorebirdEnv.isRunningOnCI), isFalse);


### PR DESCRIPTION
## Description

Adds a check for the `TF_BUILD` environment variable in our `isRunningOnCi` check, which is [set by the Azure pipeline environment](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml).

Fixes https://github.com/shorebirdtech/shorebird/issues/1809

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
