### PR TITLE
fix(shorebird_cli): ensure flutter artifacts are installed in `shorebird preview`

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -304,6 +304,8 @@ class PreviewCommand extends ShorebirdCommand {
     required DeploymentTrack track,
     String? deviceId,
   }) async {
+    await iosDeploy.installIfNeeded();
+
     const platform = ReleasePlatform.ios;
     final runnerDirectory = Directory(
       getArtifactPath(

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -976,6 +976,7 @@ channel: ${track.channel}
             device: any(named: 'device'),
           ),
         ).thenAnswer((_) async => ExitCode.success.code);
+        when(() => iosDeploy.installIfNeeded()).thenAnswer((_) async {});
         when(
           () => iosDeploy.installAndLaunchApp(
             bundlePath: any(named: 'bundlePath'),
@@ -1001,6 +1002,11 @@ channel: ${track.channel}
           )
             ..createSync(recursive: true)
             ..writeAsStringSync('app_id: $appId', flush: true);
+
+      test('ensures ios-deploy is installed', () async {
+        await runWithOverrides(command.run);
+        verify(() => iosDeploy.installIfNeeded()).called(1);
+      });
 
       test('exits with code 70 when querying for release artifact fails',
           () async {


### PR DESCRIPTION
## Description

Updates the `shorebird preview` command to run `flutter precache` to ensure artifacts required to preview have been downloaded.

Fixes https://github.com/shorebirdtech/shorebird/issues/1795

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
