### PR TITLE
refactor: Make hide _preLinkerFlutterRevisions inside AotTools.

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -14,7 +14,6 @@ import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/doctor.dart';
-import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/formatters/file_size_formatter.dart';
@@ -306,8 +305,7 @@ Current Flutter Revision: $currentFlutterRevision
           ),
         );
 
-        final useLinker = engineConfig.localEngine != null ||
-            !preLinkerFlutterRevisions.contains(release.flutterRevision);
+        final useLinker = AotTools.usesLinker(release.flutterRevision);
         if (useLinker) {
           final exitCode = await _runLinker(
             releaseArtifact: releaseArtifactFile,

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
@@ -14,7 +14,6 @@ import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/doctor.dart';
-import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/executables/aot_tools.dart';
 import 'package:shorebird_cli/src/formatters/file_size_formatter.dart';
 import 'package:shorebird_cli/src/logger.dart';
@@ -249,8 +248,7 @@ Please re-run the release command for this version or create a new release.''');
           ),
         );
 
-        final useLinker = engineConfig.localEngine != null ||
-            !preLinkerFlutterRevisions.contains(release.flutterRevision);
+        final useLinker = AotTools.usesLinker(release.flutterRevision);
         if (useLinker) {
           final exitCode = await _runLinker(
             aotSnapshot: aotSnapshotFile,

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -4,6 +4,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/cache.dart';
+import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
@@ -15,7 +16,7 @@ final aotToolsRef = create(AotTools.new);
 AotTools get aotTools => read(aotToolsRef);
 
 /// Revisions of Flutter that were released before the linker was enabled.
-const preLinkerFlutterRevisions = <String>{
+const _preLinkerFlutterRevisions = <String>{
   '45d609090a2313d47a4e657d449ff25710abc853',
   '0b0086ffa92c25c22f50cbadc3851054f08a9cd8',
   'a3d5f7c614aa1cc4d6cb1506e74fd1c81678e68e',
@@ -63,6 +64,20 @@ const preLinkerFlutterRevisions = <String>{
 
 /// Wrapper around the shorebird `aot-tools` executable.
 class AotTools {
+  /// Returns true if the linker should be used for the given Flutter revision.
+  static bool usesLinker(String flutterRevision) {
+    // We always use the linker when we have a localEngine build.
+    // This will be wrong if we ever need new shorebird to work with old local
+    // engine build.
+    if (engineConfig.localEngine != null) {
+      return true;
+    }
+    // We could also probably just check if aot_tools exists in the flutter
+    // revision, although I think we released a couple versions of Flutter that
+    // included a broken aot_tools before we enabled the linker.
+    return !_preLinkerFlutterRevisions.contains(flutterRevision);
+  }
+
   Future<ShorebirdProcessResult> _exec(
     List<String> command, {
     String? workingDirectory,


### PR DESCRIPTION
I'm about to make AotTools have to answer the question of what's
enabled for a given version, so it felt correct to also make
"should I use the linker" a question that we ask AotTools rather
than checking a global list in callsites.