### PR TITLE
chore: remove iOS status warning

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -17,7 +17,6 @@ import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
-import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 
 /// {@template patch_artifact_bundle}
 /// Metadata about a patch artifact that we are about to upload.

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -131,8 +131,6 @@ If this option is not provided, the version number will be determined from the p
       return ExitCode.usage.code;
     }
 
-    showiOSStatusWarning();
-
     final allowAssetDiffs = results['allow-asset-diffs'] == true;
     final allowNativeDiffs = results['allow-native-diffs'] == true;
     final dryRun = results['dry-run'] == true;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
@@ -19,7 +19,6 @@ import 'package:shorebird_cli/src/formatters/file_size_formatter.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform.dart';
-import 'package:shorebird_cli/src/platform/ios.dart';
 import 'package:shorebird_cli/src/shorebird_artifact_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
 import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
@@ -114,8 +113,6 @@ of the iOS app that is using this module.''',
     final allowAssetDiffs = results['allow-asset-diffs'] == true;
     final allowNativeDiffs = results['allow-native-diffs'] == true;
     final dryRun = results['dry-run'] == true;
-
-    showiOSStatusWarning();
 
     const arch = 'aarch64';
     const releasePlatform = ReleasePlatform.ios;

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -300,7 +300,6 @@ ${summary.join('\n')}
             releaseId: release.id,
             platform: releasePlatform,
             status: ReleaseStatus.draft,
-            metadata: null,
           );
         } else {
           release = await codePushClientWrapper.createRelease(

--- a/packages/shorebird_cli/lib/src/platform/ios.dart
+++ b/packages/shorebird_cli/lib/src/platform/ios.dart
@@ -1,23 +1,12 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
-import 'package:shorebird_cli/src/logger.dart';
 
 const exportMethodArgName = 'export-method';
 const exportOptionsPlistArgName = 'export-options-plist';
-
-void showiOSStatusWarning() {
-  final url = link(
-    uri: Uri.parse('https://docs.shorebird.dev/status'),
-  );
-  logger
-    ..warn('iOS support is beta. Some apps may run slower after patching.')
-    ..info('See $url for more information.');
-}
 
 /// {@template export_method}
 /// The method used to export the IPA.

--- a/packages/shorebird_cli/test/src/executables/xcodebuild_test.dart
+++ b/packages/shorebird_cli/test/src/executables/xcodebuild_test.dart
@@ -6,7 +6,6 @@ import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
-import 'package:test/expect.dart';
 import 'package:test/test.dart';
 
 import '../mocks.dart';


### PR DESCRIPTION
As we get ready to release 1.0 we can now remove the iOS beta warning.

I also resolved a few other small analyzer warnings.