### PR TITLE
feat(shorebird_cli): suggest running with verbose on command failure

### DIFF
--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -181,7 +181,7 @@ ${lightCyan.wrap('shorebird release android -- --no-pub lib/main.dart')}''';
     }
 
     // Run the command or show version
-    final int? exitCode;
+    int? exitCode;
     if (topLevelResults['version'] == true) {
       final flutterVersion = await _tryGetFlutterVersion();
       final shorebirdFlutterPrefix = StringBuffer('Flutter');
@@ -205,7 +205,22 @@ Run ${lightCyan.wrap('shorebird upgrade')} to upgrade.''');
       }
       exitCode = ExitCode.success.code;
     } else {
-      exitCode = await super.runCommand(topLevelResults);
+      try {
+        exitCode = await super.runCommand(topLevelResults);
+      } catch (error, stackTrace) {
+        logger
+          ..err('$error')
+          ..info('$stackTrace');
+        exitCode = ExitCode.software.code;
+      }
+    }
+
+    if (exitCode == ExitCode.software.code && logger.level != Level.verbose) {
+      logger.info(
+        '''
+
+If you aren't sure why this command failed, re-run with the ${lightCyan.wrap('--verbose')} flag to see more information.''',
+      );
     }
 
     return exitCode;

--- a/packages/shorebird_cli/test/src/command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/command_runner_test.dart
@@ -278,7 +278,8 @@ Run ${lightCyan.wrap('shorebird upgrade')} to upgrade.'''),
         });
 
         test('does not suggest running with --verbose', () async {
-          // This will fail due to missing scoped overrides.
+          // This will fail due to the release android command missing scoped
+          // dependencies.
           // Note: the --verbose flag is here for illustrative purposes only.
           // Because logger is a mock, setting the log level in code does
           // nothing.
@@ -291,7 +292,8 @@ Run ${lightCyan.wrap('shorebird upgrade')} to upgrade.'''),
 
       group('when running without --verbose', () {
         test('suggests using --verbose flag', () async {
-          // This will fail due to missing scoped overrides.
+          // This will fail due to the release android command missing scoped
+          // dependencies.
           await runWithOverrides(
             () => commandRunner.run(['release', 'android']),
           );

--- a/packages/shorebird_cli/test/src/command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/command_runner_test.dart
@@ -8,7 +8,6 @@ import 'package:shorebird_cli/src/logger.dart' hide logger;
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
-import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/shorebird_version.dart';
 import 'package:shorebird_cli/src/version.dart';
 import 'package:test/test.dart';
@@ -26,7 +25,6 @@ void main() {
     late ShorebirdEnv shorebirdEnv;
     late ShorebirdFlutter shorebirdFlutter;
     late ShorebirdVersion shorebirdVersion;
-    late ShorebirdProcessResult processResult;
     late ShorebirdCliCommandRunner commandRunner;
 
     R runWithOverrides<R>(R Function() body) {
@@ -48,8 +46,7 @@ void main() {
       shorebirdEnv = MockShorebirdEnv();
       shorebirdFlutter = MockShorebirdFlutter();
       shorebirdVersion = MockShorebirdVersion();
-      processResult = MockProcessResult();
-      when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+      when(() => logger.level).thenReturn(Level.info);
       when(
         () => shorebirdEnv.shorebirdEngineRevision,
       ).thenReturn(shorebirdEngineRevision);
@@ -270,6 +267,35 @@ Run ${lightCyan.wrap('shorebird upgrade')} to upgrade.'''),
             ),
             throwsArgumentError,
           );
+        });
+      });
+    });
+
+    group('on command failure', () {
+      group('when running with --verbose', () {
+        setUp(() {
+          when(() => logger.level).thenReturn(Level.verbose);
+        });
+
+        test('does not suggest running with --verbose', () async {
+          // This will fail due to missing scoped overrides.
+          // Note: the --verbose flag is here for illustrative purposes only.
+          // Because logger is a mock, setting the log level in code does
+          // nothing.
+          await runWithOverrides(
+            () => commandRunner.run(['release', 'android', '--verbose']),
+          );
+          verifyNever(() => logger.info(any(that: contains('--verbose'))));
+        });
+      });
+
+      group('when running without --verbose', () {
+        test('suggests using --verbose flag', () async {
+          // This will fail due to missing scoped overrides.
+          await runWithOverrides(
+            () => commandRunner.run(['release', 'android']),
+          );
+          verify(() => logger.info(any(that: contains('--verbose')))).called(1);
         });
       });
     });


### PR DESCRIPTION
## Description

If a command fails with a `software` exit code (what we conventionally use for exceptions and general "something went wrong" errors), suggest that the user re-run the command with `--verbose` if they aren't already using that flag.

Fixes https://github.com/shorebirdtech/shorebird/issues/1848

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
