### PR TITLE
fix(shorebird_cli): `PathExistsException` in `ArtifactManager.extractZip`

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_manager.dart
+++ b/packages/shorebird_cli/lib/src/artifact_manager.dart
@@ -88,6 +88,7 @@ Failed to create diff (exit code ${result.exitCode}).
     await Isolate.run(() async {
       final inputStream = InputFileStream(zipFile.path);
       final archive = ZipDecoder().decodeBuffer(inputStream);
+      inputStream.closeSync();
       extractArchiveToDisk(archive, outputDirectory.path);
     });
   }


### PR DESCRIPTION
## Description

Close [inputStream](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_cli/lib/src/artifact_manager.dart#L84) used in [extractZip](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_cli/lib/src/artifact_manager.dart#L84), which was causing [tmpAabFile.copySync(aabFile.path)](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_cli/lib/src/commands/preview_command.dart#L517) to fail because the **aabFile** was being used by another process. This is only an issue windows apparently. 

- Fixes #1856 


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
