### PR TITLE
fix(shorebird_cli): properly close zip input stream

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_manager.dart
+++ b/packages/shorebird_cli/lib/src/artifact_manager.dart
@@ -88,8 +88,8 @@ Failed to create diff (exit code ${result.exitCode}).
     await Isolate.run(() async {
       final inputStream = InputFileStream(zipFile.path);
       final archive = ZipDecoder().decodeBuffer(inputStream);
-      inputStream.closeSync();
       extractArchiveToDisk(archive, outputDirectory.path);
+      inputStream.closeSync();
     });
   }
 


### PR DESCRIPTION
## Description

This stream was being closed prematurely and causing iOS patching to fail due to incomplete ZIP extraction.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
