### PR TITLE
chore(shorebird_cli): remove deprecated force flag from release and patch commands

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -55,12 +55,6 @@ of the Android app that is using this module.''',
         mandatory: true,
       )
       ..addFlag(
-        'force',
-        abbr: 'f',
-        help: PatchCommand.forceHelpText,
-        negatable: false,
-      )
-      ..addFlag(
         'allow-native-diffs',
         help: PatchCommand.allowNativeDiffsHelpText,
         negatable: false,
@@ -98,14 +92,6 @@ of the Android app that is using this module.''',
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;
-    }
-
-    final force = results['force'] == true;
-    if (force) {
-      logger
-        ..err(PatchCommand.forceDeprecationErrorMessage)
-        ..info(PatchCommand.forceDeprecationExplanation);
-      return ExitCode.usage.code;
     }
 
     final dryRun = results['dry-run'] == true;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -58,12 +58,6 @@ The version of the release being patched (e.g. "1.0.0+1").
 If this option is not provided, the version number will be determined from the patch artifact.''',
       )
       ..addFlag(
-        'force',
-        abbr: 'f',
-        help: PatchCommand.forceHelpText,
-        negatable: false,
-      )
-      ..addFlag(
         'allow-native-diffs',
         help: PatchCommand.allowNativeDiffsHelpText,
         negatable: false,
@@ -106,14 +100,6 @@ If this option is not provided, the version number will be determined from the p
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;
-    }
-
-    final force = results['force'] == true;
-    if (force) {
-      logger
-        ..err(PatchCommand.forceDeprecationErrorMessage)
-        ..info(PatchCommand.forceDeprecationExplanation);
-      return ExitCode.usage.code;
     }
 
     final allowAssetDiffs = results['allow-asset-diffs'] == true;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -32,18 +32,6 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Native code changes cannot b
 Patch even if asset diffs are detected.
 NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be included in a patch can cause your app to behave unexpectedly.''';
 
-  static const forceDeprecationErrorMessage =
-      'The --force flag has been deprecated';
-
-  static final forceDeprecationExplanation =
-      'If your app has known safe native code or asset changes, you can use '
-      'the ${cyan.wrap('--allow-native-diffs')} or '
-      '${cyan.wrap('--allow-asset-diffs')} '
-      'flags. We do not recommend using these flags unless you are '
-      '${styleBold.wrap('absolutely sure')} that the changes are safe. '
-      'Note: the ${cyan.wrap('--force flag')} is not required for use in CI '
-      'environments.';
-
   @override
   String get description =>
       'Manage patches for a specific release in Shorebird.';

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -15,15 +15,6 @@ class PatchCommand extends ShorebirdCommand {
     addSubcommand(PatchIosFrameworkCommand());
   }
 
-  static final forceHelpText = '''
-${styleBold.wrap('Deprecated')}
-'''
-      'If your app has known safe native code or asset changes, you can use '
-      'the ${cyan.wrap('--allow-native-diffs')} or '
-      '${cyan.wrap('--allow-asset-diffs')} flags instead. We do not recommend '
-      'using these flags unless you are '
-      '${styleBold.wrap('absolutely')} sure that the changes are safe.';
-
   static final allowNativeDiffsHelpText = '''
 Patch even if native code diffs are detected.
 NOTE: this is ${styleBold.wrap('not')} recommended. Native code changes cannot be included in a patch and attempting to do so can cause your app to crash or behave unexpectedly.''';

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -69,12 +69,6 @@ If this option is not provided, the version number will be determined from the p
             '''Export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys.''',
       )
       ..addFlag(
-        'force',
-        abbr: 'f',
-        help: PatchCommand.forceHelpText,
-        negatable: false,
-      )
-      ..addFlag(
         'allow-native-diffs',
         help: PatchCommand.allowNativeDiffsHelpText,
         negatable: false,
@@ -133,14 +127,6 @@ https://docs.shorebird.dev/status#link-percentage-ios
       );
     } on PreconditionFailedException catch (error) {
       return error.exitCode.code;
-    }
-
-    final force = results['force'] == true;
-    if (force) {
-      logger
-        ..err(PatchCommand.forceDeprecationErrorMessage)
-        ..info(PatchCommand.forceDeprecationExplanation);
-      return ExitCode.usage.code;
     }
 
     final allowAssetDiffs = results['allow-asset-diffs'] == true;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_framework_command.dart
@@ -43,12 +43,6 @@ The version of the associated release (e.g. "1.0.0"). This should be the version
 of the iOS app that is using this module.''',
       )
       ..addFlag(
-        'force',
-        abbr: 'f',
-        help: PatchCommand.forceHelpText,
-        negatable: false,
-      )
-      ..addFlag(
         'allow-native-diffs',
         help: PatchCommand.allowNativeDiffsHelpText,
         negatable: false,
@@ -100,14 +94,6 @@ of the iOS app that is using this module.''',
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;
-    }
-
-    final force = results['force'] == true;
-    if (force) {
-      logger
-        ..err(PatchCommand.forceDeprecationErrorMessage)
-        ..info(PatchCommand.forceDeprecationExplanation);
-      return ExitCode.usage.code;
     }
 
     final allowAssetDiffs = results['allow-asset-diffs'] == true;

--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -8,7 +8,6 @@ import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
-import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
@@ -49,12 +48,6 @@ of the Android app that is using this module.''',
         help: 'The build number of the aar',
         defaultsTo: '1.0',
       )
-      ..addFlag(
-        'force',
-        abbr: 'f',
-        help: ReleaseCommand.forceHelpText,
-        negatable: false,
-      )
       ..addOption(
         'flutter-version',
         help: 'The Flutter version to use when building the app (e.g: 3.16.3).',
@@ -82,14 +75,6 @@ make smaller updates to your app.
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;
-    }
-
-    final force = results['force'] == true;
-    if (force) {
-      logger
-        ..err(ReleaseCommand.forceDeprecationErrorMessage)
-        ..info(ReleaseCommand.forceDeprecationExplanation);
-      return ExitCode.usage.code;
     }
 
     if (shorebirdEnv.androidPackageName == null) {

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -5,7 +5,6 @@ import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
-import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
@@ -57,12 +56,6 @@ class ReleaseAndroidCommand extends ShorebirdCommand
             'To learn more, see: https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split',
         hide: true,
         negatable: false,
-      )
-      ..addFlag(
-        'force',
-        abbr: 'f',
-        help: ReleaseCommand.forceHelpText,
-        negatable: false,
       );
   }
 
@@ -86,14 +79,6 @@ make smaller updates to your app.
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;
-    }
-
-    final force = results['force'] == true;
-    if (force) {
-      logger
-        ..err(ReleaseCommand.forceDeprecationErrorMessage)
-        ..info(ReleaseCommand.forceDeprecationExplanation);
-      return ExitCode.usage.code;
     }
 
     const releasePlatform = ReleasePlatform.android;

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -1,4 +1,3 @@
-import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
 
@@ -20,14 +19,4 @@ class ReleaseCommand extends ShorebirdCommand {
 
   @override
   String get name => 'release';
-
-  static const forceHelpText = 'The force flag has been deprecated';
-
-  static const forceDeprecationErrorMessage =
-      'The --force flag has been deprecated';
-
-  static final forceDeprecationExplanation = '''
-If you believe you have a valid reason to use the --force flag, please reach out to the Shorebird team by filing an issue at ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}
-
-Note: the --force flag is not required for use in CI environments.''';
 }

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -8,7 +8,6 @@ import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
-import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/xcodebuild.dart';
@@ -65,12 +64,6 @@ class ReleaseIosCommand extends ShorebirdCommand
         'codesign',
         help: 'Codesign the application bundle.',
         defaultsTo: true,
-      )
-      ..addFlag(
-        'force',
-        abbr: 'f',
-        help: ReleaseCommand.forceHelpText,
-        negatable: false,
       );
   }
 
@@ -98,14 +91,6 @@ make smaller updates to your app.
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;
-    }
-
-    final force = results['force'] == true;
-    if (force) {
-      logger
-        ..err(ReleaseCommand.forceDeprecationErrorMessage)
-        ..info(ReleaseCommand.forceDeprecationExplanation);
-      return ExitCode.usage.code;
     }
 
     if (results.rest.contains('--obfuscate')) {

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -8,7 +8,6 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
-import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/xcodebuild.dart';
@@ -37,12 +36,6 @@ of the iOS app that is using this module.''',
       ..addOption(
         'flutter-version',
         help: 'The Flutter version to use when building the app (e.g: 3.16.3).',
-      )
-      ..addFlag(
-        'force',
-        abbr: 'f',
-        help: ReleaseCommand.forceHelpText,
-        negatable: false,
       );
   }
 
@@ -67,14 +60,6 @@ of the iOS app that is using this module.''',
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;
-    }
-
-    final force = results['force'] == true;
-    if (force) {
-      logger
-        ..err(ReleaseCommand.forceDeprecationErrorMessage)
-        ..info(ReleaseCommand.forceDeprecationExplanation);
-      return ExitCode.usage.code;
     }
 
     const releasePlatform = ReleasePlatform.ios;

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -386,20 +386,6 @@ void main() {
       expect(exitCode, ExitCode.config.code);
     });
 
-    test('exits with explanation if force flag is used', () async {
-      when(() => argResults['force']).thenReturn(true);
-
-      await expectLater(
-        runWithOverrides(command.run),
-        completion(equals(ExitCode.usage.code)),
-      );
-
-      verify(() => logger.err(PatchCommand.forceDeprecationErrorMessage))
-          .called(1);
-      verify(() => logger.info(PatchCommand.forceDeprecationExplanation))
-          .called(1);
-    });
-
     test('prompts for release when release-version is not specified', () async {
       when(() => argResults['release-version']).thenReturn(null);
       when(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -418,20 +418,6 @@ flutter:
       ).called(1);
     });
 
-    test('exits with explanation if force flag is used', () async {
-      when(() => argResults['force']).thenReturn(true);
-
-      await expectLater(
-        runWithOverrides(command.run),
-        completion(equals(ExitCode.usage.code)),
-      );
-
-      verify(() => logger.err(PatchCommand.forceDeprecationErrorMessage))
-          .called(1);
-      verify(() => logger.info(PatchCommand.forceDeprecationExplanation))
-          .called(1);
-    });
-
     test('exits with code 70 when building fails', () async {
       when(() => flutterBuildProcessResult.exitCode).thenReturn(1);
       when(() => flutterBuildProcessResult.stderr).thenReturn('oops');

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -557,20 +557,6 @@ flutter:
       ).called(1);
     });
 
-    test('exits with explanation if force flag is used', () async {
-      when(() => argResults['force']).thenReturn(true);
-
-      await expectLater(
-        runWithOverrides(command.run),
-        completion(equals(ExitCode.usage.code)),
-      );
-
-      verify(() => logger.err(PatchCommand.forceDeprecationErrorMessage))
-          .called(1);
-      verify(() => logger.info(PatchCommand.forceDeprecationExplanation))
-          .called(1);
-    });
-
     group('when exportOptionsPlistFromArgs throws exception', () {
       setUp(() {
         when(() => ios.exportOptionsPlistFromArgs(argResults))

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_framework_command_test.dart
@@ -453,20 +453,6 @@ flutter:
       ).called(1);
     });
 
-    test('exits with explanation if force flag is used', () async {
-      when(() => argResults['force']).thenReturn(true);
-
-      await expectLater(
-        runWithOverrides(command.run),
-        completion(equals(ExitCode.usage.code)),
-      );
-
-      verify(() => logger.err(PatchCommand.forceDeprecationErrorMessage))
-          .called(1);
-      verify(() => logger.info(PatchCommand.forceDeprecationExplanation))
-          .called(1);
-    });
-
     test('prompts for release when release-version is not specified', () async {
       when(() => argResults['release-version']).thenReturn(null);
       when(

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -300,20 +300,6 @@ void main() {
       ).called(1);
     });
 
-    test('exits with explanation if force flag is used', () async {
-      when(() => argResults['force']).thenReturn(true);
-
-      await expectLater(
-        runWithOverrides(command.run),
-        completion(equals(ExitCode.usage.code)),
-      );
-
-      verify(() => logger.err(ReleaseCommand.forceDeprecationErrorMessage))
-          .called(1);
-      verify(() => logger.info(ReleaseCommand.forceDeprecationExplanation))
-          .called(1);
-    });
-
     test('exits with 78 if no module entry exists in pubspec.yaml', () async {
       when(() => shorebirdEnv.androidPackageName).thenReturn(null);
 

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -299,20 +299,6 @@ void main() {
       ).called(1);
     });
 
-    test('exits with explanation if force flag is used', () async {
-      when(() => argResults['force']).thenReturn(true);
-
-      await expectLater(
-        runWithOverrides(command.run),
-        completion(equals(ExitCode.usage.code)),
-      );
-
-      verify(() => logger.err(ReleaseCommand.forceDeprecationErrorMessage))
-          .called(1);
-      verify(() => logger.info(ReleaseCommand.forceDeprecationExplanation))
-          .called(1);
-    });
-
     test('exits with code unavailable when --split-per-abi is provided',
         () async {
       when(() => argResults['artifact']).thenReturn('apk');

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -369,20 +369,6 @@ flutter:
       ).called(1);
     });
 
-    test('exits with explanation if force flag is used', () async {
-      when(() => argResults['force']).thenReturn(true);
-
-      await expectLater(
-        runWithOverrides(command.run),
-        completion(equals(ExitCode.usage.code)),
-      );
-
-      verify(() => logger.err(ReleaseCommand.forceDeprecationErrorMessage))
-          .called(1);
-      verify(() => logger.info(ReleaseCommand.forceDeprecationExplanation))
-          .called(1);
-    });
-
     group('when obfuscate flag is passed', () {
       setUp(() {
         when(() => argResults.rest).thenReturn(['--obfuscate']);

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -298,20 +298,6 @@ flutter:
       ).called(1);
     });
 
-    test('exits with explanation if force flag is used', () async {
-      when(() => argResults['force']).thenReturn(true);
-
-      await expectLater(
-        runWithOverrides(command.run),
-        completion(equals(ExitCode.usage.code)),
-      );
-
-      verify(() => logger.err(ReleaseCommand.forceDeprecationErrorMessage))
-          .called(1);
-      verify(() => logger.info(ReleaseCommand.forceDeprecationExplanation))
-          .called(1);
-    });
-
     group('when flutter-version is provided', () {
       const flutterVersion = '3.19.5';
       setUp(() {


### PR DESCRIPTION
## Description

The `--force` flag has been deprecated and is now being removed in anticipation of the 1.0 release.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
