### PR TITLE
chore: raise minLinkPercentage to 75%

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -104,9 +104,14 @@ If this option is not provided, the version number will be determined from the p
   final HashFunction _hashFn;
   final IosArchiveDiffer _archiveDiffer;
 
-  // Link percentage that is considered the minimum for acceptable perfromance.
-  // This was selected arbitrarily and may need to be adjusted.
-  static const double minLinkPercentage = 50;
+  // Link percentage that is considered the minimum before a user might notice.
+  // Our early testing has shown that about:
+  // - 1/3rd of patches link at 99%
+  // - 1/3rd of patches link between 20% and 99%
+  // - 1/3rd of patches link below 20%
+  // Most lowering is likely due to:
+  // https://github.com/shorebirdtech/shorebird/issues/1825
+  static const double minLinkPercentage = 75;
 
   static String lowLinkPercentageWarning(double linkPercentage) {
     return '''


### PR DESCRIPTION
We guess that this will end up showing this warning on about 2/3rds
of `patch` commands, up from about 50% before.

It seems better to warn users too much, rather than disappoint them
after patching.

This should all go away after we fix
https://github.com/shorebirdtech/shorebird/issues/1825 and any similar remaining
linker issues (there can't be that many left).