### PR TITLE
fix(shorebird_cli): remove early call to `closeSync` in `extractZip`

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_manager.dart
+++ b/packages/shorebird_cli/lib/src/artifact_manager.dart
@@ -88,7 +88,6 @@ Failed to create diff (exit code ${result.exitCode}).
     await Isolate.run(() async {
       final inputStream = InputFileStream(zipFile.path);
       final archive = ZipDecoder().decodeBuffer(inputStream);
-      inputStream.closeSync();
       extractArchiveToDisk(archive, outputDirectory.path);
       inputStream.closeSync();
     });

--- a/packages/shorebird_cli/test/src/artifact_manager_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_manager_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:archive/archive_io.dart';
 import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
@@ -189,6 +190,34 @@ void main() {
           completes,
         );
         expect(tempDir.listSync(recursive: true), hasLength(146));
+      });
+
+      test('unzips large file to provided output path', () async {
+        // Prevent regressions where extractZip closes the input sync too soon.
+        // https://github.com/shorebirdtech/shorebird/pull/1866
+        final tempDir = Directory.systemTemp.createTempSync();
+        final outDir = Directory.systemTemp.createTempSync();
+        final file = File(p.join(tempDir.path, 'large.txt'))
+          ..writeAsBytesSync(
+            List.generate(999999999, (index) => index),
+          );
+        final zipFile = File(p.join(tempDir.path, 'large.zip'));
+        final encoder = ZipFileEncoder()..open(zipFile.path);
+        await encoder.addFile(file);
+        encoder.close();
+
+        expect(outDir.listSync(recursive: true), isEmpty);
+        await expectLater(
+          runWithOverrides(
+            () => artifactManager.extractZip(
+              zipFile: zipFile,
+              outputDirectory: outDir,
+            ),
+          ),
+          completes,
+        );
+        expect(outDir.listSync(recursive: true), hasLength(1));
+        expect(File(p.join(outDir.path, 'large.txt')).lengthSync(), 999999999);
       });
     });
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- fix(shorebird_cli): remove early call to `closeSync` in `extractZip`
  - re-introduced in #1861 
  - working on unit tests to prevent regressions but figured we'd want to merge this asap since it breaks lots of CLI functionality (preview, patch, etc.)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
