### PR TITLE
feat: adding message with link to the release when releasing an existing release

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -162,7 +162,10 @@ This app may not exist or you may not have permission to view it.''',
       logger.err(
         '''
 It looks like you have an existing ${platform.name} release for version ${lightCyan.wrap(release.version)}.
-Please bump your version number and try again.''',
+Please bump your version number and try again.
+
+You can manage this release in the Shorebird Console at:
+https://console.shorebird.dev/apps/${release.appId}/releases/${release.id}''',
       );
       exit(ExitCode.software.code);
     }

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -165,8 +165,7 @@ This app may not exist or you may not have permission to view it.''',
 It looks like you have an existing ${platform.name} release for version ${lightCyan.wrap(release.version)}.
 Please bump your version number and try again.
 
-You can manage this release in the Shorebird Console at:
-${ShorebirdWebConsole.linkToAppRelease(release.appId, release.id)}''',
+You can manage your ${ShorebirdWebConsole.linkToAppRelease(release.appId, release.id)} in the console.''',
       );
       exit(ExitCode.software.code);
     }

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -160,12 +160,16 @@ This app may not exist or you may not have permission to view it.''',
     required ReleasePlatform platform,
   }) {
     if (release.platformStatuses[platform] == ReleaseStatus.active) {
+      final uri = ShorebirdWebConsole.buildAppReleaseLink(
+        release.appId,
+        release.id,
+      );
       logger.err(
         '''
 It looks like you have an existing ${platform.name} release for version ${lightCyan.wrap(release.version)}.
 Please bump your version number and try again.
 
-You can manage this release in the ${ShorebirdWebConsole.linkToAppRelease(release.appId, release.id, message: 'Shorebird Console')}''',
+You can manage this release in the ${link(uri: uri, message: 'Shorebird Console')}''',
       );
       exit(ExitCode.software.code);
     }

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -15,6 +15,7 @@ import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_web_console.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
@@ -165,7 +166,7 @@ It looks like you have an existing ${platform.name} release for version ${lightC
 Please bump your version number and try again.
 
 You can manage this release in the Shorebird Console at:
-https://console.shorebird.dev/apps/${release.appId}/releases/${release.id}''',
+${ShorebirdWebConsole.linkToAppRelease(release.appId, release.id)}''',
       );
       exit(ExitCode.software.code);
     }

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -160,7 +160,7 @@ This app may not exist or you may not have permission to view it.''',
     required ReleasePlatform platform,
   }) {
     if (release.platformStatuses[platform] == ReleaseStatus.active) {
-      final uri = ShorebirdWebConsole.buildAppReleaseLink(
+      final uri = ShorebirdWebConsole.appReleaseUri(
         release.appId,
         release.id,
       );

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -165,7 +165,7 @@ This app may not exist or you may not have permission to view it.''',
 It looks like you have an existing ${platform.name} release for version ${lightCyan.wrap(release.version)}.
 Please bump your version number and try again.
 
-You can manage your ${ShorebirdWebConsole.linkToAppRelease(release.appId, release.id)} in the console.''',
+You can manage this release in the ${ShorebirdWebConsole.linkToAppRelease(release.appId, release.id, message: 'Shorebird Console')}''',
       );
       exit(ExitCode.software.code);
     }

--- a/packages/shorebird_cli/lib/src/shorebird_web_console.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_web_console.dart
@@ -1,24 +1,14 @@
-import 'package:mason_logger/mason_logger.dart';
-
 class ShorebirdWebConsole {
-  static String linkTo(
-    String path, {
-    String? message,
-  }) {
-    return link(
-      uri: Uri.parse('https://console.shorebird.dev/$path'),
-      message: message,
-    );
+  static Uri buildLink(String path) {
+    return Uri.parse('https://console.shorebird.dev/$path');
   }
 
-  static String linkToAppRelease(
+  static Uri buildAppReleaseLink(
     String appId,
-    int releaseId, {
-    String? message,
-  }) {
-    return linkTo(
+    int releaseId,
+  ) {
+    return buildLink(
       'apps/$appId/releases/$releaseId',
-      message: message,
     );
   }
 }

--- a/packages/shorebird_cli/lib/src/shorebird_web_console.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_web_console.dart
@@ -1,0 +1,9 @@
+class ShorebirdWebConsole {
+  static String linkTo(String path) {
+    return 'https://console.shorebird.dev/$path';
+  }
+
+  static String linkToAppRelease(String appId, int releaseId) {
+    return linkTo('apps/$appId/releases/$releaseId');
+  }
+}

--- a/packages/shorebird_cli/lib/src/shorebird_web_console.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_web_console.dart
@@ -1,9 +1,20 @@
+import 'package:mason_logger/mason_logger.dart';
+
 class ShorebirdWebConsole {
-  static String linkTo(String path) {
-    return 'https://console.shorebird.dev/$path';
+  static String linkTo(
+    String path, {
+    String? message,
+  }) {
+    return link(
+      uri: Uri.parse('https://console.shorebird.dev/$path'),
+      message: message,
+    );
   }
 
   static String linkToAppRelease(String appId, int releaseId) {
-    return linkTo('apps/$appId/releases/$releaseId');
+    return linkTo(
+      'apps/$appId/releases/$releaseId',
+      message: 'Shorebird release',
+    );
   }
 }

--- a/packages/shorebird_cli/lib/src/shorebird_web_console.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_web_console.dart
@@ -1,13 +1,13 @@
 class ShorebirdWebConsole {
-  static Uri buildLink(String path) {
+  static Uri uri(String path) {
     return Uri.parse('https://console.shorebird.dev/$path');
   }
 
-  static Uri buildAppReleaseLink(
+  static Uri appReleaseUri(
     String appId,
     int releaseId,
   ) {
-    return buildLink(
+    return ShorebirdWebConsole.uri(
       'apps/$appId/releases/$releaseId',
     );
   }

--- a/packages/shorebird_cli/lib/src/shorebird_web_console.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_web_console.dart
@@ -11,10 +11,14 @@ class ShorebirdWebConsole {
     );
   }
 
-  static String linkToAppRelease(String appId, int releaseId) {
+  static String linkToAppRelease(
+    String appId,
+    int releaseId, {
+    String? message,
+  }) {
     return linkTo(
       'apps/$appId/releases/$releaseId',
-      message: 'Shorebird release',
+      message: message,
     );
   }
 }

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   asn1lib:
     dependency: transitive
     description:
@@ -493,10 +493,10 @@ packages:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29"
+      sha256: "70fe966348fe08c34bf929582f1d8247d9d9408130723206472b4687227e4333"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.4"
+    version: "3.8.0"
   pool:
     dependency: transitive
     description:
@@ -698,26 +698,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "7ee446762c2c50b3bd4ea96fe13ffac69919352bd3b4b17bac3f3465edc58073"
+      sha256: d87214d19fb311997d8128ec501a980f77cb240ac4e7e219accf452813ff473c
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.2"
+    version: "1.25.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
+      sha256: "2236f70be1e5ab405c675e88c36935a87dad9e05a506b57dd5c0f617f5aebcb2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   timing:
     dependency: transitive
     description:
@@ -746,10 +746,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: cd210a09f7c18cbe5a02511718e0334de6559871052c90a90c0cca46a4aa81c8
+      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.3"
+    version: "4.4.0"
   very_good_analysis:
     dependency: "direct dev"
     description:
@@ -786,10 +786,10 @@ packages:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "1d8e795e2a8b3730c41b8a98a2dff2e0fb57ae6f0764a1c46ec5915387d257b2"
+      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "2.4.5"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -456,7 +456,7 @@ void main() {
               ),
               exitsWithCode(ExitCode.software),
             );
-            final uri = ShorebirdWebConsole.buildAppReleaseLink(
+            final uri = ShorebirdWebConsole.appReleaseUri(
               appId,
               releaseId,
             );

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -11,6 +11,7 @@ import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_web_console.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
@@ -462,8 +463,7 @@ void main() {
 It looks like you have an existing ios release for version ${lightCyan.wrap(release.version)}.
 Please bump your version number and try again.
 
-You can manage this release in the Shorebird Console at:
-https://console.shorebird.dev/apps/$appId/releases/$releaseId''',
+You can manage your ${ShorebirdWebConsole.linkToAppRelease(appId, releaseId)} in the console.''',
               ),
             ).called(1);
           },

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -456,6 +456,10 @@ void main() {
               ),
               exitsWithCode(ExitCode.software),
             );
+            final uri = ShorebirdWebConsole.buildAppReleaseLink(
+              appId,
+              releaseId,
+            );
 
             verify(
               () => logger.err(
@@ -463,7 +467,7 @@ void main() {
 It looks like you have an existing ios release for version ${lightCyan.wrap(release.version)}.
 Please bump your version number and try again.
 
-You can manage this release in the ${ShorebirdWebConsole.linkToAppRelease(appId, releaseId, message: 'Shorebird Console')}''',
+You can manage this release in the ${link(uri: uri, message: 'Shorebird Console')}''',
               ),
             ).called(1);
           },

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -460,7 +460,10 @@ void main() {
               () => logger.err(
                 '''
 It looks like you have an existing ios release for version ${lightCyan.wrap(release.version)}.
-Please bump your version number and try again.''',
+Please bump your version number and try again.
+
+You can manage this release in the Shorebird Console at:
+https://console.shorebird.dev/apps/$appId/releases/$releaseId''',
               ),
             ).called(1);
           },

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -463,7 +463,7 @@ void main() {
 It looks like you have an existing ios release for version ${lightCyan.wrap(release.version)}.
 Please bump your version number and try again.
 
-You can manage your ${ShorebirdWebConsole.linkToAppRelease(appId, releaseId)} in the console.''',
+You can manage this release in the ${ShorebirdWebConsole.linkToAppRelease(appId, releaseId, message: 'Shorebird Console')}''',
               ),
             ).called(1);
           },

--- a/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
@@ -13,8 +13,24 @@ void main() {
     test('linkToAppRelease returns the expected link to an app release', () {
       expect(
         ShorebirdWebConsole.linkToAppRelease('appId', 123),
-        '\x1B]8;;https://console.shorebird.dev/apps/appId/releases/123\x1B\\Shorebird release\x1B]8;;\x1B\\',
+        '\x1B]8;;https://console.shorebird.dev/apps/appId/releases/123\x1B\\https://console.shorebird.dev/apps/appId/releases/123\x1B]8;;\x1B\\',
       );
+    });
+
+    group('when passing a message', () {
+      test('linkTo returns the expected link to the root of the site', () {
+        expect(
+          ShorebirdWebConsole.linkTo('path', message: 'label'),
+          '\x1B]8;;https://console.shorebird.dev/path\x1B\\label\x1B]8;;\x1B\\',
+        );
+      });
+
+      test('linkToAppRelease returns the expected link to an app release', () {
+        expect(
+          ShorebirdWebConsole.linkToAppRelease('appId', 123, message: 'label'),
+          '\x1B]8;;https://console.shorebird.dev/apps/appId/releases/123\x1B\\label\x1B]8;;\x1B\\',
+        );
+      });
     });
   });
 }

--- a/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
@@ -5,32 +5,16 @@ void main() {
   group('ShorebirdWebConsole', () {
     test('linkTo returns the expected link to the root of the site', () {
       expect(
-        ShorebirdWebConsole.linkTo('path'),
-        '\x1B]8;;https://console.shorebird.dev/path\x1B\\https://console.shorebird.dev/path\x1B]8;;\x1B\\',
+        ShorebirdWebConsole.buildLink('path'),
+        Uri.parse('https://console.shorebird.dev/path'),
       );
     });
 
     test('linkToAppRelease returns the expected link to an app release', () {
       expect(
-        ShorebirdWebConsole.linkToAppRelease('appId', 123),
-        '\x1B]8;;https://console.shorebird.dev/apps/appId/releases/123\x1B\\https://console.shorebird.dev/apps/appId/releases/123\x1B]8;;\x1B\\',
+        ShorebirdWebConsole.buildAppReleaseLink('appId', 123),
+        Uri.parse('https://console.shorebird.dev/apps/appId/releases/123'),
       );
-    });
-
-    group('when passing a message', () {
-      test('linkTo returns the expected link to the root of the site', () {
-        expect(
-          ShorebirdWebConsole.linkTo('path', message: 'label'),
-          '\x1B]8;;https://console.shorebird.dev/path\x1B\\label\x1B]8;;\x1B\\',
-        );
-      });
-
-      test('linkToAppRelease returns the expected link to an app release', () {
-        expect(
-          ShorebirdWebConsole.linkToAppRelease('appId', 123, message: 'label'),
-          '\x1B]8;;https://console.shorebird.dev/apps/appId/releases/123\x1B\\label\x1B]8;;\x1B\\',
-        );
-      });
     });
   });
 }

--- a/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
@@ -1,0 +1,20 @@
+import 'package:shorebird_cli/src/shorebird_web_console.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ShorebirdWebConsole', () {
+    test('linkTo returns the expected link to the root of the site', () {
+      expect(
+        ShorebirdWebConsole.linkTo('path'),
+        'https://console.shorebird.dev/path',
+      );
+    });
+
+    test('linkToAppRelease returns the expected link to an app release', () {
+      expect(
+        ShorebirdWebConsole.linkToAppRelease('appId', 123),
+        'https://console.shorebird.dev/apps/appId/releases/123',
+      );
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
@@ -3,16 +3,16 @@ import 'package:test/test.dart';
 
 void main() {
   group('ShorebirdWebConsole', () {
-    test('linkTo returns the expected link to the root of the site', () {
+    test('uri returns the correct uri with the received path', () {
       expect(
-        ShorebirdWebConsole.buildLink('path'),
+        ShorebirdWebConsole.uri('path'),
         Uri.parse('https://console.shorebird.dev/path'),
       );
     });
 
-    test('linkToAppRelease returns the expected link to an app release', () {
+    test('appReleaseUri returns the correct uri to an app release', () {
       expect(
-        ShorebirdWebConsole.buildAppReleaseLink('appId', 123),
+        ShorebirdWebConsole.appReleaseUri('appId', 123),
         Uri.parse('https://console.shorebird.dev/apps/appId/releases/123'),
       );
     });

--- a/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
@@ -2,7 +2,7 @@ import 'package:shorebird_cli/src/shorebird_web_console.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('ShorebirdWebConsole', () {
+  group(ShorebirdWebConsole, () {
     test('uri returns the correct uri with the received path', () {
       expect(
         ShorebirdWebConsole.uri('path'),

--- a/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_web_console_test.dart
@@ -6,14 +6,14 @@ void main() {
     test('linkTo returns the expected link to the root of the site', () {
       expect(
         ShorebirdWebConsole.linkTo('path'),
-        'https://console.shorebird.dev/path',
+        '\x1B]8;;https://console.shorebird.dev/path\x1B\\https://console.shorebird.dev/path\x1B]8;;\x1B\\',
       );
     });
 
     test('linkToAppRelease returns the expected link to an app release', () {
       expect(
         ShorebirdWebConsole.linkToAppRelease('appId', 123),
-        'https://console.shorebird.dev/apps/appId/releases/123',
+        '\x1B]8;;https://console.shorebird.dev/apps/appId/releases/123\x1B\\Shorebird release\x1B]8;;\x1B\\',
       );
     });
   });


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adds a new message to the shorebird release [any] that will print a link to the release on the console when trying to run release in a version number that already exists!

Fixes #1890 

Output

![Screenshot 2024-04-12 at 15 52 20](https://github.com/shorebirdtech/shorebird/assets/835641/21248690-0f67-497a-9ba9-01c837da9fcd)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
