### PR TITLE
feat(shorebird_cli): add patch instructions to release commands

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_aar_command.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
@@ -306,6 +307,12 @@ dependencies {
   // ...
 }''')}
 ''');
+
+        ReleaseCommand.printPatchInstructions(
+          name: name,
+          releaseVersion: release.version,
+          requiresReleaseVersion: true,
+        );
 
         return ExitCode.success.code;
       },

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
@@ -337,6 +338,13 @@ $apkText
 For information on uploading to the Play Store, see:
 ${link(uri: Uri.parse('https://support.google.com/googleplay/android-developer/answer/9859152?hl=en'))}
 ''');
+
+        ReleaseCommand.printPatchInstructions(
+          name: name,
+          flavor: flavor,
+          target: target,
+          releaseVersion: release.version,
+        );
 
         return ExitCode.success.code;
       },

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -1,5 +1,7 @@
+import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
+import 'package:shorebird_cli/src/logger.dart';
 
 /// {@template release_command}
 /// `shorebird release`
@@ -19,4 +21,31 @@ class ReleaseCommand extends ShorebirdCommand {
 
   @override
   String get name => 'release';
+
+  static void printPatchInstructions({
+    required String name,
+    required String releaseVersion,
+    String? flavor,
+    String? target,
+    bool requiresReleaseVersion = false,
+  }) {
+    final baseCommand = [
+      'shorebird patch',
+      name,
+      if (flavor != null) '--flavor=$flavor',
+      if (target != null) '--target=$target',
+    ].join(' ');
+    logger.info(
+      '''To create a patch for this release, run ${lightCyan.wrap('$baseCommand --release-version=$releaseVersion')}''',
+    );
+
+    if (!requiresReleaseVersion) {
+      logger.info(
+        '''
+
+Note: ${lightCyan.wrap(baseCommand)} without the --release-version option will patch the current version of the app.
+''',
+      );
+    }
+  }
 }

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_command.dart
@@ -8,6 +8,7 @@ import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/xcodebuild.dart';
@@ -359,6 +360,13 @@ You can open the archive in Xcode by running:
 ${styleBold.wrap('Make sure to uncheck "Manage Version and Build Number", or else shorebird will not work.')}
 ''');
         }
+
+        ReleaseCommand.printPatchInstructions(
+          name: name,
+          flavor: flavor,
+          target: target,
+          releaseVersion: release.version,
+        );
 
         return ExitCode.success.code;
       },

--- a/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_ios_framework_command.dart
@@ -8,6 +8,7 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/xcodebuild.dart';
@@ -252,6 +253,12 @@ To do this:
 
 Instructions for these steps can be found at https://docs.flutter.dev/add-to-app/ios/project-setup#option-b---embed-frameworks-in-xcode.
 ''');
+
+        ReleaseCommand.printPatchInstructions(
+          name: name,
+          releaseVersion: release.version,
+          requiresReleaseVersion: true,
+        );
 
         return ExitCode.success.code;
       },

--- a/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_aar_command_test.dart
@@ -564,6 +564,19 @@ $exception''',
           ),
         ),
       ).called(1);
+      verify(
+        () => logger.info(
+          '''To create a patch for this release, run ${lightCyan.wrap('shorebird patch aar --release-version=${release.version}')}''',
+        ),
+      ).called(1);
+      verifyNever(
+        () => logger.info(
+          '''
+
+Note: ${lightCyan.wrap('shorebird patch aar')} without the --release-version option will patch the current version of the app.
+''',
+        ),
+      );
     });
 
     test('copies aar library to a releases folder', () async {

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -636,6 +636,19 @@ ${link(uri: Uri.parse('https://support.google.com/googleplay/android-developer/a
           runInShell: true,
         ),
       ).called(1);
+      verify(
+        () => logger.info(
+          '''To create a patch for this release, run ${lightCyan.wrap('shorebird patch android --release-version=${release.version}')}''',
+        ),
+      ).called(1);
+      verify(
+        () => logger.info(
+          '''
+
+Note: ${lightCyan.wrap('shorebird patch android')} without the --release-version option will patch the current version of the app.
+''',
+        ),
+      ).called(1);
       expect(exitCode, ExitCode.success.code);
     });
 
@@ -785,6 +798,19 @@ Either run `flutter pub get` manually, or follow the steps in ${link(uri: Uri.pa
           platform: releasePlatform,
           status: ReleaseStatus.active,
           metadata: any(named: 'metadata'),
+        ),
+      ).called(1);
+      verify(
+        () => logger.info(
+          '''To create a patch for this release, run ${lightCyan.wrap('shorebird patch android --flavor=$flavor --target=$target --release-version=${release.version}')}''',
+        ),
+      ).called(1);
+      verify(
+        () => logger.info(
+          '''
+
+Note: ${lightCyan.wrap('shorebird patch android --flavor=$flavor --target=$target')} without the --release-version option will patch the current version of the app.
+''',
         ),
       ).called(1);
       expect(exitCode, ExitCode.success.code);

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_command_test.dart
@@ -952,6 +952,19 @@ error: exportArchive: No signing certificate "iOS Distribution" found
             ),
           ),
         ).called(1);
+        verify(
+          () => logger.info(
+            '''To create a patch for this release, run ${lightCyan.wrap('shorebird patch ios --release-version=${release.version}')}''',
+          ),
+        ).called(1);
+        verify(
+          () => logger.info(
+            '''
+
+Note: ${lightCyan.wrap('shorebird patch ios')} without the --release-version option will patch the current version of the app.
+''',
+          ),
+        ).called(1);
         expect(exitCode, ExitCode.success.code);
       });
 
@@ -1010,6 +1023,19 @@ flavors:
                 any(named: 'xcarchivePath', that: endsWith('.xcarchive')),
             runnerPath: any(named: 'runnerPath', that: endsWith('Runner.app')),
             isCodesigned: true,
+          ),
+        ).called(1);
+        verify(
+          () => logger.info(
+            '''To create a patch for this release, run ${lightCyan.wrap('shorebird patch ios --flavor=$flavor --target=$target --release-version=${release.version}')}''',
+          ),
+        ).called(1);
+        verify(
+          () => logger.info(
+            '''
+
+Note: ${lightCyan.wrap('shorebird patch ios --flavor=$flavor --target=$target')} without the --release-version option will patch the current version of the app.
+''',
           ),
         ).called(1);
         expect(exitCode, ExitCode.success.code);

--- a/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_ios_framework_command_test.dart
@@ -571,6 +571,19 @@ $exception''',
             ),
           ),
         ).called(1);
+        verify(
+          () => logger.info(
+            '''To create a patch for this release, run ${lightCyan.wrap('shorebird patch ios-framework --release-version=${release.version}')}''',
+          ),
+        ).called(1);
+        verifyNever(
+          () => logger.info(
+            '''
+
+Note: ${lightCyan.wrap('shorebird patch ios-framework')} without the --release-version option will patch the current version of the app.
+''',
+          ),
+        );
         expect(exitCode, ExitCode.success.code);
       });
 


### PR DESCRIPTION
## Description

Adds instructions explaining how to patch the just-created release to the end of all `release` subcommands.

![Screenshot 2024-04-15 at 3 48 20 PM](https://github.com/shorebirdtech/shorebird/assets/581764/189f37a3-7adf-4ac6-9ef8-58661bd78cf7)

Fixes https://github.com/shorebirdtech/shorebird/issues/1898

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
