### PR TITLE
chore(bootstrap): pin very_good_cli and remove  --analytics

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -6,6 +6,5 @@
 # export PATH=$HOME/.pub-cache/bin:$PATH
 
 # Fetch dart dependencies
-dart pub global activate very_good_cli
-very_good --analytics=false
+dart pub global activate very_good_cli 0.20.0
 very_good packages get -r ./packages


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Pinned `very_good_cli` to the latest current version `0.20.0`

Removed the `very_good --analytics=false` line from the bootstrap script as it was removed in version `0.16.0` of `very_good_cli`

By using a pinned version we can ensure that the bootstrap script will continue to function even when `very_good_cli` is updated.

When `very_good_cli` updates their package, the pinned version can be bumped after ensuring that their latest version doesn't break existing bootstrapping functionality.


Resolves https://github.com/shorebirdtech/shorebird/issues/1904


<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
