### PR TITLE
feat: add support for custom code push client headers, add `x-cli-version` header to CLI requests

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -51,7 +51,7 @@ ScopedRef<CodePushClientWrapper> codePushClientWrapperRef = create(() {
     codePushClient: CodePushClient(
       httpClient: auth.client,
       hostedUri: shorebirdEnv.hostedUri,
-      additionalRequestHeaders: {'x-cli-version': packageVersion},
+      customHeaders: {'x-cli-version': packageVersion},
     ),
   );
 });

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -17,6 +17,7 @@ import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_web_console.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
+import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// {@template patch_artifact_bundle}
@@ -50,6 +51,7 @@ ScopedRef<CodePushClientWrapper> codePushClientWrapperRef = create(() {
     codePushClient: CodePushClient(
       httpClient: auth.client,
       hostedUri: shorebirdEnv.hostedUri,
+      additionalRequestHeaders: {'x-cli-version': packageVersion},
     ),
   );
 });

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -219,8 +219,12 @@ Use `shorebird flutter versions list` to list available versions.
               )
             : p.join(bundleDirPath, 'release', 'app-release.aab');
         final apkPath = flavor != null
-            ? p.join(apkDirPath, flavor, 'release',
-                'app-${flavor.toKebabCase}-release.apk')
+            ? p.join(
+                apkDirPath,
+                flavor,
+                'release',
+                'app-${flavor.toKebabCase}-release.apk',
+              )
             : p.join(apkDirPath, 'release', 'app-release.apk');
 
         final String releaseVersion;

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -51,6 +51,9 @@ void main() {
       when(() => logger.progress(any())).thenReturn(progress);
     });
 
+    // TODO: this is a consolidation of what should be two separate tests.
+    // Accessing the codePushClientWrapperRef more than once causes mock
+    // failures in all tests after the first.
     test('includes x-cli-version in headers', () async {
       when(() => httpClient.send(any())).thenAnswer(
         (_) async => http.StreamedResponse(

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
@@ -13,32 +15,40 @@ import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_web_console.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
+import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
 
+import 'fakes.dart';
 import 'mocks.dart';
 
 void main() {
   group('scoped', () {
     late Auth auth;
     late http.Client httpClient;
+    late Logger logger;
     late Platform platform;
+    late Progress progress;
     late ShorebirdEnv shorebirdEnv;
 
     setUpAll(() {
       registerFallbackValue(CreatePatchMetadata.forTest());
+      registerFallbackValue(FakeBaseRequest());
     });
 
     setUp(() {
       auth = MockAuth();
       httpClient = MockHttpClient();
+      logger = MockLogger();
       platform = MockPlatform();
+      progress = MockProgress();
       shorebirdEnv = MockShorebirdEnv();
 
       when(() => auth.client).thenReturn(httpClient);
       when(() => shorebirdEnv.hostedUri).thenReturn(
         Uri.parse('http://example.com'),
       );
+      when(() => logger.progress(any())).thenReturn(progress);
     });
 
     test('creates instance from scoped Auth and ShorebirdEnvironment', () {
@@ -56,6 +66,39 @@ void main() {
         Uri.parse('http://example.com'),
       );
       verify(() => auth.client).called(1);
+    });
+
+    test('includes x-cli-version in headers', () async {
+      when(() => httpClient.send(any())).thenAnswer(
+        (_) async => http.StreamedResponse(
+          Stream.value(
+            utf8.encode(
+              json.encode(const GetAppsResponse(apps: []).toJson()),
+            ),
+          ),
+          HttpStatus.ok,
+        ),
+      );
+
+      final captured = await runScoped(
+        () async {
+          // We don't care about the response of getApps, we just need to make a
+          // request.
+          await codePushClientWrapper.getApps();
+          return verify(() => httpClient.send(captureAny())).captured;
+        },
+        values: {
+          codePushClientWrapperRef,
+          authRef.overrideWith(() => auth),
+          loggerRef.overrideWith(() => logger),
+          platformRef.overrideWith(() => platform),
+          shorebirdEnvRef.overrideWith(() => shorebirdEnv),
+        },
+      );
+      expect(
+        (captured.first as http.BaseRequest).headers['x-cli-version'],
+        equals(packageVersion),
+      );
     });
   });
 

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -53,7 +53,8 @@ void main() {
 
     // TODO: this is a consolidation of what should be two separate tests.
     // Accessing the codePushClientWrapperRef more than once causes mock
-    // failures in all tests after the first.
+    // failures in all tests after the first. We should figure out why this is
+    // and fix it.
     test('includes x-cli-version in headers', () async {
       when(() => httpClient.send(any())).thenAnswer(
         (_) async => http.StreamedResponse(

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -80,12 +80,13 @@ void main() {
         ),
       );
 
-      final captured = await runScoped(
+      final request = await runScoped(
         () async {
           // We don't care about the response of getApps, we just need to make a
           // request.
           await codePushClientWrapper.getApps();
-          return verify(() => httpClient.send(captureAny())).captured;
+          return verify(() => httpClient.send(captureAny())).captured.first
+              as http.BaseRequest;
         },
         values: {
           codePushClientWrapperRef,
@@ -96,7 +97,7 @@ void main() {
         },
       );
       expect(
-        (captured.first as http.BaseRequest).headers['x-cli-version'],
+        request.headers['x-cli-version'],
         equals(packageVersion),
       );
     });

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -44,7 +44,7 @@ void main() {
       progress = MockProgress();
       shorebirdEnv = MockShorebirdEnv();
 
-      when(() => auth.client).thenReturn(httpClient);
+      when(() => auth.client).thenAnswer((_) => httpClient);
       when(() => shorebirdEnv.hostedUri).thenReturn(
         Uri.parse('http://example.com'),
       );

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -83,7 +83,7 @@ void main() {
       final request = await runScoped(
         () async {
           // We don't care about the response of getApps, we just need to make a
-          // request.
+          // request using the underlying codePushClient.
           await codePushClientWrapper.getApps();
           return verify(() => httpClient.send(captureAny())).captured.first
               as http.BaseRequest;

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -51,23 +51,6 @@ void main() {
       when(() => logger.progress(any())).thenReturn(progress);
     });
 
-    test('creates instance from scoped Auth and ShorebirdEnvironment', () {
-      final instance = runScoped(
-        () => codePushClientWrapper,
-        values: {
-          codePushClientWrapperRef,
-          authRef.overrideWith(() => auth),
-          platformRef.overrideWith(() => platform),
-          shorebirdEnvRef.overrideWith(() => shorebirdEnv),
-        },
-      );
-      expect(
-        instance.codePushClient.hostedUri,
-        Uri.parse('http://example.com'),
-      );
-      verify(() => auth.client).called(1);
-    });
-
     test('includes x-cli-version in headers', () async {
       when(() => httpClient.send(any())).thenAnswer(
         (_) async => http.StreamedResponse(
@@ -85,6 +68,11 @@ void main() {
           // We don't care about the response of getApps, we just need to make a
           // request using the underlying codePushClient.
           await codePushClientWrapper.getApps();
+          expect(
+            codePushClientWrapper.codePushClient.hostedUri,
+            Uri.parse('http://example.com'),
+          );
+          verify(() => auth.client).called(1);
           return verify(() => httpClient.send(captureAny())).captured.first
               as http.BaseRequest;
         },

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -62,13 +62,15 @@ class CodePushUpgradeRequiredException extends CodePushException {
 /// are consistent.
 /// For example, all requests include the standard `x-version` header.
 class _CodePushHttpClient extends http.BaseClient {
-  _CodePushHttpClient(this._client);
+  _CodePushHttpClient(this._client, this._headers);
 
   final http.Client _client;
 
+  final Map<String, String> _headers;
+
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {
-    return _client.send(request..headers.addAll(CodePushClient.headers));
+    return _client.send(request..headers.addAll(_headers));
   }
 
   @override
@@ -86,11 +88,15 @@ class CodePushClient {
   CodePushClient({
     http.Client? httpClient,
     Uri? hostedUri,
-  })  : _httpClient = _CodePushHttpClient(httpClient ?? http.Client()),
+    Map<String, String>? additionalRequestHeaders,
+  })  : _httpClient = _CodePushHttpClient(
+          httpClient ?? http.Client(),
+          {...baseHeaders, ...?additionalRequestHeaders},
+        ),
         hostedUri = hostedUri ?? Uri.https('api.shorebird.dev');
 
   /// The standard headers applied to all requests.
-  static const headers = <String, String>{'x-version': packageVersion};
+  static const baseHeaders = <String, String>{'x-version': packageVersion};
 
   /// The default error message to use when an unknown error occurs.
   static const unknownErrorMessage = 'An unknown error occurred.';

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -70,7 +70,8 @@ class _CodePushHttpClient extends http.BaseClient {
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {
-    return _client.send(request..headers.addAll(_headers));
+    request.headers.addAll(_headers);
+    return _client.send(request);
   }
 
   @override

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -91,12 +91,12 @@ class CodePushClient {
     Map<String, String>? additionalRequestHeaders,
   })  : _httpClient = _CodePushHttpClient(
           httpClient ?? http.Client(),
-          {...baseHeaders, ...?additionalRequestHeaders},
+          {...standardHeaders, ...?additionalRequestHeaders},
         ),
         hostedUri = hostedUri ?? Uri.https('api.shorebird.dev');
 
   /// The standard headers applied to all requests.
-  static const baseHeaders = <String, String>{'x-version': packageVersion};
+  static const standardHeaders = <String, String>{'x-version': packageVersion};
 
   /// The default error message to use when an unknown error occurs.
   static const unknownErrorMessage = 'An unknown error occurred.';

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -88,10 +88,10 @@ class CodePushClient {
   CodePushClient({
     http.Client? httpClient,
     Uri? hostedUri,
-    Map<String, String>? additionalRequestHeaders,
+    Map<String, String>? customHeaders,
   })  : _httpClient = _CodePushHttpClient(
           httpClient ?? http.Client(),
-          {...standardHeaders, ...?additionalRequestHeaders},
+          {...standardHeaders, ...?customHeaders},
         ),
         hostedUri = hostedUri ?? Uri.https('api.shorebird.dev');
 

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -44,7 +44,7 @@ void main() {
       httpClient = _MockHttpClient();
       codePushClient = CodePushClient(
         httpClient: httpClient,
-        additionalRequestHeaders: customHeaders,
+        customHeaders: customHeaders,
       );
       when(() => httpClient.send(any())).thenAnswer(
         (_) async => http.StreamedResponse(Stream.empty(), HttpStatus.ok),

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -23,7 +23,10 @@ void main() {
       details: 'test details',
     );
     const customHeaders = {'x-custom-header': 'custom-value'};
-    final expectedHeaders = {...CodePushClient.baseHeaders, ...customHeaders};
+    final expectedHeaders = {
+      ...CodePushClient.standardHeaders,
+      ...customHeaders,
+    };
 
     late http.Client httpClient;
     late CodePushClient codePushClient;

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -22,6 +22,8 @@ void main() {
       message: 'test message',
       details: 'test details',
     );
+    const customHeaders = {'x-custom-header': 'custom-value'};
+    final expectedHeaders = {...CodePushClient.baseHeaders, ...customHeaders};
 
     late http.Client httpClient;
     late CodePushClient codePushClient;
@@ -37,7 +39,10 @@ void main() {
 
     setUp(() {
       httpClient = _MockHttpClient();
-      codePushClient = CodePushClient(httpClient: httpClient);
+      codePushClient = CodePushClient(
+        httpClient: httpClient,
+        additionalRequestHeaders: customHeaders,
+      );
       when(() => httpClient.send(any())).thenAnswer(
         (_) async => http.StreamedResponse(Stream.empty(), HttpStatus.ok),
       );
@@ -102,7 +107,7 @@ void main() {
             .single as http.BaseRequest;
         expect(request.method, equals('GET'));
         expect(request.url, equals(v1('users/me')));
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('returns null if reponse is a 404', () async {
@@ -182,7 +187,7 @@ void main() {
           request.url,
           equals(v1('apps/$appId/patches/$patchId/artifacts')),
         );
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails (unknown)', () async {
@@ -397,7 +402,7 @@ void main() {
           request.url,
           equals(v1('apps/$appId/releases/$releaseId/artifacts')),
         );
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails (unknown)', () async {
@@ -646,7 +651,7 @@ void main() {
             .single as http.BaseRequest;
         expect(request.method, equals('POST'));
         expect(request.url, equals(v1('apps')));
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails (unknown)', () async {
@@ -733,7 +738,7 @@ void main() {
             .single as http.BaseRequest;
         expect(request.method, equals('POST'));
         expect(request.url, equals(v1('apps/$appId/channels')));
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails (unknown)', () async {
@@ -832,7 +837,7 @@ void main() {
             .single as http.BaseRequest;
         expect(request.method, equals('POST'));
         expect(request.url, equals(v1('apps/$appId/patches')));
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails (unknown)', () async {
@@ -940,7 +945,7 @@ void main() {
             .single as http.BaseRequest;
         expect(request.method, equals('POST'));
         expect(request.url, equals(v1('apps/$appId/releases')));
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails (unknown)', () async {
@@ -1078,7 +1083,7 @@ void main() {
             .single as http.BaseRequest;
         expect(request.method, equals('PATCH'));
         expect(request.url, equals(v1('apps/$appId/releases/$releaseId')));
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the response is not a 204', () async {
@@ -1143,7 +1148,7 @@ void main() {
             .single as http.BaseRequest;
         expect(request.method, equals('POST'));
         expect(request.url, equals(v1('users')));
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails', () {
@@ -1188,7 +1193,7 @@ void main() {
             .single as http.BaseRequest;
         expect(request.method, equals('DELETE'));
         expect(request.url, equals(v1('apps/$appId')));
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails (unknown)', () async {
@@ -1262,7 +1267,7 @@ void main() {
             .single as http.BaseRequest;
         expect(request.method, equals('GET'));
         expect(request.url, equals(v1('apps')));
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails (unknown)', () async {
@@ -1360,7 +1365,7 @@ void main() {
             .single as http.BaseRequest;
         expect(request.method, equals('GET'));
         expect(request.url, equals(v1('apps/$appId/channels')));
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails (unknown)', () async {
@@ -1444,7 +1449,7 @@ void main() {
               .single as http.BaseRequest;
           expect(request.method, equals('GET'));
           expect(request.url, equals(v1('apps/$appId/releases')));
-          expect(request.hasStandardHeaders, isTrue);
+          expect(request.hasHeaders(expectedHeaders), isTrue);
         });
 
         test('when sideloadableOnly is true', () async {
@@ -1459,7 +1464,7 @@ void main() {
             request.url,
             equals(v1('apps/$appId/releases?sideloadable=true')),
           );
-          expect(request.hasStandardHeaders, isTrue);
+          expect(request.hasHeaders(expectedHeaders), isTrue);
         });
       });
 
@@ -1580,7 +1585,7 @@ void main() {
             v1('apps/$appId/releases/$releaseId/artifacts?arch=$arch&platform=${platform.name}'),
           ),
         );
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails (unknown)', () async {
@@ -1680,7 +1685,7 @@ void main() {
             .single as http.BaseRequest;
         expect(request.method, equals('POST'));
         expect(request.url, equals(v1('apps/$appId/patches/promote')));
-        expect(request.hasStandardHeaders, isTrue);
+        expect(request.hasHeaders(expectedHeaders), isTrue);
       });
 
       test('throws an exception if the http request fails (unknown)', () async {
@@ -1770,8 +1775,8 @@ void main() {
 }
 
 extension on http.BaseRequest {
-  bool get hasStandardHeaders {
-    return CodePushClient.headers.entries.every(
+  bool hasHeaders(Map<String, String> expectedHeaders) {
+    return headers.entries.every(
       (entry) => headers[entry.key] == entry.value,
     );
   }


### PR DESCRIPTION
## Description

- Adds support for additional headers in code push client requests
- Adds the `x-cli-version` to all code push client request headers made by the CLI

Part of https://github.com/shorebirdtech/shorebird/issues/1910

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
