### PR TITLE
feat: add filename to CreateReleaseArtifactRequest

### DIFF
--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -699,10 +699,10 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: d87214d19fb311997d8128ec501a980f77cb240ac4e7e219accf452813ff473c
+      sha256: d72b538180efcf8413cd2e4e6fcc7ae99c7712e0909eb9223f9da6e6d0ef715f
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.3"
+    version: "1.25.4"
   test_api:
     dependency: transitive
     description:
@@ -715,10 +715,10 @@ packages:
     dependency: transitive
     description:
       name: test_core
-      sha256: "2236f70be1e5ab405c675e88c36935a87dad9e05a506b57dd5c0f617f5aebcb2"
+      sha256: "4d070a6bc36c1c4e89f20d353bfd71dc30cdf2bd0e14349090af360a029ab292"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.6.2"
   timing:
     dependency: transitive
     description:
@@ -763,10 +763,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: a75f83f14ad81d5fe4b3319710b90dec37da0e22612326b696c9e1b8f34bbf48
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:shorebird_code_push_client/src/version.dart';
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
@@ -190,6 +191,7 @@ class CodePushClient {
       hash: hash,
       size: file.length,
       canSideload: canSideload,
+      filename: p.basename(artifactPath),
     ).toJson().map((key, value) => MapEntry(key, '$value'));
     request.fields.addAll(payload);
 

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -95,7 +95,8 @@ class CodePushClient {
           httpClient ?? http.Client(),
           {...standardHeaders, ...?customHeaders},
         ),
-        hostedUri = hostedUri ?? Uri.https('api.shorebird.dev');
+        // hostedUri = hostedUri ?? Uri.https('api.shorebird.dev');
+        hostedUri = hostedUri ?? Uri.http('localhost:8080');
 
   /// The standard headers applied to all requests.
   static const standardHeaders = <String, String>{'x-version': packageVersion};

--- a/packages/shorebird_code_push_client/pubspec.yaml
+++ b/packages/shorebird_code_push_client/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   http: ^1.0.0
+  path: ^1.9.0
   shorebird_code_push_protocol:
     path: ../shorebird_code_push_protocol
 
@@ -18,6 +19,5 @@ dev_dependencies:
   build_verify: ^3.0.0
   build_version: ^2.0.0
   mocktail: ^1.0.0
-  path: ^1.8.3
   test: ^1.19.2
   very_good_analysis: ^5.1.0

--- a/packages/shorebird_code_push_client/pubspec.yaml
+++ b/packages/shorebird_code_push_client/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
+  collection: ^1.18.0
   http: ^1.0.0
   path: ^1.9.0
   shorebird_code_push_protocol:

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -377,13 +377,22 @@ void main() {
       const arch = 'aarch64';
       const platform = ReleasePlatform.android;
       const hash = 'test-hash';
-      const size = 42;
+      const size = 5;
       const canSideload = true;
 
       test('makes the correct request', () async {
         final tempDir = Directory.systemTemp.createTempSync();
         final fixture = File(path.join(tempDir.path, 'release.txt'))
-          ..createSync();
+          ..createSync()
+          ..writeAsStringSync('hello');
+        final expectedRequest = CreateReleaseArtifactRequest(
+          arch: arch,
+          platform: platform,
+          hash: hash,
+          size: size,
+          canSideload: canSideload,
+          filename: 'release.txt',
+        );
 
         try {
           await codePushClient.createReleaseArtifact(
@@ -399,13 +408,17 @@ void main() {
 
         final request = verify(() => httpClient.send(captureAny()))
             .captured
-            .single as http.BaseRequest;
+            .single as http.MultipartRequest;
         expect(request.method, equals('POST'));
         expect(
           request.url,
           equals(v1('apps/$appId/releases/$releaseId/artifacts')),
         );
         expect(request.hasHeaders(expectedHeaders), isTrue);
+        expect(
+          request.fields.entries,
+          equals(expectedRequest.toJson().entries),
+        );
       });
 
       test('throws an exception if the http request fails (unknown)', () async {

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -2,6 +2,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:http/http.dart' as http;
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as path;
@@ -416,8 +417,11 @@ void main() {
         );
         expect(request.hasHeaders(expectedHeaders), isTrue);
         expect(
-          request.fields.entries,
-          equals(expectedRequest.toJson().entries),
+          MapEquality<String, dynamic>().equals(
+            request.fields,
+            expectedRequest.toJson(),
+          ),
+          isTrue,
         );
       });
 

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
@@ -18,6 +18,7 @@ class CreateReleaseArtifactRequest {
     required this.hash,
     required this.size,
     required this.canSideload,
+    required this.filename,
   });
 
   /// Converts a Map<String, dynamic> to a [CreateReleaseArtifactRequest]
@@ -35,6 +36,10 @@ class CreateReleaseArtifactRequest {
 
   /// The hash of the artifact.
   final String hash;
+
+  /// The name of the file.
+  /// TODO(NEXT_API): make this non-nullable.
+  final String? filename;
 
   /// Whether the artifact can installed and run on a device/emulator as-is.
   @JsonKey(fromJson: _parseStringToBool, toJson: _parseBoolToString)

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
@@ -38,8 +38,7 @@ class CreateReleaseArtifactRequest {
   final String hash;
 
   /// The name of the file.
-  /// TODO(NEXT_API): make this non-nullable.
-  final String? filename;
+  final String filename;
 
   /// Whether the artifact can installed and run on a device/emulator as-is.
   @JsonKey(fromJson: _parseStringToBool, toJson: _parseBoolToString)

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.g.dart
@@ -23,7 +23,7 @@ CreateReleaseArtifactRequest _$CreateReleaseArtifactRequestFromJson(
               'size', (v) => CreateReleaseArtifactRequest._parseStringToInt(v)),
           canSideload: $checkedConvert('can_sideload',
               (v) => CreateReleaseArtifactRequest._parseStringToBool(v)),
-          filename: $checkedConvert('filename', (v) => v as String?),
+          filename: $checkedConvert('filename', (v) => v as String),
         );
         return val;
       },

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.g.dart
@@ -23,6 +23,7 @@ CreateReleaseArtifactRequest _$CreateReleaseArtifactRequestFromJson(
               'size', (v) => CreateReleaseArtifactRequest._parseStringToInt(v)),
           canSideload: $checkedConvert('can_sideload',
               (v) => CreateReleaseArtifactRequest._parseStringToBool(v)),
+          filename: $checkedConvert('filename', (v) => v as String?),
         );
         return val;
       },
@@ -35,6 +36,7 @@ Map<String, dynamic> _$CreateReleaseArtifactRequestToJson(
       'arch': instance.arch,
       'platform': _$ReleasePlatformEnumMap[instance.platform]!,
       'hash': instance.hash,
+      'filename': instance.filename,
       'can_sideload':
           CreateReleaseArtifactRequest._parseBoolToString(instance.canSideload),
       'size': CreateReleaseArtifactRequest._parseIntToString(instance.size),

--- a/packages/shorebird_code_push_protocol/test/src/messages/create_release_artifact/create_release_artifact_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/create_release_artifact/create_release_artifact_request_test.dart
@@ -10,6 +10,7 @@ void main() {
         hash: '1234',
         size: 9876,
         canSideload: true,
+        filename: 'test.apk',
       );
       expect(
         CreateReleaseArtifactRequest.fromJson(request.toJson()).toJson(),


### PR DESCRIPTION
## Description

Sends a filename in the `CreateReleaseArtifactRequest`, which the server will use when writing to Google Cloud Storage. This will allow users to download release artifacts from the console with the correct extension (they are currently all have the `.vmcode` extension).

Part of https://github.com/shorebirdtech/_console/issues/158

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
