### PR TITLE
fix(shorebird_cli): close input stream when extracting cache artifacts

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -1,7 +1,5 @@
 import 'dart:io' hide Platform;
-import 'dart:isolate';
 
-import 'package:archive/archive_io.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';

--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -35,10 +35,11 @@ typedef ArchiveExtractor = Future<void> Function(
 );
 
 Future<void> _defaultArchiveExtractor(String archivePath, String outputPath) {
-  return Isolate.run(() {
+  return Isolate.run(() async {
     final inputStream = InputFileStream(archivePath);
     final archive = ZipDecoder().decodeBuffer(inputStream);
-    extractArchiveToDisk(archive, outputPath);
+    await extractArchiveToDisk(archive, outputPath);
+    await inputStream.close();
   });
 }
 


### PR DESCRIPTION
## Description

Possibly the cause of the e2e failures in https://github.com/shorebirdtech/shorebird/actions/runs/8725954542/job/23940129912

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
