### PR TITLE
chore: remove has(asset|native)Changes property from CreatePatchRequest

### DIFF
--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -260,8 +260,6 @@ class CodePushClient {
     final request = CreatePatchRequest(
       releaseId: releaseId,
       wasForced: false,
-      hasAssetChanges: metadata.hasAssetChanges,
-      hasNativeChanges: metadata.hasNativeChanges,
       metadata: metadata,
     );
     final response = await _httpClient.post(

--- a/packages/shorebird_code_push_client/lib/src/version.dart
+++ b/packages/shorebird_code_push_client/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.6.0+3';
+const packageVersion = '0.7.0+1';

--- a/packages/shorebird_code_push_client/pubspec.yaml
+++ b/packages/shorebird_code_push_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_code_push_client
 description: Library which allows Dart applications to interact with the ShoreBird CodePush API
-version: 0.6.0+3
+version: 0.7.0+1
 repository: https://github.com/shorebirdtech/shorebird
 
 publish_to: none

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_request.dart
@@ -12,8 +12,6 @@ class CreatePatchRequest {
   const CreatePatchRequest({
     required this.releaseId,
     required this.wasForced,
-    required this.hasAssetChanges,
-    required this.hasNativeChanges,
     required this.metadata,
   });
 
@@ -30,14 +28,6 @@ class CreatePatchRequest {
   /// Whether the user used the --force flag when authoring this patch.
   final bool? wasForced;
 
-  /// Whether the patch's assets were not the same as those of the release
-  // TODO(bryanoltman): remove this after metadata change is fully rolled out.
-  final bool? hasAssetChanges;
-
-  /// Whether the patch's native code is different than that of the release.
-  // TODO(bryanoltman): remove this after metadata change is fully rolled out.
-  final bool? hasNativeChanges;
-
   /// Additional information about the creation of the patch.
-  final CreatePatchMetadata? metadata;
+  final CreatePatchMetadata metadata;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_request.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_request.g.dart
@@ -16,31 +16,17 @@ CreatePatchRequest _$CreatePatchRequestFromJson(Map<String, dynamic> json) =>
         final val = CreatePatchRequest(
           releaseId: $checkedConvert('release_id', (v) => v as int),
           wasForced: $checkedConvert('was_forced', (v) => v as bool?),
-          hasAssetChanges:
-              $checkedConvert('has_asset_changes', (v) => v as bool?),
-          hasNativeChanges:
-              $checkedConvert('has_native_changes', (v) => v as bool?),
-          metadata: $checkedConvert(
-              'metadata',
-              (v) => v == null
-                  ? null
-                  : CreatePatchMetadata.fromJson(v as Map<String, dynamic>)),
+          metadata: $checkedConvert('metadata',
+              (v) => CreatePatchMetadata.fromJson(v as Map<String, dynamic>)),
         );
         return val;
       },
-      fieldKeyMap: const {
-        'releaseId': 'release_id',
-        'wasForced': 'was_forced',
-        'hasAssetChanges': 'has_asset_changes',
-        'hasNativeChanges': 'has_native_changes'
-      },
+      fieldKeyMap: const {'releaseId': 'release_id', 'wasForced': 'was_forced'},
     );
 
 Map<String, dynamic> _$CreatePatchRequestToJson(CreatePatchRequest instance) =>
     <String, dynamic>{
       'release_id': instance.releaseId,
       'was_forced': instance.wasForced,
-      'has_asset_changes': instance.hasAssetChanges,
-      'has_native_changes': instance.hasNativeChanges,
-      'metadata': instance.metadata?.toJson(),
+      'metadata': instance.metadata.toJson(),
     };

--- a/packages/shorebird_code_push_protocol/test/src/messages/create_patch/create_patch_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/create_patch/create_patch_request_test.dart
@@ -7,8 +7,6 @@ void main() {
       const request = CreatePatchRequest(
         releaseId: 1234,
         wasForced: true,
-        hasAssetChanges: true,
-        hasNativeChanges: false,
         metadata: CreatePatchMetadata(
           releasePlatform: ReleasePlatform.android,
           usedIgnoreAssetChangesFlag: true,
@@ -31,12 +29,10 @@ void main() {
     });
 
     test('can be (de)serialized without metadata', () {
-      const request = CreatePatchRequest(
+      final request = CreatePatchRequest(
         releaseId: 1234,
         wasForced: true,
-        hasAssetChanges: true,
-        hasNativeChanges: false,
-        metadata: null,
+        metadata: CreatePatchMetadata.forTest(),
       );
       expect(
         CreatePatchRequest.fromJson(request.toJson()).toJson(),


### PR DESCRIPTION
## Description

This is deprecated, we're removing as part of a breaking change. Also bumps shorebird_code_push_client version.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
