### PR TITLE
fix(shorebird_cli): revert 'camel case flavors can confuse path finding for android'

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -215,7 +215,7 @@ Use `shorebird flutter versions list` to list available versions.
             ? p.join(
                 bundleDirPath,
                 '${flavor}Release',
-                'app-${flavor.toKebabCase}-release.aab',
+                'app-$flavor-release.aab',
               )
             : p.join(bundleDirPath, 'release', 'app-release.aab');
         final apkPath = flavor != null
@@ -223,7 +223,7 @@ Use `shorebird flutter versions list` to list available versions.
                 apkDirPath,
                 flavor,
                 'release',
-                'app-${flavor.toKebabCase}-release.apk',
+                'app-$flavor-release.apk',
               )
             : p.join(apkDirPath, 'release', 'app-release.apk');
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -9,7 +9,6 @@ import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
-import 'package:shorebird_cli/src/extensions/string.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';

--- a/packages/shorebird_cli/lib/src/extensions/string.dart
+++ b/packages/shorebird_cli/lib/src/extensions/string.dart
@@ -2,14 +2,3 @@ extension NullOrEmtpy on String? {
   /// Returns `true` if this string is null or empty.
   bool get isNullOrEmpty => this == null || this!.isEmpty;
 }
-
-extension Case on String {
-  /// Converts to kebab-case.
-  String get toKebabCase {
-    final exp = RegExp('(?<=[a-z])[A-Z]');
-    return replaceAllMapped(exp, (m) => '-${m.group(0)}')
-        .toLowerCase()
-        .replaceAll(' ', '-')
-        .replaceAll('_', '-');
-  }
-}

--- a/packages/shorebird_cli/test/src/extensions/string_test.dart
+++ b/packages/shorebird_cli/test/src/extensions/string_test.dart
@@ -7,12 +7,4 @@ void main() {
     expect(''.isNullOrEmpty, true);
     expect('test'.isNullOrEmpty, false);
   });
-
-  test('ToKebabCase', () async {
-    expect('sentenceCase'.toKebabCase, 'sentence-case');
-    expect('SentenceCase'.toKebabCase, 'sentence-case');
-    expect('sentence_case'.toKebabCase, 'sentence-case');
-    expect('sentence-case'.toKebabCase, 'sentence-case');
-    expect('sentence case'.toKebabCase, 'sentence-case');
-  });
 }


### PR DESCRIPTION
Reverts https://github.com/shorebirdtech/shorebird/pull/1861. This was causing flavors with a camel case names (`retailerStaging`) to be incorrectly kebab-cased (`retailer-staging`).
