### PR TITLE
chore(shorebird_cli): improve patch output when release uses non-default flutter version

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -184,13 +184,9 @@ Please re-run the release command for this version or create a new release.''');
 
     final currentFlutterRevision = shorebirdEnv.flutterRevision;
     if (release.flutterRevision != currentFlutterRevision) {
-      logger.info('''
-
-The release you are trying to patch was built with a different version of Flutter.
-
-Release Flutter Revision: ${release.flutterRevision}
-Current Flutter Revision: $currentFlutterRevision
-''');
+      logger.info(
+        'Release was built with Flutter revision ${release.flutterRevision}',
+      );
     }
 
     try {

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -202,13 +202,7 @@ Please re-run the release command for this version or create a new release.''');
     final currentFlutterRevision = shorebirdEnv.flutterRevision;
     if (release.flutterRevision != currentFlutterRevision) {
       logger.info(
-        '''
-
-The release you are trying to patch was built with a different version of Flutter.
-
-Release Flutter Revision: ${release.flutterRevision}
-Current Flutter Revision: $currentFlutterRevision
-''',
+        'Release was built with Flutter revision ${release.flutterRevision}',
       );
     }
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_android_command_test.dart
@@ -515,13 +515,7 @@ Please re-run the release command for this version or create a new release.'''),
       expect(exitCode, ExitCode.success.code);
       verify(
         () => logger.info(
-          any(
-            that: stringContainsInOrder([
-              '''The release you are trying to patch was built with a different version of Flutter.''',
-              'Release Flutter Revision: ${release.flutterRevision}',
-              'Current Flutter Revision: $otherRevision',
-            ]),
-          ),
+          'Release was built with Flutter revision ${release.flutterRevision}',
         ),
       ).called(1);
     });

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -858,13 +858,7 @@ Please re-run the release command for this version or create a new release.'''),
         ).thenAnswer((_) async {});
         verify(
           () => logger.info(
-            any(
-              that: stringContainsInOrder([
-                '''The release you are trying to patch was built with a different version of Flutter.''',
-                'Release Flutter Revision: ${preLinkerRelease.flutterRevision}',
-                'Current Flutter Revision: $otherRevision',
-              ]),
-            ),
+            '''Release was built with Flutter revision ${preLinkerRelease.flutterRevision}''',
           ),
         ).called(1);
       });


### PR DESCRIPTION
## Description

When patching a release that uses a version of Flutter older than the default, we show the message:

```
The release you are trying to patch was built with a different version of Flutter.

Release Flutter Revision: 03e895ee09dfbb9c18681d103f4b27671ff65429
Current Flutter Revision: 47571af6a3acdebedf88255099ff1de1c3324049
```

It looks like an error, but it's not. This has confused several users.

This PR changes the message to simply say `Release was built with Flutter revision 03e895ee09dfbb9c18681d103f4b27671ff65429`.

Fixes https://github.com/shorebirdtech/shorebird/issues/1930

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
