### PR TITLE
feat: Adding debug-linker flag to patch ios command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -93,7 +93,7 @@ If this option is not provided, the version number will be determined from the p
       ..addFlag(
         'debug-linker',
         negatable: false,
-        help: 'Collects linker percentage data to help troubleshooting.',
+        help: 'Collects linker diagnostic information to help troubleshoot low link percentages.',
       );
   }
 

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -93,8 +93,8 @@ If this option is not provided, the version number will be determined from the p
       ..addFlag(
         'debug-linker',
         negatable: false,
-        help:
-            'Collects linker diagnostic information to help troubleshoot low link percentages.',
+        help: 'Collects linker diagnostic information to help troubleshoot low '
+            'link percentages.',
       );
   }
 
@@ -378,6 +378,8 @@ Please re-run the release command for this version or create a new release.''');
             '🟢 Track: ${lightCyan.wrap('Production')}',
           if (percentLinked != null)
             '''🔗 Running ${lightCyan.wrap('${percentLinked.toStringAsFixed(1)}%')} on CPU''',
+          if (results['debug-linker'] == true)
+            '''🔍 Debug Info: ${lightCyan.wrap(_debugInfoOutpath)}''',
         ];
 
         logger.info(
@@ -567,14 +569,12 @@ ${summary.join('\n')}
 
       if (dumpDebugInfo) {
         final debugInfoZip = await tmpLinkerDiagnosticDirectory.zipToTempFile();
-        final zippedDiagnostic = debugInfoZip.copySync(
+        debugInfoZip.copySync(
           p.join(
             'build',
             _debugInfoOutpath,
           ),
         );
-
-        logger.warn('Debug info written to ${zippedDiagnostic.absolute}');
       }
     } catch (error) {
       linkProgress.fail('Failed to link AOT files: $error');

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -552,8 +552,8 @@ ${summary.join('\n')}
     final linkProgress = logger.progress('Linking AOT files');
     double? linkPercentage;
     try {
-      late final tmpLinkerDiagnosticDirectory =
-          Directory.systemTemp.createTempSync();
+      final dumpDebugInfoDir =
+          dumpDebugInfo ? Directory.systemTemp.createTempSync() : null;
 
       linkPercentage = await aotTools.link(
         base: releaseArtifact.path,
@@ -563,12 +563,11 @@ ${summary.join('\n')}
         outputPath: _vmcodeOutputPath,
         workingDirectory: _buildDirectory,
         kernel: newestAppDill().path,
-        dumpDebugInfoPath:
-            dumpDebugInfo ? tmpLinkerDiagnosticDirectory.path : null,
+        dumpDebugInfoPath: dumpDebugInfoDir?.path,
       );
 
-      if (dumpDebugInfo) {
-        final debugInfoZip = await tmpLinkerDiagnosticDirectory.zipToTempFile();
+      if (dumpDebugInfo && dumpDebugInfoDir != null) {
+        final debugInfoZip = await dumpDebugInfoDir.zipToTempFile();
         debugInfoZip.copySync(
           p.join(
             'build',

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -140,6 +140,7 @@ class AotTools {
     required String kernel,
     required String outputPath,
     String? workingDirectory,
+    String? dumpDebugInfoPath,
   }) async {
     // We use the json lines format. https://jsonlines.org
     const linkJson = 'link.jsonl';
@@ -158,6 +159,7 @@ class AotTools {
           '--reporter=json',
           '--redirect-to=${p.join(outputDir, linkJson)}',
         ],
+        if (dumpDebugInfoPath != null) '--dump-debug-info=$dumpDebugInfoPath',
       ],
       workingDirectory: workingDirectory,
     );

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -406,10 +406,10 @@ packages:
     dependency: "direct main"
     description:
       name: mason_logger
-      sha256: "0e90e637dcfcb7fb6c30b38e71cd41fa0e4e3df6f1da177f8251ac3f15147e9f"
+      sha256: "56c44e588e908ef0d1dbb593e1b4473b8ee5fb48fcc8d645c925ab6c8041ebdf"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.12"
+    version: "0.2.15"
   matcher:
     dependency: transitive
     description:
@@ -494,10 +494,10 @@ packages:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: "70fe966348fe08c34bf929582f1d8247d9d9408130723206472b4687227e4333"
+      sha256: "79fbafed02cfdbe85ef3fd06c7f4bc2cbcba0177e61b765264853d4253b21744"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.0"
+    version: "3.9.0"
   pool:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -351,6 +351,7 @@ flutter:
             kernel: any(named: 'kernel'),
             workingDirectory: any(named: 'workingDirectory'),
             outputPath: any(named: 'outputPath'),
+            dumpDebugInfoPath: any(named: 'dumpDebugInfoPath'),
           ),
         ).thenAnswer((_) async => null);
         when(() => aotTools.isGeneratePatchDiffBaseSupported())
@@ -1295,6 +1296,31 @@ Please re-run the release command for this version or create a new release.'''),
               ),
             ).called(1);
           });
+        });
+
+        group('when debug-linker is true', () {
+          test(
+            'succeeds and create debug info zip',
+            () async {
+              when(() => argResults['debug-linker']).thenReturn(true);
+              setUpProjectRoot();
+              setUpProjectRootArtifacts();
+              final exitCode = await runWithOverrides(command.run);
+              expect(exitCode, ExitCode.success.code);
+              verify(
+                () => aotTools.link(
+                  base: any(named: 'base'),
+                  patch: any(named: 'patch'),
+                  analyzeSnapshot: any(named: 'analyzeSnapshot'),
+                  genSnapshot: any(named: 'genSnapshot'),
+                  kernel: any(named: 'kernel'),
+                  workingDirectory: any(named: 'workingDirectory'),
+                  outputPath: any(named: 'outputPath'),
+                  dumpDebugInfoPath: any(named: 'dumpDebugInfoPath'),
+                ),
+              ).called(1);
+            },
+          );
         });
       });
 

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -157,6 +157,67 @@ void main() {
         });
       });
 
+      group(
+        'when dumpDebugInfoPath is not null, forward the argument to the '
+        'executable',
+        () {
+          const aotToolsPath = 'aot_tools';
+
+          setUp(() {
+            when(
+              () => shorebirdArtifacts.getArtifactPath(
+                artifact: ShorebirdArtifact.aotTools,
+              ),
+            ).thenReturn(aotToolsPath);
+          });
+
+          test('links and exits with code 0', () async {
+            when(
+              () => process.run(
+                aotToolsPath,
+                any(),
+                workingDirectory: any(named: 'workingDirectory'),
+              ),
+            ).thenAnswer(
+              (_) async => const ShorebirdProcessResult(
+                exitCode: 0,
+                stdout: '',
+                stderr: '',
+              ),
+            );
+            await expectLater(
+              runWithOverrides(
+                () => aotTools.link(
+                  base: base,
+                  patch: patch,
+                  analyzeSnapshot: analyzeSnapshot,
+                  genSnapshot: genSnapshot,
+                  kernel: kernel,
+                  workingDirectory: workingDirectory.path,
+                  outputPath: outputPath,
+                  dumpDebugInfoPath: 'my_debug_path',
+                ),
+              ),
+              completes,
+            );
+            verify(
+              () => process.run(
+                aotToolsPath,
+                [
+                  'link',
+                  '--base=$base',
+                  '--patch=$patch',
+                  '--analyze-snapshot=$analyzeSnapshot',
+                  '--output=$outputPath',
+                  '--dump-debug-info=my_debug_path',
+                ],
+                workingDirectory: any(named: 'workingDirectory'),
+              ),
+            ).called(1);
+          });
+        },
+      );
+
       group('when aot-tools is a kernel file', () {
         const aotToolsPath = 'aot_tools.dill';
 

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -158,8 +158,7 @@ void main() {
       });
 
       group(
-        'when dumpDebugInfoPath is not null, forward the argument to the '
-        'executable',
+        'when --dump-debug-info is provided',
         () {
           const aotToolsPath = 'aot_tools';
 
@@ -171,7 +170,7 @@ void main() {
             ).thenReturn(aotToolsPath);
           });
 
-          test('links and exits with code 0', () async {
+          test('forwards the option to aot_tools', () async {
             when(
               () => process.run(
                 aotToolsPath,

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -171,6 +171,7 @@ void main() {
           });
 
           test('forwards the option to aot_tools', () async {
+            const debugPath = 'my_debug_path';
             when(
               () => process.run(
                 aotToolsPath,
@@ -194,7 +195,7 @@ void main() {
                   kernel: kernel,
                   workingDirectory: workingDirectory.path,
                   outputPath: outputPath,
-                  dumpDebugInfoPath: 'my_debug_path',
+                  dumpDebugInfoPath: debugPath,
                 ),
               ),
               completes,
@@ -208,7 +209,7 @@ void main() {
                   '--patch=$patch',
                   '--analyze-snapshot=$analyzeSnapshot',
                   '--output=$outputPath',
-                  '--dump-debug-info=my_debug_path',
+                  '--dump-debug-info=$debugPath',
                 ],
                 workingDirectory: any(named: 'workingDirectory'),
               ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adds a `debug-linker` flag to the `shorebird patch ios` command generate debug data in the aot tools.

WIP: Manual test missing.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
