### PR TITLE
fix(shorebird_cli): fix release android target_platform with local_engine

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_android_command.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
@@ -97,9 +98,11 @@ make smaller updates to your app.
     final flutterVersion = results['flutter-version'] as String?;
     final architectures = (results['target-platform'] as List<String>)
         .map(
-          (platform) => AndroidArch.availableAndroidArchs
-              .firstWhere((arch) => arch.targetPlatformCliArg == platform),
+          (platform) => AndroidArch.availableAndroidArchs.firstWhereOrNull(
+            (arch) => arch.targetPlatformCliArg == platform,
+          ),
         )
+        .whereType<Arch>()
         .toSet();
 
     if (generateApk && splitApk) {

--- a/packages/shorebird_cli/lib/src/platform/android.dart
+++ b/packages/shorebird_cli/lib/src/platform/android.dart
@@ -44,7 +44,7 @@ extension AndroidArch on Arch {
     if (engineConfig.localEngine != null) {
       final localEngineOutName = engineConfig.localEngine!;
       final arch = Arch.values.firstWhereOrNull(
-        (element) => localEngineOutName.contains(element.androidEnginePath),
+        (element) => localEngineOutName == element.androidEnginePath,
       );
       if (arch == null) {
         throw Exception(


### PR DESCRIPTION
## Description

Because the default value for `shorebird release android`'s `target-platform` option is `android-arm,android-arm64,android-x64` and because a local engine build targets only one of these, this PR updates the command to only use the target-platform args included in `AndroidArch.availableAndroidArchs`. An alternative solution would be to require `--target-platform` to be specified for local engine builds.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
