### PR TITLE
fix(shorebird_cli): use completion command when compiling shorebird for Windows

### DIFF
--- a/bin/shorebird.ps1
+++ b/bin/shorebird.ps1
@@ -137,9 +137,14 @@ function Update-Shorebird {
 
     Write-Output "Compiling shorebird..."
 
+    # Compile our snapshot
+    # We invoke `$SNAPSHOT_PATH completion` to trigger the "completion" command, which
+    # avoids executing as much of our code as possible. We do this because running
+    # the script here (instead of from the compiled snapshot) invalidates a lot of
+    # assumptions we make about the cwd in the shorebird_cli tool.
     & $dart --verbosity=error --disable-dart-dev --snapshot="$snapshotPath" `
         --snapshot-kind="app-jit" --packages="$shorebirdCliDir/.dart_tool/package_config.json" `
-        --no-enable-mirrors "$shorebirdScript" > $null
+        --no-enable-mirrors "$shorebirdScript" completion > $null
 
     Write-Debug "writing $compileKey to $stampPath"
     Set-Content -Path $stampPath -Value $compileKey


### PR DESCRIPTION
## Description

Fixes the issue where attempting to compile shorebird for windows results in the following:

```
Running pub upgrade... 
PathNotFoundException: Cannot open file, path = 'D:\a\shorebird\shorebird\packages\bin\internal\flutter.version' (OS Error: The system cannot find the path specified.
, errno = 3)
bin/cache/shorebird.snapshot: Error: Error when reading 'bin/cache/shorebird.snapshot': The system cannot find the file specified.
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
