### PR TITLE
fix: revert " update cache artifacts on every command run"

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -1,7 +1,6 @@
 import 'dart:io' hide Platform;
 
 import 'package:http/http.dart' as http;
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:scoped/scoped.dart';
@@ -50,17 +49,15 @@ class Cache {
     registerArtifact(AotToolsExeArtifact(cache: this, platform: platform));
   }
 
-  void registerArtifact(CachedArtifact artifact) => artifacts.add(artifact);
+  void registerArtifact(CachedArtifact artifact) => _artifacts.add(artifact);
 
   Future<void> updateAll() async {
-    for (final artifact in artifacts) {
+    for (final artifact in _artifacts) {
       if (await artifact.isUpToDate()) {
         continue;
       }
 
-      final progress = logger.progress('Downloading ${artifact.name} artifact');
       await artifact.update();
-      progress.complete('Downloaded ${artifact.name} artifact');
     }
   }
 
@@ -101,8 +98,7 @@ class Cache {
     );
   }
 
-  @visibleForTesting
-  final List<CachedArtifact> artifacts = [];
+  final List<CachedArtifact> _artifacts = [];
 
   String get storageBaseUrl => 'https://storage.googleapis.com';
 
@@ -211,14 +207,6 @@ class AotToolsDillArtifact extends CachedArtifact {
 
 /// For a few revisions in Dec 2023, we distributed aot-tools as an executable.
 /// Should be removed sometime after June 2024.
-///
-/// The change to use a .dill file was made in
-/// https://github.com/shorebirdtech/_build_engine/commit/babbc37d93e7a2f36e62787e47eee5a3b5458901
-/// The Flutter versions that use this are:
-///  - 3.13.9 (a3d5f7c614aa1cc4d6cb1506e74fd1c81678e68e)
-///  - 3.16.3 (b9b23902966504a9778f4c07e3a3487fa84dcb2a)
-///  - 3.16.4 (7e92b034c5dddb727cf5e802c23cddd39b325a7f)
-///  - 3.16.5 (4e8a7c746ae6f10951f3e676f10b82b21d7300a5)
 class AotToolsExeArtifact extends CachedArtifact {
   AotToolsExeArtifact({required super.cache, required super.platform});
 

--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -5,7 +5,6 @@ import 'package:args/command_runner.dart';
 import 'package:cli_completion/cli_completion.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:scoped/scoped.dart';
-import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/logger.dart';
@@ -207,13 +206,6 @@ Run ${lightCyan.wrap('shorebird upgrade')} to upgrade.''');
       exitCode = ExitCode.success.code;
     } else {
       try {
-        // Most commands need shorebird artifacts, so we ensure the cache
-        // is up to date for all commands (even ones which don't need it).  We
-        // could make a Command subclass and move the cache onto that and
-        // only update in that case, but it didn't seem worth it at the time.
-        // Ensure all cached artifacts are up-to-date before running the
-        // command.
-        await cache.updateAll();
         exitCode = await super.runCommand(topLevelResults);
       } catch (error, stackTrace) {
         logger

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_aar_command.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
+import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/commands/patch/patch.dart';
@@ -97,6 +98,8 @@ of the Android app that is using this module.''',
     final dryRun = results['dry-run'] == true;
     final allowAssetDiffs = results['allow-asset-diffs'] == true;
     final allowNativeDiffs = results['allow-native-diffs'] == true;
+
+    await cache.updateAll();
 
     if (shorebirdEnv.androidPackageName == null) {
       logger.err('Could not find androidPackage in pubspec.yaml.');

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_android_command.dart
@@ -7,6 +7,7 @@ import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
+import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
@@ -106,6 +107,8 @@ If this option is not provided, the version number will be determined from the p
     final allowNativeDiffs = results['allow-native-diffs'] == true;
     final dryRun = results['dry-run'] == true;
     final isStaging = results['staging'] == true;
+
+    await cache.updateAll();
 
     const releasePlatform = ReleasePlatform.android;
     final flavor = results.findOption('flavor', argParser: argParser);

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -6,6 +6,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/extensions/version.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
@@ -85,6 +86,8 @@ class AotTools {
     List<String> command, {
     String? workingDirectory,
   }) async {
+    await cache.updateAll();
+
     // This will be a path to either a kernel (.dill) file or a Dart script if
     // we're running with a local engine.
     final artifactPath = shorebirdArtifacts.getArtifactPath(

--- a/packages/shorebird_cli/lib/src/executables/bundletool.dart
+++ b/packages/shorebird_cli/lib/src/executables/bundletool.dart
@@ -16,6 +16,7 @@ class Bundletool {
   static const jar = 'bundletool.jar';
 
   Future<ShorebirdProcessResult> _exec(List<String> command) async {
+    await cache.updateAll();
     final bundletool = p.join(cache.getArtifactDirectory(jar).path, jar);
     final javaHome = java.home;
     final javaExecutable = java.executable ?? 'java';

--- a/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_release_version_mixin.dart
@@ -1,3 +1,4 @@
+import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 
@@ -8,6 +9,8 @@ mixin ShorebirdReleaseVersionMixin on ShorebirdCommand {
   Future<String> extractReleaseVersionFromAppBundle(
     String appBundlePath,
   ) async {
+    await cache.updateAll();
+
     final results = await Future.wait([
       bundletool.getVersionName(appBundlePath),
       bundletool.getVersionCode(appBundlePath),

--- a/packages/shorebird_cli/test/src/command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/command_runner_test.dart
@@ -3,7 +3,6 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:platform/platform.dart';
 import 'package:scoped/scoped.dart';
-import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/command_runner.dart';
 import 'package:shorebird_cli/src/logger.dart' hide logger;
 import 'package:shorebird_cli/src/platform.dart';
@@ -21,7 +20,6 @@ void main() {
     const flutterRevision = 'test-flutter-revision';
     const flutterVersion = '1.2.3';
 
-    late Cache cache;
     late Logger logger;
     late Platform platform;
     late ShorebirdEnv shorebirdEnv;
@@ -33,7 +31,6 @@ void main() {
       return runScoped(
         body,
         values: {
-          cacheRef.overrideWith(() => cache),
           loggerRef.overrideWith(() => logger),
           platformRef.overrideWith(() => platform),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
@@ -44,13 +41,11 @@ void main() {
     }
 
     setUp(() {
-      cache = MockCache();
       logger = MockLogger();
       platform = MockPlatform();
       shorebirdEnv = MockShorebirdEnv();
       shorebirdFlutter = MockShorebirdFlutter();
       shorebirdVersion = MockShorebirdVersion();
-      when(() => cache.updateAll()).thenAnswer((_) async {});
       when(() => logger.level).thenReturn(Level.info);
       when(
         () => shorebirdEnv.shorebirdEngineRevision,
@@ -277,16 +272,6 @@ Run ${lightCyan.wrap('shorebird upgrade')} to upgrade.'''),
     });
 
     group('on command failure', () {
-      test('updates cache artifacts', () async {
-        // This will fail due to the release android command missing scoped
-        // dependencies. Because the cache update should happen before the
-        // command runs, we verify that behavior here.
-        await runWithOverrides(
-          () => commandRunner.run(['release', 'android']),
-        );
-        verify(() => cache.updateAll()).called(1);
-      });
-
       test('logs a stack trace using detail', () async {
         // This will fail due to the release android command missing scoped
         // dependencies.

--- a/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_aar_command_test.dart
@@ -10,6 +10,7 @@ import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
+import 'package:shorebird_cli/src/cache.dart' show Cache, cacheRef;
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/config.dart';
@@ -101,6 +102,7 @@ void main() {
     late ShorebirdProcessResult flutterBuildProcessResult;
     late ShorebirdProcessResult flutterPubGetProcessResult;
     late http.Client httpClient;
+    late Cache cache;
     late ShorebirdEnv shorebirdEnv;
     late ShorebirdFlutter shorebirdFlutter;
     late ShorebirdProcess shorebirdProcess;
@@ -113,6 +115,7 @@ void main() {
         values: {
           artifactManagerRef.overrideWith(() => artifactManager),
           authRef.overrideWith(() => auth),
+          cacheRef.overrideWith(() => cache),
           codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           engineConfigRef.overrideWith(() => const EngineConfig.empty()),
           httpClientRef.overrideWith(() => httpClient),
@@ -187,6 +190,7 @@ void main() {
       flutterBuildProcessResult = MockProcessResult();
       flutterPubGetProcessResult = MockProcessResult();
       httpClient = MockHttpClient();
+      cache = MockCache();
       shorebirdEnv = MockShorebirdEnv();
       shorebirdFlutter = MockShorebirdFlutter();
       shorebirdProcess = MockShorebirdProcess();
@@ -314,6 +318,10 @@ void main() {
           metadata: any(named: 'metadata'),
         ),
       ).thenAnswer((_) async {});
+      when(() => cache.updateAll()).thenAnswer((_) async => {});
+      when(
+        () => cache.getArtifactDirectory(any()),
+      ).thenReturn(Directory.systemTemp.createTempSync());
       when(
         () => shorebirdFlutter.getVersionAndRevision(),
       ).thenAnswer((_) async => flutterVersionAndRevision);

--- a/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_android_command_test.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
+import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/config/config.dart';
@@ -73,6 +74,7 @@ void main() {
     late Doctor doctor;
     late Platform platform;
     late Auth auth;
+    late Cache cache;
     late Java java;
     late Logger logger;
     late OperatingSystemInterface operatingSystemInterface;
@@ -96,6 +98,7 @@ void main() {
         values: {
           authRef.overrideWith(() => auth),
           bundletoolRef.overrideWith(() => bundletool),
+          cacheRef.overrideWith(() => cache),
           codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
           doctorRef.overrideWith(() => doctor),
           engineConfigRef.overrideWith(() => const EngineConfig.empty()),
@@ -132,6 +135,7 @@ void main() {
       shorebirdRoot = Directory.systemTemp.createTempSync();
       projectRoot = Directory.systemTemp.createTempSync();
       auth = MockAuth();
+      cache = MockCache();
       java = MockJava();
       progress = MockProgress();
       logger = MockLogger();
@@ -217,6 +221,10 @@ void main() {
       when(() => argResults.wasParsed(any())).thenReturn(true);
       when(() => auth.isAuthenticated).thenReturn(true);
       when(() => auth.client).thenReturn(httpClient);
+      when(() => cache.updateAll()).thenAnswer((_) async => {});
+      when(
+        () => cache.getArtifactDirectory(any()),
+      ).thenReturn(Directory.systemTemp.createTempSync());
       when(() => logger.progress(any())).thenReturn(progress);
       when(() => logger.confirm(any())).thenReturn(true);
       when(

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -4,6 +4,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -14,6 +15,7 @@ import '../mocks.dart';
 
 void main() {
   group(AotTools, () {
+    late Cache cache;
     late ShorebirdArtifacts shorebirdArtifacts;
     late ShorebirdProcess process;
     late ShorebirdEnv shorebirdEnv;
@@ -25,6 +27,7 @@ void main() {
       return runScoped(
         body,
         values: {
+          cacheRef.overrideWith(() => cache),
           processRef.overrideWith(() => process),
           shorebirdArtifactsRef.overrideWith(() => shorebirdArtifacts),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
@@ -33,6 +36,7 @@ void main() {
     }
 
     setUp(() {
+      cache = MockCache();
       process = MockShorebirdProcess();
       shorebirdArtifacts = MockShorebirdArtifacts();
       shorebirdEnv = MockShorebirdEnv();
@@ -40,6 +44,7 @@ void main() {
       workingDirectory = Directory('aot-tools test');
       aotTools = AotTools();
 
+      when(() => cache.updateAll()).thenAnswer((_) async {});
       when(() => shorebirdEnv.dartBinaryFile).thenReturn(dartBinaryFile);
       when(
         () => shorebirdArtifacts.getArtifactPath(

--- a/packages/shorebird_cli/test/src/executables/bundletool_test.dart
+++ b/packages/shorebird_cli/test/src/executables/bundletool_test.dart
@@ -45,6 +45,7 @@ void main() {
       bundletool = Bundletool();
 
       when(() => androidSdk.path).thenReturn(androidSdkPath);
+      when(() => cache.updateAll()).thenAnswer((_) async {});
       when(
         () => cache.getArtifactDirectory(any()),
       ).thenReturn(workingDirectory);

--- a/third_party/flutter/bin/internal/shared.sh
+++ b/third_party/flutter/bin/internal/shared.sh
@@ -164,12 +164,8 @@ function upgrade_shorebird () (
       mv "$SNAPSHOT_PATH" "$SNAPSHOT_PATH_OLD"
     fi
 
-    # Compile our snapshot.
-    # We invoke `$SNAPSHOT_PATH completion` to trigger the "completion" command, which
-    # avoids executing as much of our code as possible. We do this because running
-    # the script here (instead of from the compiled snapshot) invalidates a lot of
-    # assumptions we make about the cwd in the shorebird_cli tool.
-    $DART_PATH --verbosity=error --disable-dart-dev --snapshot="$SNAPSHOT_PATH" --snapshot-kind="app-jit" --packages="$SHOREBIRD_CLI_DIR/.dart_tool/package_config.json" --no-enable-mirrors "$SCRIPT_PATH" completion > /dev/null
+    # Compile...
+    $DART_PATH --verbosity=error --disable-dart-dev --snapshot="$SNAPSHOT_PATH" --snapshot-kind="app-jit" --packages="$SHOREBIRD_CLI_DIR/.dart_tool/package_config.json" --no-enable-mirrors "$SCRIPT_PATH" > /dev/null
     echo "$compilekey" > "$STAMP_PATH"
 
     # Delete any temporary snapshot path.


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
Reverts https://github.com/shorebirdtech/shorebird/pull/1958

Reverting this change because for customers patching or releasing using older flutter revisions, this change results in the cache only downloading artifacts for the latest stable engine revision instead of the engine revision being used to patch/release.

Also filed #1976 to prevent this type of regression in the future.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
