### PR TITLE
refactor(shorebird_cli): introduce ArtifactBuilder to move away from ShorebirdBuildMixin

### DIFF
--- a/packages/shorebird_cli/bin/shorebird.dart
+++ b/packages/shorebird_cli/bin/shorebird.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:scoped/scoped.dart';
 import 'package:shorebird_cli/src/android_sdk.dart';
 import 'package:shorebird_cli/src/android_studio.dart';
+import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/cache.dart';
@@ -35,6 +36,7 @@ Future<void> main(List<String> args) async {
         androidSdkRef,
         androidStudioRef,
         aotToolsRef,
+        artifactBuilderRef,
         artifactManagerRef,
         authRef,
         bundletoolRef,

--- a/packages/shorebird_cli/lib/src/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder.dart
@@ -13,22 +13,30 @@ import 'package:shorebird_cli/src/shorebird_process.dart';
 /// Flutter.
 typedef ShorebirdBuildCommand = Future<void> Function();
 
-/// {@template build_exception}
+/// {@template artifact_build_exception}
 /// Thrown when a build fails.
 /// {@endtemplate}
-class BuildException implements Exception {
-  /// {@macro build_exception}
-  BuildException(this.message);
+class ArtifactBuildException implements Exception {
+  /// {@macro artifact_build_exception}
+  ArtifactBuildException(this.message);
 
   /// Information about the build failure.
   final String message;
 }
 
+/// A reference to a [ArtifactBuilder] instance.
 final artifactBuilderRef = create(ArtifactBuilder.new);
 
+/// The [ArtifactBuilder] instance available in the current zone.
 ArtifactBuilder get artifactBuilder => read(artifactBuilderRef);
 
+/// @{template artifact_builder}
+/// Builds aabs, ipas, and other artifacts produced by `flutter build`.
+/// @{endtemplate}
 class ArtifactBuilder {
+  /// Builds an aab using `flutter build appbundle`. Runs `flutter pub get` with
+  /// the system installation of Flutter to reset
+  /// `.dart_tool/package_config.json` after the build completes or fails.
   Future<File> buildAppBundle({
     String? flavor,
     String? target,
@@ -55,7 +63,7 @@ class ArtifactBuilder {
       );
 
       if (result.exitCode != ExitCode.success.code) {
-        throw BuildException(
+        throw ArtifactBuildException(
           'Failed to build: ${result.stderr}',
         );
       }
@@ -68,12 +76,12 @@ class ArtifactBuilder {
         flavor: flavor,
       );
     } on MultipleArtifactsFoundException catch (error) {
-      throw BuildException(
+      throw ArtifactBuildException(
         'Build succeeded, but it generated multiple AABs in the '
         'build directory. ${error.foundArtifacts.map((e) => e.path)}',
       );
     } on ArtifactNotFoundException catch (error) {
-      throw BuildException(
+      throw ArtifactBuildException(
         'Build succeeded, but could not find the AAB in the build directory. '
         'Expected to find ${error.artifactName}',
       );

--- a/packages/shorebird_cli/lib/src/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
+import 'package:shorebird_cli/src/platform/platform.dart';
+import 'package:shorebird_cli/src/shorebird_android_artifacts.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
+
+/// Used to wrap code that invokes `flutter build` with Shorebird's fork of
+/// Flutter.
+typedef ShorebirdBuildCommand = Future<void> Function();
+
+/// {@template build_exception}
+/// Thrown when a build fails.
+/// {@endtemplate}
+class BuildException implements Exception {
+  /// {@macro build_exception}
+  BuildException(this.message);
+
+  /// Information about the build failure.
+  final String message;
+}
+
+final artifactBuilderRef = create(ArtifactBuilder.new);
+
+ArtifactBuilder get artifactBuilder => read(artifactBuilderRef);
+
+class ArtifactBuilder {
+  Future<File> buildAppBundle({
+    String? flavor,
+    String? target,
+    Iterable<Arch>? targetPlatforms,
+    List<String> argResultsRest = const [],
+  }) async {
+    await _runShorebirdBuildCommand(() async {
+      const executable = 'flutter';
+      final targetPlatformArgs = targetPlatforms?.targetPlatformArg;
+      final arguments = [
+        'build',
+        'appbundle',
+        '--release',
+        if (flavor != null) '--flavor=$flavor',
+        if (target != null) '--target=$target',
+        if (targetPlatformArgs != null) '--target-platform=$targetPlatformArgs',
+        ...argResultsRest,
+      ];
+
+      final result = await process.run(
+        executable,
+        arguments,
+        runInShell: true,
+      );
+
+      if (result.exitCode != ExitCode.success.code) {
+        throw BuildException(
+          'Failed to build: ${result.stderr}',
+        );
+      }
+    });
+
+    final projectRoot = shorebirdEnv.getShorebirdProjectRoot()!;
+    try {
+      return shorebirdAndroidArtifacts.findAab(
+        project: projectRoot,
+        flavor: flavor,
+      );
+    } on MultipleArtifactsFoundException catch (error) {
+      throw BuildException(
+        'Build succeeded, but it generated multiple AABs in the '
+        'build directory. ${error.foundArtifacts.map((e) => e.path)}',
+      );
+    } on ArtifactNotFoundException catch (error) {
+      throw BuildException(
+        'Build succeeded, but could not find the AAB in the build directory. '
+        'Expected to find ${error.artifactName}',
+      );
+    }
+  }
+
+  /// A wrapper around [command] (which runs a `flutter build` command with
+  /// Shorebird's fork of Flutter) with a try/finally that runs
+  /// `flutter pub get` with the system installation of Flutter to reset
+  /// `.dart_tool/package_config.json` to the system Flutter.
+  Future<void> _runShorebirdBuildCommand(ShorebirdBuildCommand command) async {
+    try {
+      await command();
+    } finally {
+      await _systemFlutterPubGet();
+    }
+  }
+
+  /// This is a hack to reset `.dart_tool/package_config.json` to point to the
+  /// Flutter SDK on the user's PATH. This is necessary because Flutter commands
+  /// run by shorebird update the package_config.json file to point to
+  /// shorebird's version of Flutter, which confuses VS Code. See
+  /// https://github.com/shorebirdtech/shorebird/issues/1101 for more info.
+  Future<void> _systemFlutterPubGet() async {
+    const executable = 'flutter';
+    if (osInterface.which(executable) == null) {
+      // If the user doesn't have Flutter on their PATH, then we can't run
+      // `flutter pub get` with the system Flutter.
+      return;
+    }
+
+    final arguments = ['--no-version-check', 'pub', 'get', '--offline'];
+
+    final result = await process.run(
+      executable,
+      arguments,
+      runInShell: true,
+      useVendedFlutter: false,
+    );
+
+    if (result.exitCode != ExitCode.success.code) {
+      logger.warn(
+        '''
+Build was successful, but `flutter pub get` failed to run after the build completed. You may see unexpected behavior in VS Code.
+
+Either run `flutter pub get` manually, or follow the steps in ${link(uri: Uri.parse('https://docs.shorebird.dev/troubleshooting#i-installed-shorebird-and-now-i-cant-run-my-app-in-vs-code'))}.
+''',
+      );
+    }
+  }
+}

--- a/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart
@@ -1,9 +1,9 @@
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/command.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logger.dart';
-import 'package:shorebird_cli/src/shorebird_build_mixin.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 
 /// {@template build_app_bundle_command}
@@ -11,7 +11,7 @@ import 'package:shorebird_cli/src/shorebird_validator.dart';
 /// `shorebird build appbundle`
 /// Build an Android App Bundle file from your app.
 /// {@endtemplate}
-class BuildAppBundleCommand extends ShorebirdCommand with ShorebirdBuildMixin {
+class BuildAppBundleCommand extends ShorebirdCommand {
   /// {@macro build_app_bundle_command}
   BuildAppBundleCommand() {
     argParser
@@ -48,7 +48,7 @@ class BuildAppBundleCommand extends ShorebirdCommand with ShorebirdBuildMixin {
     final target = results['target'] as String?;
     final buildProgress = logger.progress('Building appbundle');
     try {
-      await buildAppBundle(flavor: flavor, target: target);
+      await artifactBuilder.buildAppBundle(flavor: flavor, target: target);
     } on BuildException catch (error) {
       buildProgress.fail(error.message);
       return ExitCode.software.code;

--- a/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart
@@ -49,7 +49,7 @@ class BuildAppBundleCommand extends ShorebirdCommand {
     final buildProgress = logger.progress('Building appbundle');
     try {
       await artifactBuilder.buildAppBundle(flavor: flavor, target: target);
-    } on BuildException catch (error) {
+    } on ArtifactBuildException catch (error) {
       buildProgress.fail(error.message);
       return ExitCode.software.code;
     }

--- a/packages/shorebird_cli/test/src/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder_test.dart
@@ -149,7 +149,7 @@ void main() {
           expect(
             () async => runWithOverrides(() => builder.buildAppBundle()),
             throwsA(
-              isA<BuildException>().having(
+              isA<ArtifactBuildException>().having(
                 (e) => e.message,
                 'message',
                 '''Build succeeded, but it generated multiple AABs in the build directory. (a, b)''',
@@ -178,7 +178,7 @@ void main() {
           expect(
             () async => runWithOverrides(() => builder.buildAppBundle()),
             throwsA(
-              isA<BuildException>().having(
+              isA<ArtifactBuildException>().having(
                 (e) => e.message,
                 'message',
                 '''Build succeeded, but could not find the AAB in the build directory. Expected to find app-release.aab''',
@@ -251,7 +251,7 @@ void main() {
             test('runs flutter pub get with system flutter', () async {
               await expectLater(
                 () async => runWithOverrides(() => builder.buildAppBundle()),
-                throwsA(isA<BuildException>()),
+                throwsA(isA<ArtifactBuildException>()),
               );
 
               verify(
@@ -270,7 +270,7 @@ void main() {
 
               await expectLater(
                 () async => runWithOverrides(() => builder.buildAppBundle()),
-                throwsA(isA<BuildException>()),
+                throwsA(isA<ArtifactBuildException>()),
               );
 
               verify(
@@ -294,7 +294,7 @@ Either run `flutter pub get` manually, or follow the steps in ${link(uri: Uri.pa
             test('does not attempt to run flutter pub get', () async {
               await expectLater(
                 () async => runWithOverrides(() => builder.buildAppBundle()),
-                throwsA(isA<BuildException>()),
+                throwsA(isA<ArtifactBuildException>()),
               );
 
               verifyNever(

--- a/packages/shorebird_cli/test/src/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder_test.dart
@@ -1,0 +1,314 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/artifact_builder.dart';
+import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/os/operating_system_interface.dart';
+import 'package:shorebird_cli/src/platform/platform.dart';
+import 'package:shorebird_cli/src/shorebird_android_artifacts.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
+import 'package:test/test.dart';
+
+import 'fakes.dart';
+import 'mocks.dart';
+
+void main() {
+  group(ArtifactBuilder, () {
+    late Logger logger;
+    late OperatingSystemInterface operatingSystemInterface;
+    late ShorebirdAndroidArtifacts shorebirdAndroidArtifacts;
+    late ShorebirdEnv shorebirdEnv;
+    late ShorebirdProcess shorebirdProcess;
+    late ShorebirdProcessResult buildProcessResult;
+    late ShorebirdProcessResult pubGetProcessResult;
+    late ArtifactBuilder builder;
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        body,
+        values: {
+          loggerRef.overrideWith(() => logger),
+          osInterfaceRef.overrideWith(() => operatingSystemInterface),
+          processRef.overrideWith(() => shorebirdProcess),
+          shorebirdEnvRef.overrideWith(() => shorebirdEnv),
+          shorebirdAndroidArtifactsRef
+              .overrideWith(() => shorebirdAndroidArtifacts),
+        },
+      );
+    }
+
+    setUpAll(() {
+      registerFallbackValue(FakeShorebirdProcess());
+      registerFallbackValue(Directory(''));
+    });
+
+    setUp(() {
+      buildProcessResult = MockProcessResult();
+      logger = MockLogger();
+      operatingSystemInterface = MockOperatingSystemInterface();
+      pubGetProcessResult = MockProcessResult();
+      shorebirdAndroidArtifacts = MockShorebirdAndroidArtifacts();
+      shorebirdEnv = MockShorebirdEnv();
+      shorebirdProcess = MockShorebirdProcess();
+
+      when(
+        () => shorebirdProcess.run(
+          'flutter',
+          ['--no-version-check', 'pub', 'get', '--offline'],
+          runInShell: any(named: 'runInShell'),
+          useVendedFlutter: false,
+        ),
+      ).thenAnswer((_) async => pubGetProcessResult);
+      when(() => pubGetProcessResult.exitCode)
+          .thenReturn(ExitCode.success.code);
+      when(
+        () => shorebirdProcess.run(
+          any(),
+          any(),
+          runInShell: any(named: 'runInShell'),
+        ),
+      ).thenAnswer((_) async => buildProcessResult);
+      when(() => buildProcessResult.exitCode).thenReturn(ExitCode.success.code);
+      when(() => logger.progress(any())).thenReturn(MockProgress());
+      when(() => logger.info(any())).thenReturn(null);
+      when(() => operatingSystemInterface.which('flutter'))
+          .thenReturn('/path/to/flutter');
+      when(() => shorebirdEnv.flutterRevision).thenReturn('1234');
+      when(shorebirdEnv.getShorebirdProjectRoot).thenReturn(Directory(''));
+      when(
+        () => shorebirdAndroidArtifacts.findAab(
+          project: any(named: 'project'),
+          flavor: any(named: 'flavor'),
+        ),
+      ).thenReturn(File('app-release.aab'));
+
+      builder = ArtifactBuilder();
+    });
+
+    group('buildAppBundle', () {
+      test('invokes the correct flutter build command', () async {
+        await runWithOverrides(() => builder.buildAppBundle());
+
+        verify(
+          () => shorebirdProcess.run(
+            'flutter',
+            ['build', 'appbundle', '--release'],
+            runInShell: any(named: 'runInShell'),
+            environment: any(named: 'environment'),
+          ),
+        ).called(1);
+      });
+
+      test('forward arguments to flutter build', () async {
+        await runWithOverrides(
+          () => builder.buildAppBundle(
+            flavor: 'flavor',
+            target: 'target',
+            targetPlatforms: [Arch.arm64],
+            argResultsRest: ['--foo', 'bar'],
+          ),
+        );
+
+        verify(
+          () => shorebirdProcess.run(
+            'flutter',
+            [
+              'build',
+              'appbundle',
+              '--release',
+              '--flavor=flavor',
+              '--target=target',
+              '--target-platform=android-arm64',
+              '--foo',
+              'bar',
+            ],
+            runInShell: any(named: 'runInShell'),
+          ),
+        ).called(1);
+      });
+
+      group('when multiple artifacts are found', () {
+        setUp(() {
+          when(
+            () => shorebirdAndroidArtifacts.findAab(
+              project: any(named: 'project'),
+              flavor: any(named: 'flavor'),
+            ),
+          ).thenThrow(
+            MultipleArtifactsFoundException(
+              foundArtifacts: [File('a'), File('b')],
+              buildDir: 'buildDir',
+            ),
+          );
+        });
+
+        test('throws BuildException', () async {
+          expect(
+            () async => runWithOverrides(() => builder.buildAppBundle()),
+            throwsA(
+              isA<BuildException>().having(
+                (e) => e.message,
+                'message',
+                '''Build succeeded, but it generated multiple AABs in the build directory. (a, b)''',
+              ),
+            ),
+          );
+        });
+      });
+
+      group('when no artifacts are found', () {
+        setUp(() {
+          when(
+            () => shorebirdAndroidArtifacts.findAab(
+              project: any(named: 'project'),
+              flavor: any(named: 'flavor'),
+            ),
+          ).thenThrow(
+            ArtifactNotFoundException(
+              artifactName: 'app-release.aab',
+              buildDir: 'buildDir',
+            ),
+          );
+        });
+
+        test('throws BuildException', () async {
+          expect(
+            () async => runWithOverrides(() => builder.buildAppBundle()),
+            throwsA(
+              isA<BuildException>().having(
+                (e) => e.message,
+                'message',
+                '''Build succeeded, but could not find the AAB in the build directory. Expected to find app-release.aab''',
+              ),
+            ),
+          );
+        });
+      });
+
+      group('after a build', () {
+        group('when the build is successful', () {
+          setUp(() {
+            when(() => buildProcessResult.exitCode)
+                .thenReturn(ExitCode.success.code);
+          });
+
+          group('when flutter is installed', () {
+            setUp(() {
+              when(() => operatingSystemInterface.which('flutter'))
+                  .thenReturn('/path/to/flutter');
+            });
+
+            test('runs flutter pub get with system flutter', () async {
+              await runWithOverrides(() => builder.buildAppBundle());
+
+              verify(
+                () => shorebirdProcess.run(
+                  'flutter',
+                  ['--no-version-check', 'pub', 'get', '--offline'],
+                  runInShell: any(named: 'runInShell'),
+                  useVendedFlutter: false,
+                ),
+              ).called(1);
+            });
+          });
+
+          group('when flutter is not installed', () {
+            setUp(() {
+              when(() => operatingSystemInterface.which('flutter'))
+                  .thenReturn(null);
+            });
+
+            test('does not attempt to run flutter pub get', () async {
+              await runWithOverrides(() => builder.buildAppBundle());
+
+              verifyNever(
+                () => shorebirdProcess.run(
+                  'flutter',
+                  ['--no-version-check', 'pub', 'get', '--offline'],
+                  runInShell: any(named: 'runInShell'),
+                  useVendedFlutter: false,
+                ),
+              );
+            });
+          });
+        });
+
+        group('when the build fails', () {
+          setUp(() {
+            when(() => buildProcessResult.exitCode)
+                .thenReturn(ExitCode.software.code);
+          });
+
+          group('when flutter is installed', () {
+            setUp(() {
+              when(() => operatingSystemInterface.which('flutter'))
+                  .thenReturn('/path/to/flutter');
+            });
+
+            test('runs flutter pub get with system flutter', () async {
+              await expectLater(
+                () async => runWithOverrides(() => builder.buildAppBundle()),
+                throwsA(isA<BuildException>()),
+              );
+
+              verify(
+                () => shorebirdProcess.run(
+                  'flutter',
+                  ['--no-version-check', 'pub', 'get', '--offline'],
+                  runInShell: any(named: 'runInShell'),
+                  useVendedFlutter: false,
+                ),
+              ).called(1);
+            });
+
+            test('prints error message if system flutter pub get fails',
+                () async {
+              when(() => pubGetProcessResult.exitCode).thenReturn(1);
+
+              await expectLater(
+                () async => runWithOverrides(() => builder.buildAppBundle()),
+                throwsA(isA<BuildException>()),
+              );
+
+              verify(
+                () => logger.warn(
+                  '''
+Build was successful, but `flutter pub get` failed to run after the build completed. You may see unexpected behavior in VS Code.
+
+Either run `flutter pub get` manually, or follow the steps in ${link(uri: Uri.parse('https://docs.shorebird.dev/troubleshooting#i-installed-shorebird-and-now-i-cant-run-my-app-in-vs-code'))}.
+''',
+                ),
+              ).called(1);
+            });
+          });
+
+          group('when flutter is not installed', () {
+            setUp(() {
+              when(() => operatingSystemInterface.which('flutter'))
+                  .thenReturn(null);
+            });
+
+            test('does not attempt to run flutter pub get', () async {
+              await expectLater(
+                () async => runWithOverrides(() => builder.buildAppBundle()),
+                throwsA(isA<BuildException>()),
+              );
+
+              verifyNever(
+                () => shorebirdProcess.run(
+                  'flutter',
+                  ['--no-version-check', 'pub', 'get', '--offline'],
+                  runInShell: any(named: 'runInShell'),
+                  useVendedFlutter: false,
+                ),
+              );
+            });
+          });
+        });
+      });
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
@@ -108,7 +108,7 @@ void main() {
 
     test('exits with code 70 when building appbundle fails', () async {
       when(() => artifactBuilder.buildAppBundle()).thenThrow(
-        BuildException('Failed to build: oops'),
+        ArtifactBuildException('Failed to build: oops'),
       );
 
       final exitCode = await runWithOverrides(command.run);

--- a/packages/shorebird_cli/test/src/mocks.dart
+++ b/packages/shorebird_cli/test/src/mocks.dart
@@ -11,6 +11,7 @@ import 'package:shorebird_cli/src/android_sdk.dart';
 import 'package:shorebird_cli/src/android_studio.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
+import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/cache.dart' show Cache;
@@ -53,6 +54,8 @@ class MockAppleDevice extends Mock implements AppleDevice {}
 class MockArchiveDiffer extends Mock implements ArchiveDiffer {}
 
 class MockArgResults extends Mock implements ArgResults {}
+
+class MockArtifactBuilder extends Mock implements ArtifactBuilder {}
 
 class MockArtifactManager extends Mock implements ArtifactManager {}
 


### PR DESCRIPTION
## Description

As part of https://github.com/shorebirdtech/shorebird/issues/1988, we will need to remove our reliance on mixins.

This introduces an `ArtifactBuilder` class, which will replace `ShorebirdBuildMixin`. There are no plans to migrate the existing Release and Patch commands to use this, but the Build commands will be migrated, and the new Release and Patch commands will use this.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
