### PR TITLE
feat: always saving the debug info data

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -94,7 +94,7 @@ If this option is not provided, the version number will be determined from the p
         'debug-linker',
         defaultsTo: true,
         help: 'Collects linker diagnostic information to help troubleshoot low '
-            'link percentages. File is saved to build/$_debugInfoFileName.',
+            'link percentages. File is saved to build/$_linkDebugInfoFileName.',
       );
   }
 
@@ -454,10 +454,10 @@ ${summary.join('\n')}
         'out.vmcode',
       );
 
-  static const _debugInfoFileName = 'linker_diagnostic.zip';
+  static const _linkDebugInfoFileName = 'linker_diagnostic.zip';
   String get _debugInfoOutputPath => p.join(
         _buildDirectory,
-        _debugInfoFileName,
+        _linkDebugInfoFileName,
       );
 
   String _readVersionFromPlist() {

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -530,7 +530,8 @@ ${summary.join('\n')}
     required File releaseArtifact,
   }) async {
     final patch = File(_aotOutputPath);
-    final dumpDebugInfo = results['debug-linker'] == true;
+    final dumpDebugInfo = results['debug-linker'] == true &&
+        (await aotTools.isLinkDebugInfoSupported());
 
     if (!patch.existsSync()) {
       logger.err('Unable to find patch AOT file at ${patch.path}');

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -93,8 +93,9 @@ If this option is not provided, the version number will be determined from the p
       ..addFlag(
         'debug-linker',
         negatable: false,
+        defaultsTo: true,
         help: 'Collects linker diagnostic information to help troubleshoot low '
-            'link percentages.',
+            'link percentages. File is saved to build/$_debugInfoFileName.',
       );
   }
 
@@ -378,8 +379,9 @@ Please re-run the release command for this version or create a new release.''');
             '🟢 Track: ${lightCyan.wrap('Production')}',
           if (percentLinked != null)
             '''🔗 Running ${lightCyan.wrap('${percentLinked.toStringAsFixed(1)}%')} on CPU''',
-          if (results['debug-linker'] == true)
-            '''🔍 Debug Info: ${lightCyan.wrap(_debugInfoOutpath)}''',
+          if (results['debug-linker'] == true &&
+              (percentLinked != null && percentLinked < minLinkPercentage))
+            '''🔍 Debug Info: ${lightCyan.wrap(_debugInfoOutputPath)}''',
         ];
 
         logger.info(
@@ -453,9 +455,10 @@ ${summary.join('\n')}
         'out.vmcode',
       );
 
-  String get _debugInfoOutpath => p.join(
+  static const _debugInfoFileName = 'linker_diagnostic.zip';
+  String get _debugInfoOutputPath => p.join(
         _buildDirectory,
-        'linker_diagnostic.zip',
+        _debugInfoFileName,
       );
 
   String _readVersionFromPlist() {
@@ -571,7 +574,7 @@ ${summary.join('\n')}
         debugInfoZip.copySync(
           p.join(
             'build',
-            _debugInfoOutpath,
+            _debugInfoOutputPath,
           ),
         );
       }

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_ios_command.dart
@@ -92,7 +92,6 @@ If this option is not provided, the version number will be determined from the p
       )
       ..addFlag(
         'debug-linker',
-        negatable: false,
         defaultsTo: true,
         help: 'Collects linker diagnostic information to help troubleshoot low '
             'link percentages. File is saved to build/$_debugInfoFileName.',

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -131,6 +131,11 @@ class AotTools {
     return tryParseVersion(version) ?? noVersion;
   }
 
+  Future<bool> isLinkDebugInfoSupported() async {
+    final result = await _exec(['link --help']);
+    return result.stdout.toString().contains('dump-debug-info');
+  }
+
   /// Generate a link vmcode file from two AOT snapshots.
   Future<double?> link({
     required String base,

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -132,7 +132,7 @@ class AotTools {
   }
 
   Future<bool> isLinkDebugInfoSupported() async {
-    final result = await _exec(['link --help']);
+    final result = await _exec(['link', '--help']);
     return result.stdout.toString().contains('dump-debug-info');
   }
 

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -214,10 +214,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "8acabb8306b57a409bf4c83522065672ee13179297a6bb0cb9ead73948df7c76"
+      sha256: "3945034e86ea203af7a056d98e98e42a5518fff200d6e8e6647e1886b07e936e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.7.2"
+    version: "1.8.0"
   crypto:
     dependency: "direct main"
     description:
@@ -366,10 +366,10 @@ packages:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
   json_path:
     dependency: "direct main"
     description:
@@ -382,10 +382,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: aa1f5a8912615733e0fdc7a02af03308933c93235bdc8d50d0b0c8a8ccb0b969
+      sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.1"
+    version: "6.8.0"
   jwt:
     dependency: "direct main"
     description:
@@ -802,10 +802,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "0a989dc7ca2bb51eac91e8fd00851297cfffd641aa7538b165c62637ca0eaa4a"
+      sha256: "0eaf06e3446824099858367950a813472af675116bf63f008a4c2a75ae13e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "5.5.0"
   xml:
     dependency: "direct main"
     description:
@@ -826,9 +826,9 @@ packages:
     dependency: "direct main"
     description:
       name: yaml_edit
-      sha256: c566f4f804215d84a7a2c377667f546c6033d5b34b4f9e60dfb09d17c4e97826
+      sha256: e9c1a3543d2da0db3e90270dbb1e4eebc985ee5e3ffe468d83224472b2194a5f
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
 sdks:
   dart: ">=3.3.0 <4.0.0"

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -698,10 +698,10 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: d72b538180efcf8413cd2e4e6fcc7ae99c7712e0909eb9223f9da6e6d0ef715f
+      sha256: d11b55850c68c1f6c0cf00eabded4e66c4043feaf6c0d7ce4a36785137df6331
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.4"
+    version: "1.25.5"
   test_api:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -762,10 +762,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.2"
   watcher:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -1328,6 +1328,7 @@ Please re-run the release command for this version or create a new release.'''),
           test(
             'prints the file location when linking is less than the minimum',
             () async {
+              const notEnoughLinkPercentage = 60.0;
               when(
                 () => aotTools.link(
                   base: any(named: 'base'),
@@ -1340,7 +1341,7 @@ Please re-run the release command for this version or create a new release.'''),
                   dumpDebugInfoPath: any(named: 'dumpDebugInfoPath'),
                 ),
               ).thenAnswer(
-                (_) async => 20,
+                (_) async => notEnoughLinkPercentage,
               );
               when(() => argResults['debug-linker']).thenReturn(true);
               setUpProjectRoot();

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -18,6 +18,7 @@ import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/executables/aot_tools.dart';
+import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/executables/xcodebuild.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
@@ -529,6 +530,8 @@ flutter:
         command = runWithOverrides(
           () => PatchIosCommand(archiveDiffer: archiveDiffer),
         )..testArgResults = argResults;
+
+        when(aotTools.isLinkDebugInfoSupported).thenAnswer((_) async => true);
       });
 
       test('supports alpha alias', () {
@@ -1353,6 +1356,34 @@ Please re-run the release command for this version or create a new release.'''),
               expect(contains, isTrue);
             },
           );
+
+          group("when aot-tools don't support debugging the link command", () {
+            test(
+              "don't debug even when the flag is true",
+              () async {
+                when(() => argResults['debug-linker']).thenReturn(true);
+                when(aotTools.isLinkDebugInfoSupported).thenAnswer(
+                  (_) async => false,
+                );
+
+                setUpProjectRoot();
+                setUpProjectRootArtifacts();
+                final exitCode = await runWithOverrides(command.run);
+                expect(exitCode, ExitCode.success.code);
+                verify(
+                  () => aotTools.link(
+                    base: any(named: 'base'),
+                    patch: any(named: 'patch'),
+                    analyzeSnapshot: any(named: 'analyzeSnapshot'),
+                    genSnapshot: any(named: 'genSnapshot'),
+                    kernel: any(named: 'kernel'),
+                    workingDirectory: any(named: 'workingDirectory'),
+                    outputPath: any(named: 'outputPath'),
+                  ),
+                ).called(1);
+              },
+            );
+          });
         });
       });
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_ios_command_test.dart
@@ -1321,6 +1321,38 @@ Please re-run the release command for this version or create a new release.'''),
               ).called(1);
             },
           );
+
+          test(
+            'prints the file location when linking is less than the minimum',
+            () async {
+              when(
+                () => aotTools.link(
+                  base: any(named: 'base'),
+                  patch: any(named: 'patch'),
+                  analyzeSnapshot: any(named: 'analyzeSnapshot'),
+                  genSnapshot: any(named: 'genSnapshot'),
+                  kernel: any(named: 'kernel'),
+                  workingDirectory: any(named: 'workingDirectory'),
+                  outputPath: any(named: 'outputPath'),
+                  dumpDebugInfoPath: any(named: 'dumpDebugInfoPath'),
+                ),
+              ).thenAnswer(
+                (_) async => 20,
+              );
+              when(() => argResults['debug-linker']).thenReturn(true);
+              setUpProjectRoot();
+              setUpProjectRootArtifacts();
+              final exitCode = await runWithOverrides(command.run);
+              expect(exitCode, ExitCode.success.code);
+
+              final captured = verify(() => logger.info(captureAny())).captured
+                  as List<Object?>;
+              final contains = captured.whereType<String>().any(
+                    (element) => element.contains('Debug Info'),
+                  );
+              expect(contains, isTrue);
+            },
+          );
         });
       });
 

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -474,6 +474,92 @@ void main() {
           ).called(1);
         });
       });
+
+      group('isLinkDebugInfoSupported', () {
+        test('returns true when the argument is present in the help', () async {
+          final result = MockShorebirdProcessResult();
+          when(() => result.exitCode).thenReturn(ExitCode.success.code);
+          when(() => result.stdout).thenReturn('''
+Link two aot snapshots.
+
+Usage: aot_tools link [arguments]
+-h, --help                            Print this usage information.
+    --base (mandatory)                Path to the base snapshot to link against.
+    --patch (mandatory)               Path to the patch snapshot to link.
+    --analyze-snapshot (mandatory)    Path to analyze_snapshot binary.
+    --gen-snapshot (mandatory)        Path to gen_snapshot binary.
+    --kernel (mandatory)              Path to the patch kernel (.dill) file.
+    --output (mandatory)              Path to the output vmcode file.
+    --enable-asserts                  Whether to enable asserts.
+    --linker-overrides                Path to the linker overrides json file.
+    --dump-debug-info                 When specified, debug information will be generated and written to the provided path.
+    --reporter                        Set how to print link results.
+
+          [json]                      Prints the results in json format.
+          [pretty] (default)          Prints the results in a human readable format.
+
+    --redirect-to                     Redirect output to a file.
+
+Run "aot_tools help" to see global options.
+''');
+
+          when(
+            () => process.run(
+              any(),
+              any(),
+              workingDirectory: any(named: 'workingDirectory'),
+            ),
+          ).thenAnswer((_) async => result);
+
+          await expectLater(
+            runWithOverrides(() => aotTools.isLinkDebugInfoSupported()),
+            completion(isTrue),
+          );
+        });
+
+        test(
+          'returns false when the argument is not present in the help',
+          () async {
+            final result = MockShorebirdProcessResult();
+            when(() => result.exitCode).thenReturn(ExitCode.success.code);
+            when(() => result.stdout).thenReturn('''
+Link two aot snapshots.
+
+Usage: aot_tools link [arguments]
+-h, --help                            Print this usage information.
+    --base (mandatory)                Path to the base snapshot to link against.
+    --patch (mandatory)               Path to the patch snapshot to link.
+    --analyze-snapshot (mandatory)    Path to analyze_snapshot binary.
+    --gen-snapshot (mandatory)        Path to gen_snapshot binary.
+    --kernel (mandatory)              Path to the patch kernel (.dill) file.
+    --output (mandatory)              Path to the output vmcode file.
+    --enable-asserts                  Whether to enable asserts.
+    --linker-overrides                Path to the linker overrides json file.
+    --reporter                        Set how to print link results.
+
+          [json]                      Prints the results in json format.
+          [pretty] (default)          Prints the results in a human readable format.
+
+    --redirect-to                     Redirect output to a file.
+
+Run "aot_tools help" to see global options.
+''');
+
+            when(
+              () => process.run(
+                any(),
+                any(),
+                workingDirectory: any(named: 'workingDirectory'),
+              ),
+            ).thenAnswer((_) async => result);
+
+            await expectLater(
+              runWithOverrides(() => aotTools.isLinkDebugInfoSupported()),
+              completion(isFalse),
+            );
+          },
+        );
+      });
     });
 
     group('isGeneratePatchDiffBaseSupported', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR changes our CLI regarding the saving of the linker data so:
 - Always save debug data, unless explicit informed otherwise
 - Only print the file location when the minimum percentage is not met
 - Adds the file location in the help of the CLI

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
