### PR TITLE
chore(shorebird_cli): add split-per-abi arg to release command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -86,6 +86,13 @@ On Xcode builds it is used as "CFBundleVersion".''',
         // TODO(bryanoltman): uncomment this once https://github.com/dart-lang/args/pull/273 lands
         // mandatory: true.
       )
+      ..addFlag(
+        'split-per-abi',
+        help: 'Whether to split the APKs per ABIs (Android only). '
+            'To learn more, see: https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split',
+        hide: true,
+        negatable: false,
+      )
       ..addOption(
         'release-version',
         help: '''


### PR DESCRIPTION
## Description

Recognize `--split-per-abi` flag (to inform users that we don't support it)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
