### PR TITLE
fix(shorebird_cli): add missing exportMethodArgName to release command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -64,6 +64,16 @@ On Xcode builds it is used as "CFBundleVersion".''',
             '''Export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys (iOS only).''',
       )
       ..addOption(
+        exportMethodArgName,
+        defaultsTo: ExportMethod.appStore.argName,
+        allowed: ExportMethod.values.map((e) => e.argName),
+        help: 'Specify how the IPA will be distributed.',
+        allowedHelp: {
+          for (final method in ExportMethod.values)
+            method.argName: method.description,
+        },
+      )
+      ..addOption(
         'flutter-version',
         help: 'The Flutter version to use when building the app (e.g: 3.16.3).',
       )


### PR DESCRIPTION
## Description

This was an argument that was part of the iOS release command that didn't make it over in the rewrite. 

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
