### PR TITLE
fix(shorebird_cli): forward argResults.rest throughout

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/build/build_aar_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_aar_command.dart
@@ -53,7 +53,10 @@ class BuildAarCommand extends ShorebirdCommand {
     final buildNumber = results['build-number'] as String;
     final buildProgress = logger.progress('Building aar');
     try {
-      await artifactBuilder.buildAar(buildNumber: buildNumber);
+      await artifactBuilder.buildAar(
+        buildNumber: buildNumber,
+        argResultsRest: results.rest,
+      );
     } on ArtifactBuildException catch (error) {
       buildProgress.fail('Failed to build: ${error.message}');
       return ExitCode.software.code;

--- a/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_apk_command.dart
@@ -48,7 +48,11 @@ class BuildApkCommand extends ShorebirdCommand {
     final target = results['target'] as String?;
     final buildProgress = logger.progress('Building apk');
     try {
-      await artifactBuilder.buildApk(flavor: flavor, target: target);
+      await artifactBuilder.buildApk(
+        flavor: flavor,
+        target: target,
+        argResultsRest: results.rest,
+      );
     } on ArtifactBuildException catch (error) {
       buildProgress.fail(error.message);
       return ExitCode.software.code;

--- a/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_app_bundle_command.dart
@@ -48,7 +48,11 @@ class BuildAppBundleCommand extends ShorebirdCommand {
     final target = results['target'] as String?;
     final buildProgress = logger.progress('Building appbundle');
     try {
-      await artifactBuilder.buildAppBundle(flavor: flavor, target: target);
+      await artifactBuilder.buildAppBundle(
+        flavor: flavor,
+        target: target,
+        argResultsRest: results.rest,
+      );
     } on ArtifactBuildException catch (error) {
       buildProgress.fail(error.message);
       return ExitCode.software.code;

--- a/packages/shorebird_cli/lib/src/commands/build/build_ipa_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_ipa_command.dart
@@ -65,6 +65,7 @@ Codesigning is disabled. You must manually codesign before deploying to devices.
         flavor: flavor,
         target: target,
         codesign: codesign,
+        argResultsRest: results.rest,
       );
     } on ArtifactBuildException catch (error) {
       buildProgress.fail('Failed to build: ${error.message}');

--- a/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
@@ -70,7 +70,10 @@ class AarPatcher extends Patcher {
         logger.progress('Building patch with Flutter $flutterVersionString');
 
     try {
-      await artifactBuilder.buildAar(buildNumber: buildNumber);
+      await artifactBuilder.buildAar(
+        argResultsRest: argResults.rest,
+        buildNumber: buildNumber,
+      );
       buildProgress.complete();
     } on ArtifactBuildException catch (error) {
       buildProgress.fail('Failed to build: ${error.message}');

--- a/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
@@ -71,8 +71,8 @@ class AarPatcher extends Patcher {
 
     try {
       await artifactBuilder.buildAar(
-        argResultsRest: argResults.rest,
         buildNumber: buildNumber,
+        argResultsRest: argResults.rest,
       );
       buildProgress.complete();
     } on ArtifactBuildException catch (error) {

--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -61,8 +61,11 @@ class AndroidPatcher extends Patcher {
         logger.progress('Building patch with Flutter $flutterVersionString');
 
     try {
-      aabFile =
-          await artifactBuilder.buildAppBundle(flavor: flavor, target: target);
+      aabFile = await artifactBuilder.buildAppBundle(
+        flavor: flavor,
+        target: target,
+        argResultsRest: argResults.rest,
+      );
       buildProgress.complete();
     } on ArtifactBuildException catch (error) {
       buildProgress.fail(error.message);

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
@@ -83,7 +83,9 @@ class IosFrameworkPatcher extends Patcher {
       'Building patch with Flutter $flutterVersionString',
     );
     try {
-      await artifactBuilder.buildIosFramework();
+      await artifactBuilder.buildIosFramework(
+        argResultsRest: argResults.rest,
+      );
     } on ArtifactBuildException catch (error) {
       buildProgress.fail(error.message);
       exit(ExitCode.software.code);

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -92,6 +92,7 @@ class IosPatcher extends Patcher {
         // If buildIpa is called with a different codesign value than the
         // release was, we will erroneously report native diffs.
         await artifactBuilder.buildIpa(
+          argResultsRest: argResults.rest,
           codesign: shouldCodesign,
           exportOptionsPlist: exportOptionsPlist,
           flavor: flavor,

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -92,11 +92,11 @@ class IosPatcher extends Patcher {
         // If buildIpa is called with a different codesign value than the
         // release was, we will erroneously report native diffs.
         await artifactBuilder.buildIpa(
-          argResultsRest: argResults.rest,
           codesign: shouldCodesign,
           exportOptionsPlist: exportOptionsPlist,
           flavor: flavor,
           target: target,
+          argResultsRest: argResults.rest,
         );
       } on ProcessException catch (error) {
         buildProgress.fail('Failed to build: ${error.message}');

--- a/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
@@ -80,6 +80,7 @@ class AarReleaser extends Releaser {
       await artifactBuilder.buildAar(
         buildNumber: buildNumber,
         targetPlatforms: architectures,
+        argResultsRest: argResults.rest,
       );
     } catch (e) {
       logger.err('Failed to build aar: $e');

--- a/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
@@ -95,6 +95,7 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
         flavor: flavor,
         target: target,
         targetPlatforms: architectures,
+        argResultsRest: argResults.rest,
       );
     } on ArtifactBuildException catch (e) {
       buildAppBundleProgress.fail(e.message);
@@ -111,6 +112,7 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
           flavor: flavor,
           target: target,
           targetPlatforms: architectures,
+          argResultsRest: argResults.rest,
         );
       } on ArtifactBuildException catch (e) {
         buildApkProgress.fail(e.message);

--- a/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
@@ -70,7 +70,9 @@ class IosFrameworkReleaser extends Releaser {
     );
 
     try {
-      await artifactBuilder.buildIosFramework();
+      await artifactBuilder.buildIosFramework(
+        argResultsRest: argResults.rest,
+      );
     } catch (error) {
       buildProgress.fail('Failed to build iOS framework: $error');
       exit(ExitCode.software.code);

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -104,6 +104,7 @@ class IosReleaser extends Releaser {
         exportOptionsPlist: exportOptionsPlist,
         flavor: flavor,
         target: target,
+        argResultsRest: argResults.rest,
       );
       buildProgress.complete();
     } on ArtifactBuildException catch (error) {

--- a/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
@@ -50,8 +50,8 @@ void main() {
       when(() => logger.progress(any())).thenReturn(progress);
       when(
         () => artifactBuilder.buildAar(
-          argResultsRest: any(named: 'argResultsRest'),
           buildNumber: any(named: 'buildNumber'),
+          argResultsRest: any(named: 'argResultsRest'),
         ),
       ).thenAnswer((_) async => {});
       when(
@@ -101,8 +101,8 @@ void main() {
     test('exits with code 70 when building aar fails', () async {
       when(
         () => artifactBuilder.buildAar(
-          argResultsRest: any(named: 'argResultsRest'),
           buildNumber: any(named: 'buildNumber'),
+          argResultsRest: any(named: 'argResultsRest'),
         ),
       ).thenThrow(ArtifactBuildException('Failed to build: error'));
 
@@ -127,8 +127,8 @@ void main() {
 
       verify(
         () => artifactBuilder.buildAar(
-          argResultsRest: [],
           buildNumber: buildNumber,
+          argResultsRest: [],
         ),
       ).called(1);
       verify(

--- a/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_aar_command_test.dart
@@ -49,7 +49,10 @@ void main() {
       when(() => argResults.rest).thenReturn([]);
       when(() => logger.progress(any())).thenReturn(progress);
       when(
-        () => artifactBuilder.buildAar(buildNumber: any(named: 'buildNumber')),
+        () => artifactBuilder.buildAar(
+          argResultsRest: any(named: 'argResultsRest'),
+          buildNumber: any(named: 'buildNumber'),
+        ),
       ).thenAnswer((_) async => {});
       when(
         () => shorebirdEnv.androidPackageName,
@@ -97,14 +100,21 @@ void main() {
 
     test('exits with code 70 when building aar fails', () async {
       when(
-        () => artifactBuilder.buildAar(buildNumber: any(named: 'buildNumber')),
+        () => artifactBuilder.buildAar(
+          argResultsRest: any(named: 'argResultsRest'),
+          buildNumber: any(named: 'buildNumber'),
+        ),
       ).thenThrow(ArtifactBuildException('Failed to build: error'));
 
       final result = await runWithOverrides(command.run);
 
       expect(result, equals(ExitCode.software.code));
-      verify(() => artifactBuilder.buildAar(buildNumber: buildNumber))
-          .called(1);
+      verify(
+        () => artifactBuilder.buildAar(
+          buildNumber: buildNumber,
+          argResultsRest: [],
+        ),
+      ).called(1);
       verify(
         () => progress.fail(any(that: contains('Failed to build'))),
       ).called(1);
@@ -115,8 +125,12 @@ void main() {
 
       expect(result, equals(ExitCode.success.code));
 
-      verify(() => artifactBuilder.buildAar(buildNumber: buildNumber))
-          .called(1);
+      verify(
+        () => artifactBuilder.buildAar(
+          argResultsRest: [],
+          buildNumber: buildNumber,
+        ),
+      ).called(1);
       verify(
         () => logger.info(
           '''

--- a/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_apk_command_test.dart
@@ -69,6 +69,7 @@ void main() {
         () => artifactBuilder.buildApk(
           flavor: any(named: 'flavor'),
           target: any(named: 'target'),
+          argResultsRest: any(named: 'argResultsRest'),
         ),
       ).thenAnswer((_) async => File(''));
 
@@ -107,13 +108,18 @@ void main() {
         () => artifactBuilder.buildApk(
           flavor: any(named: 'flavor'),
           target: any(named: 'target'),
+          argResultsRest: any(named: 'argResultsRest'),
         ),
       ).thenThrow(ArtifactBuildException('oops'));
 
       final exitCode = await runWithOverrides(command.run);
 
       expect(exitCode, equals(ExitCode.software.code));
-      verify(() => artifactBuilder.buildApk()).called(1);
+      verify(
+        () => artifactBuilder.buildApk(
+          argResultsRest: [],
+        ),
+      ).called(1);
     });
 
     test('exits with code 0 when building apk succeeds', () async {
@@ -121,7 +127,11 @@ void main() {
 
       expect(exitCode, equals(ExitCode.success.code));
 
-      verify(() => artifactBuilder.buildApk()).called(1);
+      verify(
+        () => artifactBuilder.buildApk(
+          argResultsRest: [],
+        ),
+      ).called(1);
       verify(
         () => logger.info(
           '''
@@ -146,6 +156,7 @@ ${lightCyan.wrap(p.join('build', 'app', 'outputs', 'apk', 'release', 'app-releas
         () => artifactBuilder.buildApk(
           flavor: flavor,
           target: target,
+          argResultsRest: [],
         ),
       ).called(1);
       verify(

--- a/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_app_bundle_command_test.dart
@@ -71,6 +71,7 @@ void main() {
         () => artifactBuilder.buildAppBundle(
           flavor: any(named: 'flavor'),
           target: any(named: 'target'),
+          argResultsRest: any(named: 'argResultsRest'),
         ),
       ).thenAnswer(
         (_) async => File(''),
@@ -107,21 +108,33 @@ void main() {
     });
 
     test('exits with code 70 when building appbundle fails', () async {
-      when(() => artifactBuilder.buildAppBundle()).thenThrow(
+      when(
+        () => artifactBuilder.buildAppBundle(
+          argResultsRest: any(named: 'argResultsRest'),
+        ),
+      ).thenThrow(
         ArtifactBuildException('Failed to build: oops'),
       );
 
       final exitCode = await runWithOverrides(command.run);
 
       expect(exitCode, equals(ExitCode.software.code));
-      verify(() => artifactBuilder.buildAppBundle()).called(1);
+      verify(
+        () => artifactBuilder.buildAppBundle(
+          argResultsRest: [],
+        ),
+      ).called(1);
     });
 
     test('exits with code 0 when building appbundle succeeds', () async {
       final exitCode = await runWithOverrides(command.run);
 
       expect(exitCode, equals(ExitCode.success.code));
-      verify(() => artifactBuilder.buildAppBundle()).called(1);
+      verify(
+        () => artifactBuilder.buildAppBundle(
+          argResultsRest: [],
+        ),
+      ).called(1);
 
       verify(
         () => logger.info(
@@ -146,6 +159,7 @@ ${lightCyan.wrap(p.join('build', 'app', 'outputs', 'bundle', 'release', 'app-rel
         () => artifactBuilder.buildAppBundle(
           flavor: flavor,
           target: target,
+          argResultsRest: [],
         ),
       ).called(1);
 

--- a/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
@@ -69,6 +69,7 @@ void main() {
           flavor: any(named: 'flavor'),
           target: any(named: 'target'),
           codesign: any(named: 'codesign'),
+          argResultsRest: any(named: 'argResultsRest'),
         ),
       ).thenAnswer((_) async => File(''));
       when(() => ios.createExportOptionsPlist()).thenReturn(File('.'));
@@ -122,13 +123,18 @@ void main() {
           flavor: any(named: 'flavor'),
           target: any(named: 'target'),
           codesign: any(named: 'codesign'),
+          argResultsRest: any(named: 'argResultsRest'),
         ),
       ).thenThrow(ArtifactBuildException('oops'));
 
       final exitCode = await runWithOverrides(command.run);
 
       expect(exitCode, equals(ExitCode.software.code));
-      verify(() => artifactBuilder.buildIpa()).called(1);
+      verify(
+        () => artifactBuilder.buildIpa(
+          argResultsRest: [],
+        ),
+      ).called(1);
     });
 
     test('exits with code 0 when building ipa succeeds', () async {
@@ -136,7 +142,7 @@ void main() {
 
       expect(exitCode, equals(ExitCode.success.code));
 
-      verify(() => artifactBuilder.buildIpa()).called(1);
+      verify(() => artifactBuilder.buildIpa(argResultsRest: [])).called(1);
 
       verifyInOrder([
         () => logger.info(
@@ -164,7 +170,11 @@ ${lightCyan.wrap(p.join('build', 'ios', 'ipa', 'Runner.ipa'))}''',
       expect(exitCode, equals(ExitCode.success.code));
 
       verify(
-        () => artifactBuilder.buildIpa(flavor: flavor, target: target),
+        () => artifactBuilder.buildIpa(
+          flavor: flavor,
+          target: target,
+          argResultsRest: [],
+        ),
       ).called(1);
 
       verifyInOrder([
@@ -190,7 +200,7 @@ ${lightCyan.wrap(p.join('build', 'ios', 'ipa', 'Runner.ipa'))}''',
       expect(exitCode, equals(ExitCode.success.code));
 
       verify(
-        () => artifactBuilder.buildIpa(codesign: false),
+        () => artifactBuilder.buildIpa(codesign: false, argResultsRest: []),
       ).called(1);
 
       verify(

--- a/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
@@ -103,6 +103,7 @@ void main() {
       shorebirdAndroidArtifacts = MockShorebirdAndroidArtifacts();
 
       when(() => argResults['build-number']).thenReturn('1.0');
+      when(() => argResults.rest).thenReturn([]);
 
       when(() => logger.progress(any())).thenReturn(progress);
 
@@ -235,6 +236,7 @@ void main() {
           when(
             () => artifactBuilder.buildAar(
               buildNumber: any(named: 'buildNumber'),
+              argResultsRest: any(named: 'argResultsRest'),
             ),
           ).thenThrow(exception);
         });
@@ -254,6 +256,7 @@ void main() {
           when(
             () => artifactBuilder.buildAar(
               buildNumber: any(named: 'buildNumber'),
+              argResultsRest: any(named: 'argResultsRest'),
             ),
           ).thenAnswer((_) async => {});
         });
@@ -280,8 +283,12 @@ void main() {
             ),
           );
 
-          verify(() => artifactBuilder.buildAar(buildNumber: buildNumber))
-              .called(1);
+          verify(
+            () => artifactBuilder.buildAar(
+              buildNumber: buildNumber,
+              argResultsRest: any(named: 'argResultsRest'),
+            ),
+          ).called(1);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -114,6 +114,8 @@ void main() {
       shorebirdValidator = MockShorebirdValidator();
       shorebirdAndroidArtifacts = MockShorebirdAndroidArtifacts();
 
+      when(() => argResults.rest).thenReturn([]);
+
       when(() => logger.progress(any())).thenReturn(progress);
 
       when(
@@ -226,6 +228,7 @@ void main() {
             flavor: any(named: 'flavor'),
             target: any(named: 'target'),
             targetPlatforms: any(named: 'targetPlatforms'),
+            argResultsRest: any(named: 'argResultsRest'),
           ),
         ).thenAnswer((_) async => aabFile);
       });
@@ -238,6 +241,7 @@ void main() {
             () => artifactBuilder.buildAppBundle(
               flavor: any(named: 'flavor'),
               target: any(named: 'target'),
+              argResultsRest: any(named: 'argResultsRest'),
             ),
           ).thenThrow(exception);
           when(() => logger.progress(any())).thenReturn(progress);

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -114,6 +114,7 @@ void main() {
         xcodeBuild = MockXcodeBuild();
 
         when(() => argResults['build-number']).thenReturn('1.0');
+        when(() => argResults.rest).thenReturn([]);
 
         when(() => logger.progress(any())).thenReturn(progress);
 
@@ -285,7 +286,11 @@ void main() {
 
         group('when build fails', () {
           setUp(() {
-            when(() => artifactBuilder.buildIosFramework()).thenThrow(
+            when(
+              () => artifactBuilder.buildIosFramework(
+                argResultsRest: any(named: 'argResultsRest'),
+              ),
+            ).thenThrow(
               ArtifactBuildException('Build failed'),
             );
           });
@@ -302,7 +307,11 @@ void main() {
 
         group('when elf aot snapshot build fails', () {
           setUp(() {
-            when(() => artifactBuilder.buildIosFramework()).thenAnswer(
+            when(
+              () => artifactBuilder.buildIosFramework(
+                argResultsRest: any(named: 'argResultsRest'),
+              ),
+            ).thenAnswer(
               (_) async {},
             );
             when(() => artifactManager.newestAppDill()).thenReturn(File(''));
@@ -328,7 +337,11 @@ void main() {
 
         group('when build succeeds', () {
           setUp(() {
-            when(() => artifactBuilder.buildIosFramework()).thenAnswer(
+            when(
+              () => artifactBuilder.buildIosFramework(
+                argResultsRest: any(named: 'argResultsRest'),
+              ),
+            ).thenAnswer(
               (_) async {},
             );
             when(() => artifactManager.newestAppDill()).thenReturn(File(''));

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -119,6 +119,7 @@ void main() {
         xcodeBuild = MockXcodeBuild();
 
         when(() => argResults['build-number']).thenReturn('1.0');
+        when(() => argResults.rest).thenReturn([]);
 
         when(() => logger.progress(any())).thenReturn(progress);
 

--- a/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
@@ -92,6 +92,7 @@ void main() {
       when(() => argResults['build-number']).thenReturn(buildNumber);
       when(() => argResults['target-platform'])
           .thenReturn(Arch.values.map((a) => a.targetPlatformCliArg).toList());
+      when(() => argResults.rest).thenReturn([]);
 
       when(() => logger.progress(any())).thenReturn(progress);
 
@@ -260,6 +261,7 @@ void main() {
           () => artifactBuilder.buildAar(
             buildNumber: any(named: 'buildNumber'),
             targetPlatforms: any(named: 'targetPlatforms'),
+            argResultsRest: any(named: 'argResultsRest'),
           ),
         ).thenAnswer(
           (_) async => File(''),
@@ -282,6 +284,7 @@ void main() {
             () => artifactBuilder.buildAar(
               buildNumber: buildNumber,
               targetPlatforms: Arch.values.toSet(),
+              argResultsRest: [],
             ),
           ).called(1);
         });
@@ -293,6 +296,7 @@ void main() {
             () => artifactBuilder.buildAar(
               buildNumber: any(named: 'buildNumber'),
               targetPlatforms: any(named: 'targetPlatforms'),
+              argResultsRest: any(named: 'argResultsRest'),
             ),
           ).thenThrow(Exception('build failed'));
         });

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -95,6 +95,7 @@ void main() {
 
       when(() => argResults['target-platform'])
           .thenReturn(Arch.values.map((a) => a.targetPlatformCliArg).toList());
+      when(() => argResults.rest).thenReturn([]);
 
       when(() => logger.progress(any())).thenReturn(progress);
 
@@ -224,6 +225,7 @@ void main() {
             flavor: any(named: 'flavor'),
             target: any(named: 'target'),
             targetPlatforms: any(named: 'targetPlatforms'),
+            argResultsRest: any(named: 'argResultsRest'),
           ),
         ).thenAnswer((_) async => aabFile);
         when(
@@ -231,6 +233,7 @@ void main() {
             flavor: any(named: 'flavor'),
             target: any(named: 'target'),
             targetPlatforms: any(named: 'targetPlatforms'),
+            argResultsRest: any(named: 'argResultsRest'),
           ),
         ).thenAnswer(
           (_) async => File(''),
@@ -253,6 +256,7 @@ void main() {
               flavor: any(named: 'flavor'),
               target: any(named: 'target'),
               targetPlatforms: any(named: 'targetPlatforms'),
+              argResultsRest: any(named: 'argResultsRest'),
             ),
           ).thenThrow(ArtifactBuildException('Uh oh'));
         });
@@ -278,6 +282,7 @@ void main() {
                 flavor: any(named: 'flavor'),
                 target: any(named: 'target'),
                 targetPlatforms: any(named: 'targetPlatforms'),
+                argResultsRest: any(named: 'argResultsRest'),
               ),
             ).thenThrow(ArtifactBuildException('Uh oh'));
           });
@@ -299,7 +304,10 @@ void main() {
           );
           expect(result, aabFile);
           verify(
-            () => artifactBuilder.buildAppBundle(targetPlatforms: Arch.values),
+            () => artifactBuilder.buildAppBundle(
+              targetPlatforms: Arch.values,
+              argResultsRest: [],
+            ),
           ).called(1);
         });
 
@@ -312,6 +320,7 @@ void main() {
               flavor: any(named: 'flavor'),
               target: any(named: 'target'),
               targetPlatforms: any(named: 'targetPlatforms'),
+              argResultsRest: any(named: 'argResultsRest'),
             ),
           );
         });
@@ -337,6 +346,7 @@ void main() {
               flavor: flavor,
               target: target,
               targetPlatforms: Arch.values,
+              argResultsRest: [],
             ),
           ).called(1);
           verify(
@@ -344,6 +354,7 @@ void main() {
               flavor: flavor,
               target: target,
               targetPlatforms: Arch.values,
+              argResultsRest: [],
             ),
           ).called(1);
         });

--- a/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
@@ -95,6 +95,8 @@ void main() {
         shorebirdValidator = MockShorebirdValidator();
         xcodeBuild = MockXcodeBuild();
 
+        when(() => argResults.rest).thenReturn([]);
+
         when(() => logger.progress(any())).thenReturn(progress);
 
         when(
@@ -244,7 +246,9 @@ void main() {
 
         setUp(() {
           when(
-            () => artifactBuilder.buildIosFramework(),
+            () => artifactBuilder.buildIosFramework(
+              argResultsRest: any(named: 'argResultsRest'),
+            ),
           ).thenAnswer(
             (_) async => File(''),
           );
@@ -273,14 +277,18 @@ void main() {
             );
 
             expect(xcframework.path, p.join(projectRoot.path, 'release'));
-            verify(artifactBuilder.buildIosFramework).called(1);
+            verify(
+              () => artifactBuilder.buildIosFramework(argResultsRest: []),
+            ).called(1);
           });
         });
 
         group('when build fails', () {
           setUp(() {
             when(
-              () => artifactBuilder.buildIosFramework(),
+              () => artifactBuilder.buildIosFramework(
+                argResultsRest: any(named: 'argResultsRest'),
+              ),
             ).thenThrow(Exception('build failed'));
           });
 

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -261,6 +261,7 @@ void main() {
               exportOptionsPlist: any(named: 'exportOptionsPlist'),
               flavor: any(named: 'flavor'),
               target: any(named: 'target'),
+              argResultsRest: any(named: 'argResultsRest'),
             ),
           ).thenAnswer((_) async => {});
 
@@ -330,6 +331,7 @@ void main() {
                 exportOptionsPlist: any(named: 'exportOptionsPlist'),
                 flavor: any(named: 'flavor'),
                 target: any(named: 'target'),
+                argResultsRest: any(named: 'argResultsRest'),
               ),
             ).thenThrow(ArtifactBuildException('Failed to build'));
           });


### PR DESCRIPTION
## Description

The new releasers/patchers were not always forwarding `argResults.rest` to their build commands. This PR fixes that.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
