### PR TITLE
fix(shorebird_cli): make cache clear async

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -106,14 +106,11 @@ class Cache {
 
   Future<void> clear() async {
     final cacheDir = shorebirdCacheDirectory;
-    if (cacheDir.existsSync()) {
-      await cacheDir.delete(recursive: true);
-    }
-
     final logsDirectory = shorebirdEnv.logsDirectory;
-    if (logsDirectory.existsSync()) {
-      await logsDirectory.delete(recursive: true);
-    }
+    await Future.wait([
+      if (cacheDir.existsSync()) cacheDir.delete(recursive: true),
+      if (logsDirectory.existsSync()) logsDirectory.delete(recursive: true),
+    ]);
   }
 }
 

--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -104,15 +104,15 @@ class Cache {
 
   String get storageBucket => 'download.shorebird.dev';
 
-  void clear() {
+  Future<void> clear() async {
     final cacheDir = shorebirdCacheDirectory;
     if (cacheDir.existsSync()) {
-      cacheDir.deleteSync(recursive: true);
+      await cacheDir.delete(recursive: true);
     }
 
     final logsDirectory = shorebirdEnv.logsDirectory;
     if (logsDirectory.existsSync()) {
-      logsDirectory.deleteSync(recursive: true);
+      await logsDirectory.delete(recursive: true);
     }
   }
 }

--- a/packages/shorebird_cli/lib/src/commands/cache/clean_cache_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/cache/clean_cache_command.dart
@@ -28,7 +28,7 @@ class CleanCacheCommand extends ShorebirdCommand {
   Future<int> run() async {
     final progress = logger.progress('Clearing Cache');
     try {
-      cache.clear();
+      await cache.clear();
     } on FileSystemException catch (error) {
       final cachePath = Cache.shorebirdCacheDirectory.path;
       progress.fail(

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -171,7 +171,7 @@ void main() {
         )..createSync(recursive: true);
         expect(shorebirdCacheDirectory.existsSync(), isTrue);
         expect(logsDirectory.existsSync(), isTrue);
-        runWithOverrides(cache.clear);
+        await runWithOverrides(cache.clear);
         expect(shorebirdCacheDirectory.existsSync(), isFalse);
         expect(logsDirectory.existsSync(), isFalse);
       });

--- a/packages/shorebird_cli/test/src/commands/cache/clean_cache_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/cache/clean_cache_command_test.dart
@@ -48,11 +48,12 @@ void main() {
       );
     });
 
-    test('has a description', () {
+    test('has a non-empty description', () {
       expect(command.description, isNotEmpty);
     });
 
     test('clears the cache', () async {
+      when(cache.clear).thenAnswer((_) async {});
       final result = await runWithOverrides(command.run);
       expect(result, equals(ExitCode.success.code));
       verify(() => progress.complete('Cleared cache')).called(1);
@@ -75,7 +76,18 @@ void main() {
 
           expect(result, equals(ExitCode.software.code));
           verify(() => progress.fail(any())).called(1);
-          verify(() => logger.info(any())).called(1);
+          verify(
+            () => logger.info(
+              any(
+                that: stringContainsInOrder(
+                  [
+                    '''This could be because a program is using a file in the cache directory. To find and stop such a program, see''',
+                    'https://superuser.com/questions/1333118/cant-delete-empty-folder-because-it-is-used',
+                  ],
+                ),
+              ),
+            ),
+          ).called(1);
         });
       });
 


### PR DESCRIPTION
## Description

This allows the progress spinner to display while `shorebird cache clear` is doing its thing (currently, the command just hangs until the cache has been cleared, which can take several seconds).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
