### PR TITLE
fix(shorebird_cli): install release flutter on patch

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -16,6 +16,7 @@ import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
@@ -193,6 +194,13 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
       releaseVersion: releaseVersion,
       patcher: patcher,
     );
+
+    try {
+      await shorebirdFlutter.installRevision(revision: release.flutterRevision);
+    } catch (_) {
+      exit(ExitCode.software.code);
+    }
+
     final releaseArtifact = await downloadPrimaryReleaseArtifact(
       release: release,
       patcher: patcher,

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -523,6 +523,9 @@ void main() {
 
           verifyInOrder([
             () => patcher.buildPatchArtifact(),
+            () => shorebirdFlutter.installRevision(
+                  revision: releaseFlutterRevision,
+                ),
             () => shorebirdEnv.copyWith(
                   flutterRevisionOverride: releaseFlutterRevision,
                 ),


### PR DESCRIPTION
## Description

If the release that we're patching uses a different version of Flutter, make sure we install it before attempting to patch.

Fixes https://github.com/shorebirdtech/shorebird/issues/2079

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
