### PR TITLE
fix(shorebird_cli): only pass dump-debug-info to aot_tools if supported

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -287,7 +287,6 @@ class IosPatcher extends Patcher {
     required File releaseArtifact,
   }) async {
     final patch = File(_aotOutputPath);
-    final dumpDebugInfo = await aotTools.isLinkDebugInfoSupported();
 
     if (!patch.existsSync()) {
       logger.err('Unable to find patch AOT file at ${patch.path}');
@@ -312,7 +311,10 @@ class IosPatcher extends Patcher {
     final linkProgress = logger.progress('Linking AOT files');
     double? linkPercentage;
     try {
-      final dumpDebugInfoDir = Directory.systemTemp.createTempSync();
+      final dumpDebugInfoDir = await aotTools.isLinkDebugInfoSupported()
+          ? Directory.systemTemp.createTempSync()
+          : null;
+
       linkPercentage = await aotTools.link(
         base: releaseArtifact.path,
         patch: patch.path,
@@ -321,10 +323,10 @@ class IosPatcher extends Patcher {
         outputPath: _vmcodeOutputPath,
         workingDirectory: buildDirectory.path,
         kernel: artifactManager.newestAppDill().path,
-        dumpDebugInfoPath: dumpDebugInfoDir.path,
+        dumpDebugInfoPath: dumpDebugInfoDir?.path,
       );
 
-      if (dumpDebugInfo) {
+      if (dumpDebugInfoDir != null) {
         final debugInfoZip = await dumpDebugInfoDir.zipToTempFile();
         debugInfoZip.copySync(p.join('build', debugInfoFile.path));
       }

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -896,7 +896,7 @@ void main() {
                 );
               });
 
-              group('when isLinkDebugInfoSupported', () {
+              group('when isLinkDebugInfoSupported is true', () {
                 setUp(() {
                   when(
                     aotTools.isLinkDebugInfoSupported,
@@ -919,7 +919,40 @@ void main() {
                       kernel: any(named: 'kernel'),
                       outputPath: any(named: 'outputPath'),
                       workingDirectory: any(named: 'workingDirectory'),
-                      dumpDebugInfoPath: any(named: 'dumpDebugInfoPath'),
+                      dumpDebugInfoPath: any(
+                        named: 'dumpDebugInfoPath',
+                        that: isNotNull,
+                      ),
+                    ),
+                  ).called(1);
+                });
+              });
+
+              group('when isLinkDebugInfoSupported is false', () {
+                setUp(() {
+                  when(aotTools.isLinkDebugInfoSupported)
+                      .thenAnswer((_) async => false);
+                });
+
+                test('does not pass dumpDebugInfoPath to aotTools.link',
+                    () async {
+                  await runWithOverrides(
+                    () => patcher.createPatchArtifacts(
+                      appId: appId,
+                      releaseId: releaseId,
+                    ),
+                  );
+                  verify(
+                    () => aotTools.link(
+                      base: any(named: 'base'),
+                      patch: any(named: 'patch'),
+                      analyzeSnapshot: any(named: 'analyzeSnapshot'),
+                      genSnapshot: any(named: 'genSnapshot'),
+                      kernel: any(named: 'kernel'),
+                      outputPath: any(named: 'outputPath'),
+                      workingDirectory: any(named: 'workingDirectory'),
+                      // ignore: avoid_redundant_argument_values
+                      dumpDebugInfoPath: null,
                     ),
                   ).called(1);
                 });


### PR DESCRIPTION
## Description

Fixes https://github.com/shorebirdtech/shorebird/issues/2089

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
