### PR TITLE
fix(shorebird_cli): don't export FLUTTER_STORAGE_BASE_URL in shorebird.ps1

### DIFF
--- a/bin/shorebird.ps1
+++ b/bin/shorebird.ps1
@@ -117,9 +117,13 @@ function Update-Flutter {
 
     # Set FLUTTER_STORAGE_BASE_URL=https://download.shorebird.dev and execute
     # a `flutter` command to trigger a download of Dart, etc.
-    $env:FLUTTER_STORAGE_BASE_URL = 'https://download.shorebird.dev';
-    & $flutter --version
-    Remove-Item Env:\FLUTTER_STORAGE_BASE_URL
+    # 
+    # This is invoked in a subshell to avoid polluting the environment if the 
+    # flutter command fails. See https://stackoverflow.com/a/69758192 for
+    # subshell suggestion and
+    # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.4
+    # for official documentation on pwsh.
+    pwsh -Command { $env:FLUTTER_STORAGE_BASE_URL="https://download.shorebird.dev"; & $args[0] --version } -args $flutter
 }
 
 function Update-Shorebird {


### PR DESCRIPTION
## Description

Invoke `flutter --version` in a "subshell" to avoid polluting the powershell environment.

Fixes https://github.com/shorebirdtech/shorebird/issues/2108

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
