### PR TITLE
refactor(shorebird_cli): don't redownload iOS release artifacts

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
@@ -92,6 +92,7 @@ class AarPatcher extends Patcher {
   Future<Map<Arch, PatchArtifactBundle>> createPatchArtifacts({
     required String appId,
     required int releaseId,
+    required File releaseArtifact,
   }) async {
     final releaseArtifacts = await codePushClientWrapper.getReleaseArtifacts(
       appId: appId,

--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -100,6 +100,7 @@ Looked in:
   Future<Map<Arch, PatchArtifactBundle>> createPatchArtifacts({
     required String appId,
     required int releaseId,
+    required File releaseArtifact,
   }) async {
     final releaseArtifacts = await codePushClientWrapper.getReleaseArtifacts(
       appId: appId,

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
@@ -119,30 +119,12 @@ class IosFrameworkPatcher extends Patcher {
   Future<Map<Arch, PatchArtifactBundle>> createPatchArtifacts({
     required String appId,
     required int releaseId,
+    required File releaseArtifact,
   }) async {
-    final releaseArtifact = await codePushClientWrapper.getReleaseArtifact(
-      appId: appId,
-      releaseId: releaseId,
-      arch: 'xcframework',
-      platform: ReleasePlatform.ios,
-    );
-
-    final downloadProgress = logger.progress('Downloading release artifact');
-    final File releaseArtifactZipFile;
-    try {
-      releaseArtifactZipFile = await artifactManager.downloadFile(
-        Uri.parse(releaseArtifact.url),
-      );
-    } catch (error) {
-      downloadProgress.fail('$error');
-      exit(ExitCode.software.code);
-    }
-    downloadProgress.complete();
-
     final unzipProgress = logger.progress('Extracting release artifact');
     final tempDir = Directory.systemTemp.createTempSync();
     await artifactManager.extractZip(
-      zipFile: releaseArtifactZipFile,
+      zipFile: releaseArtifact,
       outputDirectory: tempDir,
     );
     final releaseXcframeworkPath = tempDir.path;

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -227,6 +227,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
         final patchArtifactBundles = await patcher.createPatchArtifacts(
           appId: appId,
           releaseId: release.id,
+          releaseArtifact: releaseArtifact,
         );
 
         final dryRun = results['dry-run'] == true;

--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -80,6 +80,7 @@ https://docs.shorebird.dev/status#link-percentage-ios
   Future<Map<Arch, PatchArtifactBundle>> createPatchArtifacts({
     required String appId,
     required int releaseId,
+    required File releaseArtifact,
   });
 
   /// Metadata to attach to the patch when creating it, used for debugging

--- a/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
@@ -402,6 +402,7 @@ void main() {
               () => patcher.createPatchArtifacts(
                 appId: appId,
                 releaseId: releaseId,
+                releaseArtifact: releaseArtifactFile,
               ),
             ),
             exitsWithCode(ExitCode.software),
@@ -427,6 +428,7 @@ void main() {
               () => patcher.createPatchArtifacts(
                 appId: appId,
                 releaseId: releaseId,
+                releaseArtifact: releaseArtifactFile,
               ),
             ),
             exitsWithCode(ExitCode.software),
@@ -442,6 +444,7 @@ void main() {
             () => patcher.createPatchArtifacts(
               appId: appId,
               releaseId: releaseId,
+              releaseArtifact: releaseArtifactFile,
             ),
           );
 

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -353,6 +353,7 @@ Looked in:
               () => patcher.createPatchArtifacts(
                 appId: 'appId',
                 releaseId: 0,
+                releaseArtifact: File('release.aab'),
               ),
             ),
             exitsWithCode(ExitCode.software),
@@ -369,6 +370,7 @@ Looked in:
               () => patcher.createPatchArtifacts(
                 appId: 'appId',
                 releaseId: 0,
+                releaseArtifact: File('release.aab'),
               ),
             ),
             exitsWithCode(ExitCode.software),
@@ -396,6 +398,7 @@ Looked in:
               () => patcher.createPatchArtifacts(
                 appId: 'appId',
                 releaseId: 0,
+                releaseArtifact: File('release.aab'),
               ),
             ),
             exitsWithCode(ExitCode.software),
@@ -428,6 +431,7 @@ Looked in:
             () => patcher.createPatchArtifacts(
               appId: 'appId',
               releaseId: 0,
+              releaseArtifact: File('release.aab'),
             ),
           );
 

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -401,6 +401,7 @@ void main() {
           size: 42,
           url: 'https://example.com',
         );
+        late File releaseArtifactFile;
 
         void setUpProjectRootArtifacts() {
           // Create a second app.dill for coverage of newestAppDill file.
@@ -438,6 +439,13 @@ void main() {
         }
 
         setUp(() {
+          releaseArtifactFile = File(
+            p.join(
+              Directory.systemTemp.createTempSync().path,
+              'release.xcframework',
+            ),
+          )..createSync(recursive: true);
+
           when(
             () => codePushClientWrapper.getReleaseArtifact(
               appId: any(named: 'appId'),
@@ -465,26 +473,6 @@ void main() {
                 .createSync();
           });
           when(() => engineConfig.localEngine).thenReturn(null);
-        });
-
-        group('when release artifact download fails', () {
-          setUp(() {
-            when(
-              () => artifactManager.downloadFile(any()),
-            ).thenThrow(Exception('Failed to download release artifact'));
-          });
-
-          test('logs error and exits with code 70', () async {
-            await expectLater(
-              () => runWithOverrides(
-                () => patcher.createPatchArtifacts(
-                  appId: appId,
-                  releaseId: releaseId,
-                ),
-              ),
-              exitsWithCode(ExitCode.software),
-            );
-          });
         });
 
         group('when uses linker', () {
@@ -554,6 +542,7 @@ void main() {
                     () => patcher.createPatchArtifacts(
                       appId: appId,
                       releaseId: releaseId,
+                      releaseArtifact: releaseArtifactFile,
                     ),
                   ),
                   exitsWithCode(ExitCode.software),
@@ -583,6 +572,7 @@ void main() {
                     () => patcher.createPatchArtifacts(
                       appId: appId,
                       releaseId: releaseId,
+                      releaseArtifact: releaseArtifactFile,
                     ),
                   ),
                   exitsWithCode(ExitCode.software),
@@ -617,6 +607,7 @@ void main() {
                     () => patcher.createPatchArtifacts(
                       appId: appId,
                       releaseId: releaseId,
+                      releaseArtifact: releaseArtifactFile,
                     ),
                   ),
                   exitsWithCode(ExitCode.software),
@@ -662,6 +653,7 @@ void main() {
                     () => patcher.createPatchArtifacts(
                       appId: appId,
                       releaseId: releaseId,
+                      releaseArtifact: releaseArtifactFile,
                     ),
                   ),
                   exitsWithCode(ExitCode.software),
@@ -689,6 +681,7 @@ void main() {
                   () => patcher.createPatchArtifacts(
                     appId: appId,
                     releaseId: releaseId,
+                    releaseArtifact: releaseArtifactFile,
                   ),
                 );
 
@@ -718,6 +711,7 @@ void main() {
                 () => patcher.createPatchArtifacts(
                   appId: appId,
                   releaseId: releaseId,
+                  releaseArtifact: releaseArtifactFile,
                 ),
               );
 
@@ -751,6 +745,7 @@ void main() {
               () => patcher.createPatchArtifacts(
                 appId: appId,
                 releaseId: releaseId,
+                releaseArtifact: releaseArtifactFile,
               ),
             );
 

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -451,6 +451,7 @@ void main() {
           size: 42,
           url: 'https://example.com',
         );
+        late File releaseArtifactFile;
 
         void setUpProjectRootArtifacts() {
           // Create a second app.dill for coverage of newestAppDill file.
@@ -503,6 +504,13 @@ void main() {
         }
 
         setUp(() {
+          releaseArtifactFile = File(
+            p.join(
+              Directory.systemTemp.createTempSync().path,
+              'release.xcarchive',
+            ),
+          )..createSync(recursive: true);
+
           when(
             () => codePushClientWrapper.getReleaseArtifact(
               appId: any(named: 'appId'),
@@ -550,7 +558,7 @@ void main() {
           when(() => engineConfig.localEngine).thenReturn(null);
         });
 
-        group('when xcarchive does not exist', () {
+        group('when patch .xcarchive does not exist', () {
           setUp(() {
             when(
               () => artifactManager.getXcarchiveDirectory(),
@@ -563,54 +571,10 @@ void main() {
                 () => patcher.createPatchArtifacts(
                   appId: appId,
                   releaseId: releaseId,
+                  releaseArtifact: releaseArtifactFile,
                 ),
               ),
               exitsWithCode(ExitCode.software),
-            );
-          });
-        });
-
-        group('when release artifact download fails', () {
-          setUp(() {
-            when(
-              () => artifactManager.downloadFile(any()),
-            ).thenThrow(Exception('Failed to download release artifact'));
-          });
-
-          test('logs error and exits with code 70', () async {
-            await expectLater(
-              () => runWithOverrides(
-                () => patcher.createPatchArtifacts(
-                  appId: appId,
-                  releaseId: releaseId,
-                ),
-              ),
-              exitsWithCode(ExitCode.software),
-            );
-          });
-        });
-
-        group('when release artifact does not exist', () {
-          setUp(() {
-            when(
-              () => artifactManager.downloadFile(any()),
-            ).thenAnswer((_) async => File(''));
-          });
-
-          test('logs error and exits with code 70', () async {
-            await expectLater(
-              () => runWithOverrides(
-                () => patcher.createPatchArtifacts(
-                  appId: appId,
-                  releaseId: releaseId,
-                ),
-              ),
-              exitsWithCode(ExitCode.software),
-            );
-            verify(
-              () => progress.fail(
-                'Exception: Failed to download release artifact',
-              ),
             );
           });
         });
@@ -722,6 +686,7 @@ void main() {
                     () => patcher.createPatchArtifacts(
                       appId: appId,
                       releaseId: releaseId,
+                      releaseArtifact: releaseArtifactFile,
                     ),
                   ),
                   exitsWithCode(ExitCode.software),
@@ -746,6 +711,7 @@ void main() {
                     () => patcher.createPatchArtifacts(
                       appId: appId,
                       releaseId: releaseId,
+                      releaseArtifact: releaseArtifactFile,
                     ),
                   ),
                   exitsWithCode(ExitCode.software),
@@ -775,6 +741,7 @@ void main() {
                     () => patcher.createPatchArtifacts(
                       appId: appId,
                       releaseId: releaseId,
+                      releaseArtifact: releaseArtifactFile,
                     ),
                   ),
                   exitsWithCode(ExitCode.software),
@@ -810,6 +777,7 @@ void main() {
                     () => patcher.createPatchArtifacts(
                       appId: appId,
                       releaseId: releaseId,
+                      releaseArtifact: releaseArtifactFile,
                     ),
                   ),
                   exitsWithCode(ExitCode.software),
@@ -855,6 +823,7 @@ void main() {
                     () => patcher.createPatchArtifacts(
                       appId: appId,
                       releaseId: releaseId,
+                      releaseArtifact: releaseArtifactFile,
                     ),
                   ),
                   exitsWithCode(ExitCode.software),
@@ -882,6 +851,7 @@ void main() {
                   () => patcher.createPatchArtifacts(
                     appId: appId,
                     releaseId: releaseId,
+                    releaseArtifact: releaseArtifactFile,
                   ),
                 );
 
@@ -908,6 +878,7 @@ void main() {
                     () => patcher.createPatchArtifacts(
                       appId: appId,
                       releaseId: releaseId,
+                      releaseArtifact: releaseArtifactFile,
                     ),
                   );
                   verify(
@@ -940,6 +911,7 @@ void main() {
                     () => patcher.createPatchArtifacts(
                       appId: appId,
                       releaseId: releaseId,
+                      releaseArtifact: releaseArtifactFile,
                     ),
                   );
                   verify(
@@ -973,6 +945,7 @@ void main() {
                 () => patcher.createPatchArtifacts(
                   appId: appId,
                   releaseId: releaseId,
+                  releaseArtifact: releaseArtifactFile,
                 ),
               );
 
@@ -1006,6 +979,7 @@ void main() {
               () => patcher.createPatchArtifacts(
                 appId: appId,
                 releaseId: releaseId,
+                releaseArtifact: releaseArtifactFile,
               ),
             );
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -231,6 +231,7 @@ void main() {
         () => patcher.createPatchArtifacts(
           appId: any(named: 'appId'),
           releaseId: any(named: 'releaseId'),
+          releaseArtifact: any(named: 'releaseArtifact'),
         ),
       ).thenAnswer((_) async => patchArtifactBundles);
       when(
@@ -446,6 +447,7 @@ void main() {
           () => patcher.createPatchArtifacts(
                 appId: appId,
                 releaseId: release.id,
+                releaseArtifact: any(named: 'releaseArtifact'),
               ),
           () => logger.confirm('Would you like to continue?'),
           () => patcher.createPatchMetadata(any()),
@@ -499,6 +501,7 @@ void main() {
           () => patcher.createPatchArtifacts(
                 appId: appId,
                 releaseId: release.id,
+                releaseArtifact: any(named: 'releaseArtifact'),
               ),
           () => logger.confirm('Would you like to continue?'),
           () => codePushClientWrapper.publishPatch(

--- a/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
@@ -52,6 +52,7 @@ class _TestPatcher extends Patcher {
   Future<Map<Arch, PatchArtifactBundle>> createPatchArtifacts({
     required String appId,
     required int releaseId,
+    required File releaseArtifact,
   }) {
     throw UnimplementedError();
   }


### PR DESCRIPTION
## Description

Updates Patcher's `createPatchArtifacts` method to accept a release artifact. We are already downloading this to check for unpatchable changes and will need this to support the upcoming changes to Updater.

Because we download Android release artifacts separately from the aab, this change only impacts iOS for the time being.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
