### PR TITLE
feat(shorebird_cli): always prompt for release version when patching

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -350,27 +350,6 @@ ${summary.join('\n')}
     }
   }
 
-  Future<Release> getRelease({
-    required String releaseVersion,
-    required Patcher patcher,
-  }) async {
-    final release = await codePushClientWrapper.getRelease(
-      appId: appId,
-      releaseVersion: releaseVersion,
-    );
-
-    final releaseStatus =
-        release.platformStatuses[patcher.releaseType.releasePlatform];
-    if (releaseStatus != ReleaseStatus.active) {
-      logger.err('''
-Release ${release.version} is in an incomplete state. It's possible that the original release was terminated or failed to complete.
-Please re-run the release command for this version or create a new release.''');
-      exit(ExitCode.software.code);
-    }
-
-    return release;
-  }
-
   Future<File> downloadPrimaryReleaseArtifact({
     required Release release,
     required Patcher patcher,

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:scoped_deps/scoped_deps.dart';
@@ -279,7 +280,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
     );
     return logger.chooseOne<Release>(
       'Which release would you like to patch?',
-      choices: releases,
+      choices: releases.sortedBy((r) => r.createdAt).reversed.toList(),
       display: (r) => r.version,
     );
   }


### PR DESCRIPTION
## Description

Updates the shorebird patch command to prompt for release version if not provided by the --release-version arg (unless on CI, where we maintain the current behavior).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
