### PR TITLE
feat: adding patch signing key path arg to release command

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder.dart
@@ -46,7 +46,7 @@ class ArtifactBuilder {
     String? target,
     Iterable<Arch>? targetPlatforms,
     List<String> args = const [],
-    String? encodedPublicKey,
+    String? base64PublicKey,
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
@@ -65,8 +65,8 @@ class ArtifactBuilder {
         executable,
         arguments,
         runInShell: true,
-        environment: encodedPublicKey != null
-            ? {'SHOREBIRD_PUBLIC_KEY': encodedPublicKey}
+        environment: base64PublicKey != null
+            ? {'SHOREBIRD_PUBLIC_KEY': base64PublicKey}
             : null,
       );
 
@@ -102,7 +102,7 @@ class ArtifactBuilder {
     Iterable<Arch>? targetPlatforms,
     bool splitPerAbi = false,
     List<String> args = const [],
-    String? encodedPublicKey,
+    String? base64PublicKey,
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
@@ -126,8 +126,8 @@ class ArtifactBuilder {
         executable,
         arguments,
         runInShell: true,
-        environment: encodedPublicKey != null
-            ? {'SHOREBIRD_PUBLIC_KEY': encodedPublicKey}
+        environment: base64PublicKey != null
+            ? {'SHOREBIRD_PUBLIC_KEY': base64PublicKey}
             : null,
       );
 

--- a/packages/shorebird_cli/lib/src/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder.dart
@@ -46,7 +46,7 @@ class ArtifactBuilder {
     String? target,
     Iterable<Arch>? targetPlatforms,
     List<String> args = const [],
-    String? encodedPatchSigningPublicKey,
+    String? encodedPublicKey,
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
@@ -65,8 +65,8 @@ class ArtifactBuilder {
         executable,
         arguments,
         runInShell: true,
-        environment: encodedPatchSigningPublicKey != null
-            ? {'SHOREBIRD_PUBLIC_KEY': encodedPatchSigningPublicKey}
+        environment: encodedPublicKey != null
+            ? {'SHOREBIRD_PUBLIC_KEY': encodedPublicKey}
             : null,
       );
 
@@ -102,7 +102,7 @@ class ArtifactBuilder {
     Iterable<Arch>? targetPlatforms,
     bool splitPerAbi = false,
     List<String> args = const [],
-    String? encodedPatchSigningPublicKey,
+    String? encodedPublicKey,
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
@@ -126,8 +126,8 @@ class ArtifactBuilder {
         executable,
         arguments,
         runInShell: true,
-        environment: encodedPatchSigningPublicKey != null
-            ? {'SHOREBIRD_PUBLIC_KEY': encodedPatchSigningPublicKey}
+        environment: encodedPublicKey != null
+            ? {'SHOREBIRD_PUBLIC_KEY': encodedPublicKey}
             : null,
       );
 

--- a/packages/shorebird_cli/lib/src/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder.dart
@@ -46,6 +46,7 @@ class ArtifactBuilder {
     String? target,
     Iterable<Arch>? targetPlatforms,
     List<String> args = const [],
+    String? encodedPatchSigningPublicKey,
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
@@ -64,6 +65,9 @@ class ArtifactBuilder {
         executable,
         arguments,
         runInShell: true,
+        environment: encodedPatchSigningPublicKey != null
+            ? {'SHOREBIRD_PUBLIC_KEY': encodedPatchSigningPublicKey}
+            : null,
       );
 
       if (result.exitCode != ExitCode.success.code) {
@@ -98,6 +102,7 @@ class ArtifactBuilder {
     Iterable<Arch>? targetPlatforms,
     bool splitPerAbi = false,
     List<String> args = const [],
+    String? encodedPatchSigningPublicKey,
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
@@ -121,6 +126,9 @@ class ArtifactBuilder {
         executable,
         arguments,
         runInShell: true,
+        environment: encodedPatchSigningPublicKey != null
+            ? {'SHOREBIRD_PUBLIC_KEY': encodedPatchSigningPublicKey}
+            : null,
       );
 
       if (result.exitCode != ExitCode.success.code) {

--- a/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
@@ -6,6 +6,8 @@ import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/commands/release/releaser.dart';
 import 'package:shorebird_cli/src/doctor.dart';
+import 'package:shorebird_cli/src/extensions/arg_results.dart';
+import 'package:shorebird_cli/src/extensions/file.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
@@ -61,7 +63,7 @@ class AndroidReleaser extends Releaser {
 
   @override
   Future<void> assertArgsAreValid() async {
-    assertPublicKeyArg();
+    argResults.file('public-key-path')?.assertExists();
     if (generateApk && splitApk) {
       logger
         ..err(

--- a/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
@@ -61,6 +61,7 @@ class AndroidReleaser extends Releaser {
 
   @override
   Future<void> assertArgsAreValid() async {
+    assertPublicKeyArg();
     if (generateApk && splitApk) {
       logger
         ..err(
@@ -93,16 +94,14 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
 
     final File aab;
 
-    final patchSigningKeyPath =
-        argResults['patch-signing-public-key-path'] as String?;
+    final publicKeyPath = argResults['public-key-path'] as String?;
 
-    String? encodedPatchSigningPublicKey;
-    if (patchSigningKeyPath != null) {
-      final patchSigningPublicKeyFile = File(patchSigningKeyPath);
-      final rawPatchSigningPublicKey =
-          patchSigningPublicKeyFile.readAsBytesSync();
+    String? encodedPublicKey;
+    if (publicKeyPath != null) {
+      final publicKeyFile = File(publicKeyPath);
+      final rawPublicKey = publicKeyFile.readAsBytesSync();
 
-      encodedPatchSigningPublicKey = base64Encode(rawPatchSigningPublicKey);
+      encodedPublicKey = base64Encode(rawPublicKey);
     }
     try {
       aab = await artifactBuilder.buildAppBundle(
@@ -110,7 +109,7 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
         target: target,
         targetPlatforms: architectures,
         args: argResults.forwardedArgs,
-        encodedPatchSigningPublicKey: encodedPatchSigningPublicKey,
+        encodedPublicKey: encodedPublicKey,
       );
     } on ArtifactBuildException catch (e) {
       buildAppBundleProgress.fail(e.message);
@@ -128,7 +127,7 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
           target: target,
           targetPlatforms: architectures,
           args: argResults.forwardedArgs,
-          encodedPatchSigningPublicKey: encodedPatchSigningPublicKey,
+          encodedPublicKey: encodedPublicKey,
         );
       } on ArtifactBuildException catch (e) {
         buildApkProgress.fail(e.message);

--- a/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
@@ -96,12 +96,12 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
 
     final publicKeyPath = argResults['public-key-path'] as String?;
 
-    String? encodedPublicKey;
+    String? base64PublicKey;
     if (publicKeyPath != null) {
       final publicKeyFile = File(publicKeyPath);
       final rawPublicKey = publicKeyFile.readAsBytesSync();
 
-      encodedPublicKey = base64Encode(rawPublicKey);
+      base64PublicKey = base64Encode(rawPublicKey);
     }
     try {
       aab = await artifactBuilder.buildAppBundle(
@@ -109,7 +109,7 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
         target: target,
         targetPlatforms: architectures,
         args: argResults.forwardedArgs,
-        encodedPublicKey: encodedPublicKey,
+        base64PublicKey: base64PublicKey,
       );
     } on ArtifactBuildException catch (e) {
       buildAppBundleProgress.fail(e.message);
@@ -127,7 +127,7 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
           target: target,
           targetPlatforms: architectures,
           args: argResults.forwardedArgs,
-          encodedPublicKey: encodedPublicKey,
+          base64PublicKey: base64PublicKey,
         );
       } on ArtifactBuildException catch (e) {
         buildApkProgress.fail(e.message);

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -114,6 +114,13 @@ of the iOS app that is using this module.''',
         help: 'The target platform(s) for which the app is compiled.',
         defaultsTo: Arch.values.map((arch) => arch.targetPlatformCliArg),
         allowed: Arch.values.map((arch) => arch.targetPlatformCliArg),
+      )
+      ..addOption(
+        'patch-signing-public-key-path',
+        hide: true,
+        help: '''
+The path for a public key file that will be used to validate patch signatures.
+''',
       );
   }
 
@@ -126,8 +133,24 @@ of the iOS app that is using this module.''',
   @override
   String get name => 'release';
 
+  void _assertArgs() {
+    final patchSignKeyPath =
+        results['patch-signing-public-key-path'] as String?;
+    if (patchSignKeyPath != null) {
+      final file = File(patchSignKeyPath);
+      if (!file.existsSync()) {
+        logger.err(
+          'Received a patch signing key path, but no files exists for '
+          'it: $patchSignKeyPath',
+        );
+        exit(ExitCode.software.code);
+      }
+    }
+  }
+
   @override
   Future<int> run() async {
+    _assertArgs();
     final releaserFutures =
         results.releaseTypes.map(_resolveReleaser).map(createRelease);
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -116,7 +116,7 @@ of the iOS app that is using this module.''',
         allowed: Arch.values.map((arch) => arch.targetPlatformCliArg),
       )
       ..addOption(
-        'patch-signing-public-key-path',
+        'public-key-path',
         hide: true,
         help: '''
 The path for a public key file that will be used to validate patch signatures.
@@ -133,24 +133,8 @@ The path for a public key file that will be used to validate patch signatures.
   @override
   String get name => 'release';
 
-  void _assertArgs() {
-    final patchSignKeyPath =
-        results['patch-signing-public-key-path'] as String?;
-    if (patchSignKeyPath != null) {
-      final file = File(patchSignKeyPath);
-      if (!file.existsSync()) {
-        logger.err(
-          'Received a patch signing key path, but no files exists for '
-          'it: $patchSignKeyPath',
-        );
-        exit(ExitCode.software.code);
-      }
-    }
-  }
-
   @override
   Future<int> run() async {
-    _assertArgs();
     final releaserFutures =
         results.releaseTypes.map(_resolveReleaser).map(createRelease);
 

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -80,15 +81,11 @@ abstract class Releaser {
   /// This method should be called in [assertArgsAreValid] from releasers that
   /// require a public key argument.
   void assertPublicKeyArg() {
-    final patchSignKeyPath = argResults['public-key-path'] as String?;
-    if (patchSignKeyPath != null) {
-      final file = File(patchSignKeyPath);
-      if (!file.existsSync()) {
-        logger.err(
-          'No file found at $patchSignKeyPath',
-        );
-        exit(ExitCode.software.code);
-      }
+    if (!argResults.wasParsedAndFileExists('public-key-path')) {
+      logger.err(
+        'No file found at ${argResults['public-key-path']}',
+      );
+      exit(ExitCode.software.code);
     }
   }
 }

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -71,4 +73,22 @@ abstract class Releaser {
   Future<String> getReleaseVersion({
     required FileSystemEntity releaseArtifactRoot,
   });
+
+  /// Method for validating a public key argument, which will check, when
+  /// provided, that the file exists.
+  ///
+  /// This method should be called in [assertArgsAreValid] from releasers that
+  /// require a public key argument.
+  void assertPublicKeyArg() {
+    final patchSignKeyPath = argResults['public-key-path'] as String?;
+    if (patchSignKeyPath != null) {
+      final file = File(patchSignKeyPath);
+      if (!file.existsSync()) {
+        logger.err(
+          'No file found at $patchSignKeyPath',
+        );
+        exit(ExitCode.software.code);
+      }
+    }
+  }
 }

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -1,9 +1,6 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:mason_logger/mason_logger.dart';
-import 'package:shorebird_cli/src/extensions/arg_results.dart';
-import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -74,18 +74,4 @@ abstract class Releaser {
   Future<String> getReleaseVersion({
     required FileSystemEntity releaseArtifactRoot,
   });
-
-  /// Method for validating a public key argument, which will check, when
-  /// provided, that the file exists.
-  ///
-  /// This method should be called in [assertArgsAreValid] from releasers that
-  /// require a public key argument.
-  void assertPublicKeyArg() {
-    if (!argResults.wasParsedAndFileExists('public-key-path')) {
-      logger.err(
-        'No file found at ${argResults['public-key-path']}',
-      );
-      exit(ExitCode.software.code);
-    }
-  }
 }

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -42,16 +42,14 @@ extension OptionFinder on ArgResults {
   }
 }
 
-/// Extension on [ArgResults] to provide file validation.
-extension FileValidation on ArgResults {
-  /// Checks if an option is a path that points to an existing file.
-  ///
-  /// This method will only return false when the argument with [name] is
-  /// provided and the file does not exist.
-  bool wasParsedAndFileExists(String name) {
-    final filePath = this[name] as String?;
-    if (filePath == null) return true;
-    final file = File(this[name] as String);
-    return file.existsSync();
+/// Extension on [ArgResults] to provide file related extensions.
+extension FileArgs on ArgResults {
+  /// Returns a [File] from the argument [name].
+  File? file(String name) {
+    final path = this[name] as String?;
+    if (path == null) {
+      return null;
+    }
+    return File(path);
   }
 }

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 
@@ -37,5 +39,19 @@ extension OptionFinder on ArgResults {
     }
 
     return null;
+  }
+}
+
+/// Extension on [ArgResults] to provide file validation.
+extension FileValidation on ArgResults {
+  /// Checks if an option is a path that points to an existing file.
+  ///
+  /// This method will only return false when the argument with [name] is
+  /// provided and the file does not exist.
+  bool wasParsedAndFileExists(String name) {
+    final filePath = this[name] as String?;
+    if (filePath == null) return true;
+    final file = File(this[name] as String);
+    return file.existsSync();
   }
 }

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -44,7 +44,7 @@ extension OptionFinder on ArgResults {
 
 /// Extension on [ArgResults] to provide file related extensions.
 extension FileArgs on ArgResults {
-  /// Returns a [File] from the argument [name].
+  /// Returns a [File] from the argument [name] or null if the argument was not provided.
   File? file(String name) {
     final path = this[name] as String?;
     if (path == null) {

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -44,7 +44,8 @@ extension OptionFinder on ArgResults {
 
 /// Extension on [ArgResults] to provide file related extensions.
 extension FileArgs on ArgResults {
-  /// Returns a [File] from the argument [name] or null if the argument was not provided.
+  /// Returns a [File] from the argument [name] or null if the argument was not
+  /// provided.
   File? file(String name) {
     final path = this[name] as String?;
     if (path == null) {

--- a/packages/shorebird_cli/lib/src/extensions/file.dart
+++ b/packages/shorebird_cli/lib/src/extensions/file.dart
@@ -1,7 +1,6 @@
-import 'dart:io';
-
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/third_party/flutter_tools/lib/src/base/io.dart';
 
 /// Extension methods for validating [File]s.
 extension FileValidations on File {

--- a/packages/shorebird_cli/lib/src/extensions/file.dart
+++ b/packages/shorebird_cli/lib/src/extensions/file.dart
@@ -5,9 +5,7 @@ import 'package:shorebird_cli/src/logger.dart';
 
 /// Extension methods for validating [File]s.
 extension FileValidations on File {
-  /// Asserts that the file exists.
-  ///
-  /// When it doesn't, logs an error and exits with [ExitCode.usage].
+  /// Logs an error and exits with [ExitCode.usage] if this file does not exist.
   void assertExists() {
     if (!existsSync()) {
       logger.err(

--- a/packages/shorebird_cli/lib/src/extensions/file.dart
+++ b/packages/shorebird_cli/lib/src/extensions/file.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/logger.dart';
+
+/// Extension methods for validating [File]s.
+extension FileValidations on File {
+  /// Asserts that the file exists.
+  ///
+  /// When it doesn't, logs an error and exits with [ExitCode.usage].
+  void assertExists() {
+    if (!existsSync()) {
+      logger.err(
+        'No file found at $path',
+      );
+      exit(ExitCode.usage.code);
+    }
+  }
+}

--- a/packages/shorebird_cli/test/src/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder_test.dart
@@ -210,6 +210,59 @@ Either run `flutter pub get` manually, or follow the steps in ${link(uri: Uri.pa
         ).called(1);
       });
 
+      group('when base64PublicKey is not null', () {
+        const base64PublicKey = 'base64PublicKey';
+
+        setUp(() {
+          when(
+            () => shorebirdProcess.run(
+              'flutter',
+              [
+                'build',
+                'appbundle',
+                '--release',
+                '--flavor=flavor',
+                '--target=target',
+                '--target-platform=android-arm64',
+              ],
+              runInShell: any(named: 'runInShell'),
+              environment: {
+                'SHOREBIRD_PUBLIC_KEY': base64PublicKey,
+              },
+            ),
+          ).thenAnswer((_) async => buildProcessResult);
+        });
+
+        test('adds the SHOREBIRD_PUBLIC_KEY to the environment', () async {
+          await runWithOverrides(
+            () => builder.buildAppBundle(
+              flavor: 'flavor',
+              target: 'target',
+              targetPlatforms: [Arch.arm64],
+              base64PublicKey: 'base64PublicKey',
+            ),
+          );
+
+          verify(
+            () => shorebirdProcess.run(
+              'flutter',
+              [
+                'build',
+                'appbundle',
+                '--release',
+                '--flavor=flavor',
+                '--target=target',
+                '--target-platform=android-arm64',
+              ],
+              runInShell: any(named: 'runInShell'),
+              environment: {
+                'SHOREBIRD_PUBLIC_KEY': base64PublicKey,
+              },
+            ),
+          ).called(1);
+        });
+      });
+
       group('when multiple artifacts are found', () {
         setUp(() {
           when(
@@ -345,6 +398,59 @@ Either run `flutter pub get` manually, or follow the steps in ${link(uri: Uri.pa
             runInShell: any(named: 'runInShell'),
           ),
         ).called(1);
+      });
+
+      group('when base64PublicKey is not null', () {
+        const base64PublicKey = 'base64PublicKey';
+
+        setUp(() {
+          when(
+            () => shorebirdProcess.run(
+              'flutter',
+              [
+                'build',
+                'apk',
+                '--release',
+                '--flavor=flavor',
+                '--target=target',
+                '--target-platform=android-arm64',
+              ],
+              runInShell: any(named: 'runInShell'),
+              environment: {
+                'SHOREBIRD_PUBLIC_KEY': base64PublicKey,
+              },
+            ),
+          ).thenAnswer((_) async => buildProcessResult);
+        });
+
+        test('adds the SHOREBIRD_PUBLIC_KEY to the environment', () async {
+          await runWithOverrides(
+            () => builder.buildApk(
+              flavor: 'flavor',
+              target: 'target',
+              targetPlatforms: [Arch.arm64],
+              base64PublicKey: 'base64PublicKey',
+            ),
+          );
+
+          verify(
+            () => shorebirdProcess.run(
+              'flutter',
+              [
+                'build',
+                'apk',
+                '--release',
+                '--flavor=flavor',
+                '--target=target',
+                '--target-platform=android-arm64',
+              ],
+              runInShell: any(named: 'runInShell'),
+              environment: {
+                'SHOREBIRD_PUBLIC_KEY': base64PublicKey,
+              },
+            ),
+          ).called(1);
+        });
       });
 
       group('when multiple artifacts are found', () {

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -226,6 +226,7 @@ void main() {
           when(() => argResults['public-key-path'])
               .thenReturn(publicKeyFile.path);
         });
+
         test('returns normally', () async {
           expect(
             () => runWithOverrides(androidReleaser.assertArgsAreValid),
@@ -240,6 +241,7 @@ void main() {
           when(() => argResults['public-key-path'])
               .thenReturn('non-existing-key.pem');
         });
+
         test('logs and exits with usage err', () async {
           await expectLater(
             () => runWithOverrides(androidReleaser.assertArgsAreValid),

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -438,7 +438,7 @@ void main() {
               target: any(named: 'target'),
               targetPlatforms: any(named: 'targetPlatforms'),
               args: any(named: 'args'),
-              encodedPublicKey: any(named: 'encodedPublicKey'),
+              base64PublicKey: any(named: 'base64PublicKey'),
             ),
           ).thenAnswer((_) async => aabFile);
 
@@ -448,7 +448,7 @@ void main() {
               target: any(named: 'target'),
               targetPlatforms: any(named: 'targetPlatforms'),
               args: any(named: 'args'),
-              encodedPublicKey: any(named: 'encodedPublicKey'),
+              base64PublicKey: any(named: 'base64PublicKey'),
             ),
           ).thenAnswer((_) async => File(''));
         });
@@ -466,7 +466,7 @@ void main() {
                 target: any(named: 'target'),
                 targetPlatforms: any(named: 'targetPlatforms'),
                 args: any(named: 'args'),
-                encodedPublicKey: base64Encode(
+                base64PublicKey: base64Encode(
                   patchSigningPublicKeyFile.readAsBytesSync(),
                 ),
               ),
@@ -492,7 +492,7 @@ void main() {
                   target: any(named: 'target'),
                   targetPlatforms: any(named: 'targetPlatforms'),
                   args: any(named: 'args'),
-                  encodedPublicKey: base64Encode(
+                  base64PublicKey: base64Encode(
                     patchSigningPublicKeyFile.readAsBytesSync(),
                   ),
                 ),
@@ -504,7 +504,7 @@ void main() {
                   target: any(named: 'target'),
                   targetPlatforms: any(named: 'targetPlatforms'),
                   args: any(named: 'args'),
-                  encodedPublicKey: base64Encode(
+                  base64PublicKey: base64Encode(
                     patchSigningPublicKeyFile.readAsBytesSync(),
                   ),
                 ),

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -222,9 +222,7 @@ void main() {
               Directory.systemTemp.createTempSync().path,
               'public-key.pem',
             ),
-          )
-            ..createSync()
-            ..writeAsStringSync('public key');
+          )..writeAsStringSync('public key');
           when(() => argResults['public-key-path'])
               .thenReturn(publicKeyFile.path);
         });
@@ -426,9 +424,7 @@ void main() {
               Directory.systemTemp.createTempSync().path,
               'patch-signing-public-key.pem',
             ),
-          )
-            ..createSync()
-            ..writeAsStringSync('public key');
+          )..writeAsStringSync('public key');
           when(() => argResults['public-key-path'])
               .thenReturn(patchSigningPublicKeyFile.path);
 

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -213,6 +213,42 @@ void main() {
           );
         });
       });
+
+      group('when a public key is provided and it exists', () {
+        setUp(() {
+          when(() => argResults['artifact']).thenReturn('apk');
+          final publicKeyFile = File(
+            p.join(
+              Directory.systemTemp.createTempSync().path,
+              'public-key.pem',
+            ),
+          )
+            ..createSync()
+            ..writeAsStringSync('public key');
+          when(() => argResults['public-key-path'])
+              .thenReturn(publicKeyFile.path);
+        });
+        test('returns normally ', () async {
+          expect(
+            () => runWithOverrides(androidReleaser.assertArgsAreValid),
+            returnsNormally,
+          );
+        });
+      });
+
+      group('when a public key is provided but it does not exists', () {
+        setUp(() {
+          when(() => argResults['artifact']).thenReturn('apk');
+          when(() => argResults['public-key-path'])
+              .thenReturn('non-existing-key.pem');
+        });
+        test('returns normally ', () async {
+          await expectLater(
+            () => runWithOverrides(androidReleaser.assertArgsAreValid),
+            exitsWithCode(ExitCode.software),
+          );
+        });
+      });
     });
 
     group('buildReleaseArtifacts', () {
@@ -393,7 +429,7 @@ void main() {
           )
             ..createSync()
             ..writeAsStringSync('public key');
-          when(() => argResults['patch-signing-public-key-path'])
+          when(() => argResults['public-key-path'])
               .thenReturn(patchSigningPublicKeyFile.path);
 
           when(
@@ -402,8 +438,7 @@ void main() {
               target: any(named: 'target'),
               targetPlatforms: any(named: 'targetPlatforms'),
               args: any(named: 'args'),
-              encodedPatchSigningPublicKey:
-                  any(named: 'encodedPatchSigningPublicKey'),
+              encodedPublicKey: any(named: 'encodedPublicKey'),
             ),
           ).thenAnswer((_) async => aabFile);
 
@@ -413,8 +448,7 @@ void main() {
               target: any(named: 'target'),
               targetPlatforms: any(named: 'targetPlatforms'),
               args: any(named: 'args'),
-              encodedPatchSigningPublicKey:
-                  any(named: 'encodedPatchSigningPublicKey'),
+              encodedPublicKey: any(named: 'encodedPublicKey'),
             ),
           ).thenAnswer((_) async => File(''));
         });
@@ -432,7 +466,7 @@ void main() {
                 target: any(named: 'target'),
                 targetPlatforms: any(named: 'targetPlatforms'),
                 args: any(named: 'args'),
-                encodedPatchSigningPublicKey: base64Encode(
+                encodedPublicKey: base64Encode(
                   patchSigningPublicKeyFile.readAsBytesSync(),
                 ),
               ),
@@ -458,7 +492,7 @@ void main() {
                   target: any(named: 'target'),
                   targetPlatforms: any(named: 'targetPlatforms'),
                   args: any(named: 'args'),
-                  encodedPatchSigningPublicKey: base64Encode(
+                  encodedPublicKey: base64Encode(
                     patchSigningPublicKeyFile.readAsBytesSync(),
                   ),
                 ),
@@ -470,7 +504,7 @@ void main() {
                   target: any(named: 'target'),
                   targetPlatforms: any(named: 'targetPlatforms'),
                   args: any(named: 'args'),
-                  encodedPatchSigningPublicKey: base64Encode(
+                  encodedPublicKey: base64Encode(
                     patchSigningPublicKeyFile.readAsBytesSync(),
                   ),
                 ),

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -226,7 +226,7 @@ void main() {
           when(() => argResults['public-key-path'])
               .thenReturn(publicKeyFile.path);
         });
-        test('returns normally ', () async {
+        test('returns normally', () async {
           expect(
             () => runWithOverrides(androidReleaser.assertArgsAreValid),
             returnsNormally,
@@ -240,11 +240,14 @@ void main() {
           when(() => argResults['public-key-path'])
               .thenReturn('non-existing-key.pem');
         });
-        test('returns normally ', () async {
+        test('logs and exits with usage err', () async {
           await expectLater(
             () => runWithOverrides(androidReleaser.assertArgsAreValid),
-            exitsWithCode(ExitCode.software),
+            exitsWithCode(ExitCode.usage),
           );
+
+          verify(() => logger.err('No file found at non-existing-key.pem'))
+              .called(1);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -500,34 +500,12 @@ $exception''',
               keyName,
             ),
           )..writeAsStringSync('KEY');
-          when(() => argResults['patch-signing-public-key-path'])
-              .thenReturn(file.path);
+          when(() => argResults['public-key-path']).thenReturn(file.path);
         });
 
         test('completes successfully', () async {
           final exitCode = await runWithOverrides(command.run);
           expect(exitCode, equals(ExitCode.success.code));
-        });
-      });
-
-      group('when the key does not exists', () {
-        setUp(() {
-          when(() => argResults['patch-signing-public-key-path'])
-              .thenReturn('non-existent-key.pem');
-        });
-
-        test('returns error', () async {
-          await expectLater(
-            () => runWithOverrides(command.run),
-            exitsWithCode(ExitCode.software),
-          );
-
-          verify(
-            () => logger.err(
-              'Received a patch signing key path, but no files exists for '
-              'it: non-existent-key.pem',
-            ),
-          ).called(1);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -1,6 +1,7 @@
 import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as p;
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -485,6 +486,48 @@ $exception''',
               () => shorebirdFlutter.installRevision(revision: revision),
             ).called(1);
           });
+        });
+      });
+    });
+
+    group('when a patch signing public key is provided', () {
+      const keyName = 'test-key-path.pem';
+      group('when the key exists', () {
+        setUp(() {
+          final file = File(
+            p.join(
+              Directory.systemTemp.createTempSync().path,
+              keyName,
+            ),
+          )..writeAsStringSync('KEY');
+          when(() => argResults['patch-signing-public-key-path'])
+              .thenReturn(file.path);
+        });
+
+        test('completes successfully', () async {
+          final exitCode = await runWithOverrides(command.run);
+          expect(exitCode, equals(ExitCode.success.code));
+        });
+      });
+
+      group('when the key does not exists', () {
+        setUp(() {
+          when(() => argResults['patch-signing-public-key-path'])
+              .thenReturn('non-existent-key.pem');
+        });
+
+        test('returns error', () async {
+          await expectLater(
+            () => runWithOverrides(command.run),
+            exitsWithCode(ExitCode.software),
+          );
+
+          verify(
+            () => logger.err(
+              'Received a patch signing key path, but no files exists for '
+              'it: non-existent-key.pem',
+            ),
+          ).called(1);
         });
       });
     });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adding a new argument to the release command, where the user can provide a path for a pem file key, which will be bundled in the release artifact, so patch signatures can be verified.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
