### PR TITLE
fix(shorebird_cli): don't warn about changed shorebird.yaml in patches

### DIFF
--- a/packages/shorebird_cli/lib/src/archive_analysis/archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/archive_differ.dart
@@ -16,6 +16,7 @@ abstract class ArchiveDiffer {
     'AssetManifest.bin',
     'AssetManifest.json',
     'NOTICES.Z',
+    'shorebird.yaml',
   };
 
   /// Whether there are asset differences between the archives that may cause

--- a/packages/shorebird_cli/test/src/archive_analysis/archive_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/archive_differ_test.dart
@@ -2,8 +2,6 @@ import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/archive_analysis/file_set_diff.dart';
 import 'package:test/test.dart';
 
-const assetFilePath = 'some/assets/file';
-
 void main() {
   group(ArchiveDiffer, () {
     late TestArchiveDiffer archiveDiffer;
@@ -14,42 +12,49 @@ void main() {
 
     group('containsPotentiallyBreakingAssetDiffs', () {
       test('returns true if any assets were added', () {
-        archiveDiffer.changedFileSetDiff = FileSetDiff(
-          addedPaths: {assetFilePath},
+        final changedFileSetDiff = FileSetDiff(
+          addedPaths: {'assets/asset1.png'},
           removedPaths: {},
           changedPaths: {},
         );
         expect(
           archiveDiffer.containsPotentiallyBreakingAssetDiffs(
-            archiveDiffer.changedFileSetDiff,
+            changedFileSetDiff,
           ),
           isTrue,
         );
       });
 
       test('returns false if changed assets are all in the ignore list', () {
-        archiveDiffer.changedFileSetDiff = FileSetDiff(
+        final changedFileSetDiff = FileSetDiff(
           addedPaths: {},
           removedPaths: {},
-          changedPaths: {'AssetManifest.bin'},
+          changedPaths: {
+            'assets/AssetManifest.bin',
+            'assets/NOTICES.Z',
+            'assets/shorebird.yaml',
+          },
         );
         expect(
           archiveDiffer.containsPotentiallyBreakingAssetDiffs(
-            archiveDiffer.changedFileSetDiff,
+            changedFileSetDiff,
           ),
           isFalse,
         );
       });
 
       test('returns true if changed assets are not all in the ignore list', () {
-        archiveDiffer.changedFileSetDiff = FileSetDiff(
+        final changedFileSetDiff = FileSetDiff(
           addedPaths: {},
           removedPaths: {},
-          changedPaths: {assetFilePath},
+          changedPaths: {
+            'assets/AssetManifest.bin',
+            'assets/unignored_asset.png',
+          },
         );
         expect(
           archiveDiffer.containsPotentiallyBreakingAssetDiffs(
-            archiveDiffer.changedFileSetDiff,
+            changedFileSetDiff,
           ),
           isTrue,
         );
@@ -58,21 +63,18 @@ void main() {
   });
 }
 
+/// An implementation of the abstract [ArchiveDiffer] class for testing.
+/// [ArchiveDiffer] only implements [containsPotentiallyBreakingAssetDiffs], so
+/// only method relevant to that method are implemented here.
 class TestArchiveDiffer extends ArchiveDiffer {
-  FileSetDiff changedFileSetDiff = FileSetDiff.empty();
-
+  // This method is implemented by subclasses. For our purposes, a path will be
+  // considered an asset if it starts with 'assets/'
   @override
-  Future<FileSetDiff> changedFiles(
-    String oldArchivePath,
-    String newArchivePath,
-  ) async =>
-      changedFileSetDiff;
+  bool isAssetFilePath(String filePath) => filePath.startsWith('assets/');
 
+  // The following methods are irrelevant to checking for asset changes.
   @override
   bool containsPotentiallyBreakingNativeDiffs(FileSetDiff fileSetDiff) => false;
-
-  @override
-  bool isAssetFilePath(String filePath) => filePath == assetFilePath;
 
   @override
   bool isDartFilePath(String filePath) => true;


### PR DESCRIPTION
## Description

The new support for signed patches introduced in https://github.com/shorebirdtech/shorebird/pull/2133 will cause the patch command to warned about a changed shorebird_cli asset because the release build will contain a public key and the patch build will not. We should not warn users about this, as it is expected.

We could also do something more sophisticated if we are worried about users thinking they can make changes to shorebird.yaml in patches (e.g., changing auto update behavior).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
