### PR TITLE
fix(shorebird_cli): don't assume credentials are well-formed if present

### DIFF
--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -225,6 +225,9 @@ class Auth {
     required void Function(String) prompt,
   }) async {
     if (isAuthenticated) {
+      // Because isAuthenticated is checks for the presence of either an email
+      // or a CI token, and because this method is for logging in without a CI
+      // token, we can safely assume that _email is not null.
       throw UserAlreadyLoggedInException(email: _email!);
     }
 

--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -224,8 +224,9 @@ class Auth {
     AuthProvider authProvider, {
     required void Function(String) prompt,
   }) async {
-    if (_credentials != null) {
-      throw UserAlreadyLoggedInException(email: _credentials!.email!);
+    final email = _credentials?.email;
+    if (email != null) {
+      throw UserAlreadyLoggedInException(email: email);
     }
 
     final client = http.Client();

--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -224,9 +224,8 @@ class Auth {
     AuthProvider authProvider, {
     required void Function(String) prompt,
   }) async {
-    final email = _credentials?.email;
-    if (email != null) {
-      throw UserAlreadyLoggedInException(email: email);
+    if (isAuthenticated) {
+      throw UserAlreadyLoggedInException(email: _email!);
     }
 
     final client = http.Client();

--- a/packages/shorebird_cli/test/src/auth/auth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_test.dart
@@ -490,6 +490,26 @@ Run `shorebird login:ci` to obtain a new token.'''),
         expect(auth.isAuthenticated, isTrue);
       });
 
+      group('when login credentials are corrupted', () {
+        setUp(() {
+          accessCredentials = oauth2.AccessCredentials(
+            accessToken,
+            refreshToken,
+            scopes,
+            idToken: 'not a valid jwt',
+          );
+          writeCredentials();
+          auth = buildAuth();
+        });
+
+        test('proceeds with login', () async {
+          expect(auth.email, isNull);
+          await auth.login(AuthProvider.google, prompt: (_) {});
+          expect(auth.email, equals(email));
+          expect(auth.isAuthenticated, isTrue);
+        });
+      });
+
       test('should not set the email when user does not exist', () async {
         when(() => codePushClient.getCurrentUser())
             .thenAnswer((_) async => null);


### PR DESCRIPTION
## Description

In my attempts to reproduce https://github.com/shorebirdtech/shorebird/issues/2141, I tried to edit the jwt that we store on disk. Doing this caused `shorebird login` to throw a null reference exception because an email could not be parsed out of the jwt. This change updates the check to be more defensive against corrupted files on disk and treat this case as logged out.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
