### PR TITLE
feat(shorebird_cli): extract public key from PEM file

### DIFF
--- a/packages/shorebird_cli/lib/src/code_signer.dart
+++ b/packages/shorebird_cli/lib/src/code_signer.dart
@@ -87,7 +87,8 @@ extension _RSAPrivateKeyFromBytes on RSAPrivateKey {
 
 extension _RSAPublicKeyFromBytes on RSAPublicKey {
   /// Converts an RSA public key to a pointycastle [RSAPublicKey].
-  /// From https://github.com/Ephenodrom/Dart-Basic-Utils/blob/45ed0a3087b2051004f17b39eb5289874b9c0390/lib/src/CryptoUtils.dart#L525-L547
+  ///
+  /// Based on https://github.com/Ephenodrom/Dart-Basic-Utils/blob/45ed0a3087b2051004f17b39eb5289874b9c0390/lib/src/CryptoUtils.dart#L525-L547
   static RSAPublicKey rsaPublicKeyFromBytes(List<int> bytes) {
     final asn1Parser = ASN1Parser(Uint8List.fromList(bytes));
     final topLevelSeq = asn1Parser.nextObject() as ASN1Sequence;

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:collection/collection.dart';
+import 'package:shorebird_cli/src/code_signer.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/extensions/file.dart';
 
@@ -57,7 +58,7 @@ extension CodeSign on ArgResults {
     final publicKeyFile = file(CommonArguments.publicKeyArgName);
 
     return publicKeyFile != null
-        ? base64Encode(publicKeyFile.readAsBytesSync())
+        ? codeSigner.base64PublicKey(publicKeyFile)
         : null;
   }
 }

--- a/packages/shorebird_cli/test/src/code_signer_test.dart
+++ b/packages/shorebird_cli/test/src/code_signer_test.dart
@@ -52,7 +52,7 @@ void main() {
         });
       });
 
-      group('base64DerFromFile', () {
+      group('base64PublicKey', () {
         test('output matches equivalent openssl command', () async {
           final tempDir = Directory.systemTemp.createTempSync();
           final expectedDerFile = File(p.join(tempDir.path, 'public.der'));
@@ -73,7 +73,7 @@ void main() {
             ],
           );
           expect(
-            codeSigner.base64DerFromPemFile(publicKeyFile),
+            codeSigner.base64PublicKey(publicKeyFile),
             equals(base64Encode(expectedDerFile.readAsBytesSync())),
           );
         });

--- a/packages/shorebird_cli/test/src/code_signer_test.dart
+++ b/packages/shorebird_cli/test/src/code_signer_test.dart
@@ -13,6 +13,9 @@ void main() {
       final privateKeyFile = File(
         p.join(cryptoFixturesBasePath, 'private.pem'),
       );
+      final publicKeyFile = File(
+        p.join(cryptoFixturesBasePath, 'public.pem'),
+      );
 
       late CodeSigner codeSigner;
 
@@ -46,6 +49,33 @@ void main() {
             privateKeyPemFile: privateKeyFile,
           );
           expect(actualSignature, equals(expectedSignature));
+        });
+      });
+
+      group('base64DerFromFile', () {
+        test('output matches equivalent openssl command', () async {
+          final tempDir = Directory.systemTemp.createTempSync();
+          final expectedDerFile = File(p.join(tempDir.path, 'public.der'));
+          await Process.run(
+            'openssl',
+            [
+              'rsa',
+              '-pubin',
+              '-in',
+              publicKeyFile.path,
+              '-inform',
+              'PEM',
+              '-RSAPublicKey_out',
+              '-outform',
+              'DER',
+              '-out',
+              expectedDerFile.path,
+            ],
+          );
+          expect(
+            codeSigner.base64DerFromPemFile(publicKeyFile),
+            equals(base64Encode(expectedDerFile.readAsBytesSync())),
+          );
         });
       });
     },


### PR DESCRIPTION
## Description

Update `CodeSigner` to extract just the public key from a PEM public key file. This is what is expected by our rust code (see [here](https://docs.rs/ring/latest/ring/signature/index.html#signing-and-verifying-with-rsa-pkcs1-15-padding)) and makes the following step unnecessary for the user to perform:

```
openssl rsa -pubin \
            -in public.pem \
            -inform PEM \
            -RSAPublicKey_out \
            -outform DER \
            -out public.der
```

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
