### PR TITLE
feat: adding public key to the patch command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -35,11 +35,6 @@ class AndroidPatcher extends Patcher {
   });
 
   @override
-  Future<void> assertArgsAreValid() async {
-    argResults.assertAbsentOrValidKeyPair();
-  }
-
-  @override
   ReleaseType get releaseType => ReleaseType.android;
 
   @override

--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -158,7 +158,9 @@ Looked in:
       final patchArtifact = File(patchArtifactPath);
       final hash = sha256.convert(await patchArtifact.readAsBytes()).toString();
 
-      final privateKeyFile = argResults.file(CommonArguments.privateKeyArgName);
+      final privateKeyFile = argResults.file(
+        CommonArguments.privateKeyArg.name,
+      );
       final hashSignature = privateKeyFile != null
           ? codeSigner.sign(
               message: hash,

--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -11,7 +11,6 @@ import 'package:shorebird_cli/src/commands/patch/patcher.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
-import 'package:shorebird_cli/src/extensions/file.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform.dart';
@@ -37,7 +36,7 @@ class AndroidPatcher extends Patcher {
 
   @override
   Future<void> assertArgsAreValid() async {
-    argResults.file(CommonArguments.privateKeyArgName)?.assertExists();
+    argResults.assertAbsentOrValidKeyPair();
   }
 
   @override
@@ -74,6 +73,7 @@ class AndroidPatcher extends Patcher {
         flavor: flavor,
         target: target,
         args: argResults.forwardedArgs,
+        base64PublicKey: argResults.encodedPublicKey,
       );
       buildProgress.complete();
     } on ArtifactBuildException catch (error) {

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
@@ -70,6 +70,7 @@ class IosFrameworkPatcher extends Patcher {
 
   @override
   Future<void> assertArgsAreValid() async {
+    await super.assertArgsAreValid();
     if (!argResults.wasParsed('release-version')) {
       logger.err('Missing required argument: --release-version');
       exit(ExitCode.usage.code);

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -61,6 +61,11 @@ class IosPatcher extends Patcher {
   ArchiveDiffer get archiveDiffer => IosArchiveDiffer();
 
   @override
+  Future<void> assertArgsAreValid() async {
+    argResults.assertAbsentOrValidKeyPair();
+  }
+
+  @override
   Future<void> assertPreconditions() async {
     try {
       await shorebirdValidator.validatePreconditions(
@@ -100,6 +105,7 @@ class IosPatcher extends Patcher {
           flavor: flavor,
           target: target,
           args: argResults.forwardedArgs,
+          base64PublicKey: argResults.encodedPublicKey,
         );
       } on ProcessException catch (error) {
         buildProgress.fail('Failed to build: ${error.message}');

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -61,11 +61,6 @@ class IosPatcher extends Patcher {
   ArchiveDiffer get archiveDiffer => IosArchiveDiffer();
 
   @override
-  Future<void> assertArgsAreValid() async {
-    argResults.assertAbsentOrValidKeyPair();
-  }
-
-  @override
   Future<void> assertPreconditions() async {
     try {
       await shorebirdValidator.validatePreconditions(

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -219,7 +219,7 @@ class IosPatcher extends Patcher {
     }
 
     final patchFileSize = patchFile.statSync().size;
-    final privateKeyFile = argResults.file(CommonArguments.privateKeyArgName);
+    final privateKeyFile = argResults.file(CommonArguments.privateKeyArg.name);
     final hash = sha256.convert(patchBuildFile.readAsBytesSync()).toString();
     final hashSignature = privateKeyFile != null
         ? codeSigner.sign(

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -95,11 +95,14 @@ of the iOS app that is using this module.''',
         help: 'Validate but do not upload the patch.',
       )
       ..addOption(
-        CommonArguments.privateKeyArgName,
+        CommonArguments.privateKeyArg.name,
         hide: true,
-        help: '''
-The path for a private key file that will be used to sign the patch artifact.
-''',
+        help: CommonArguments.privateKeyArg.description,
+      )
+      ..addOption(
+        CommonArguments.publicKeyArg.name,
+        hide: true,
+        help: CommonArguments.publicKeyArg.description,
       );
   }
 

--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -5,6 +5,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
+import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
@@ -67,7 +68,9 @@ https://docs.shorebird.dev/status#link-percentage-ios
   Future<void> assertPreconditions();
 
   /// Asserts that the combination arguments passed to the command are valid.
-  Future<void> assertArgsAreValid() async {}
+  Future<void> assertArgsAreValid() async {
+    argResults.assertAbsentOrValidKeyPair();
+  }
 
   /// Builds the release artifacts for the given platform. Returns the "primary"
   /// artifact for the platform (e.g. the AAB for Android, the IPA for iOS).

--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -67,8 +68,12 @@ https://docs.shorebird.dev/status#link-percentage-ios
   /// Asserts that the command can be run.
   Future<void> assertPreconditions();
 
+  @mustCallSuper
+
   /// Asserts that the combination arguments passed to the command are valid.
   Future<void> assertArgsAreValid() async {
+    // TODO(erickzanardo): Move this call to the patch_command so we don't need
+    // to required sub classes to call super.
     argResults.assertAbsentOrValidKeyPair();
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -117,11 +117,9 @@ of the iOS app that is using this module.''',
         allowed: Arch.values.map((arch) => arch.targetPlatformCliArg),
       )
       ..addOption(
-        CommonArguments.publicKeyArgName,
+        CommonArguments.publicKeyArg.name,
         hide: true,
-        help: '''
-The path for a public key file that will be used to validate patch signatures.
-''',
+        help: CommonArguments.publicKeyArg.description,
       );
   }
 

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -1,6 +1,27 @@
+class ArgumentDescriber {
+  const ArgumentDescriber({
+    required this.name,
+    required this.description,
+  });
+
+  final String name;
+  final String description;
+}
+
 /// A class that houses the name of arguments that are shared between different
 /// commands and layers.
 class CommonArguments {
-  static const String publicKeyArgName = 'public-key-path';
-  static const String privateKeyArgName = 'private-key-path';
+  static const publicKeyArg = ArgumentDescriber(
+    name: 'public-key-path',
+    description: '''
+The path for a public key file that will be used to validate patch signatures.
+''',
+  );
+
+  static const privateKeyArg = ArgumentDescriber(
+    name: 'private-key-path',
+    description: '''
+The path for a private key file that will be used to sign the patch artifact.
+''',
+  );
 }

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -1,10 +1,16 @@
+/// {@template argument_describer}
+/// A class that describes an argument from a command/sub command.
+/// {@endtemplate}
 class ArgumentDescriber {
   const ArgumentDescriber({
     required this.name,
     required this.description,
   });
 
+  /// Argument name as how the user writes it.
   final String name;
+
+  /// Argument description that will be shown in the help of the command.
   final String description;
 }
 

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -1,8 +1,7 @@
-import 'dart:convert';
-
 import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/code_signer.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/extensions/file.dart';
 import 'package:shorebird_cli/src/logger.dart';

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -59,10 +59,10 @@ extension CodeSign on ArgResults {
   }
 
   void assertAbsentOrValidKeyPair() {
-    final public = wasParsed(CommonArguments.publicKeyArg.name);
-    final private = wasParsed(CommonArguments.privateKeyArg.name);
+    final publicKeyWasParsed = wasParsed(CommonArguments.publicKeyArg.name);
+    final publicKeyWasParsed = wasParsed(CommonArguments.privateKeyArg.name);
 
-    if (public == private) {
+    if (publicKeyWasParsed == publicKeyWasParsed) {
       assertAbsentOrValidPublicKey();
       assertAbsentOrValidPrivateKey();
     } else {

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -51,16 +51,16 @@ extension CodeSign on ArgResults {
   /// Asserts that either there is no public key argument
   /// or that the path received exists.
   void assertAbsentOrValidPublicKey() {
-    file(CommonArguments.publicKeyArgName)?.assertExists();
+    file(CommonArguments.publicKeyArg.name)?.assertExists();
   }
 
   void assertAbsentOrValidPrivateKey() {
-    file(CommonArguments.privateKeyArgName)?.assertExists();
+    file(CommonArguments.privateKeyArg.name)?.assertExists();
   }
 
   void assertAbsentOrValidKeyPair() {
-    final public = wasParsed(CommonArguments.publicKeyArgName);
-    final private = wasParsed(CommonArguments.privateKeyArgName);
+    final public = wasParsed(CommonArguments.publicKeyArg.name);
+    final private = wasParsed(CommonArguments.privateKeyArg.name);
 
     if (public == private) {
       assertAbsentOrValidPublicKey();
@@ -73,7 +73,7 @@ extension CodeSign on ArgResults {
 
   /// Read the public key file and encode it to base64 if any.
   String? get encodedPublicKey {
-    final publicKeyFile = file(CommonArguments.publicKeyArgName);
+    final publicKeyFile = file(CommonArguments.publicKeyArg.name);
 
     return publicKeyFile != null
         ? codeSigner.base64PublicKey(publicKeyFile)

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -60,9 +60,9 @@ extension CodeSign on ArgResults {
 
   void assertAbsentOrValidKeyPair() {
     final publicKeyWasParsed = wasParsed(CommonArguments.publicKeyArg.name);
-    final publicKeyWasParsed = wasParsed(CommonArguments.privateKeyArg.name);
+    final privateKeyWasParsed = wasParsed(CommonArguments.privateKeyArg.name);
 
-    if (publicKeyWasParsed == publicKeyWasParsed) {
+    if (publicKeyWasParsed == privateKeyWasParsed) {
       assertAbsentOrValidPublicKey();
       assertAbsentOrValidPrivateKey();
     } else {

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -54,10 +54,14 @@ extension CodeSign on ArgResults {
     file(CommonArguments.publicKeyArg.name)?.assertExists();
   }
 
+  /// Asserts that either there is no private key argument
+  /// or that the path received exists.
   void assertAbsentOrValidPrivateKey() {
     file(CommonArguments.privateKeyArg.name)?.assertExists();
   }
 
+  /// Asserts that both public and private keys are either absent or
+  /// when provided, that both of them are pointing to existing files.
   void assertAbsentOrValidKeyPair() {
     final publicKeyWasParsed = wasParsed(CommonArguments.publicKeyArg.name);
     final privateKeyWasParsed = wasParsed(CommonArguments.privateKeyArg.name);

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -1,10 +1,13 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:collection/collection.dart';
+import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/extensions/file.dart';
+import 'package:shorebird_cli/src/logger.dart';
+
+import 'package:shorebird_cli/src/third_party/flutter_tools/lib/src/base/io.dart';
 
 extension OptionFinder on ArgResults {
   /// // Detects flags even when passed to underlying commands via a `--`
@@ -50,6 +53,23 @@ extension CodeSign on ArgResults {
   /// or that the path received exists.
   void assertAbsentOrValidPublicKey() {
     file(CommonArguments.publicKeyArgName)?.assertExists();
+  }
+
+  void assertAbsentOrValidPrivateKey() {
+    file(CommonArguments.privateKeyArgName)?.assertExists();
+  }
+
+  void assertAbsentOrValidKeyPair() {
+    final public = wasParsed(CommonArguments.publicKeyArgName);
+    final private = wasParsed(CommonArguments.privateKeyArgName);
+
+    if (public == private) {
+      assertAbsentOrValidPublicKey();
+      assertAbsentOrValidPrivateKey();
+    } else {
+      logger.err('Both public and private keys must be provided or absent.');
+      exit(ExitCode.usage.code);
+    }
   }
 
   /// Read the public key file and encode it to base64 if any.

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -414,6 +414,11 @@ Looked in:
         });
 
         group('when the key pair is provided', () {
+          setUp(() {
+            when(() => codeSigner.base64PublicKey(any()))
+                .thenReturn('public_key_encoded');
+          });
+
           test('calls the buildIpa passing the key', () async {
             when(() => argResults.wasParsed(CommonArguments.publicKeyArgName))
                 .thenReturn(true);
@@ -434,7 +439,7 @@ Looked in:
                 args: any(named: 'args'),
                 flavor: any(named: 'flavor'),
                 target: any(named: 'target'),
-                base64PublicKey: base64Encode(utf8.encode('public_key')),
+                base64PublicKey: 'public_key_encoded',
               ),
             ).called(1);
           });

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -141,10 +141,10 @@ void main() {
       shorebirdAndroidArtifacts = MockShorebirdAndroidArtifacts();
 
       when(() => argResults.rest).thenReturn([]);
-      when(() => argResults.wasParsed(CommonArguments.publicKeyArgName))
+      when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
           .thenReturn(false);
 
-      when(() => argResults.wasParsed(CommonArguments.privateKeyArgName))
+      when(() => argResults.wasParsed(CommonArguments.privateKeyArg.name))
           .thenReturn(false);
 
       when(() => logger.progress(any())).thenReturn(progress);
@@ -187,13 +187,13 @@ void main() {
         () {
           test('is valid', () async {
             when(
-              () => argResults.wasParsed(CommonArguments.privateKeyArgName),
+              () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
             ).thenReturn(true);
-            when(() => argResults.wasParsed(CommonArguments.publicKeyArgName))
+            when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
                 .thenReturn(true);
-            when(() => argResults[CommonArguments.privateKeyArgName])
+            when(() => argResults[CommonArguments.privateKeyArg.name])
                 .thenReturn(createFakeKey('private.pem').path);
-            when(() => argResults[CommonArguments.publicKeyArgName])
+            when(() => argResults[CommonArguments.publicKeyArg.name])
                 .thenReturn(createFakeKey('public.pem').path);
 
             expect(
@@ -209,11 +209,11 @@ void main() {
         () {
           test('fails and logs the err', () async {
             when(
-              () => argResults.wasParsed(CommonArguments.privateKeyArgName),
+              () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
             ).thenReturn(true);
-            when(() => argResults.wasParsed(CommonArguments.publicKeyArgName))
+            when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
                 .thenReturn(false);
-            when(() => argResults[CommonArguments.privateKeyArgName])
+            when(() => argResults[CommonArguments.privateKeyArg.name])
                 .thenReturn(createFakeKey('private.pem').path);
 
             await expectLater(
@@ -234,11 +234,11 @@ void main() {
         () {
           test('fails and logs the err', () async {
             when(
-              () => argResults.wasParsed(CommonArguments.privateKeyArgName),
+              () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
             ).thenReturn(false);
-            when(() => argResults.wasParsed(CommonArguments.publicKeyArgName))
+            when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
                 .thenReturn(true);
-            when(() => argResults[CommonArguments.publicKeyArgName])
+            when(() => argResults[CommonArguments.publicKeyArg.name])
                 .thenReturn(createFakeKey('public.pem').path);
 
             await expectLater(
@@ -418,15 +418,15 @@ Looked in:
           });
 
           test('calls the buildIpa passing the key', () async {
-            when(() => argResults.wasParsed(CommonArguments.publicKeyArgName))
+            when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
                 .thenReturn(true);
 
             final key = createFakeKey('public.der')
               ..writeAsStringSync('public_key');
 
-            when(() => argResults[CommonArguments.publicKeyArgName])
+            when(() => argResults[CommonArguments.publicKeyArg.name])
                 .thenReturn(key.path);
-            when(() => argResults[CommonArguments.publicKeyArgName])
+            when(() => argResults[CommonArguments.publicKeyArg.name])
                 .thenReturn(key.path);
             await runWithOverrides(
               patcher.buildPatchArtifact,
@@ -591,7 +591,7 @@ Looked in:
               ),
             )..createSync();
 
-            when(() => argResults[CommonArguments.privateKeyArgName])
+            when(() => argResults[CommonArguments.privateKeyArg.name])
                 .thenReturn(privateKey.path);
 
             when(

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -183,7 +183,7 @@ void main() {
       });
 
       group(
-        'when the private key is provided, it exists, so does the public',
+        'when given existing private and public key files',
         () {
           test('is valid', () async {
             when(
@@ -205,9 +205,9 @@ void main() {
       );
 
       group(
-        'when the private key is provided, it exists, but not the public',
+        'when given an existing private key and nonexistent public key',
         () {
-          test('fails and logs the err', () async {
+          test('logs error and exits with usage code', () async {
             when(
               () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
             ).thenReturn(true);
@@ -230,7 +230,7 @@ void main() {
       );
 
       group(
-        'when the public key is provided, it exists, but not the private',
+        'when given an existing public key and nonexistent private key',
         () {
           test('fails and logs the err', () async {
             when(
@@ -417,7 +417,7 @@ Looked in:
                 .thenReturn('public_key_encoded');
           });
 
-          test('calls the buildIpa passing the key', () async {
+          test('calls buildIpa with the provided key', () async {
             when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
                 .thenReturn(true);
 

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -29,6 +29,7 @@ import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
 
+import '../../helpers.dart';
 import '../../matchers.dart';
 import '../../mocks.dart';
 
@@ -113,15 +114,6 @@ void main() {
 
     tearDownAll(restoreExitFunction);
 
-    File createFakeKey(String name) {
-      return File(
-        p.join(
-          Directory.systemTemp.createTempSync().path,
-          name,
-        ),
-      )..createSync();
-    }
-
     setUp(() {
       argResults = MockArgResults();
       artifactBuilder = MockArtifactBuilder();
@@ -192,9 +184,9 @@ void main() {
             when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
                 .thenReturn(true);
             when(() => argResults[CommonArguments.privateKeyArg.name])
-                .thenReturn(createFakeKey('private.pem').path);
+                .thenReturn(createTempFile('private.pem').path);
             when(() => argResults[CommonArguments.publicKeyArg.name])
-                .thenReturn(createFakeKey('public.pem').path);
+                .thenReturn(createTempFile('public.pem').path);
 
             expect(
               runWithOverrides(patcher.assertArgsAreValid),
@@ -214,7 +206,7 @@ void main() {
             when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
                 .thenReturn(false);
             when(() => argResults[CommonArguments.privateKeyArg.name])
-                .thenReturn(createFakeKey('private.pem').path);
+                .thenReturn(createTempFile('private.pem').path);
 
             await expectLater(
               () => runWithOverrides(patcher.assertArgsAreValid),
@@ -239,7 +231,7 @@ void main() {
             when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
                 .thenReturn(true);
             when(() => argResults[CommonArguments.publicKeyArg.name])
-                .thenReturn(createFakeKey('public.pem').path);
+                .thenReturn(createTempFile('public.pem').path);
 
             await expectLater(
               () => runWithOverrides(patcher.assertArgsAreValid),
@@ -421,7 +413,7 @@ Looked in:
             when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
                 .thenReturn(true);
 
-            final key = createFakeKey('public.der')
+            final key = createTempFile('public.der')
               ..writeAsStringSync('public_key');
 
             when(() => argResults[CommonArguments.publicKeyArg.name])

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:args/args.dart';
 import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -133,11 +133,6 @@ void main() {
       shorebirdAndroidArtifacts = MockShorebirdAndroidArtifacts();
 
       when(() => argResults.rest).thenReturn([]);
-      when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
-          .thenReturn(false);
-
-      when(() => argResults.wasParsed(CommonArguments.privateKeyArg.name))
-          .thenReturn(false);
 
       when(() => logger.progress(any())).thenReturn(progress);
 
@@ -162,89 +157,6 @@ void main() {
       test('is "aab"', () {
         expect(patcher.primaryReleaseArtifactArch, equals('aab'));
       });
-    });
-
-    group('assertArgsAreValid', () {
-      group('when no key pair is provided', () {
-        test('is valid', () {
-          expect(
-            runWithOverrides(patcher.assertArgsAreValid),
-            completes,
-          );
-        });
-      });
-
-      group(
-        'when given existing private and public key files',
-        () {
-          test('is valid', () async {
-            when(
-              () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
-            ).thenReturn(true);
-            when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
-                .thenReturn(true);
-            when(() => argResults[CommonArguments.privateKeyArg.name])
-                .thenReturn(createTempFile('private.pem').path);
-            when(() => argResults[CommonArguments.publicKeyArg.name])
-                .thenReturn(createTempFile('public.pem').path);
-
-            expect(
-              runWithOverrides(patcher.assertArgsAreValid),
-              completes,
-            );
-          });
-        },
-      );
-
-      group(
-        'when given an existing private key and nonexistent public key',
-        () {
-          test('logs error and exits with usage code', () async {
-            when(
-              () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
-            ).thenReturn(true);
-            when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
-                .thenReturn(false);
-            when(() => argResults[CommonArguments.privateKeyArg.name])
-                .thenReturn(createTempFile('private.pem').path);
-
-            await expectLater(
-              () => runWithOverrides(patcher.assertArgsAreValid),
-              exitsWithCode(ExitCode.usage),
-            );
-            verify(
-              () => logger.err(
-                'Both public and private keys must be provided or absent.',
-              ),
-            ).called(1);
-          });
-        },
-      );
-
-      group(
-        'when given an existing public key and nonexistent private key',
-        () {
-          test('fails and logs the err', () async {
-            when(
-              () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
-            ).thenReturn(false);
-            when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
-                .thenReturn(true);
-            when(() => argResults[CommonArguments.publicKeyArg.name])
-                .thenReturn(createTempFile('public.pem').path);
-
-            await expectLater(
-              () => runWithOverrides(patcher.assertArgsAreValid),
-              exitsWithCode(ExitCode.usage),
-            );
-            verify(
-              () => logger.err(
-                'Both public and private keys must be provided or absent.',
-              ),
-            ).called(1);
-          });
-        },
-      );
     });
 
     group('assertPreconditions', () {

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -9,6 +9,7 @@ import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/patch/patch.dart';
+import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/executables/aot_tools.dart';
@@ -115,6 +116,10 @@ void main() {
 
         when(() => argResults['build-number']).thenReturn('1.0');
         when(() => argResults.rest).thenReturn([]);
+        when(() => argResults.wasParsed(CommonArguments.privateKeyArg.name))
+            .thenReturn(false);
+        when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
+            .thenReturn(false);
 
         when(() => logger.progress(any())).thenReturn(progress);
 

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -126,17 +126,6 @@ void main() {
 
         when(() => argResults['build-number']).thenReturn('1.0');
         when(() => argResults.rest).thenReturn([]);
-        when(
-          () => argResults.wasParsed(
-            CommonArguments.privateKeyArg.name,
-          ),
-        ).thenReturn(false);
-
-        when(
-          () => argResults.wasParsed(
-            CommonArguments.publicKeyArg.name,
-          ),
-        ).thenReturn(false);
 
         when(() => logger.progress(any())).thenReturn(progress);
 
@@ -152,92 +141,6 @@ void main() {
           argResults: argResults,
           flavor: null,
           target: null,
-        );
-      });
-
-      group('assertArgsAreValid', () {
-        group('when no key pair is provided', () {
-          test('is valid', () {
-            expect(
-              runWithOverrides(patcher.assertArgsAreValid),
-              completes,
-            );
-          });
-        });
-
-        group(
-          'when the private key is provided, it exists, so does the public',
-          () {
-            test('is valid', () async {
-              when(
-                () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
-              ).thenReturn(true);
-              when(
-                () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
-              ).thenReturn(true);
-              when(() => argResults[CommonArguments.privateKeyArg.name])
-                  .thenReturn(createTempFile('private.pem').path);
-              when(() => argResults[CommonArguments.publicKeyArg.name])
-                  .thenReturn(createTempFile('public.pem').path);
-
-              expect(
-                runWithOverrides(patcher.assertArgsAreValid),
-                completes,
-              );
-            });
-          },
-        );
-
-        group(
-          'when the private key is provided, it exists, but not the public',
-          () {
-            test('fails and logs the err', () async {
-              when(
-                () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
-              ).thenReturn(true);
-              when(
-                () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
-              ).thenReturn(false);
-              when(() => argResults[CommonArguments.privateKeyArg.name])
-                  .thenReturn(createTempFile('private.pem').path);
-
-              await expectLater(
-                () => runWithOverrides(patcher.assertArgsAreValid),
-                exitsWithCode(ExitCode.usage),
-              );
-              verify(
-                () => logger.err(
-                  'Both public and private keys must be provided or absent.',
-                ),
-              ).called(1);
-            });
-          },
-        );
-
-        group(
-          'when the public key is provided, it exists, but not the private',
-          () {
-            test('fails and logs the err', () async {
-              when(
-                () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
-              ).thenReturn(false);
-              when(
-                () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
-              ).thenReturn(true);
-              when(() => argResults[CommonArguments.publicKeyArg.name])
-                  .thenReturn(createTempFile('public.pem').path);
-
-              await expectLater(
-                () => runWithOverrides(patcher.assertArgsAreValid),
-                exitsWithCode(ExitCode.usage),
-              );
-              verify(
-                () => logger.err(
-                  'Both public and private keys must be provided or absent.',
-                ),
-              ).called(1);
-            });
-          },
         );
       });
 

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -136,13 +136,13 @@ void main() {
         when(() => argResults.rest).thenReturn([]);
         when(
           () => argResults.wasParsed(
-            CommonArguments.privateKeyArgName,
+            CommonArguments.privateKeyArg.name,
           ),
         ).thenReturn(false);
 
         when(
           () => argResults.wasParsed(
-            CommonArguments.publicKeyArgName,
+            CommonArguments.publicKeyArg.name,
           ),
         ).thenReturn(false);
 
@@ -178,13 +178,14 @@ void main() {
           () {
             test('is valid', () async {
               when(
-                () => argResults.wasParsed(CommonArguments.privateKeyArgName),
+                () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
               ).thenReturn(true);
-              when(() => argResults.wasParsed(CommonArguments.publicKeyArgName))
-                  .thenReturn(true);
-              when(() => argResults[CommonArguments.privateKeyArgName])
+              when(
+                () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
+              ).thenReturn(true);
+              when(() => argResults[CommonArguments.privateKeyArg.name])
                   .thenReturn(createFakeKey('private.pem').path);
-              when(() => argResults[CommonArguments.publicKeyArgName])
+              when(() => argResults[CommonArguments.publicKeyArg.name])
                   .thenReturn(createFakeKey('public.pem').path);
 
               expect(
@@ -200,11 +201,12 @@ void main() {
           () {
             test('fails and logs the err', () async {
               when(
-                () => argResults.wasParsed(CommonArguments.privateKeyArgName),
+                () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
               ).thenReturn(true);
-              when(() => argResults.wasParsed(CommonArguments.publicKeyArgName))
-                  .thenReturn(false);
-              when(() => argResults[CommonArguments.privateKeyArgName])
+              when(
+                () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
+              ).thenReturn(false);
+              when(() => argResults[CommonArguments.privateKeyArg.name])
                   .thenReturn(createFakeKey('private.pem').path);
 
               await expectLater(
@@ -225,11 +227,12 @@ void main() {
           () {
             test('fails and logs the err', () async {
               when(
-                () => argResults.wasParsed(CommonArguments.privateKeyArgName),
+                () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
               ).thenReturn(false);
-              when(() => argResults.wasParsed(CommonArguments.publicKeyArgName))
-                  .thenReturn(true);
-              when(() => argResults[CommonArguments.publicKeyArgName])
+              when(
+                () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
+              ).thenReturn(true);
+              when(() => argResults[CommonArguments.publicKeyArg.name])
                   .thenReturn(createFakeKey('public.pem').path);
 
               await expectLater(
@@ -541,15 +544,16 @@ void main() {
             });
 
             test('calls the buildIpa passing the key', () async {
-              when(() => argResults.wasParsed(CommonArguments.publicKeyArgName))
-                  .thenReturn(true);
+              when(
+                () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
+              ).thenReturn(true);
 
               final key = createFakeKey('public.der')
                 ..writeAsStringSync('public_key');
 
-              when(() => argResults[CommonArguments.publicKeyArgName])
+              when(() => argResults[CommonArguments.publicKeyArg.name])
                   .thenReturn(key.path);
-              when(() => argResults[CommonArguments.publicKeyArgName])
+              when(() => argResults[CommonArguments.publicKeyArg.name])
                   .thenReturn(key.path);
               await runWithOverrides(
                 patcher.buildPatchArtifact,
@@ -1082,7 +1086,7 @@ void main() {
                     ),
                   )..createSync();
 
-                  when(() => argResults[CommonArguments.privateKeyArgName])
+                  when(() => argResults[CommonArguments.privateKeyArg.name])
                       .thenReturn(privateKey.path);
 
                   when(

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -443,7 +443,7 @@ void main() {
                 () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
               ).thenReturn(true);
 
-              final key = createTempFile('public.der')
+              final key = createTempFile('public.pem')
                 ..writeAsStringSync('public_key');
 
               when(() => argResults[CommonArguments.publicKeyArg.name])

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -537,6 +537,11 @@ void main() {
           });
 
           group('when the key pair is provided', () {
+            setUp(() {
+              when(() => codeSigner.base64PublicKey(any()))
+                  .thenReturn('public_key_encoded');
+            });
+
             test('calls the buildIpa passing the key', () async {
               when(() => argResults.wasParsed(CommonArguments.publicKeyArgName))
                   .thenReturn(true);
@@ -559,7 +564,7 @@ void main() {
                   args: any(named: 'args'),
                   flavor: any(named: 'flavor'),
                   target: any(named: 'target'),
-                  base64PublicKey: base64Encode(utf8.encode('public_key')),
+                  base64PublicKey: 'public_key_encoded',
                 ),
               ).called(1);
             });

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -33,6 +33,7 @@ import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
 
 import '../../fakes.dart';
+import '../../helpers.dart';
 import '../../matchers.dart';
 import '../../mocks.dart';
 
@@ -99,15 +100,6 @@ void main() {
       });
 
       tearDownAll(restoreExitFunction);
-
-      File createFakeKey(String name) {
-        return File(
-          p.join(
-            Directory.systemTemp.createTempSync().path,
-            name,
-          ),
-        )..createSync();
-      }
 
       setUp(() {
         aotTools = MockAotTools();
@@ -184,9 +176,9 @@ void main() {
                 () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
               ).thenReturn(true);
               when(() => argResults[CommonArguments.privateKeyArg.name])
-                  .thenReturn(createFakeKey('private.pem').path);
+                  .thenReturn(createTempFile('private.pem').path);
               when(() => argResults[CommonArguments.publicKeyArg.name])
-                  .thenReturn(createFakeKey('public.pem').path);
+                  .thenReturn(createTempFile('public.pem').path);
 
               expect(
                 runWithOverrides(patcher.assertArgsAreValid),
@@ -207,7 +199,7 @@ void main() {
                 () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
               ).thenReturn(false);
               when(() => argResults[CommonArguments.privateKeyArg.name])
-                  .thenReturn(createFakeKey('private.pem').path);
+                  .thenReturn(createTempFile('private.pem').path);
 
               await expectLater(
                 () => runWithOverrides(patcher.assertArgsAreValid),
@@ -233,7 +225,7 @@ void main() {
                 () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
               ).thenReturn(true);
               when(() => argResults[CommonArguments.publicKeyArg.name])
-                  .thenReturn(createFakeKey('public.pem').path);
+                  .thenReturn(createTempFile('public.pem').path);
 
               await expectLater(
                 () => runWithOverrides(patcher.assertArgsAreValid),
@@ -548,7 +540,7 @@ void main() {
                 () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
               ).thenReturn(true);
 
-              final key = createFakeKey('public.der')
+              final key = createTempFile('public.der')
                 ..writeAsStringSync('public_key');
 
               when(() => argResults[CommonArguments.publicKeyArg.name])

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';

--- a/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';

--- a/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
@@ -1,14 +1,23 @@
 import 'dart:io';
 
+import 'package:args/args.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
+import 'package:shorebird_cli/src/common_arguments.dart';
+import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
+import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_protocol/src/models/create_patch_metadata.dart';
 import 'package:test/test.dart';
 
+import '../../helpers.dart';
+import '../../matchers.dart';
 import '../../mocks.dart';
 
 void main() {
@@ -24,6 +33,119 @@ void main() {
           isNull,
         );
       });
+    });
+
+    group('assertArgsAreValid', () {
+      late _TestPatcher patcher;
+      late ArgResults argResults;
+      late ShorebirdLogger logger;
+
+      R runWithOverrides<R>(R Function() body) {
+        return runScoped(
+          body,
+          values: {
+            loggerRef.overrideWith(() => logger),
+          },
+        );
+      }
+
+      setUp(() {
+        setExitFunctionForTests();
+        argResults = MockArgResults();
+        logger = MockShorebirdLogger();
+        patcher = _TestPatcher(
+          argResults: argResults,
+          flavor: null,
+          target: null,
+        );
+
+        when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
+            .thenReturn(false);
+
+        when(() => argResults.wasParsed(CommonArguments.privateKeyArg.name))
+            .thenReturn(false);
+      });
+
+      group('when no key pair is provided', () {
+        test('is valid', () {
+          expect(
+            runWithOverrides(patcher.assertArgsAreValid),
+            completes,
+          );
+        });
+      });
+
+      group(
+        'when given existing private and public key files',
+        () {
+          test('is valid', () async {
+            when(
+              () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
+            ).thenReturn(true);
+            when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
+                .thenReturn(true);
+            when(() => argResults[CommonArguments.privateKeyArg.name])
+                .thenReturn(createTempFile('private.pem').path);
+            when(() => argResults[CommonArguments.publicKeyArg.name])
+                .thenReturn(createTempFile('public.pem').path);
+
+            expect(
+              runWithOverrides(patcher.assertArgsAreValid),
+              completes,
+            );
+          });
+        },
+      );
+
+      group(
+        'when given an existing private key and nonexistent public key',
+        () {
+          test('logs error and exits with usage code', () async {
+            when(
+              () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
+            ).thenReturn(true);
+            when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
+                .thenReturn(false);
+            when(() => argResults[CommonArguments.privateKeyArg.name])
+                .thenReturn(createTempFile('private.pem').path);
+
+            await expectLater(
+              () => runWithOverrides(patcher.assertArgsAreValid),
+              exitsWithCode(ExitCode.usage),
+            );
+            verify(
+              () => logger.err(
+                'Both public and private keys must be provided or absent.',
+              ),
+            ).called(1);
+          });
+        },
+      );
+
+      group(
+        'when given an existing public key and nonexistent private key',
+        () {
+          test('fails and logs the err', () async {
+            when(
+              () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
+            ).thenReturn(false);
+            when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
+                .thenReturn(true);
+            when(() => argResults[CommonArguments.publicKeyArg.name])
+                .thenReturn(createTempFile('public.pem').path);
+
+            await expectLater(
+              () => runWithOverrides(patcher.assertArgsAreValid),
+              exitsWithCode(ExitCode.usage),
+            );
+            verify(
+              () => logger.err(
+                'Both public and private keys must be provided or absent.',
+              ),
+            ).called(1);
+          });
+        },
+      );
     });
   });
 }

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -227,7 +227,7 @@ void main() {
               'public-key.pem',
             ),
           )..writeAsStringSync('public key');
-          when(() => argResults[CommonArguments.publicKeyArgName])
+          when(() => argResults[CommonArguments.publicKeyArg.name])
               .thenReturn(publicKeyFile.path);
         });
 
@@ -242,7 +242,7 @@ void main() {
       group('when a public key is provided but does not exist', () {
         setUp(() {
           when(() => argResults['artifact']).thenReturn('apk');
-          when(() => argResults[CommonArguments.publicKeyArgName])
+          when(() => argResults[CommonArguments.publicKeyArg.name])
               .thenReturn('non-existing-key.pem');
         });
 
@@ -434,7 +434,7 @@ void main() {
               'patch-signing-public-key.pem',
             ),
           )..createSync(recursive: true);
-          when(() => argResults[CommonArguments.publicKeyArgName])
+          when(() => argResults[CommonArguments.publicKeyArg.name])
               .thenReturn(patchSigningPublicKeyFile.path);
 
           when(

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -258,7 +258,7 @@ void main() {
                 'public-key.pem',
               ),
             )..writeAsStringSync('public key');
-            when(() => argResults[CommonArguments.publicKeyArgName])
+            when(() => argResults[CommonArguments.publicKeyArg.name])
                 .thenReturn(publicKeyFile.path);
           });
 
@@ -272,7 +272,7 @@ void main() {
 
         group('when the provided public key is a nonexistent file', () {
           setUp(() {
-            when(() => argResults[CommonArguments.publicKeyArgName])
+            when(() => argResults[CommonArguments.publicKeyArg.name])
                 .thenReturn('non-existing-key.pem');
           });
 
@@ -339,7 +339,7 @@ void main() {
                 'patch-signing-public-key.pem',
               ),
             )..createSync(recursive: true);
-            when(() => argResults[CommonArguments.publicKeyArgName])
+            when(() => argResults[CommonArguments.publicKeyArg.name])
                 .thenReturn(patchSigningPublicKeyFile.path);
 
             when(

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -501,7 +501,7 @@ $exception''',
               keyName,
             ),
           )..writeAsStringSync('KEY');
-          when(() => argResults[CommonArguments.publicKeyArgName])
+          when(() => argResults[CommonArguments.publicKeyArg.name])
               .thenReturn(file.path);
         });
 

--- a/packages/shorebird_cli/test/src/helpers.dart
+++ b/packages/shorebird_cli/test/src/helpers.dart
@@ -1,0 +1,11 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+File createTempFile(String name) {
+  return File(
+    p.join(
+      Directory.systemTemp.createTempSync().path,
+      name,
+    ),
+  )..createSync();
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Makes the patch command receive both the private and public key when signing a patch.

DRAFT note: Still need some local test to do
 - Android seems to be working!

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
