### PR TITLE
fix(shorebird_cli): don't fail validation when flutter versions differ

### DIFF
--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -17,7 +17,13 @@ class FlutterValidationException implements Exception {
 
 class CommandNotFoundException implements Exception {}
 
+/// {@template shorebird_flutter_validator}
+/// Compares the version of Flutter that Shorebird includes with the version
+/// of Flutter on the user's path. Will error if no system Flutter is found, and
+/// will warn if major or minor versions differ.
+/// {@endtemplate}
 class ShorebirdFlutterValidator extends Validator {
+  /// {@macro shorebird_flutter_validator}
   ShorebirdFlutterValidator();
 
   @override
@@ -28,8 +34,8 @@ class ShorebirdFlutterValidator extends Validator {
     final issues = <ValidationIssue>[];
 
     if (!shorebirdEnv.flutterDirectory.existsSync()) {
-      final message = 'No Flutter directory found at '
-          '${shorebirdEnv.flutterDirectory}';
+      final message =
+          'No Flutter directory found at ${shorebirdEnv.flutterDirectory}';
       issues.add(
         ValidationIssue(
           severity: ValidationIssueSeverity.error,
@@ -42,8 +48,7 @@ class ShorebirdFlutterValidator extends Validator {
       issues.add(
         ValidationIssue(
           severity: ValidationIssueSeverity.warning,
-          message: '${shorebirdEnv.flutterDirectory} has local '
-              'modifications',
+          message: '${shorebirdEnv.flutterDirectory} has local modifications',
         ),
       );
     }

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -545,10 +545,10 @@ packages:
     dependency: "direct main"
     description:
       name: pubspec_parse
-      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.3.0"
   rfc_6901:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/test/src/doctor_test.dart
+++ b/packages/shorebird_cli/test/src/doctor_test.dart
@@ -89,6 +89,28 @@ void main() {
         ).called(1);
       });
 
+      group('when validators only yield warnings', () {
+        test('completes validator progress as success', () async {
+          await runWithOverrides(
+            () => doctor.runValidators([warningValidator]),
+          );
+
+          verify(() => progress.complete(any())).called(1);
+          verifyNever(() => progress.fail(any()));
+        });
+      });
+
+      group('when validators yield errors', () {
+        test('completes validator progress as failure', () async {
+          await runWithOverrides(
+            () => doctor.runValidators([errorValidator]),
+          );
+
+          verify(() => progress.fail(any())).called(1);
+          verifyNever(() => progress.complete(any()));
+        });
+      });
+
       test('only runs validators that can run in the current context',
           () async {
         final validators = [


### PR DESCRIPTION
## Description

Updates `shorebird doctor` output to only treat errors as validation failures (validators that return only warnings are now treated as successful).

Before
![Screenshot 2024-05-29 at 2 47 25 PM](https://github.com/shorebirdtech/shorebird/assets/581764/f7df1228-1ef3-425c-a846-407b0ce577cf)

After
![Screenshot 2024-05-29 at 2 47 01 PM](https://github.com/shorebirdtech/shorebird/assets/581764/72308b49-0e9b-4d66-b290-556936ab4df7)

Fixes https://github.com/shorebirdtech/shorebird/issues/2136

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
