### PR TITLE
feat: adding better debugging logging for aot tools link

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -311,7 +311,7 @@ class IosPatcher extends Patcher {
 
       if (dumpDebugInfoDir != null) {
         logger.detail(
-          '''Dumping link debug info to temporary location: ${dumpDebugInfoDir.path}''',
+          '''Dumping link debug info to ${dumpDebugInfoDir.path}''',
         );
       }
 
@@ -330,7 +330,7 @@ class IosPatcher extends Patcher {
         final debugInfoZip = await dumpDebugInfoDir.zipToTempFile();
         debugInfoZip.copySync(p.join('build', debugInfoFile.path));
         logger.detail(
-          'Temporary Link debug info saved to: ${debugInfoFile.path}',
+          'Link debug info saved to ${debugInfoFile.path}',
         );
       }
     } catch (error) {

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -311,7 +311,7 @@ class IosPatcher extends Patcher {
 
       if (dumpDebugInfoDir != null) {
         logger.detail(
-          '''Dumping link debug info to ${dumpDebugInfoDir.path}''',
+          'Dumping link debug info to ${dumpDebugInfoDir.path}',
         );
       }
 

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -309,6 +309,12 @@ class IosPatcher extends Patcher {
           ? Directory.systemTemp.createTempSync()
           : null;
 
+      if (dumpDebugInfoDir != null) {
+        logger.detail(
+          '''Dumping link debug info to temporary location: ${dumpDebugInfoDir.path}''',
+        );
+      }
+
       linkPercentage = await aotTools.link(
         base: releaseArtifact.path,
         patch: patch.path,
@@ -323,6 +329,9 @@ class IosPatcher extends Patcher {
       if (dumpDebugInfoDir != null) {
         final debugInfoZip = await dumpDebugInfoDir.zipToTempFile();
         debugInfoZip.copySync(p.join('build', debugInfoFile.path));
+        logger.detail(
+          'Temporary Link debug info saved to: ${debugInfoFile.path}',
+        );
       }
     } catch (error) {
       linkProgress.fail('Failed to link AOT files: $error');

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -938,6 +938,24 @@ void main() {
                       ),
                     ),
                   ).called(1);
+                  verify(
+                    () => logger.detail(
+                      any(
+                        that: contains(
+                          'Dumping link debug info to temporary location:',
+                        ),
+                      ),
+                    ),
+                  ).called(1);
+                  verify(
+                    () => logger.detail(
+                      any(
+                        that: contains(
+                          'Temporary Link debug info saved to:',
+                        ),
+                      ),
+                    ),
+                  ).called(1);
                 });
               });
 

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -942,7 +942,7 @@ void main() {
                     () => logger.detail(
                       any(
                         that: contains(
-                          'Dumping link debug info to temporary location:',
+                          'Dumping link debug info to',
                         ),
                       ),
                     ),
@@ -951,7 +951,7 @@ void main() {
                     () => logger.detail(
                       any(
                         that: contains(
-                          'Temporary Link debug info saved to:',
+                          'Link debug info saved to',
                         ),
                       ),
                     ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Shorebird CLI calls `aot_tools link`, which stores its logging data in a temporary folder.  When the `link` command finishes, the CLI will consolidate everything in that temp folder in a single zip file.

But if that command hangs, the consolidation will never happen, making it virtually impossible to recover those files.

This PR adds a debug log, which will print the path for the temporary debug info folder, which, by using the `-v` flag, will allow us to check on those debug files when we get in a situation described above.

This PR is an effort in the investigation of #2160 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
