### PR TITLE
feat(shorebird_cli): Add logs directory to verbose doctor output

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/doctor_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/doctor_command.dart
@@ -59,6 +59,7 @@ Engine • revision ${shorebirdEnv.shorebirdEngineRevision}''',
       final notDetected = red.wrap('not detected');
       output.writeln('''
 
+Logs: ${shorebirdEnv.logsDirectory.path}
 Android Toolchain
   • Android Studio: ${androidStudio.path ?? notDetected}
   • Android SDK: ${androidSdk.path ?? notDetected}

--- a/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
@@ -10,6 +10,7 @@ import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
+import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
 import 'package:shorebird_cli/src/version.dart';
 import 'package:test/test.dart';
@@ -24,6 +25,7 @@ void main() {
     late ArgResults argResults;
     late AndroidStudio androidStudio;
     late AndroidSdk androidSdk;
+    late Directory logsDirectory;
     late Doctor doctor;
     late Java java;
     late ShorebirdLogger logger;
@@ -52,6 +54,7 @@ void main() {
       androidStudio = MockAndroidStudio();
       androidSdk = MockAndroidSdk();
       doctor = MockDoctor();
+      logsDirectory = Directory.systemTemp.createTempSync('shorebird_logs');
       java = MockJava();
       logger = MockShorebirdLogger();
       shorebirdEnv = MockShorebirdEnv();
@@ -70,6 +73,7 @@ void main() {
       when(
         () => shorebirdEnv.flutterRevision,
       ).thenReturn(shorebirdFlutterRevision);
+      when(() => shorebirdEnv.logsDirectory).thenReturn(logsDirectory);
       when(() => doctor.allValidators).thenReturn([validator]);
       when(
         () => doctor.runValidators(any(), applyFixes: any(named: 'applyFixes')),
@@ -126,6 +130,7 @@ Shorebird v$packageVersion • git@github.com:shorebirdtech/shorebird.git
 Flutter • revision ${shorebirdEnv.flutterRevision}
 Engine • revision $shorebirdEngineRevision
 
+Logs: ${logsDirectory.path}
 Android Toolchain
   • Android Studio: $notDetectedText
   • Android SDK: $notDetectedText


### PR DESCRIPTION
## Description

Adds the path to the logs directory to `shorebird doctor -v` output.

Ex:

```
⑆ shorebird doctor -v
Shorebird 1.1.8 • git@github.com:shorebirdtech/shorebird.git
Flutter 3.22.1 • revision 985ec84cb99d3c60341e2c78be9826e0a88cc697
Engine • revision 0f962124273f5bdbd5732c7fd8e7dc8addd9ee7d

Logs: /Users/bryanoltman/Library/Application Support/shorebird/logs
Android Toolchain
  • Android Studio: /Applications/Android Studio.app/Contents
  • Android SDK: /Users/bryanoltman/Library/Android/sdk
  • ADB: /Users/bryanoltman/Library/Android/sdk/platform-tools/adb
  • JAVA_HOME: /Applications/Android Studio.app/Contents/jbr/Contents/Home

✓ Shorebird is up-to-date (1.2s)
✓ Flutter install is correct (0.3s)
✓ AndroidManifest.xml files contain INTERNET permission (28ms)
✓ Has access to storage.googleapis.com (0.1s)
✓ shorebird.yaml found in pubspec.yaml assets (3ms)

No issues detected!
```

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
