### PR TITLE
fix(shorebird_cli): add export-method option to patch command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -79,9 +79,18 @@ of the iOS app that is using this module.''',
         help: 'Whether to publish the patch to the staging environment.',
       )
       ..addOption(
-        exportOptionsPlistArgName,
-        help:
-            '''Export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys (iOS only).''',
+        CommonArguments.exportOptionsPlistArg.name,
+        help: CommonArguments.exportOptionsPlistArg.description,
+      )
+      ..addOption(
+        CommonArguments.exportMethodArg.name,
+        defaultsTo: ExportMethod.appStore.argName,
+        allowed: ExportMethod.values.map((e) => e.argName),
+        help: CommonArguments.exportMethodArg.description,
+        allowedHelp: {
+          for (final method in ExportMethod.values)
+            method.argName: method.description,
+        },
       )
       ..addFlag(
         'codesign',

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -60,15 +60,14 @@ On Xcode builds it is used as "CFBundleVersion".''',
         help: 'Validate but do not upload the release.',
       )
       ..addOption(
-        exportOptionsPlistArgName,
-        help:
-            '''Export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys (iOS only).''',
+        CommonArguments.exportOptionsPlistArg.name,
+        help: CommonArguments.exportOptionsPlistArg.description,
       )
       ..addOption(
-        exportMethodArgName,
+        CommonArguments.exportMethodArg.name,
         defaultsTo: ExportMethod.appStore.argName,
         allowed: ExportMethod.values.map((e) => e.argName),
-        help: 'Specify how the IPA will be distributed.',
+        help: CommonArguments.exportMethodArg.description,
         allowedHelp: {
           for (final method in ExportMethod.values)
             method.argName: method.description,

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -1,3 +1,5 @@
+import 'package:shorebird_cli/src/platform/ios.dart';
+
 /// {@template argument_describer}
 /// A class that describes an argument from a command/sub command.
 /// {@endtemplate}
@@ -17,6 +19,20 @@ class ArgumentDescriber {
 /// A class that houses the name of arguments that are shared between different
 /// commands and layers.
 class CommonArguments {
+  /// A multioption argument that allows the user to specify an [ExportMethod].
+  static const exportMethodArg = ArgumentDescriber(
+    name: 'export-method',
+    description: 'Specify how the IPA will be distributed (iOS only).',
+  );
+
+  /// An iOS-specific argument that allows the user to provide an export options
+  /// plist, which is used by Xcode when packaging an IPA.
+  static const exportOptionsPlistArg = ArgumentDescriber(
+    name: 'export-options-plist',
+    description:
+        '''Export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys (iOS only).''',
+  );
+
   static const publicKeyArg = ArgumentDescriber(
     name: 'public-key-path',
     description: '''

--- a/packages/shorebird_cli/lib/src/executables/gradlew.dart
+++ b/packages/shorebird_cli/lib/src/executables/gradlew.dart
@@ -93,8 +93,10 @@ class Gradlew {
       if (match != null) {
         final variant = match.group(1)!;
         if (!variant.toLowerCase().endsWith('test')) {
-          // Gradle flavor name transformation seems to work with the following rules:
-          //  - If the flavor starts with at least two capital letters, use as is
+          // Gradle flavor name transformation seems to work with the following
+          // rules:
+          //  - If the flavor starts with at least two capital letters, use
+          //    as-is
           //  - Otherwise, transform to camel case
           //
           // Example:

--- a/packages/shorebird_cli/lib/src/platform/ios.dart
+++ b/packages/shorebird_cli/lib/src/platform/ios.dart
@@ -5,9 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
-
-const exportMethodArgName = 'export-method';
-const exportOptionsPlistArgName = 'export-options-plist';
+import 'package:shorebird_cli/src/common_arguments.dart';
 
 /// {@template export_method}
 /// The method used to export the IPA.
@@ -64,13 +62,15 @@ Ios get ios => read(iosRef);
 
 class Ios {
   File exportOptionsPlistFromArgs(ArgResults results) {
-    final exportPlistArg = results[exportOptionsPlistArgName] as String?;
-    final exportMethodArgExists = results.options.contains(exportMethodArgName);
+    final exportPlistArg =
+        results[CommonArguments.exportOptionsPlistArg.name] as String?;
+    final exportMethodArgExists =
+        results.options.contains(CommonArguments.exportMethodArg.name);
     if (exportPlistArg != null &&
         exportMethodArgExists &&
-        results.wasParsed(exportMethodArgName)) {
+        results.wasParsed(CommonArguments.exportMethodArg.name)) {
       throw ArgumentError(
-        '''Cannot specify both --$exportMethodArgName and --$exportOptionsPlistArgName.''',
+        '''Cannot specify both --${CommonArguments.exportMethodArg.name} and --${CommonArguments.exportOptionsPlistArg.name}.''',
       );
     }
 
@@ -82,9 +82,12 @@ class Ios {
     }
 
     final ExportMethod? exportMethod;
-    if (exportMethodArgExists && results.wasParsed(exportMethodArgName)) {
+    if (exportMethodArgExists &&
+        results.wasParsed(CommonArguments.exportMethodArg.name)) {
       exportMethod = ExportMethod.values.firstWhere(
-        (element) => element.argName == results[exportMethodArgName] as String,
+        (element) =>
+            element.argName ==
+            results[CommonArguments.exportMethodArg.name] as String,
       );
     } else {
       exportMethod = null;

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -783,10 +783,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
+      sha256: "360c4271613beb44db559547d02f8b0dc044741d0eeb9aa6ccdb47e8ec54c63a"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.2"
+    version: "14.2.3"
   watcher:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/test/src/platform/ios_test.dart
+++ b/packages/shorebird_cli/test/src/platform/ios_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:propertylistserialization/propertylistserialization.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
+import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:test/test.dart';
 
@@ -33,8 +34,8 @@ void main() {
 
         when(() => argResults.wasParsed(any())).thenReturn(false);
         when(() => argResults.options).thenReturn([
-          exportMethodArgName,
-          exportOptionsPlistArgName,
+          CommonArguments.exportMethodArg.name,
+          CommonArguments.exportOptionsPlistArg.name,
         ]);
       });
 
@@ -42,10 +43,10 @@ void main() {
           () {
         setUp(() {
           when(
-            () => argResults.wasParsed(exportMethodArgName),
+            () => argResults.wasParsed(CommonArguments.exportMethodArg.name),
           ).thenReturn(true);
           when(
-            () => argResults[exportOptionsPlistArgName],
+            () => argResults[CommonArguments.exportOptionsPlistArg.name],
           ).thenReturn('/path/to/export.plist');
         });
 
@@ -59,11 +60,12 @@ void main() {
 
       group('when export-method is provided', () {
         setUp(() {
-          when(() => argResults.wasParsed(exportMethodArgName))
+          when(() => argResults.wasParsed(CommonArguments.exportMethodArg.name))
               .thenReturn(true);
-          when(() => argResults[exportMethodArgName])
+          when(() => argResults[CommonArguments.exportMethodArg.name])
               .thenReturn(ExportMethod.adHoc.argName);
-          when(() => argResults[exportOptionsPlistArgName]).thenReturn(null);
+          when(() => argResults[CommonArguments.exportOptionsPlistArg.name])
+              .thenReturn(null);
         });
 
         test('generates an export options plist with that export method',
@@ -83,7 +85,7 @@ void main() {
         group('when file does not exist', () {
           setUp(() {
             when(
-              () => argResults[exportOptionsPlistArgName],
+              () => argResults[CommonArguments.exportOptionsPlistArg.name],
             ).thenReturn('/does/not/exist');
           });
 
@@ -117,7 +119,7 @@ void main() {
               p.join(tmpDir.path, 'export.plist'),
             )..writeAsStringSync(exportPlistContent);
             when(
-              () => argResults[exportOptionsPlistArgName],
+              () => argResults[CommonArguments.exportOptionsPlistArg.name],
             ).thenReturn(exportPlistFile.path);
             expect(
               () => ios.exportOptionsPlistFromArgs(argResults),
@@ -136,9 +138,10 @@ void main() {
       group('when neither export-method nor export-options-plist is provided',
           () {
         setUp(() {
-          when(() => argResults.wasParsed(exportMethodArgName))
+          when(() => argResults.wasParsed(CommonArguments.exportMethodArg.name))
               .thenReturn(false);
-          when(() => argResults[exportOptionsPlistArgName]).thenReturn(null);
+          when(() => argResults[CommonArguments.exportOptionsPlistArg.name])
+              .thenReturn(null);
         });
 
         test('generates an export options plist with app-store export method',
@@ -168,12 +171,14 @@ void main() {
       group('when export-method option does not exist', () {
         setUp(() {
           when(() => argResults.options)
-              .thenReturn([exportOptionsPlistArgName]);
+              .thenReturn([CommonArguments.exportOptionsPlistArg.name]);
         });
 
         test('does not check whether export-method was parsed', () {
           ios.exportOptionsPlistFromArgs(argResults);
-          verifyNever(() => argResults.wasParsed(exportMethodArgName));
+          verifyNever(
+            () => argResults.wasParsed(CommonArguments.exportMethodArg.name),
+          );
         });
       });
     });


### PR DESCRIPTION
## Description

Adds `--export-method` to PatchCommand for parity with ReleaseCommand. Also reorganizes the arguments to use the new CommonArguments class.

Fixes https://github.com/shorebirdtech/shorebird/issues/2175

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
