### PR TITLE
feat(shorebird_cli): check for available upgrade after command run

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -132,4 +132,24 @@ class Git {
     final result = await git(['status', ...?args], workingDirectory: directory);
     return '${result.stdout}'.trim();
   }
+
+  /// The output of `git symbolic-ref [revision]` for the git repository located
+  /// in [directory]. If not provided, [revision] defaults to 'HEAD'.
+  Future<String> symbolicRef({
+    required Directory directory,
+    String revision = 'HEAD',
+  }) async {
+    final result = await git(
+      ['symbolic-ref', revision],
+      workingDirectory: directory.path,
+    );
+    return '${result.stdout}'.trim();
+  }
+
+  /// Returns the name of the branch the git repository located at [directory]
+  /// is currently on.
+  Future<String> currentBranch({required Directory directory}) async {
+    return (await symbolicRef(directory: directory))
+        .replaceAll('refs/heads/', '');
+  }
 }

--- a/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
@@ -242,10 +242,10 @@ ${currentRunLogFile.absolute.path}
   /// user telling them to run `shorebird upgrade`.
   Future<void> _checkForUpdates() async {
     try {
-      if (
-          // await shorebirdVersion.isTrackingStable() &&
+      if (await shorebirdVersion.isTrackingStable() &&
           !await shorebirdVersion.isLatest()) {
         logger
+          ..info('')
           ..info('A new version of shorebird is available!')
           ..info('Run ${lightCyan.wrap('shorebird upgrade')} to upgrade.');
       }

--- a/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
@@ -192,18 +192,6 @@ ${lightCyan.wrap('shorebird release android -- --no-pub lib/main.dart')}''';
 Shorebird $packageVersion • git@github.com:shorebirdtech/shorebird.git
 $shorebirdFlutterPrefix • revision ${shorebirdEnv.flutterRevision}
 Engine • revision ${shorebirdEnv.shorebirdEngineRevision}''');
-
-      try {
-        final isUpToDate = await shorebirdVersion.isLatest();
-        if (!isUpToDate) {
-          logger.info('''
-A new version of shorebird is available!
-Run ${lightCyan.wrap('shorebird upgrade')} to upgrade.''');
-        }
-      } catch (error) {
-        logger.detail('Unable to check for updates.\n$error');
-      }
-      exitCode = ExitCode.success.code;
     } else {
       try {
         exitCode = await super.runCommand(topLevelResults);
@@ -233,6 +221,10 @@ ${currentRunLogFile.absolute.path}
       );
     }
 
+    if (topLevelResults.command?.name != UpgradeCommand.commandName) {
+      await _checkForUpdates();
+    }
+
     return exitCode;
   }
 
@@ -242,6 +234,22 @@ ${currentRunLogFile.absolute.path}
     } catch (error) {
       logger.detail('Unable to determine Flutter version.\n$error');
       return null;
+    }
+  }
+
+  /// If this version of shorebird is on the `stable` branch, checks to see if
+  /// there are newer commits available. If there are, prints a message to the
+  /// user telling them to run `shorebird upgrade`.
+  Future<void> _checkForUpdates() async {
+    try {
+      if (await shorebirdVersion.isTrackingStable() &&
+          !await shorebirdVersion.isLatest()) {
+        logger
+          ..info('A new version of shorebird is available!')
+          ..info('Run ${lightCyan.wrap('shorebird upgrade')} to upgrade.');
+      }
+    } catch (error) {
+      logger.detail('Unable to check for updates.\n$error');
     }
   }
 }

--- a/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
@@ -242,7 +242,8 @@ ${currentRunLogFile.absolute.path}
   /// user telling them to run `shorebird upgrade`.
   Future<void> _checkForUpdates() async {
     try {
-      if (await shorebirdVersion.isTrackingStable() &&
+      if (
+          // await shorebirdVersion.isTrackingStable() &&
           !await shorebirdVersion.isLatest()) {
         logger
           ..info('A new version of shorebird is available!')

--- a/packages/shorebird_cli/lib/src/shorebird_version.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_version.dart
@@ -57,4 +57,12 @@ class ShorebirdVersion {
       args: ['--hard'],
     );
   }
+
+  /// Whether the current version of shorebird is tracking the stable branch. If
+  /// we are not tracking stable, we should not check for newer versions of
+  /// shorebird or try to auto-update.
+  Future<bool> isTrackingStable() async {
+    return (await git.currentBranch(directory: Directory(_workingDirectory))) ==
+        'stable';
+  }
 }

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -378,10 +378,10 @@ packages:
     dependency: "direct main"
     description:
       name: json_path
-      sha256: "149d32ceb7dc22422ea6d09e401fd688f54e1343bc9ff8c3cb1900ca3b1ad8b1"
+      sha256: dc25b4e2297a6bd39fb52b7d122a7787b7dab751fb278d315b54706b98bb76db
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   json_serializable:
     dependency: "direct dev"
     description:

--- a/packages/shorebird_cli/test/src/executables/git_test.dart
+++ b/packages/shorebird_cli/test/src/executables/git_test.dart
@@ -460,5 +460,61 @@ origin/flutter_release/3.10.6''';
         );
       });
     });
+
+    group('symbolicRef', () {
+      setUp(() {
+        when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+        when(() => processResult.stdout).thenReturn('refs/heads/main');
+      });
+
+      test('executes correct command', () async {
+        final directory = Directory.current;
+        await expectLater(
+          runWithOverrides(
+            () => git.symbolicRef(directory: directory, revision: '1234'),
+          ),
+          completion(equals('refs/heads/main')),
+        );
+        verify(
+          () => process.run(
+            'git',
+            ['symbolic-ref', '1234'],
+            workingDirectory: directory.path,
+          ),
+        ).called(1);
+      });
+
+      test('defaults to HEAD if no revision is provided', () async {
+        final directory = Directory.current;
+        await expectLater(
+          runWithOverrides(() => git.symbolicRef(directory: directory)),
+          completion(equals('refs/heads/main')),
+        );
+        verify(
+          () => process.run(
+            'git',
+            ['symbolic-ref', 'HEAD'],
+            workingDirectory: directory.path,
+          ),
+        ).called(1);
+      });
+    });
+
+    group('currentBranch', () {
+      setUp(() {
+        when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+        when(() => processResult.stdout).thenReturn('''
+refs/heads/main
+''');
+      });
+
+      test('removes refs/heads from branch name', () async {
+        final directory = Directory.current;
+        await expectLater(
+          runWithOverrides(() => git.currentBranch(directory: directory)),
+          completion(equals('main')),
+        );
+      });
+    });
   });
 }

--- a/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
@@ -338,22 +338,25 @@ Engine • revision $shorebirdEngineRevision''',
         });
 
         group('when no update is available', () {
-          setUp(() {});
+          setUp(() {
+            when(shorebirdVersion.isLatest).thenAnswer((_) async => true);
+          });
 
           test('does not log update message', () async {
-            when(() => shorebirdVersion.isLatest())
-                .thenAnswer((_) async => false);
             final result = await runWithOverrides(
               () => commandRunner.run(['--version']),
             );
             expect(result, equals(ExitCode.success.code));
+            verifyNever(
+              () => logger.info('A new version of shorebird is available!'),
+            );
           });
         });
 
         test(
             'gracefully handles case when flutter version cannot be determined',
             () async {
-          when(() => shorebirdFlutter.getVersionString()).thenThrow('error');
+          when(shorebirdFlutter.getVersionString).thenThrow('error');
           final result = await runWithOverrides(
             () => commandRunner.run(['--version']),
           );
@@ -366,12 +369,9 @@ Engine • revision $shorebirdEngineRevision''',
 
       group('when not tracking the stable branch', () {
         setUp(() {
-          when(
-            () => shorebirdVersion.isTrackingStable(),
-          ).thenAnswer((_) async => false);
-          when(
-            () => shorebirdVersion.isLatest(),
-          ).thenAnswer((_) async => false);
+          when(shorebirdVersion.isTrackingStable)
+              .thenAnswer((_) async => false);
+          when(shorebirdVersion.isLatest).thenAnswer((_) async => false);
         });
 
         test('does not check for updates or print update message', () async {
@@ -380,7 +380,7 @@ Engine • revision $shorebirdEngineRevision''',
           );
           expect(result, equals(ExitCode.success.code));
 
-          verifyNever(() => shorebirdVersion.isLatest());
+          verifyNever(shorebirdVersion.isLatest);
           verifyNever(
             () => logger.info('A new version of shorebird is available!'),
           );

--- a/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
@@ -62,10 +62,8 @@ void main() {
       when(
         () => shorebirdFlutter.getVersionString(),
       ).thenAnswer((_) async => flutterVersion);
-      when(() => shorebirdVersion.isLatest()).thenAnswer((_) async => true);
-      when(
-        () => shorebirdVersion.isTrackingStable(),
-      ).thenAnswer((_) async => true);
+      when(shorebirdVersion.isLatest).thenAnswer((_) async => true);
+      when(shorebirdVersion.isTrackingStable).thenAnswer((_) async => true);
       commandRunner = runWithOverrides(ShorebirdCliCommandRunner.new);
     });
 
@@ -284,9 +282,9 @@ Engine • revision $shorebirdEngineRevision''',
       group('when running upgrade command', () {
         setUp(() {
           when(() => logger.progress(any())).thenReturn(MockProgress());
-          when(() => shorebirdVersion.fetchCurrentGitHash())
+          when(shorebirdVersion.fetchCurrentGitHash)
               .thenAnswer((_) async => 'current');
-          when(() => shorebirdVersion.fetchLatestGitHash())
+          when(shorebirdVersion.fetchLatestGitHash)
               .thenAnswer((_) async => 'current');
         });
         test('does not check for update', () async {
@@ -301,14 +299,12 @@ Engine • revision $shorebirdEngineRevision''',
 
       group('when tracking the stable branch', () {
         setUp(() {
-          when(
-            () => shorebirdVersion.isTrackingStable(),
-          ).thenAnswer((_) async => true);
+          when(shorebirdVersion.isTrackingStable).thenAnswer((_) async => true);
         });
 
         test('gracefully handles case when latest version cannot be determined',
             () async {
-          when(() => shorebirdVersion.isLatest()).thenThrow('error');
+          when(shorebirdVersion.isLatest).thenThrow('error');
           final result = await runWithOverrides(
             () => commandRunner.run(['--version']),
           );
@@ -320,8 +316,7 @@ Engine • revision $shorebirdEngineRevision''',
 
         group('when update is available', () {
           test('logs update message', () async {
-            when(() => shorebirdVersion.isLatest())
-                .thenAnswer((_) async => false);
+            when(shorebirdVersion.isLatest).thenAnswer((_) async => false);
             final result = await runWithOverrides(
               () => commandRunner.run(['--version']),
             );

--- a/packages/shorebird_cli/test/src/shorebird_version_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_version_test.dart
@@ -26,6 +26,10 @@ void main() {
       );
     }
 
+    setUpAll(() {
+      registerFallbackValue(Directory(''));
+    });
+
     setUp(() {
       git = MockGit();
       shorebirdVersionManager = ShorebirdVersion();
@@ -194,6 +198,36 @@ void main() {
             ),
           ),
         );
+      });
+    });
+
+    group('isTrackingStable', () {
+      group('when on the stable branch', () {
+        setUp(() {
+          when(() => git.currentBranch(directory: any(named: 'directory')))
+              .thenAnswer((_) async => 'stable');
+        });
+
+        test('returns true', () async {
+          expect(
+            await runWithOverrides(shorebirdVersionManager.isTrackingStable),
+            isTrue,
+          );
+        });
+      });
+
+      group('when on a branch other than stable', () {
+        setUp(() {
+          when(() => git.currentBranch(directory: any(named: 'directory')))
+              .thenAnswer((_) async => 'main');
+        });
+
+        test('returns false', () async {
+          expect(
+            await runWithOverrides(shorebirdVersionManager.isTrackingStable),
+            isFalse,
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
## Description

At the end of every command run (except for `upgrade`), check whether there is a newer stable version of shorebird available than what is running. If there is, inform the user and tell them to run `shorebird upgrade`.

Fixes https://github.com/shorebirdtech/shorebird/issues/1910

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
