### PR TITLE
fix(shorebird_cli): use flutter build output to find app.dill file

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder.dart
@@ -271,7 +271,10 @@ $errorMessage''');
     });
 
     if (appDillPath == null) {
-      throw ArtifactBuildException('Unable to find app.dill file');
+      throw ArtifactBuildException('''
+Unable to find app.dill file.
+Please file a bug at https://github.com/shorebirdtech/shorebird/issues/new with the logs for this command.
+''');
     }
 
     return IpaBuildResult(kernelFile: File(appDillPath!));
@@ -306,7 +309,10 @@ $errorMessage''');
     });
 
     if (appDillPath == null) {
-      throw ArtifactBuildException('Unable to find app.dill file');
+      throw ArtifactBuildException('''
+Unable to find app.dill file.
+Please file a bug at https://github.com/shorebirdtech/shorebird/issues/new with the logs for this command.
+''');
     }
 
     return IosFrameworkBuildResult(kernelFile: File(appDillPath!));

--- a/packages/shorebird_cli/lib/src/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:mason_logger/mason_logger.dart';
 import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_cli/src/extensions/shorebird_process_result.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
@@ -13,6 +14,30 @@ import 'package:shorebird_cli/src/shorebird_process.dart';
 /// Used to wrap code that invokes `flutter build` with Shorebird's fork of
 /// Flutter.
 typedef ShorebirdBuildCommand = Future<void> Function();
+
+/// {@template ipa_build_result}
+/// Metadata about the result of a `flutter build ipa` invocation.
+/// {@endtemplate}
+class IpaBuildResult {
+  /// {@macro ipa_build_result}
+  IpaBuildResult({required this.kernelFile});
+
+  /// The app.dill file produced by this invocation of `flutter build ipa`.
+  final File kernelFile;
+}
+
+/// {@template ios_framework_build_result}
+/// Metadata about the result of a `flutter build ios-framework` invocation.
+/// {@endtemplate}
+class IosFrameworkBuildResult {
+  /// {@macro ios_framework_build_result}
+  IosFrameworkBuildResult({
+    required this.kernelFile,
+  });
+
+  /// The app.dill file produced by this invocation of `flutter build ipa`.
+  final File kernelFile;
+}
 
 /// {@template artifact_build_exception}
 /// Thrown when a build fails.
@@ -195,7 +220,7 @@ class ArtifactBuilder {
 
   /// Calls `flutter build ipa`. If [codesign] is false, this will only build
   /// an .xcarchive and _not_ an .ipa.
-  Future<void> buildIpa({
+  Future<IpaBuildResult> buildIpa({
     bool codesign = true,
     File? exportOptionsPlist,
     String? flavor,
@@ -203,7 +228,8 @@ class ArtifactBuilder {
     List<String> args = const [],
     String? base64PublicKey,
   }) async {
-    return _runShorebirdBuildCommand(() async {
+    String? appDillPath;
+    await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
       final exportOptionsPlistPath =
           (exportOptionsPlist ?? ios.createExportOptionsPlist()).path;
@@ -240,14 +266,23 @@ class ArtifactBuilder {
 Failed to build:
 $errorMessage''');
       }
+
+      appDillPath = result.findAppDill();
     });
+
+    if (appDillPath == null) {
+      throw ArtifactBuildException('Unable to find app.dill file');
+    }
+
+    return IpaBuildResult(kernelFile: File(appDillPath!));
   }
 
   /// Builds a release iOS framework (.xcframework) for the current project.
-  Future<void> buildIosFramework({
+  Future<IosFrameworkBuildResult> buildIosFramework({
     List<String> args = const [],
-  }) {
-    return _runShorebirdBuildCommand(() async {
+  }) async {
+    String? appDillPath;
+    await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
       final arguments = [
         'build',
@@ -266,7 +301,15 @@ $errorMessage''');
       if (result.exitCode != ExitCode.success.code) {
         throw ArtifactBuildException('Failed to build: ${result.stderr}');
       }
+
+      appDillPath = result.findAppDill();
     });
+
+    if (appDillPath == null) {
+      throw ArtifactBuildException('Unable to find app.dill file');
+    }
+
+    return IosFrameworkBuildResult(kernelFile: File(appDillPath!));
   }
 
   String _failedToCreateIpaErrorMessage({required String stderr}) {

--- a/packages/shorebird_cli/lib/src/artifact_manager.dart
+++ b/packages/shorebird_cli/lib/src/artifact_manager.dart
@@ -270,27 +270,4 @@ class ArtifactManager {
       ),
     );
   }
-
-  /// Finds the most recently-edited app.dill file in the .dart_tool directory.
-  // TODO(bryanoltman): This is an enormous hack – we don't know that this is
-  // the correct file.
-  File newestAppDill() {
-    final projectRoot = shorebirdEnv.getShorebirdProjectRoot()!;
-    final dartToolBuildDir = Directory(
-      p.join(
-        projectRoot.path,
-        '.dart_tool',
-        'flutter_build',
-      ),
-    );
-
-    return dartToolBuildDir
-        .listSync(recursive: true)
-        .whereType<File>()
-        .where((f) => p.basename(f.path) == 'app.dill')
-        .reduce(
-          (a, b) =>
-              a.statSync().modified.isAfter(b.statSync().modified) ? a : b,
-        );
-  }
 }

--- a/packages/shorebird_cli/lib/src/extensions/shorebird_process_result.dart
+++ b/packages/shorebird_cli/lib/src/extensions/shorebird_process_result.dart
@@ -1,0 +1,19 @@
+import 'package:collection/collection.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
+
+extension FindAppDill on ShorebirdProcessResult {
+  /// Finds a line in stdout that invokes gen_snapshot with app.dill as an
+  /// argument. The path to the app.dill file is the last argument in the line.
+  ///
+  /// Example matching line from `flutter build ipa`:
+  ///   [        ] executing: /Users/bryanoltman/shorebirdtech/_shorebird/shorebird/bin/cache/flutter/985ec84cb99d3c60341e2c78be9826e0a88cc697/bin/cache/artifacts/engine/ios-release/gen_snapshot_arm64 --deterministic --snapshot_kind=app-aot-assembly --assembly=/Users/bryanoltman/Documents/sandbox/ios_signing/.dart_tool/flutter_build/804399dd5f8e05d7b9ec7e0bb4ceb22c/arm64/snapshot_assembly.S /Users/bryanoltman/Documents/sandbox/ios_signing/.dart_tool/flutter_build/804399dd5f8e05d7b9ec7e0bb4ceb22c/app.dill
+  ///
+  /// Returns null if no matching line is found.
+  String? findAppDill() {
+    final appDillLine = stdout.toString().split('\n').firstWhereOrNull(
+          (l) =>
+              l.contains('ios-release/gen_snapshot') && l.endsWith('app.dill'),
+        );
+    return appDillLine?.split(' ').last;
+  }
+}

--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/engine_config.dart';
@@ -171,11 +170,11 @@ class ShorebirdProcess {
   }) {
     var resolvedArguments = arguments;
     if (executable == 'flutter') {
+      // *Always* run with `--verbose` to get more detailed logs. We rely on
+      // this to determine the path to the app.dill file for iOS builds.
       // Ideally we'd use this for all commands, but not all commands recognize
       // `--verbose` and some error if it's provided.
-      if (logger.level == Level.verbose) {
-        resolvedArguments = [...resolvedArguments, '--verbose'];
-      }
+      resolvedArguments = [...resolvedArguments, '--verbose'];
 
       if (useVendedFlutter && engineConfig.localEngine != null) {
         resolvedArguments = [

--- a/packages/shorebird_cli/test/src/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder_test.dart
@@ -853,7 +853,10 @@ Failed to build:
                 isA<ArtifactBuildException>().having(
                   (e) => e.message,
                   'message',
-                  'Unable to find app.dill file',
+                  '''
+Unable to find app.dill file.
+Please file a bug at https://github.com/shorebirdtech/shorebird/issues/new with the logs for this command.
+''',
                 ),
               ),
             );
@@ -960,7 +963,10 @@ Failed to build:
                     isA<ArtifactBuildException>().having(
                       (e) => e.message,
                       'message',
-                      'Unable to find app.dill file',
+                      '''
+Unable to find app.dill file.
+Please file a bug at https://github.com/shorebirdtech/shorebird/issues/new with the logs for this command.
+''',
                     ),
                   ),
                 );

--- a/packages/shorebird_cli/test/src/artifact_manager_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_manager_test.dart
@@ -592,31 +592,5 @@ void main() {
         );
       });
     });
-
-    group('newestAppDill', () {
-      late File appDill2;
-
-      setUp(() {
-        final tempDir = Directory.systemTemp.createTempSync();
-        when(() => shorebirdEnv.getShorebirdProjectRoot()).thenReturn(tempDir);
-        final flutterBuildDir = Directory(
-          p.join(tempDir.path, '.dart_tool', 'flutter_build'),
-        )..createSync(recursive: true);
-        File(p.join(flutterBuildDir.path, 'app1', 'app.dill'))
-          ..createSync(recursive: true)
-          ..setLastModifiedSync(
-            DateTime.now().subtract(const Duration(days: 1)),
-          );
-        appDill2 = File(p.join(flutterBuildDir.path, 'app2', 'app.dill'))
-          ..createSync(recursive: true);
-      });
-
-      test('selects the most recently edited .app.dill file', () {
-        final result = runWithOverrides(artifactManager.newestAppDill);
-
-        expect(result, isNotNull);
-        expect(result.path, equals(appDill2.path));
-      });
-    });
   });
 }

--- a/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/build/build_ipa_command_test.dart
@@ -72,7 +72,7 @@ void main() {
           codesign: any(named: 'codesign'),
           args: any(named: 'args'),
         ),
-      ).thenAnswer((_) async => File(''));
+      ).thenAnswer((_) async => IpaBuildResult(kernelFile: File('')));
       when(() => ios.createExportOptionsPlist()).thenReturn(File('.'));
       when(() => logger.progress(any())).thenReturn(MockProgress());
       when(() => logger.info(any())).thenReturn(null);

--- a/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
@@ -249,7 +249,9 @@ void main() {
           when(
             () => artifactBuilder.buildIosFramework(args: any(named: 'args')),
           ).thenAnswer(
-            (_) async => File(''),
+            (_) async => IosFrameworkBuildResult(
+              kernelFile: File('/path/to/app.dill'),
+            ),
           );
           when(() => artifactManager.getAppXcframeworkDirectory()).thenReturn(
             Directory(

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -308,7 +308,11 @@ void main() {
               target: any(named: 'target'),
               args: any(named: 'args'),
             ),
-          ).thenAnswer((_) async => {});
+          ).thenAnswer(
+            (_) async => IpaBuildResult(
+              kernelFile: File('/path/to/app.dill'),
+            ),
+          );
 
           when(
             () => artifactManager.getIosAppDirectory(
@@ -352,7 +356,11 @@ void main() {
                 args: any(named: 'args'),
                 base64PublicKey: any(named: 'base64PublicKey'),
               ),
-            ).thenAnswer((_) async => File(''));
+            ).thenAnswer(
+              (_) async => IpaBuildResult(
+                kernelFile: File('/path/to/app.dill'),
+              ),
+            );
           });
 
           test(

--- a/packages/shorebird_cli/test/src/extensions/shorebird_process_result_test.dart
+++ b/packages/shorebird_cli/test/src/extensions/shorebird_process_result_test.dart
@@ -1,0 +1,40 @@
+import 'package:shorebird_cli/src/extensions/shorebird_process_result.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FindAppDill', () {
+    group('when gen_snapshot is invoked with app.dill', () {
+      test('returns the path to app.dill', () {
+        const result = ShorebirdProcessResult(
+          stdout: '''
+           [        ] Will strip AOT snapshot manually after build and dSYM generation.
+           [        ] executing: /Users/bryanoltman/shorebirdtech/_shorebird/shorebird/bin/cache/flutter/985ec84cb99d3c60341e2c78be9826e0a88cc697/bin/cache/artifacts/engine/ios-release/gen_snapshot_arm64 --deterministic --snapshot_kind=app-aot-assembly --assembly=/Users/bryanoltman/Documents/sandbox/ios_signing/.dart_tool/flutter_build/804399dd5f8e05d7b9ec7e0bb4ceb22c/arm64/snapshot_assembly.S /Users/bryanoltman/Documents/sandbox/ios_signing/.dart_tool/flutter_build/804399dd5f8e05d7b9ec7e0bb4ceb22c/app.dill
+           [+3688 ms] executing: sysctl hw.optional.arm64
+''',
+          stderr: '',
+          exitCode: 0,
+        );
+
+        expect(
+          result.findAppDill(),
+          equals(
+            '/Users/bryanoltman/Documents/sandbox/ios_signing/.dart_tool/flutter_build/804399dd5f8e05d7b9ec7e0bb4ceb22c/app.dill',
+          ),
+        );
+      });
+    });
+
+    group('when gen_snapshot is not invoked with app.dill', () {
+      test('returns null', () {
+        const result = ShorebirdProcessResult(
+          stdout: 'executing: .../gen_snapshot_arm64 .../snapshot_assembly.S',
+          stderr: '',
+          exitCode: 0,
+        );
+
+        expect(result.findAppDill(), isNull);
+      });
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -52,8 +52,8 @@ void main() {
         () => shorebirdEnv.flutterBinaryFile,
       ).thenReturn(File(p.join('bin', 'cache', 'flutter', 'bin', 'flutter')));
 
-      when(() => runProcessResult.stderr).thenReturn('');
-      when(() => runProcessResult.stdout).thenReturn('');
+      when(() => runProcessResult.stderr).thenReturn('stderr');
+      when(() => runProcessResult.stdout).thenReturn('stdout');
       when(() => runProcessResult.exitCode).thenReturn(ExitCode.success.code);
 
       when(() => logger.level).thenReturn(Level.info);
@@ -117,7 +117,7 @@ void main() {
                 p.join('bin', 'cache', 'flutter', 'bin', 'flutter'),
               ),
             ),
-            ['--version'],
+            ['--version', '--verbose'],
             runInShell: true,
             environment: flutterStorageBaseUrlEnv,
             workingDirectory: '~',
@@ -141,7 +141,7 @@ void main() {
         verify(
           () => processWrapper.run(
             'flutter',
-            ['--version'],
+            ['--version', '--verbose'],
             runInShell: true,
             environment: {},
             workingDirectory: '~',
@@ -164,7 +164,7 @@ void main() {
         verify(
           () => processWrapper.run(
             'flutter',
-            ['--version'],
+            ['--version', '--verbose'],
             runInShell: true,
             workingDirectory: '~',
             environment: {'ENV_VAR': 'asdfasdf'},
@@ -189,7 +189,7 @@ void main() {
           verify(
             () => processWrapper.run(
               'flutter',
-              ['--version'],
+              ['--version', '--verbose'],
               runInShell: true,
               workingDirectory: '~',
               environment: {'ENV_VAR': 'asdfasdf'},
@@ -218,6 +218,7 @@ void main() {
               '--local-engine-src-path=$localEngineSrcPath',
               '--local-engine=android_release_arm64',
               '--local-engine-host=host_release',
+              '--verbose',
             ],
             runInShell: any(named: 'runInShell'),
             environment: any(named: 'environment'),
@@ -226,64 +227,15 @@ void main() {
         ).called(1);
       });
 
-      group('when log level is verbose', () {
-        setUp(() {
-          when(() => logger.level).thenReturn(Level.verbose);
-        });
+      test('logs stdout and stderr', () async {
+        await runWithOverrides(() => shorebirdProcess.run('flutter', []));
 
-        test('passes --verbose to flutter executable', () async {
-          await runWithOverrides(
-            () => shorebirdProcess.run('flutter', []),
-          );
-
-          verify(
-            () => processWrapper.run(
-              any(),
-              ['--verbose'],
-              runInShell: any(named: 'runInShell'),
-              environment: any(named: 'environment'),
-              workingDirectory: any(named: 'workingDirectory'),
-            ),
-          ).called(1);
-        });
-
-        group('when result has 0 exit code', () {
-          setUp(() {
-            when(() => runProcessResult.exitCode).thenReturn(0);
-            when(() => runProcessResult.stdout).thenReturn('out');
-            when(() => runProcessResult.stderr).thenReturn('err');
-          });
-
-          test('logs stdout and stderr if present', () async {
-            await runWithOverrides(() => shorebirdProcess.run('flutter', []));
-
-            verify(
-              () => logger.detail(any(that: contains('stdout'))),
-            ).called(1);
-            verify(
-              () => logger.detail(any(that: contains('stderr'))),
-            ).called(1);
-          });
-        });
-
-        group('when result has non-zero exit code', () {
-          setUp(() {
-            when(() => runProcessResult.exitCode).thenReturn(1);
-            when(() => runProcessResult.stdout).thenReturn('out');
-            when(() => runProcessResult.stderr).thenReturn('err');
-          });
-
-          test('logs stdout and stderr if present', () async {
-            await runWithOverrides(() => shorebirdProcess.run('flutter', []));
-
-            verify(
-              () => logger.detail(any(that: contains('stdout'))),
-            ).called(1);
-            verify(
-              () => logger.detail(any(that: contains('stderr'))),
-            ).called(1);
-          });
-        });
+        verify(
+          () => logger.detail(any(that: contains('stdout'))),
+        ).called(1);
+        verify(
+          () => logger.detail(any(that: contains('stderr'))),
+        ).called(1);
       });
     });
 
@@ -338,7 +290,7 @@ void main() {
                 p.join('bin', 'cache', 'flutter', 'bin', 'flutter'),
               ),
             ),
-            ['--version'],
+            ['--version', '--verbose'],
             runInShell: true,
             environment: flutterStorageBaseUrlEnv,
             workingDirectory: '~',
@@ -362,7 +314,7 @@ void main() {
         verify(
           () => processWrapper.runSync(
             'flutter',
-            ['--version'],
+            ['--version', '--verbose'],
             runInShell: true,
             environment: {},
             workingDirectory: '~',
@@ -385,7 +337,7 @@ void main() {
         verify(
           () => processWrapper.runSync(
             'flutter',
-            ['--version'],
+            ['--version', '--verbose'],
             runInShell: true,
             workingDirectory: '~',
             environment: {'ENV_VAR': 'asdfasdf'},
@@ -410,7 +362,7 @@ void main() {
           verify(
             () => processWrapper.runSync(
               'flutter',
-              ['--version'],
+              ['--version', '--verbose'],
               runInShell: true,
               workingDirectory: '~',
               environment: {'ENV_VAR': 'asdfasdf'},
@@ -502,7 +454,7 @@ void main() {
                 p.join('bin', 'cache', 'flutter', 'bin', 'flutter'),
               ),
             ),
-            ['run'],
+            ['run', '--verbose'],
             runInShell: true,
             environment: flutterStorageBaseUrlEnv,
           ),
@@ -524,7 +476,7 @@ void main() {
         verify(
           () => processWrapper.start(
             'flutter',
-            ['--version'],
+            ['--version', '--verbose'],
             runInShell: true,
             environment: {},
           ),
@@ -547,7 +499,7 @@ void main() {
                 p.join('bin', 'cache', 'flutter', 'bin', 'flutter'),
               ),
             ),
-            ['--version'],
+            ['--version', '--verbose'],
             runInShell: true,
             environment: {
               'ENV_VAR': 'asdfasdf',
@@ -573,7 +525,7 @@ void main() {
           verify(
             () => processWrapper.start(
               'flutter',
-              ['--version'],
+              ['--version', '--verbose'],
               runInShell: true,
               environment: {'hello': 'world'},
             ),


### PR DESCRIPTION
## Description

Instead of just using the newest app.dill file found in `.dart_tool`, parse the verbose `flutter build` logs to find a `gen_snapshot` invocation that references app.dill. There should be only one such file referenced. 

Fixes https://github.com/shorebirdtech/shorebird/issues/1444

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
