### PR TITLE
chore(shorebird_cli): rename build to build-internal

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/build/build_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_command.dart
@@ -15,7 +15,10 @@ class BuildCommand extends ShorebirdCommand {
   }
 
   @override
-  String get description => 'Build a new release of your application.';
+  String get description => '''
+Build a new release of your application.
+
+Builds created with this command will not be patchable. If you need to create a patchable build, use the `shorebird release` command instead.`''';
 
   @override
   String get name => 'build-internal';

--- a/packages/shorebird_cli/lib/src/commands/build/build_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/build/build_command.dart
@@ -18,7 +18,7 @@ class BuildCommand extends ShorebirdCommand {
   String get description => 'Build a new release of your application.';
 
   @override
-  String get name => 'build';
+  String get name => 'build-internal';
 
   @override
   bool get hidden => true;


### PR DESCRIPTION
## Description

Renames the `build` command to `build-internal` because enough customers were finding it and using it instead of `shorebird release`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
