### PR TITLE
feat: Adding override min Flutter version flag to patch and release

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -118,6 +118,10 @@ of the iOS app that is using this module.''',
       ..addOption(
         CommonArguments.publicKeyArg.name,
         help: CommonArguments.publicKeyArg.description,
+      )
+      ..addFlag(
+        CommonArguments.overrideMinFlutterVersionArg.name,
+        help: CommonArguments.overrideMinFlutterVersionArg.description,
       );
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -7,6 +7,7 @@ import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/release/releaser.dart';
+import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/xcodebuild.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
@@ -65,16 +66,23 @@ class IosReleaser extends Releaser {
       exit(e.exitCode.code);
     }
 
-    final flutterVersionArg = argResults['flutter-version'] as String?;
+    final flutterVersionArg = argResults.version('flutter-version');
     if (flutterVersionArg != null) {
-      if (Version.parse(flutterVersionArg) <
-          minimumSupportedIosFlutterVersion) {
-        logger.err(
-          '''
+      if (flutterVersionArg < minimumSupportedIosFlutterVersion) {
+        final overrideMinFlutterVersion =
+            argResults[CommonArguments.overrideMinFlutterVersionArg.name] ==
+                true;
+        if (!overrideMinFlutterVersion) {
+          logger.err(
+            '''
 iOS releases are not supported with Flutter versions older than $minimumSupportedIosFlutterVersion.
-For more information see: $supportedVersionsLink''',
-        );
-        exit(ExitCode.usage.code);
+For more information see: $supportedVersionsLink
+
+If you are certain about the compatibility of your Flutter version, you can bypass this check by passing the --override-min-flutter-version flag.
+''',
+          );
+          exit(ExitCode.usage.code);
+        }
       }
     }
   }

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -126,6 +126,10 @@ of the iOS app that is using this module.''',
       ..addOption(
         CommonArguments.publicKeyArg.name,
         help: CommonArguments.publicKeyArg.description,
+      )
+      ..addFlag(
+        CommonArguments.overrideMinFlutterVersionArg.name,
+        help: CommonArguments.overrideMinFlutterVersionArg.description,
       );
   }
 

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -66,4 +66,13 @@ The path for a public key .pem file that will be used to validate patch signatur
 The path for a private key .pem file that will be used to sign the patch artifact.
 ''',
   );
+
+  static const overrideMinFlutterVersionArg = ArgumentDescriber(
+    name: 'override-min-flutter-version',
+    description: '''
+When specified, will override the platform minimum Flutter version supported by Shorebird.
+
+This flag is dangerous and might cause unexpected issues, be sure to only use it when extremely necessary and always do a careful testing in the artifacts generated when this flag is provided.
+''',
+  );
 }

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -1,6 +1,7 @@
 import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:shorebird_cli/src/code_signer.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/extensions/file.dart';
@@ -127,5 +128,18 @@ extension ForwardedArgs on ArgResults {
     }
 
     return forwarded;
+  }
+}
+
+/// Extension on [ArgResults] to provide [Version] releated extensions.
+extension VersionArgs on ArgResults {
+  /// Returns a [Version] from the argument [name] or null if the argument was
+  /// not provided.
+  Version? version(String name) {
+    final version = this[name] as String?;
+    if (version == null) {
+      return null;
+    }
+    return Version.parse(version);
   }
 }

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -457,10 +457,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mocktail
-      sha256: c4b5007d91ca4f67256e720cb1b6d704e79a510183a12fa551021f652577dce6
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adds a new flag `override-min-flutter-version` to the patch and release command, that when informed, will allow users to release and or patch on iOS even on non supported flutter versions by shorebird.

This PR also adds some measures to guide the user to avoid a "foot gun" scenario.

 - Make it explicit that doing so is dangerous and might produce unwanted behaviours
 - Only allow patches with unsupported flutter versions to be published on staging, which hopefully will encourage users to test the patch before releasing it to their users.

Still in draft to gather feedback on the measures and messages, will add tests once we are settled in a path to move forward.

If merged,
fixes #2222 

## Type of Change


- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
