### PR TITLE
feat: making sure we print the error log file on a command failure

### DIFF
--- a/packages/shorebird_cli/lib/src/third_party/flutter_tools/lib/src/base/io.dart
+++ b/packages/shorebird_cli/lib/src/third_party/flutter_tools/lib/src/base/io.dart
@@ -35,7 +35,6 @@ library;
 import 'dart:async';
 import 'dart:io' as io show exit;
 
-import 'package:meta/meta.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/src/base/process.dart';
 
 export 'dart:io' hide exit;
@@ -55,7 +54,7 @@ ExitFunction _exitFunction = _defaultExitFunction;
 ///
 /// This is analogous to the `exit` function in `dart:io`, except that this
 /// function may be set to a testing-friendly value by calling
-/// [setExitFunctionForTests] (and then restored to its default implementation
+/// [setExitFunction] (and then restored to its default implementation
 /// with [restoreExitFunction]). The default implementation delegates to
 /// `dart:io`.
 ExitFunction get exit {
@@ -75,8 +74,9 @@ bool _inUnitTest() {
 
 /// Sets the [exit] function to a function that throws an exception rather
 /// than exiting the process; this is intended for testing purposes.
-@visibleForTesting
-void setExitFunctionForTests([ExitFunction? exitFunction]) {
+/// And being able to capture a full log of all commands to save their output
+/// To a crash file.
+void setExitFunction([ExitFunction? exitFunction]) {
   _exitFunction = exitFunction ??
       (int exitCode) {
         throw ProcessExit(exitCode, immediate: true);
@@ -84,7 +84,6 @@ void setExitFunctionForTests([ExitFunction? exitFunction]) {
 }
 
 /// Restores the [exit] function to the `dart:io` implementation.
-@visibleForTesting
 void restoreExitFunction() {
   _exitFunction = _defaultExitFunction;
 }

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -457,10 +457,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mocktail
-      sha256: c4b5007d91ca4f67256e720cb1b6d704e79a510183a12fa551021f652577dce6
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -161,7 +161,7 @@ void main() {
     setUpAll(() {
       registerFallbackValue(ReleasePlatform.android);
       registerFallbackValue(ReleaseStatus.draft);
-      setExitFunctionForTests();
+      setExitFunction();
     });
 
     tearDownAll(restoreExitFunction);

--- a/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
@@ -83,7 +83,7 @@ void main() {
       registerFallbackValue(Directory(''));
       registerFallbackValue(ReleasePlatform.android);
       registerFallbackValue(Uri.parse('https://example.com'));
-      setExitFunctionForTests();
+      setExitFunction();
     });
 
     tearDownAll(restoreExitFunction);

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -109,7 +109,7 @@ void main() {
       registerFallbackValue(File(''));
       registerFallbackValue(ReleasePlatform.android);
       registerFallbackValue(Uri.parse('https://example.com'));
-      setExitFunctionForTests();
+      setExitFunction();
     });
 
     tearDownAll(restoreExitFunction);

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -88,7 +88,7 @@ void main() {
         registerFallbackValue(File(''));
         registerFallbackValue(ReleasePlatform.ios);
         registerFallbackValue(Uri.parse('https://example.com'));
-        setExitFunctionForTests();
+        setExitFunction();
       });
 
       tearDownAll(restoreExitFunction);

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -97,7 +97,7 @@ void main() {
         registerFallbackValue(File(''));
         registerFallbackValue(ReleasePlatform.ios);
         registerFallbackValue(Uri.parse('https://example.com'));
-        setExitFunctionForTests();
+        setExitFunction();
       });
 
       tearDownAll(restoreExitFunction);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -127,7 +127,7 @@ void main() {
       registerFallbackValue(release);
       registerFallbackValue(ReleasePlatform.android);
       registerFallbackValue(Uri.parse('https://example.com'));
-      setExitFunctionForTests();
+      setExitFunction();
     });
 
     tearDownAll(restoreExitFunction);

--- a/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
@@ -69,7 +69,7 @@ void main() {
     setUpAll(() {
       registerFallbackValue(Directory(''));
       registerFallbackValue(ReleasePlatform.android);
-      setExitFunctionForTests();
+      setExitFunction();
     });
 
     tearDownAll(restoreExitFunction);

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -76,7 +76,7 @@ void main() {
       registerFallbackValue(Directory(''));
       registerFallbackValue(File(''));
       registerFallbackValue(ReleasePlatform.android);
-      setExitFunctionForTests();
+      setExitFunction();
     });
 
     tearDownAll(restoreExitFunction);

--- a/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
@@ -72,7 +72,7 @@ void main() {
       setUpAll(() {
         registerFallbackValue(Directory(''));
         registerFallbackValue(ReleasePlatform.ios);
-        setExitFunctionForTests();
+        setExitFunction();
       });
 
       tearDownAll(restoreExitFunction);

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -80,7 +80,7 @@ void main() {
         registerFallbackValue(Directory(''));
         registerFallbackValue(File(''));
         registerFallbackValue(ReleasePlatform.android);
-        setExitFunctionForTests();
+        setExitFunction();
       });
 
       tearDownAll(restoreExitFunction);

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -75,7 +75,7 @@ void main() {
       registerFallbackValue(release);
       registerFallbackValue(ReleasePlatform.android);
       registerFallbackValue(ReleaseStatus.draft);
-      setExitFunctionForTests();
+      setExitFunction();
     });
 
     tearDownAll(restoreExitFunction);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Some time ago, we implemented some handling in the CLI to forward all of the output to a log file print the following message if a CLI command failed and the logging level was non verbose:

```
If you aren't sure why this command failed, re-run with the --verbose flag to see more information.

You can also [file an issue](https://github.com/shorebirdtech/shorebird/issues/new/choose) if you think this is a bug. Please include the following log file in your report:
/Users/erick/Library/Application Support/shorebird/logs/1718217148336_shorebird.log
```

But that noticed was only being printed when a command would return an `ExitCode`, or throw an error. In many commands, instead of return an error code, or throwing an error, `exit` would be directly called, effectively interrupting the command, and not printing the message.

This PR uses the same code infrastructure used in tests to override the exit function, so we can now be sure that any exit call made in a sub command or process will still print the message, which I believe will lead users to open issues with more information, making it easier for us to investigate eventual bugs.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
