### PR TITLE
feat: Using Process.start instead of run on call to call aot_tools link

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -125,7 +125,7 @@ class AotTools {
   }
 
   /// Similar to [_exec], but logs the sub process stdout and stderr
-  /// as they are emmited.
+  /// as they are emitted.
   Future<ShorebirdProcessResult> _execWithLiveLogs(
     List<String> command, {
     String? workingDirectory,

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -83,6 +83,10 @@ class AotTools {
     return !_preLinkerFlutterRevisions.contains(flutterRevision);
   }
 
+  /// Runs the `aot-tools` executable with the given [command] and await for
+  /// its completion.
+  ///
+  /// If no [runCommand] is provided, [ShorebirdProcess.run] is used.
   Future<ShorebirdProcessResult> _exec(
     List<String> command, {
     Future<ShorebirdProcessResult> Function(
@@ -120,7 +124,9 @@ class AotTools {
     );
   }
 
-  Future<ShorebirdProcessResult> _spawn(
+  /// Similar to [_exec], but logs the sub process stdout and stderr
+  /// as they are emmited.
+  Future<ShorebirdProcessResult> _execWithLiveLogs(
     List<String> command, {
     String? workingDirectory,
   }) {
@@ -205,7 +211,7 @@ class AotTools {
     const linkJson = 'link.jsonl';
     final outputDir = p.dirname(outputPath);
     final linkerUsesGenSnapshot = await _linkerUsesGenSnapshot();
-    final result = await _spawn(
+    final result = await _execWithLiveLogs(
       [
         'link',
         '--base=$base',

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -133,7 +133,7 @@ class AotTools {
     List<String> command, {
     String? workingDirectory,
   }) async {
-    Future<ShorebirdProcessResult> _startWrapper(
+    Future<ShorebirdProcessResult> startWrapper(
       String exe,
       List<String> args, {
       String? workingDirectory,
@@ -171,7 +171,7 @@ class AotTools {
 
     return _prepareAndRun(
       command,
-      runFn: _startWrapper,
+      runFn: startWrapper,
       workingDirectory: workingDirectory,
     );
   }
@@ -223,6 +223,7 @@ class AotTools {
         '--patch=$patch',
         '--analyze-snapshot=$analyzeSnapshot',
         '--output=$outputPath',
+        '--verbose',
         if (linkerUsesGenSnapshot) ...[
           '--gen-snapshot=$genSnapshot',
           '--kernel=$kernel',

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -151,10 +151,8 @@ class AotTools {
           stdout.write(data);
         });
 
-        final stderrSub = spawnedProcess.stderr.map(utf8.decode).listen((data) {
-          logger.err(data);
-          stderr.write(data);
-        });
+        final stderrSub =
+            spawnedProcess.stderr.map(utf8.decode).listen(stderr.write);
 
         final exitCode = await spawnedProcess.exitCode;
 

--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -112,6 +112,7 @@ class ShorebirdProcess {
     Map<String, String>? environment,
     bool runInShell = false,
     bool useVendedFlutter = true,
+    String? workingDirectory,
   }) {
     final resolvedEnvironment = environment ?? {};
     if (useVendedFlutter) {
@@ -130,7 +131,7 @@ class ShorebirdProcess {
       useVendedFlutter: useVendedFlutter,
     );
     logger.detail(
-      '[Process.start] $resolvedExecutable ${resolvedArguments.join(' ')}',
+      '''[Process.start] $resolvedExecutable ${resolvedArguments.join(' ')}${workingDirectory == null ? '' : ' (in $workingDirectory)'}''',
     );
 
     return processWrapper.start(
@@ -138,6 +139,7 @@ class ShorebirdProcess {
       resolvedArguments,
       runInShell: runInShell,
       environment: resolvedEnvironment,
+      workingDirectory: workingDirectory,
     );
   }
 
@@ -300,12 +302,14 @@ class ProcessWrapper {
     List<String> arguments, {
     bool runInShell = false,
     Map<String, String>? environment,
+    String? workingDirectory,
   }) {
     return Process.start(
       executable,
       arguments,
       runInShell: runInShell,
       environment: environment,
+      workingDirectory: workingDirectory,
     );
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR does a couple of things in order to improve our logging and ability to track down errors when running our link process.

It passes `--verbose` flag to `aot_tools link` command, so we can get all the logs we can from that process.

It changes the calling of `aot_tools link` from a `run` to a `start`. This is done so we can get any logging from the sub process "in real time" and not just when the command finishes, this will ensure that we will be able to see the logs even if the command hangs.

I am sure this change can be made generic and and applied in other places, but I guess we should start in a single place to see if this will help or not before going through a bigger change, and the link command was chosen since there are reports of that command hanging up (#2160 and #2043).

This is a first step for eventually improving our debug abilities when commands hangs (#2211)

Before this change, this was the log we would get from the `aot_tools link` command:

```
[Process.start] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/dart run /Users/erick/projects/shorebird/shorebird/bin/cache/artifacts/aot-tools/14449967f2149612759c8c2fd7527dc3114d3934/aot-tools.dill link --base=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/sMfUaC/Products/Applications/Runner.app/Frameworks/App.framework/App --patch=/Users/erick/projects/shorebird/fun_app_to_test/build/out.aot --analyze-snapshot=/Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --output=/Users/erick/projects/shorebird/fun_app_to_test/build/out.vmcode --gen-snapshot=/Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/gen_snapshot_arm64 --kernel=/Users/erick/projects/shorebird/fun_app_to_test/build/app.dill --reporter=json --redirect-to=/Users/erick/projects/shorebird/fun_app_to_test/build/link.jsonl --dump-debug-info=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/n1hk4d (in /Users/erick/projects/shorebird/fun_app_to_test/build)
```

Now we get this:

```

[Process.start] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/dart run /Users/erick/projects/shorebird/shorebird/bin/cache/artifacts/aot-tools/14449967f2149612759c8c2fd7527dc3114d3934/aot-tools.dill link --base=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App --patch=/Users/erick/projects/shorebird/fun_app_to_test/build/out.aot --analyze-snapshot=/Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --output=/Users/erick/projects/shorebird/fun_app_to_test/build/out.vmcode --verbose --gen-snapshot=/Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/gen_snapshot_arm64 --kernel=/Users/erick/projects/shorebird/fun_app_to_test/build/app.dill --reporter=json --redirect-to=/Users/erick/projects/shorebird/fun_app_to_test/build/link.jsonl --dump-debug-info=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi (in /Users/erick/projects/shorebird/fun_app_to_test/build)
⠴ Linking AOT files... (1.2s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_class_table_link_data=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App.ct.link --dump_object_pool_link_data=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App.op.link /var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App


⠸ Linking AOT files... (1.8s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_class_table_link_data=/Users/erick/projects/shorebird/fun_app_to_test/build/out.ct.link /Users/erick/projects/shorebird/fun_app_to_test/build/out.aot

⠋ Linking AOT files... (2.4s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --shorebird --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/App.analyze_snapshot.json /var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App

⠏ Linking AOT files... (3.1s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_pool /var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App

⠋ Linking AOT files... (3.2s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_class_table --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/App.class_table.json /var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App

[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_dispatch_table --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/App.dispatch_table.json /var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App

⠙ Linking AOT files... (3.3s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --shorebird --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/out.analyze_snapshot.json /Users/erick/projects/shorebird/fun_app_to_test/build/out.aot

⠋ Linking AOT files... (4.0s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_pool /Users/erick/projects/shorebird/fun_app_to_test/build/out.aot

⠙ Linking AOT files... (4.1s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_class_table --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/out.class_table.json /Users/erick/projects/shorebird/fun_app_to_test/build/out.aot

[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_dispatch_table --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/out.dispatch_table.json /Users/erick/projects/shorebird/fun_app_to_test/build/out.aot

⠹ Linking AOT files... (4.2s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/gen_snapshot_arm64 --snapshot_kind=app-aot-elf --base_ct_link_data=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App.ct.link --patch_ct_link_data=/Users/erick/projects/shorebird/fun_app_to_test/build/out.ct.link --elf=/Users/erick/projects/shorebird/fun_app_to_test/build/out.ct.aot /Users/erick/projects/shorebird/fun_app_to_test/build/app.dill

⠙ Linking AOT files... (7.3s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --shorebird --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/out.ct.analyze_snapshot.json /Users/erick/projects/shorebird/fun_app_to_test/build/out.ct.aot

⠋ Linking AOT files... (8.0s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_pool /Users/erick/projects/shorebird/fun_app_to_test/build/out.ct.aot

[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_class_table --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/out.ct.class_table.json /Users/erick/projects/shorebird/fun_app_to_test/build/out.ct.aot

⠙ Linking AOT files... (8.1s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_dispatch_table --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/out.ct.dispatch_table.json /Users/erick/projects/shorebird/fun_app_to_test/build/out.ct.aot

⠹ Linking AOT files... (8.2s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_object_pool_link_data=/Users/erick/projects/shorebird/fun_app_to_test/build/out.op.link /Users/erick/projects/shorebird/fun_app_to_test/build/out.ct.aot

⠋ Linking AOT files... (8.8s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/gen_snapshot_arm64 --snapshot_kind=app-aot-elf --base_ct_link_data=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App.ct.link --patch_ct_link_data=/Users/erick/projects/shorebird/fun_app_to_test/build/out.ct.link --base_op_link_data=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App.op.link --patch_op_link_data=/Users/erick/projects/shorebird/fun_app_to_test/build/out.op.link --elf=/Users/erick/projects/shorebird/fun_app_to_test/build/out.optimized.aot /Users/erick/projects/shorebird/fun_app_to_test/build/app.dill

⠋ Linking AOT files... (12.0s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --shorebird --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/out.optimized.analyze_snapshot.json /Users/erick/projects/shorebird/fun_app_to_test/build/out.optimized.aot


⠇ Linking AOT files... (12.6s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_pool /Users/erick/projects/shorebird/fun_app_to_test/build/out.optimized.aot

⠏ Linking AOT files... (12.7s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_class_table --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/out.optimized.class_table.json /Users/erick/projects/shorebird/fun_app_to_test/build/out.optimized.aot

[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --dump_dispatch_table --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/WyLgoi/out.optimized.dispatch_table.json /Users/erick/projects/shorebird/fun_app_to_test/build/out.optimized.aot

⠋ Linking AOT files... (12.8s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --shorebird --out=/var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App.analyze_snapshot.json /var/folders/ss/9fk0zqts6zgbx2dv4h19ctph0000gn/T/W1nkN8/Products/Applications/Runner.app/Frameworks/App.framework/App

⠏ Linking AOT files... (13.5s)[Process] /Users/erick/projects/shorebird/shorebird/bin/cache/flutter/c20374bd2ceb8bdff113cce13a4bb6180021d958/bin/cache/artifacts/engine/ios-release/analyze_snapshot_arm64 --shorebird --out=/Users/erick/projects/shorebird/fun_app_to_test/build/out.optimized.analyze_snapshot.json /Users/erick/projects/shorebird/fun_app_to_test/build/out.optimized.aot

⠋ Linking AOT files... (14.4s)[Linker Debug]: Patch collision: c2d19a029b92b1705ad6214c8eff310253f68ffb

[Linker Debug]: Patch collision: 38889fab9e51a89b0db6219a9d7d6ad375d8bdaa
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
