### PR TITLE
fix(shorebird_cli): don't allow --release-version for ios and android releases

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
@@ -63,6 +63,17 @@ class AndroidReleaser extends Releaser {
   @override
   Future<void> assertArgsAreValid() async {
     argResults.assertAbsentOrValidPublicKey();
+
+    if (argResults.wasParsed('release-version')) {
+      logger.err(
+        '''
+The "--release-version" flag is only supported for aar and ios-framework releases.
+        
+To change the version of this release, change your app's version in your pubspec.yaml.''',
+      );
+      throw ProcessExit(ExitCode.usage.code);
+    }
+
     if (generateApk && splitApk) {
       logger
         ..err(

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -42,6 +42,17 @@ class IosReleaser extends Releaser {
   @override
   Future<void> assertArgsAreValid() async {
     argResults.assertAbsentOrValidPublicKey();
+
+    if (argResults.wasParsed('release-version')) {
+      logger.err(
+        '''
+The "--release-version" flag is only supported for aar and ios-framework releases.
+        
+To change the version of this release, change your app's version in your pubspec.yaml.''',
+      );
+      throw ProcessExit(ExitCode.usage.code);
+    }
+
     if (argResults.rest.contains('--obfuscate')) {
       // Obfuscated releases break patching, so we don't support them.
       // See https://github.com/shorebirdtech/shorebird/issues/1619

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -116,7 +116,7 @@ On Xcode builds it is used as "CFBundleVersion".''',
         'release-version',
         help: '''
 The version of the associated release (e.g. "1.0.0"). This should be the version
-of the iOS app that is using this module.''',
+of the iOS app that is using this module. (aar and ios-framework only)''',
       )
       ..addMultiOption(
         'target-platform',

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -189,6 +189,28 @@ void main() {
     });
 
     group('assertArgsAreValid', () {
+      group('when release-version is passed', () {
+        setUp(() {
+          when(() => argResults.wasParsed('release-version')).thenReturn(true);
+        });
+
+        test('logs error and exits with usage err', () async {
+          await expectLater(
+            () => runWithOverrides(androidReleaser.assertArgsAreValid),
+            exitsWithCode(ExitCode.usage),
+          );
+
+          verify(
+            () => logger.err(
+              '''
+The "--release-version" flag is only supported for aar and ios-framework releases.
+        
+To change the version of this release, change your app's version in your pubspec.yaml.''',
+            ),
+          ).called(1);
+        });
+      });
+
       group('when split-per-abi is true', () {
         setUp(() {
           when(() => argResults['artifact']).thenReturn('apk');

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -218,6 +218,29 @@ For more information see: $supportedVersionsLink''',
       });
 
       group('assertArgsAreValid', () {
+        group('when release-version is passed', () {
+          setUp(() {
+            when(() => argResults.wasParsed('release-version'))
+                .thenReturn(true);
+          });
+
+          test('logs error and exits with usage err', () async {
+            await expectLater(
+              () => runWithOverrides(iosReleaser.assertArgsAreValid),
+              exitsWithCode(ExitCode.usage),
+            );
+
+            verify(
+              () => logger.err(
+                '''
+The "--release-version" flag is only supported for aar and ios-framework releases.
+        
+To change the version of this release, change your app's version in your pubspec.yaml.''',
+              ),
+            ).called(1);
+          });
+        });
+
         group('when --obfuscate is passed', () {
           setUp(() {
             when(() => argResults.rest).thenReturn(['--obfuscate']);


### PR DESCRIPTION
## Description

A quick fix for https://github.com/shorebirdtech/shorebird/issues/2240. When `--release-version` is provided to `shorebird release ios` or `shorebird release android`, print a usage error and exit. 

This flag is only useful for `aar` and `ios-framework` release targets and does nothing for `ios` or `android` releases. Because it's a valid option to the `release` command, it is parsed and the user has no idea that it isn't working.

A better long-term fix would be addressing https://github.com/shorebirdtech/shorebird/issues/793, which would decouple release versions from the actual app version.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
