### PR TITLE
feat: better handling of errors when refreshing the token fails

### DIFF
--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -117,7 +117,7 @@ class AuthenticatedClient extends http.BaseClient {
 
     if (credentials == null) {
       final token = _token!;
-      credentials = _credentials = await _refresh(
+      credentials = _credentials = await _tryRefreshCredentials(
         token.authProvider.clientId,
         oauth2.AccessCredentials(
           // This isn't relevant for a refresh operation.
@@ -135,7 +135,7 @@ class AuthenticatedClient extends http.BaseClient {
       final jwt = Jwt.parse(credentials.idToken!);
       final authProvider = jwt.authProvider;
 
-      credentials = _credentials = await _refresh(
+      credentials = _credentials = await _tryRefreshCredentials(
         authProvider.clientId,
         credentials,
         _baseClient,
@@ -149,7 +149,7 @@ class AuthenticatedClient extends http.BaseClient {
     return _baseClient.send(request);
   }
 
-  Future<oauth2.AccessCredentials> _refresh(
+  Future<oauth2.AccessCredentials> _tryRefreshCredentials(
     oauth2.ClientId clientId,
     oauth2.AccessCredentials credentials,
     http.Client client, {

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -202,10 +202,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
@@ -791,10 +791,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "360c4271613beb44db559547d02f8b0dc044741d0eeb9aa6ccdb47e8ec54c63a"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.3"
+    version: "14.2.4"
   watcher:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/test/src/auth/auth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_test.dart
@@ -269,7 +269,8 @@ void main() {
         });
 
         group('when refreshing the token fails', () {
-          test('exits and logs correctly', () async {
+          late AuthenticatedClient client;
+          setUp(() {
             when(() => httpClient.send(any())).thenAnswer(
               (_) async => http.StreamedResponse(
                 const Stream.empty(),
@@ -279,7 +280,7 @@ void main() {
 
             final onRefreshCredentialsCalls = <oauth2.AccessCredentials>[];
 
-            final client = AuthenticatedClient.token(
+            client = AuthenticatedClient.token(
               token: ciToken,
               httpClient: httpClient,
               onRefreshCredentials: onRefreshCredentialsCalls.add,
@@ -291,7 +292,9 @@ void main() {
               }) async =>
                   throw Exception('error.'),
             );
+          });
 
+          test('exits and logs correctly', () async {
             await expectLater(
               () => runWithOverrides(
                 () => client.get(Uri.parse('https://example.com')),
@@ -404,7 +407,8 @@ void main() {
         });
 
         group('when refreshing the token fails', () {
-          test('exits and logs correctly', () async {
+          late AuthenticatedClient client;
+          setUp(() {
             when(() => httpClient.send(any())).thenAnswer(
               (_) async => http.StreamedResponse(
                 const Stream.empty(),
@@ -426,7 +430,7 @@ void main() {
               idToken: expiredIdToken,
             );
 
-            final client = AuthenticatedClient.credentials(
+            client = AuthenticatedClient.credentials(
               credentials: expiredCredentials,
               httpClient: httpClient,
               onRefreshCredentials: onRefreshCredentialsCalls.add,
@@ -438,7 +442,9 @@ void main() {
               }) async =>
                   throw Exception('error.'),
             );
+          });
 
+          test('exits and logs correctly', () async {
             await expectLater(
               () => runWithOverrides(
                 () => client.get(Uri.parse('https://example.com')),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adds a better handling on our CLI when refreshing the token fails. It will print a message suggesting the user to logout and login again.

Solves #2200 

![Screenshot 2024-06-14 at 10 59 51](https://github.com/shorebirdtech/shorebird/assets/835641/ae52ee44-a3c8-4f7e-886b-71bdc3378cc8)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
