### PR TITLE
fix(shorebird_cli): validate flavor arg is correct

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/doctor_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/doctor_command.dart
@@ -87,7 +87,7 @@ Android Toolchain
 
     logger.info(output.toString());
 
-    await doctor.runValidators(doctor.allValidators, applyFixes: shouldFix);
+    await doctor.runValidators(doctor.generalValidators, applyFixes: shouldFix);
 
     return ExitCode.success.code;
   }

--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -231,7 +231,7 @@ Reference the following commands to get started:
 For more information about Shorebird, visit ${link(uri: Uri.parse('https://shorebird.dev'))}''',
     );
 
-    await doctor.runValidators(doctor.allValidators, applyFixes: true);
+    await doctor.runValidators(doctor.generalValidators, applyFixes: true);
 
     return ExitCode.success.code;
   }

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -23,6 +23,7 @@ import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
+import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
@@ -203,9 +204,9 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
   @visibleForTesting
   Future<void> createPatch(Patcher patcher) async {
     await patcher.assertPreconditions();
-
-    results.assertAbsentOrValidKeyPair();
     await patcher.assertArgsAreValid();
+    results.assertAbsentOrValidKeyPair();
+    await shorebirdValidator.validateFlavors(flavorArg: flavor);
 
     await cache.updateAll();
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -15,6 +15,7 @@ import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
+import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
@@ -206,6 +207,8 @@ of the iOS app that is using this module.''',
   Future<void> createRelease(Releaser releaser) async {
     await releaser.assertPreconditions();
     await releaser.assertArgsAreValid();
+
+    await shorebirdValidator.validateFlavors(flavorArg: flavor);
 
     await cache.updateAll();
 

--- a/packages/shorebird_cli/lib/src/commands/run_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/run_command.dart
@@ -63,7 +63,7 @@ Please use "shorebird preview" instead.''',
     try {
       await shorebirdValidator.validatePreconditions(
         checkUserIsAuthenticated: true,
-        validators: doctor.allValidators,
+        validators: doctor.generalValidators,
       );
     } on PreconditionFailedException catch (e) {
       return e.exitCode.code;

--- a/packages/shorebird_cli/lib/src/doctor.dart
+++ b/packages/shorebird_cli/lib/src/doctor.dart
@@ -24,8 +24,8 @@ class Doctor {
   /// Validators that verify shorebird will work on iOS.
   final List<Validator> iosCommandValidators = [];
 
-  /// All available validators.
-  List<Validator> allValidators = [
+  /// Validators that should run on all commands.
+  List<Validator> generalValidators = [
     ShorebirdVersionValidator(),
     ShorebirdFlutterValidator(),
     AndroidInternetPermissionValidator(),

--- a/packages/shorebird_cli/lib/src/shorebird_validator.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_validator.dart
@@ -149,7 +149,7 @@ To fix, update your pubspec.yaml to include the following:
     final issues = await flavorValidator.validate();
     if (validationIssuesContainsError(issues)) {
       for (final issue in issues) {
-        logger.info(issue.message);
+        logger.err(issue.message);
       }
 
       throw ValidationFailedException();

--- a/packages/shorebird_cli/lib/src/shorebird_validator.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_validator.dart
@@ -146,7 +146,7 @@ To fix, update your pubspec.yaml to include the following:
   /// issues are found.
   Future<void> validateFlavors({required String? flavorArg}) async {
     final flavorValidator = FlavorValidator(flavorArg: flavorArg);
-    final issues = await runValidators([flavorValidator]);
+    final issues = await flavorValidator.validate();
     if (validationIssuesContainsError(issues)) {
       for (final issue in issues) {
         logger.info(issue.message);

--- a/packages/shorebird_cli/lib/src/shorebird_validator.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_validator.dart
@@ -142,6 +142,20 @@ To fix, update your pubspec.yaml to include the following:
     return validationIssues;
   }
 
+  /// Runs [FlavorValidator] and throws a [ValidationFailedException] if any
+  /// issues are found.
+  Future<void> validateFlavors({required String? flavorArg}) async {
+    final flavorValidator = FlavorValidator(flavorArg: flavorArg);
+    final issues = await runValidators([flavorValidator]);
+    if (validationIssuesContainsError(issues)) {
+      for (final issue in issues) {
+        logger.info(issue.message);
+      }
+
+      throw ValidationFailedException();
+    }
+  }
+
   /// Whether any [ValidationIssue]s have a severity of
   /// [ValidationIssueSeverity.error].
   bool validationIssuesContainsError(List<ValidationIssue> issues) =>

--- a/packages/shorebird_cli/lib/src/validators/flavor_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/flavor_validator.dart
@@ -1,0 +1,59 @@
+import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
+import 'package:shorebird_cli/src/validators/validators.dart';
+
+/// {@template flavor_validator}
+/// Verifies that the flavors in the Shorebird configuration match the
+/// --flavor argument provided by the user. This throws a [ProcessExit] if:
+///  1. The project has flavors but no `--flavor` argument was provided.
+///  2. The project does not have flavors but a `--flavor` argument was
+///     provided.
+///  3. The project has flavors and a `--flavor` argument was provided, but
+///     the flavor does not exist in the project.
+/// {@endtemplate}
+class FlavorValidator extends Validator {
+  /// {@macro flavor_validator}
+  FlavorValidator({required this.flavorArg});
+
+  /// The flavor argument provided by the user via `--flavor`.
+  final String? flavorArg;
+
+  @override
+  String get description => 'Flavor argument is valid for project flavors';
+
+  @override
+  Future<List<ValidationIssue>> validate() async {
+    final projectFlavors = shorebirdEnv.getShorebirdYaml()!.flavors;
+    if (projectFlavors == null && flavorArg != null) {
+      return [
+        ValidationIssue.error(
+          message:
+              '''The project does not have any flavors defined, but the --flavor argument was provided''',
+        ),
+      ];
+    }
+
+    if (projectFlavors != null && flavorArg == null) {
+      print('oh no!');
+      return [
+        ValidationIssue.error(
+          message:
+              '''The project has flavors ${projectFlavors.keys}, but no --flavor argument was provided''',
+        ),
+      ];
+    }
+
+    if (projectFlavors != null &&
+        flavorArg != null &&
+        !projectFlavors.containsKey(flavorArg)) {
+      return [
+        ValidationIssue.error(
+          message:
+              '''This project does not have a flavor named "$flavorArg". Available flavors: ${projectFlavors.keys}''',
+        ),
+      ];
+    }
+
+    return [];
+  }
+}

--- a/packages/shorebird_cli/lib/src/validators/flavor_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/flavor_validator.dart
@@ -34,7 +34,6 @@ class FlavorValidator extends Validator {
     }
 
     if (projectFlavors != null && flavorArg == null) {
-      print('oh no!');
       return [
         ValidationIssue.error(
           message:

--- a/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/shorebird_flutter_validator.dart
@@ -40,18 +40,12 @@ class ShorebirdFlutterValidator extends Validator {
     if (!shorebirdEnv.flutterDirectory.existsSync()) {
       final message =
           'No Flutter directory found at ${shorebirdEnv.flutterDirectory}';
-      issues.add(
-        ValidationIssue(
-          severity: ValidationIssueSeverity.error,
-          message: message,
-        ),
-      );
+      issues.add(ValidationIssue.error(message: message));
     }
 
     if (!await shorebirdFlutter.isUnmodified()) {
       issues.add(
-        ValidationIssue(
-          severity: ValidationIssueSeverity.warning,
+        ValidationIssue.warning(
           message: '${shorebirdEnv.flutterDirectory} has local modifications',
         ),
       );
@@ -62,8 +56,7 @@ class ShorebirdFlutterValidator extends Validator {
       shorebirdFlutterVersionString = await _getFlutterVersion();
     } catch (error) {
       issues.add(
-        ValidationIssue(
-          severity: ValidationIssueSeverity.error,
+        ValidationIssue.error(
           message: 'Failed to determine Shorebird Flutter version. $error',
         ),
       );
@@ -78,8 +71,7 @@ class ShorebirdFlutterValidator extends Validator {
       // If there is no system Flutter, we don't throw a validation exception.
     } catch (error) {
       issues.add(
-        ValidationIssue(
-          severity: ValidationIssueSeverity.error,
+        ValidationIssue.error(
           message: 'Failed to determine path Flutter version. $error',
         ),
       );
@@ -98,12 +90,7 @@ The version of Flutter that Shorebird includes and the Flutter on your path are 
 \tSystem Flutter:    $pathFlutterVersionString
 This can cause unexpected behavior if you are switching between the tools and the version gap is wide. If you have any trouble, please let us know on Shorebird discord.''';
 
-        issues.add(
-          ValidationIssue(
-            severity: ValidationIssueSeverity.warning,
-            message: message,
-          ),
-        );
+        issues.add(ValidationIssue.warning(message: message));
       }
     }
 
@@ -112,8 +99,7 @@ This can cause unexpected behavior if you are switching between the tools and th
     if (flutterStorageEnvironmentValue != null &&
         flutterStorageEnvironmentValue.isNotEmpty) {
       issues.add(
-        const ValidationIssue(
-          severity: ValidationIssueSeverity.warning,
+        ValidationIssue.warning(
           message: 'Shorebird does not respect the FLUTTER_STORAGE_BASE_URL '
               'environment variable at this time',
         ),

--- a/packages/shorebird_cli/lib/src/validators/validators.dart
+++ b/packages/shorebird_cli/lib/src/validators/validators.dart
@@ -5,6 +5,7 @@ import 'package:meta/meta.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 
 export 'android_internet_permission_validator.dart';
+export 'flavor_validator.dart';
 export 'shorebird_flutter_validator.dart';
 export 'shorebird_version_validator.dart';
 export 'shorebird_yaml_asset_validator.dart';
@@ -53,6 +54,20 @@ class ValidationIssue {
     required this.message,
     this.fix,
   });
+
+  /// Creates a new [ValidationIssue] with a severity of
+  /// [ValidationIssueSeverity.error].
+  factory ValidationIssue.error({required String message}) => ValidationIssue(
+        severity: ValidationIssueSeverity.error,
+        message: message,
+      );
+
+  /// Creates a new [ValidationIssue] with a severity of
+  /// [ValidationIssueSeverity.warning].
+  factory ValidationIssue.warning({required String message}) => ValidationIssue(
+        severity: ValidationIssueSeverity.warning,
+        message: message,
+      );
 
   /// How important it is to fix this issue.
   final ValidationIssueSeverity severity;

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -202,10 +202,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
@@ -791,10 +791,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "360c4271613beb44db559547d02f8b0dc044741d0eeb9aa6ccdb47e8ec54c63a"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.3"
+    version: "14.2.4"
   watcher:
     dependency: transitive
     description:

--- a/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
@@ -75,7 +75,7 @@ void main() {
         () => shorebirdEnv.flutterRevision,
       ).thenReturn(shorebirdFlutterRevision);
       when(() => shorebirdEnv.logsDirectory).thenReturn(logsDirectory);
-      when(() => doctor.allValidators).thenReturn([validator]);
+      when(() => doctor.generalValidators).thenReturn([validator]);
       when(
         () => doctor.runValidators(any(), applyFixes: any(named: 'applyFixes')),
       ).thenAnswer((_) async => {});

--- a/packages/shorebird_cli/test/src/commands/init_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/init_command_test.dart
@@ -97,7 +97,7 @@ environment:
       when(
         () => doctor.runValidators(any(), applyFixes: any(named: 'applyFixes')),
       ).thenAnswer((_) async => {});
-      when(() => doctor.allValidators).thenReturn([]);
+      when(() => doctor.generalValidators).thenReturn([]);
       when(
         () => shorebirdEnv.getShorebirdYamlFile(cwd: any(named: 'cwd')),
       ).thenReturn(shorebirdYamlFile);

--- a/packages/shorebird_cli/test/src/commands/run_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/run_command_test.dart
@@ -62,7 +62,7 @@ void main() {
         ),
       ).thenAnswer((_) async => process);
       when(() => argResults.rest).thenReturn([]);
-      when(() => doctor.allValidators).thenReturn([validator]);
+      when(() => doctor.generalValidators).thenReturn([validator]);
       when(() => logger.progress(any())).thenReturn(MockProgress());
       when(() => ioSink.addStream(any())).thenAnswer((_) async {});
       when(

--- a/packages/shorebird_cli/test/src/shorebird_validator_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_validator_test.dart
@@ -3,6 +3,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:platform/platform.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
+import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -208,6 +209,39 @@ To fix, update your pubspec.yaml to include the following:
           throwsA(isA<UnsupportedContextException>()),
         );
         verify(() => logger.err(errorMessage)).called(1);
+      });
+    });
+
+    group('validateFlavors', () {
+      const shorebirdYaml = ShorebirdYaml(
+        appId: 'test',
+        flavors: {'flavorA': 'flavorA'},
+      );
+
+      setUp(() {
+        when(() => shorebirdEnv.getShorebirdYaml()).thenReturn(shorebirdYaml);
+      });
+
+      group('when validation fails', () {
+        test('throws ValidationException', () async {
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdValidator.validateFlavors(flavorArg: null),
+            ),
+            throwsA(isA<ValidationFailedException>()),
+          );
+        });
+      });
+
+      group('when validation succeeds', () {
+        test('completes normally', () async {
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdValidator.validateFlavors(flavorArg: 'flavorA'),
+            ),
+            completes,
+          );
+        });
       });
     });
   });

--- a/packages/shorebird_cli/test/src/validators/flavor_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/flavor_validator_test.dart
@@ -1,0 +1,138 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_cli/src/config/config.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/validators/validators.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group(FlavorValidator, () {
+    const appId = 'app-id';
+    const flavors = {'flavorA': 'flavorA', 'flavorB': 'flavorB'};
+    const shorebirdYamlWithoutFlavors = ShorebirdYaml(appId: appId);
+    const shorebirdYamlWithFlavors = ShorebirdYaml(
+      appId: appId,
+      flavors: flavors,
+    );
+    late ShorebirdEnv shorebirdEnv;
+
+    late FlavorValidator validator;
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        body,
+        values: {
+          shorebirdEnvRef.overrideWith(() => shorebirdEnv),
+        },
+      );
+    }
+
+    setUp(() {
+      shorebirdEnv = MockShorebirdEnv();
+      validator = FlavorValidator(flavorArg: 'flavor');
+    });
+
+    group('description', () {
+      test('is not empty', () {
+        expect(validator.description, isNotEmpty);
+      });
+    });
+
+    group('validate', () {
+      group('when project does not have flavors', () {
+        setUp(() {
+          when(() => shorebirdEnv.getShorebirdYaml())
+              .thenReturn(shorebirdYamlWithoutFlavors);
+        });
+
+        group('when flavor arg is provided', () {
+          setUp(() {
+            validator = FlavorValidator(flavorArg: 'flavor');
+          });
+
+          test('returns no validation issues', () async {
+            final issues = await runWithOverrides(validator.validate);
+            expect(issues, isNot(isEmpty));
+            expect(
+              issues.first.message,
+              equals(
+                '''The project does not have any flavors defined, but the --flavor argument was provided''',
+              ),
+            );
+          });
+        });
+
+        group('when no flavor arg is provided', () {
+          setUp(() {
+            validator = FlavorValidator(flavorArg: null);
+          });
+
+          test('returns no validation issues', () async {
+            final issues = await runWithOverrides(validator.validate);
+            expect(issues, isEmpty);
+          });
+        });
+      });
+
+      group('when project has flavors', () {
+        setUp(() {
+          when(() => shorebirdEnv.getShorebirdYaml())
+              .thenReturn(shorebirdYamlWithFlavors);
+        });
+
+        group('when flavor arg is provided', () {
+          group('when flavor exists in project', () {
+            setUp(() {
+              validator = FlavorValidator(flavorArg: 'flavorA');
+            });
+
+            test('returns no issues', () async {
+              final issues = await runWithOverrides(validator.validate);
+              expect(issues, isEmpty);
+            });
+          });
+
+          group('when flavor does not exist in project', () {
+            setUp(() {
+              validator = FlavorValidator(flavorArg: 'flavorC');
+            });
+
+            test('returns validation error', () async {
+              final issues = await runWithOverrides(validator.validate);
+              expect(
+                issues,
+                equals([
+                  ValidationIssue.error(
+                    message:
+                        '''This project does not have a flavor named "flavorC". Available flavors: (flavorA, flavorB)''',
+                  ),
+                ]),
+              );
+            });
+          });
+        });
+
+        group('when no flavor arg is provided', () {
+          setUp(() {
+            validator = FlavorValidator(flavorArg: null);
+          });
+
+          test('returns validation error', () async {
+            final issues = await runWithOverrides(validator.validate);
+            expect(
+              issues,
+              equals([
+                ValidationIssue.error(
+                  message:
+                      '''The project has flavors (flavorA, flavorB), but no --flavor argument was provided''',
+                ),
+              ]),
+            );
+          });
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds explicit validation that the `--flavor` arg (provided or not) is correct. This means that:

- If no flavor arg is provided, assert that the project does not have flavors
- If a flavor arg is provided, assert that the project has the flavor provided.

Fixes https://github.com/shorebirdtech/shorebird/issues/2243
Fixes https://github.com/shorebirdtech/shorebird/issues/978

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
