### PR TITLE
fix: gracefully handling patching on a app with no releases

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -313,7 +313,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
       logger.warn(
         '''No releases found for app $appId. You need to make first a release before you can create a patch.''',
       );
-      throw ProcessExit(ExitCode.success.code);
+      throw ProcessExit(ExitCode.usage.code);
     }
 
     return logger.chooseOne<Release>(

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -308,6 +308,14 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
     final releases = await codePushClientWrapper.getReleases(
       appId: appId,
     );
+
+    if (releases.isEmpty) {
+      logger.warn(
+        '''No releases found for app $appId. You need to make first a release before you can create a patch.''',
+      );
+      throw ProcessExit(ExitCode.success.code);
+    }
+
     return logger.chooseOne<Release>(
       'Which release would you like to patch?',
       choices: releases.sortedBy((r) => r.createdAt).reversed.toList(),

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -683,12 +683,12 @@ void main() {
           when(
             () => codePushClientWrapper.getReleases(appId: any(named: 'appId')),
           ).thenAnswer((_) async => []);
-        }); 
+        });
 
         test('warns and exits', () async {
           await expectLater(
             () => runWithOverrides(command.run),
-            exitsWithCode(ExitCode.success),
+            exitsWithCode(ExitCode.usage),
           );
 
           verify(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -683,7 +683,8 @@ void main() {
           when(
             () => codePushClientWrapper.getReleases(appId: any(named: 'appId')),
           ).thenAnswer((_) async => []);
-        });
+        }); 
+
         test('warns and exits', () async {
           await expectLater(
             () => runWithOverrides(command.run),

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -678,6 +678,26 @@ void main() {
         );
       });
 
+      group('when prompting for releases, but there is none', () {
+        setUp(() {
+          when(
+            () => codePushClientWrapper.getReleases(appId: any(named: 'appId')),
+          ).thenAnswer((_) async => []);
+        });
+        test('warns and exits', () async {
+          await expectLater(
+            () => runWithOverrides(command.run),
+            exitsWithCode(ExitCode.success),
+          );
+
+          verify(
+            () => logger.warn(
+              '''No releases found for app $appId. You need to make first a release before you can create a patch.''',
+            ),
+          ).called(1);
+        });
+      });
+
       group('when running on CI', () {
         setUp(() {
           when(() => shorebirdEnv.canAcceptUserInput).thenReturn(false);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

`shorebird patch` would fail with a weird message if executed in an app with no releases.

This PR tries to gracefully handle that by displaying a warning and exiting the command.

Fixes #2242

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
