### PR TITLE
fix: shorebird release deletes older preview cache

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -89,6 +89,19 @@ class Cache {
     );
   }
 
+  String getPreviewArtifactPath({
+    required String appId,
+    required String releaseVersion,
+    required String platformName,
+    required String extension,
+  }) {
+    final previewDirectory = cache.getPreviewDirectory(appId);
+    return p.join(
+      previewDirectory.path,
+      '${platformName}_$releaseVersion.$extension',
+    );
+  }
+
   /// The Shorebird cache directory.
   static Directory get shorebirdCacheDirectory {
     return Directory(

--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -415,13 +415,13 @@ class PreviewCommand extends ShorebirdCommand {
     required Release release,
     required ReleasePlatform platform,
     required String extension,
-  }) {
-    final previewDirectory = cache.getPreviewDirectory(appId);
-    return p.join(
-      previewDirectory.path,
-      '${platform.name}_${release.version}.$extension',
-    );
-  }
+  }) =>
+      cache.getPreviewArtifactPath(
+        appId: appId,
+        releaseVersion: release.version,
+        platformName: platform.name,
+        extension: extension,
+      );
 
   /// Sets the channel property in the shorebird.yaml file inside the Runner.app
   Future<void> setChannelOnRunner({

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
@@ -264,6 +265,24 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
         await prepareRelease(release: release, releaser: releaser);
         await releaser.uploadReleaseArtifacts(release: release, appId: appId);
         await finalizeRelease(release: release, releaser: releaser);
+
+        final releasePlatform = releaser.releaseType.releasePlatform;
+
+        final previewPath = cache.getPreviewArtifactPath(
+          appId: appId,
+          releaseVersion: releaseVersion,
+          platformName: releasePlatform.name,
+          extension: releasePlatform.extension,
+        );
+
+        final previewArtifact = releasePlatform == ReleasePlatform.android
+            ? File(previewPath)
+            : Directory(previewPath);
+
+        if (previewArtifact.existsSync()) {
+          previewArtifact.deleteSync(recursive: true);
+          logger.info('🧹 Deleted outdated preview artifact.');
+        }
 
         logger
           ..success('''

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -163,6 +163,32 @@ void main() {
       });
     });
 
+    group('getPreviewArtifactPath', () {
+      test('returns correct path', () {
+        final path = runWithOverrides(
+          () => cache.getPreviewArtifactPath(
+            appId: '123',
+            releaseVersion: '1.0.0',
+            platformName: 'ios',
+            extension: 'app',
+          ),
+        );
+
+        expect(
+          path.endsWith(
+            p.join(
+              'bin',
+              'cache',
+              'previews',
+              '123',
+              'ios_1.0.0.app',
+            ),
+          ),
+          isTrue,
+        );
+      });
+    });
+
     group('clear', () {
       test('deletes the cache directory', () async {
         final shorebirdCacheDirectory = runWithOverrides(

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -334,6 +334,22 @@ void main() {
           ReleasePlatform.android: ReleaseStatus.active,
           ReleasePlatform.ios: ReleaseStatus.active,
         });
+        when(
+          () => cache.getPreviewArtifactPath(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+            platformName: any(named: 'platformName'),
+            extension: 'aab',
+          ),
+        ).thenReturn(aabPath());
+        when(
+          () => cache.getPreviewArtifactPath(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+            platformName: any(named: 'platformName'),
+            extension: 'apks',
+          ),
+        ).thenReturn(apksPath());
       });
 
       // This should probably be outside of the android group, but because
@@ -990,6 +1006,14 @@ channel: ${track.channel}
         });
         when(() => releaseArtifact.url).thenReturn(releaseArtifactUrl);
         when(() => platform.isMacOS).thenReturn(true);
+        when(
+          () => cache.getPreviewArtifactPath(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+            platformName: any(named: 'platformName'),
+            extension: 'app',
+          ),
+        ).thenReturn(runnerPath());
       });
 
       File setupShorebirdYaml() => File(

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_platform.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_platform.dart
@@ -1,12 +1,15 @@
 /// A platform to which a Shorebird release can be deployed.
 enum ReleasePlatform {
   // ignore: public_member_api_docs
-  android('Android'),
+  android('Android', 'aab'),
   // ignore: public_member_api_docs
-  ios('iOS');
+  ios('iOS', 'app');
 
-  const ReleasePlatform(this.displayName);
+  const ReleasePlatform(this.displayName, this.extension);
 
   /// The display name of the platform.
   final String displayName;
+
+  /// The file extension for the platform.
+  final String extension;
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

When running a preview, the CLI will always use the cache artifact if one if found. This might make the command run an outdated artifact when a release is delete by some reason.

This command implements a new logic in the `release` command that will check if a preview artifact is cached for that app release, and delete it if there is.

Fixes #1746 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
