### PR TITLE
fix(shorebird_cli): `shorebird preview` to not use outdated cached preview artifacts

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -216,10 +216,10 @@ class PreviewCommand extends ShorebirdCommand {
 
     final downloadArtifactProgress = logger.progress('Downloading release');
     late File aabFile;
-    late ReleaseArtifact artifact;
+    late ReleaseArtifact releaseAabArtifact;
 
     try {
-      artifact = await codePushClientWrapper.getReleaseArtifact(
+      releaseAabArtifact = await codePushClientWrapper.getReleaseArtifact(
         appId: appId,
         releaseId: release.id,
         arch: 'aab',
@@ -237,7 +237,7 @@ class PreviewCommand extends ShorebirdCommand {
         getArtifactPath(
           appId: appId,
           release: release,
-          artifact: artifact,
+          artifact: releaseAabArtifact,
           platform: platform,
           extension: 'aab',
         ),
@@ -247,7 +247,7 @@ class PreviewCommand extends ShorebirdCommand {
         aabFile.createSync(recursive: true);
 
         await artifactManager.downloadFile(
-          Uri.parse(artifact.url),
+          Uri.parse(releaseAabArtifact.url),
           outputPath: aabFile.path,
         );
         downloadArtifactProgress.complete();
@@ -260,7 +260,7 @@ class PreviewCommand extends ShorebirdCommand {
     final apksPath = getArtifactPath(
       appId: appId,
       release: release,
-      artifact: artifact,
+      artifact: releaseAabArtifact,
       platform: platform,
       extension: 'apks',
     );

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -929,6 +929,7 @@ channel: ${track.channel}
             ),
           ).thenThrow(Exception('oops'));
         });
+
         test('returns error and logs', () async {
           final result = await runWithOverrides(command.run);
           expect(result, equals(ExitCode.software.code));
@@ -1238,6 +1239,7 @@ channel: ${DeploymentTrack.staging.channel}
             ),
           ).thenThrow(Exception('oops'));
         });
+
         test('returns error and logs', () async {
           when(
             () => iosDeploy.installAndLaunchApp(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

When running a preview, the CLI will always use the cache artifact if one if found. This might make the command run an outdated artifact when a release is delete by some reason.

This PR makes the artifact id to be part of the path of the preview artifact, that way, if a release is deleted and recreated, the id will be a fresh one and the cli will not accidentally use the wrong cached artifact.

Fixes https://github.com/shorebirdtech/shorebird/issues/1746

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
