### PR TITLE
feat: adding gradlew version to the doctor output

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/doctor_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/doctor_command.dart
@@ -83,6 +83,11 @@ Android Toolchain
   • JAVA_HOME: ${java.home ?? notDetected}
   • JAVA_EXECUTABLE: ${javaExe ?? notDetected}
   • JAVA_VERSION: $javaVersion''');
+
+      if (gradlew.exists(Directory.current.path)) {
+        final gradlewVersion = await gradlew.version(Directory.current.path);
+        output.writeln('Gradle Wrapper: $gradlewVersion');
+      }
     }
 
     logger.info(output.toString());

--- a/packages/shorebird_cli/lib/src/commands/doctor_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/doctor_command.dart
@@ -73,6 +73,12 @@ Engine • revision ${shorebirdEnv.shorebirdEngineRevision}''',
               .join('${Platform.lineTerminator}                  ');
         }
       }
+
+      String? gradlewVersion;
+      if (gradlew.exists(Directory.current.path)) {
+        gradlewVersion = await gradlew.version(Directory.current.path);
+      }
+
       output.writeln('''
 
 Logs: ${shorebirdEnv.logsDirectory.path}
@@ -82,12 +88,8 @@ Android Toolchain
   • ADB: ${androidSdk.adbPath ?? notDetected}
   • JAVA_HOME: ${java.home ?? notDetected}
   • JAVA_EXECUTABLE: ${javaExe ?? notDetected}
-  • JAVA_VERSION: $javaVersion''');
-
-      if (gradlew.exists(Directory.current.path)) {
-        final gradlewVersion = await gradlew.version(Directory.current.path);
-        output.writeln('Gradle Wrapper: $gradlewVersion');
-      }
+  • JAVA_VERSION: $javaVersion
+  • Gradle: ${gradlewVersion ?? notDetected}''');
     }
 
     logger.info(output.toString());

--- a/packages/shorebird_cli/lib/src/executables/gradlew.dart
+++ b/packages/shorebird_cli/lib/src/executables/gradlew.dart
@@ -97,7 +97,7 @@ class Gradlew {
     final versionPattern = RegExp(r'Gradle (\d+\.\d+\.\d+)');
     final match = versionPattern.firstMatch(result.stdout.toString());
 
-    return match?.group(1) ?? '';
+    return match?.group(1) ?? 'unknown';
   }
 
   /// Return the set of product flavors configured for the app at [projectPath].

--- a/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
@@ -146,6 +146,7 @@ Android Toolchain
   • JAVA_HOME: $notDetectedText
   • JAVA_EXECUTABLE: $notDetectedText
   • JAVA_VERSION: $notDetectedText
+  • Gradle: $notDetectedText
 '''),
         );
       });
@@ -170,6 +171,7 @@ OpenJDK 64-Bit Server VM (build 17.0.9+0-17.0.9b1087.7-11185874, mixed mode)'''
         final msg =
             verify(() => logger.info(captureAny())).captured.first as String;
 
+        final notDetectedText = red.wrap('not detected');
         expect(
           msg.replaceAll(
             Platform.lineTerminator,
@@ -191,6 +193,7 @@ Android Toolchain
   • JAVA_VERSION: openjdk version "17.0.9" 2023-10-17
                   OpenJDK Runtime Environment (build 17.0.9+0-17.0.9b1087.7-11185874)
                   OpenJDK 64-Bit Server VM (build 17.0.9+0-17.0.9b1087.7-11185874, mixed mode)
+  • Gradle: $notDetectedText
 ''',
           ),
         );
@@ -243,7 +246,7 @@ Android Toolchain
   • JAVA_VERSION: openjdk version "17.0.9" 2023-10-17
                   OpenJDK Runtime Environment (build 17.0.9+0-17.0.9b1087.7-11185874)
                   OpenJDK 64-Bit Server VM (build 17.0.9+0-17.0.9b1087.7-11185874, mixed mode)
-Gradle Wrapper: 7.6.3
+  • Gradle: 7.6.3
 ''',
             ),
           );

--- a/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/doctor_command_test.dart
@@ -203,9 +203,6 @@ Android Toolchain
         setUp(() {
           when(() => gradlew.exists(any())).thenReturn(true);
           when(() => gradlew.version(any())).thenAnswer((_) async => '7.6.3');
-        });
-
-        test('prints the gradle version', () async {
           when(() => argResults['verbose']).thenReturn(true);
           when(() => androidStudio.path).thenReturn('test-studio-path');
           when(() => androidSdk.path).thenReturn('test-sdk-path');
@@ -220,6 +217,9 @@ OpenJDK Runtime Environment (build 17.0.9+0-17.0.9b1087.7-11185874)
 OpenJDK 64-Bit Server VM (build 17.0.9+0-17.0.9b1087.7-11185874, mixed mode)'''
                 .replaceAll('\n', Platform.lineTerminator),
           );
+        });
+
+        test('prints the gradle version', () async {
           await runWithOverrides(command.run);
 
           final msg =

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -3,10 +3,8 @@ import 'dart:io' hide Platform;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
-import 'package:platform/platform.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
-import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:test/test.dart';
 
@@ -17,7 +15,6 @@ void main() {
     const javaHome = 'test_java_home';
 
     late Java java;
-    late Platform platform;
     late ShorebirdProcess process;
     late ShorebirdProcessResult result;
     late Gradlew gradlew;
@@ -27,7 +24,6 @@ void main() {
         body,
         values: {
           javaRef.overrideWith(() => java),
-          platformRef.overrideWith(() => platform),
           processRef.overrideWith(() => process),
         },
       );
@@ -35,7 +31,6 @@ void main() {
 
     setUp(() {
       java = MockJava();
-      platform = MockPlatform();
       process = MockShorebirdProcess();
       result = MockProcessResult();
       gradlew = runWithOverrides(Gradlew.new);
@@ -84,198 +79,160 @@ Make sure you have run "flutter build apk" at least once.''',
 
     group('productFlavors', () {
       test(
-          'throws MissingAndroidProjectException '
-          'when android root does not exist', () async {
-        when(() => platform.isLinux).thenReturn(true);
-        when(() => platform.isMacOS).thenReturn(false);
-        when(() => platform.isWindows).thenReturn(false);
-        final tempDir = Directory.systemTemp.createTempSync();
-        await expectLater(
-          runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
-          throwsA(isA<MissingAndroidProjectException>()),
-        );
-        verifyNever(
-          () => process.run(
-            p.join(tempDir.path, 'android', 'gradlew'),
-            ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
-            workingDirectory: p.join(tempDir.path, 'android'),
-            environment: {'JAVA_HOME': javaHome},
-          ),
-        );
-      });
-
-      test(
-          'throws MissingGradleWrapperException '
-          'when gradlew does not exist', () async {
-        when(() => platform.isLinux).thenReturn(true);
-        when(() => platform.isMacOS).thenReturn(false);
-        when(() => platform.isWindows).thenReturn(false);
-        final tempDir = setUpAppTempDir();
-        await expectLater(
-          runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
-          throwsA(isA<MissingGradleWrapperException>()),
-        );
-        verifyNever(
-          () => process.run(
-            p.join(tempDir.path, 'android', 'gradlew'),
-            ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
-            workingDirectory: p.join(tempDir.path, 'android'),
-            environment: {'JAVA_HOME': javaHome},
-          ),
-        );
-      });
-
-      test('uses existing JAVA_HOME when set', () async {
-        when(() => platform.isLinux).thenReturn(true);
-        when(() => platform.isMacOS).thenReturn(false);
-        when(() => platform.isWindows).thenReturn(false);
-        final tempDir = setUpAppTempDir();
-        File(
-          p.join(tempDir.path, 'android', 'gradlew'),
-        ).createSync(recursive: true);
-        await expectLater(
-          runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
-          completes,
-        );
-        verify(
-          () => process.run(
-            p.join(tempDir.path, 'android', 'gradlew'),
-            ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
-            workingDirectory: p.join(tempDir.path, 'android'),
-            environment: {'JAVA_HOME': javaHome},
-          ),
-        ).called(1);
-      });
-
-      test(
-          'throws Exception '
-          'when process exits with non-zero code', () async {
-        when(() => platform.isLinux).thenReturn(true);
-        when(() => platform.isMacOS).thenReturn(false);
-        when(() => platform.isWindows).thenReturn(false);
-        final tempDir = setUpAppTempDir();
-        File(
-          p.join(tempDir.path, 'android', 'gradlew'),
-        ).createSync(recursive: true);
-        when(() => result.exitCode).thenReturn(1);
-        when(() => result.stderr).thenReturn('test error');
-        await expectLater(
-          runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
-          throwsA(
-            isA<Exception>().having(
-              (e) => '$e',
-              'message',
-              contains('test error'),
+        'throws MissingAndroidProjectException '
+        'when android root does not exist',
+        () async {
+          final tempDir = Directory.systemTemp.createTempSync();
+          await expectLater(
+            runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
+            throwsA(isA<MissingAndroidProjectException>()),
+          );
+          verifyNever(
+            () => process.run(
+              p.join(tempDir.path, 'android', 'gradlew'),
+              ['app:tasks', '--all', '--console=auto'],
+              runInShell: true,
+              workingDirectory: p.join(tempDir.path, 'android'),
+              environment: {'JAVA_HOME': javaHome},
             ),
-          ),
-        );
-        verify(
-          () => process.run(
-            p.join(tempDir.path, 'android', 'gradlew'),
-            ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
-            workingDirectory: p.join(tempDir.path, 'android'),
-            environment: {'JAVA_HOME': javaHome},
-          ),
-        ).called(1);
-      });
+          );
+        },
+        testOn: 'linux',
+      );
 
-      test('extracts flavors', () async {
-        when(() => platform.isLinux).thenReturn(true);
-        when(() => platform.isMacOS).thenReturn(false);
-        when(() => platform.isWindows).thenReturn(false);
-        final tempDir = setUpAppTempDir();
-        File(
-          p.join(tempDir.path, 'android', 'gradlew'),
-        ).createSync(recursive: true);
-        const javaHome = 'test_java_home';
-        when(() => platform.environment).thenReturn({'JAVA_HOME': javaHome});
-        when(() => result.stdout).thenReturn(
+      test(
+        'throws MissingGradleWrapperException '
+        'when gradlew does not exist',
+        () async {
+          final tempDir = setUpAppTempDir();
+          await expectLater(
+            runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
+            throwsA(isA<MissingGradleWrapperException>()),
+          );
+          verifyNever(
+            () => process.run(
+              p.join(tempDir.path, 'android', 'gradlew'),
+              ['app:tasks', '--all', '--console=auto'],
+              runInShell: true,
+              workingDirectory: p.join(tempDir.path, 'android'),
+              environment: {'JAVA_HOME': javaHome},
+            ),
+          );
+        },
+        testOn: 'linux',
+      );
+
+      test(
+        'uses existing JAVA_HOME when set',
+        () async {
+          final tempDir = setUpAppTempDir();
           File(
-            p.join('test', 'fixtures', 'gradle', 'gradle_app_tasks.txt'),
-          ).readAsStringSync(),
-        );
-        await expectLater(
-          runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
-          completion(
-            equals({
-              'development',
-              'developmentInternal',
-              'staging',
-              'stagingInternal',
-              'production',
-              'productionInternal',
-            }),
-          ),
-        );
-        verify(
-          () => process.run(
             p.join(tempDir.path, 'android', 'gradlew'),
-            ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
-            workingDirectory: p.join(tempDir.path, 'android'),
-            environment: {'JAVA_HOME': javaHome},
-          ),
-        ).called(1);
-      });
+          ).createSync(recursive: true);
+          await expectLater(
+            runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
+            completes,
+          );
+          verify(
+            () => process.run(
+              p.join(tempDir.path, 'android', 'gradlew'),
+              ['app:tasks', '--all', '--console=auto'],
+              runInShell: true,
+              workingDirectory: p.join(tempDir.path, 'android'),
+              environment: {'JAVA_HOME': javaHome},
+            ),
+          ).called(1);
+        },
+        testOn: 'linux',
+      );
 
-      group('when flavors are all upper case', () {
-        test('extracts flavors', () async {
-          when(() => platform.isLinux).thenReturn(true);
-          when(() => platform.isMacOS).thenReturn(false);
-          when(() => platform.isWindows).thenReturn(false);
+      test(
+        'throws Exception '
+        'when process exits with non-zero code',
+        () async {
+          final tempDir = setUpAppTempDir();
+          File(
+            p.join(tempDir.path, 'android', 'gradlew'),
+          ).createSync(recursive: true);
+          when(() => result.exitCode).thenReturn(1);
+          when(() => result.stderr).thenReturn('test error');
+          await expectLater(
+            runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
+            throwsA(
+              isA<Exception>().having(
+                (e) => '$e',
+                'message',
+                contains('test error'),
+              ),
+            ),
+          );
+          verify(
+            () => process.run(
+              p.join(tempDir.path, 'android', 'gradlew'),
+              ['app:tasks', '--all', '--console=auto'],
+              runInShell: true,
+              workingDirectory: p.join(tempDir.path, 'android'),
+              environment: {'JAVA_HOME': javaHome},
+            ),
+          ).called(1);
+        },
+        testOn: 'linux',
+      );
+
+      test(
+        'extracts flavors',
+        () async {
           final tempDir = setUpAppTempDir();
           File(
             p.join(tempDir.path, 'android', 'gradlew'),
           ).createSync(recursive: true);
           const javaHome = 'test_java_home';
-          when(() => platform.environment).thenReturn({'JAVA_HOME': javaHome});
           when(() => result.stdout).thenReturn(
             File(
-              p.join(
-                'test',
-                'fixtures',
-                'gradle',
-                'gradle_app_tasks_upper_case_flavors.txt',
-              ),
+              p.join('test', 'fixtures', 'gradle', 'gradle_app_tasks.txt'),
             ).readAsStringSync(),
           );
           await expectLater(
             runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
             completion(
               equals({
-                'SP',
-                'RJ',
+                'development',
+                'developmentInternal',
+                'staging',
+                'stagingInternal',
+                'production',
+                'productionInternal',
               }),
             ),
           );
-        });
-      });
+          verify(
+            () => process.run(
+              p.join(tempDir.path, 'android', 'gradlew'),
+              ['app:tasks', '--all', '--console=auto'],
+              runInShell: true,
+              workingDirectory: p.join(tempDir.path, 'android'),
+              environment: {'JAVA_HOME': javaHome},
+            ),
+          ).called(1);
+        },
+        testOn: 'linux',
+      );
 
-      group(
-        'when flavors are mixed, starting with upper case, finishin with camel',
-        () {
-          test('extracts flavors', () async {
-            when(() => platform.isLinux).thenReturn(true);
-            when(() => platform.isMacOS).thenReturn(false);
-            when(() => platform.isWindows).thenReturn(false);
+      group('when flavors are all upper case', () {
+        test(
+          'extracts flavors',
+          () async {
             final tempDir = setUpAppTempDir();
             File(
               p.join(tempDir.path, 'android', 'gradlew'),
             ).createSync(recursive: true);
-            const javaHome = 'test_java_home';
-            when(() => platform.environment)
-                .thenReturn({'JAVA_HOME': javaHome});
             when(() => result.stdout).thenReturn(
               File(
                 p.join(
                   'test',
                   'fixtures',
                   'gradle',
-                  'gradle_app_tasks_mixed_case_flavors.txt',
+                  'gradle_app_tasks_upper_case_flavors.txt',
                 ),
               ).readAsStringSync(),
             );
@@ -283,49 +240,83 @@ Make sure you have run "flutter build apk" at least once.''',
               runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
               completion(
                 equals({
-                  'SPaulo',
-                  'RJaneiro',
+                  'SP',
+                  'RJ',
                 }),
               ),
             );
-          });
+          },
+          testOn: 'linux',
+        );
+      });
+
+      group(
+        'when flavors are mixed, starting with upper case, finishin with camel',
+        () {
+          test(
+            'extracts flavors',
+            () async {
+              final tempDir = setUpAppTempDir();
+              File(
+                p.join(tempDir.path, 'android', 'gradlew'),
+              ).createSync(recursive: true);
+              when(() => result.stdout).thenReturn(
+                File(
+                  p.join(
+                    'test',
+                    'fixtures',
+                    'gradle',
+                    'gradle_app_tasks_mixed_case_flavors.txt',
+                  ),
+                ).readAsStringSync(),
+              );
+              await expectLater(
+                runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
+                completion(
+                  equals({
+                    'SPaulo',
+                    'RJaneiro',
+                  }),
+                ),
+              );
+            },
+            testOn: 'linux',
+          );
         },
       );
 
       group(
         'when flavors starts with upper case, finishing with numbers',
         () {
-          test('extracts flavors', () async {
-            when(() => platform.isLinux).thenReturn(true);
-            when(() => platform.isMacOS).thenReturn(false);
-            when(() => platform.isWindows).thenReturn(false);
-            final tempDir = setUpAppTempDir();
-            File(
-              p.join(tempDir.path, 'android', 'gradlew'),
-            ).createSync(recursive: true);
-            const javaHome = 'test_java_home';
-            when(() => platform.environment)
-                .thenReturn({'JAVA_HOME': javaHome});
-            when(() => result.stdout).thenReturn(
+          test(
+            'extracts flavors',
+            () async {
+              final tempDir = setUpAppTempDir();
               File(
-                p.join(
-                  'test',
-                  'fixtures',
-                  'gradle',
-                  'gradle_app_tasks_numbers_upper_case_flavors.txt',
+                p.join(tempDir.path, 'android', 'gradlew'),
+              ).createSync(recursive: true);
+              when(() => result.stdout).thenReturn(
+                File(
+                  p.join(
+                    'test',
+                    'fixtures',
+                    'gradle',
+                    'gradle_app_tasks_numbers_upper_case_flavors.txt',
+                  ),
+                ).readAsStringSync(),
+              );
+              await expectLater(
+                runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
+                completion(
+                  equals({
+                    'CB500',
+                    'NX700',
+                  }),
                 ),
-              ).readAsStringSync(),
-            );
-            await expectLater(
-              runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
-              completion(
-                equals({
-                  'CB500',
-                  'NX700',
-                }),
-              ),
-            );
-          });
+              );
+            },
+            testOn: 'linux',
+          );
         },
       );
     });
@@ -387,16 +378,10 @@ Make sure you have run "flutter build apk" at least once.''',
       late Directory tempDir;
 
       setUp(() {
-        when(() => platform.isLinux).thenReturn(true);
-        when(() => platform.isMacOS).thenReturn(false);
-        when(() => platform.isWindows).thenReturn(false);
         tempDir = setUpAppTempDir();
         File(
           p.join(tempDir.path, 'android', 'gradlew'),
         ).createSync(recursive: true);
-        const javaHome = 'test_java_home';
-        when(() => platform.environment).thenReturn({'JAVA_HOME': javaHome});
-
         when(() => result.stdout).thenReturn('''
 
 ------------------------------------------------------------
@@ -414,24 +399,32 @@ OS:           Mac OS X 14.4.1 aarch64
 ''');
       });
 
-      test('returns the correct version', () async {
-        final version = await runWithOverrides(
-          () => gradlew.version(tempDir.path),
-        );
-        expect(version, '7.6.3');
-      });
+      test(
+        'returns the correct version',
+        () async {
+          final version = await runWithOverrides(
+            () => gradlew.version(tempDir.path),
+          );
+          expect(version, '7.6.3');
+        },
+        testOn: 'linux || mac-os',
+      );
 
       group('when the output cannot be parsed', () {
         setUp(() {
           when(() => result.stdout).thenReturn('not a real version');
         });
 
-        test('returns unknown', () async {
-          final version = await runWithOverrides(
-            () => gradlew.version(tempDir.path),
-          );
-          expect(version, 'unknown');
-        });
+        test(
+          'returns unknown',
+          () async {
+            final version = await runWithOverrides(
+              () => gradlew.version(tempDir.path),
+            );
+            expect(version, 'unknown');
+          },
+          testOn: 'linux || mac-os',
+        );
       });
     });
   });

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -344,31 +344,65 @@ Make sure you have run "flutter build apk" at least once.''',
 
       group('when gradlew exists', () {
         group(
-          'when on mac and linux',
+          'when on linux',
           () {
-            test('returns true', () {
+            setUp(() {
+              when(() => platform.isLinux).thenReturn(true);
+              when(() => platform.isMacOS).thenReturn(false);
+              when(() => platform.isWindows).thenReturn(false);
               File(
                 p.join(tempDir.path, 'android', 'gradlew'),
               ).createSync(recursive: true);
-              expect(gradlew.exists(tempDir.path), isTrue);
+            });
+
+            test('returns true', () {
+              expect(
+                runWithOverrides(() => gradlew.exists(tempDir.path)),
+                isTrue,
+              );
             });
           },
-          onPlatform: {'windows': const Skip()},
+        );
+
+        group(
+          'when on macos',
+          () {
+            setUp(() {
+              when(() => platform.isLinux).thenReturn(false);
+              when(() => platform.isMacOS).thenReturn(true);
+              when(() => platform.isWindows).thenReturn(false);
+              File(
+                p.join(tempDir.path, 'android', 'gradlew'),
+              ).createSync(recursive: true);
+            });
+
+            test('returns true', () {
+              expect(
+                runWithOverrides(() => gradlew.exists(tempDir.path)),
+                isTrue,
+              );
+            });
+          },
         );
 
         group(
           'when on windows',
           () {
-            test('returns true', () {
+            setUp(() {
+              when(() => platform.isLinux).thenReturn(false);
+              when(() => platform.isMacOS).thenReturn(false);
+              when(() => platform.isWindows).thenReturn(true);
               File(
                 p.join(tempDir.path, 'android', 'gradlew.bat'),
               ).createSync(recursive: true);
-              expect(gradlew.exists(tempDir.path), isTrue);
             });
-          },
-          onPlatform: {
-            'mac-os': const Skip(),
-            'linux': const Skip(),
+
+            test('returns true', () {
+              expect(
+                runWithOverrides(() => gradlew.exists(tempDir.path)),
+                isTrue,
+              );
+            });
           },
         );
       });

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -389,6 +389,19 @@ OS:           Mac OS X 14.4.1 aarch64
         );
         expect(version, '7.6.3');
       });
+
+      group('when the output cannot be parsed', () {
+        setUp(() {
+          when(() => result.stdout).thenReturn('not a real version');
+        });
+
+        test('returns unknown', () async {
+          final version = await runWithOverrides(
+            () => gradlew.version(tempDir.path),
+          );
+          expect(version, 'unknown');
+        });
+      });
     });
   });
 }

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -357,7 +357,7 @@ Make sure you have run "flutter build apk" at least once.''',
               () {
                 expect(gradlew.exists(tempDir.path), isTrue);
               },
-              testOn: 'linux', // Arbitrary choice on linux, could be mac-os too
+              testOn: 'linux || mac-os',
             );
           },
         );

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -330,6 +330,28 @@ Make sure you have run "flutter build apk" at least once.''',
       );
     });
 
+    group('exists', () {
+      late Directory tempDir;
+      setUp(() {
+        tempDir = setUpAppTempDir();
+      });
+
+      group('when gradlew does not exist', () {
+        test('returns false', () {
+          expect(gradlew.exists(tempDir.path), isFalse);
+        });
+      });
+
+      group('when gradlew exists', () {
+        test('returns true', () {
+          File(
+            p.join(tempDir.path, 'android', 'gradlew'),
+          ).createSync(recursive: true);
+          expect(gradlew.exists(tempDir.path), isTrue);
+        });
+      });
+    });
+
     group('version', () {
       late Directory tempDir;
 

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -344,44 +344,21 @@ Make sure you have run "flutter build apk" at least once.''',
 
       group('when gradlew exists', () {
         group(
-          'when on linux',
+          'when on unix based OSs',
           () {
             setUp(() {
-              when(() => platform.isLinux).thenReturn(true);
-              when(() => platform.isMacOS).thenReturn(false);
-              when(() => platform.isWindows).thenReturn(false);
               File(
                 p.join(tempDir.path, 'android', 'gradlew'),
               ).createSync(recursive: true);
             });
 
-            test('returns true', () {
-              expect(
-                runWithOverrides(() => gradlew.exists(tempDir.path)),
-                isTrue,
-              );
-            });
-          },
-        );
-
-        group(
-          'when on macos',
-          () {
-            setUp(() {
-              when(() => platform.isLinux).thenReturn(false);
-              when(() => platform.isMacOS).thenReturn(true);
-              when(() => platform.isWindows).thenReturn(false);
-              File(
-                p.join(tempDir.path, 'android', 'gradlew'),
-              ).createSync(recursive: true);
-            });
-
-            test('returns true', () {
-              expect(
-                runWithOverrides(() => gradlew.exists(tempDir.path)),
-                isTrue,
-              );
-            });
+            test(
+              'returns true',
+              () {
+                expect(gradlew.exists(tempDir.path), isTrue);
+              },
+              testOn: 'linux', // Arbitrary choice on linux, could be mac-os too
+            );
           },
         );
 
@@ -389,20 +366,18 @@ Make sure you have run "flutter build apk" at least once.''',
           'when on windows',
           () {
             setUp(() {
-              when(() => platform.isLinux).thenReturn(false);
-              when(() => platform.isMacOS).thenReturn(false);
-              when(() => platform.isWindows).thenReturn(true);
               File(
                 p.join(tempDir.path, 'android', 'gradlew.bat'),
               ).createSync(recursive: true);
             });
 
-            test('returns true', () {
-              expect(
-                runWithOverrides(() => gradlew.exists(tempDir.path)),
-                isTrue,
-              );
-            });
+            test(
+              'returns true',
+              () {
+                expect(gradlew.exists(tempDir.path), isTrue);
+              },
+              testOn: 'windows',
+            );
           },
         );
       });

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -76,13 +76,13 @@ Make sure you have run "flutter build apk" at least once.''',
       });
     });
 
-    group('productFlavors', () {
-      Directory setUpAppTempDir() {
-        final tempDir = Directory.systemTemp.createTempSync();
-        Directory(p.join(tempDir.path, 'android')).createSync(recursive: true);
-        return tempDir;
-      }
+    Directory setUpAppTempDir() {
+      final tempDir = Directory.systemTemp.createTempSync();
+      Directory(p.join(tempDir.path, 'android')).createSync(recursive: true);
+      return tempDir;
+    }
 
+    group('productFlavors', () {
       test(
           'throws MissingAndroidProjectException '
           'when android root does not exist', () async {
@@ -328,6 +328,45 @@ Make sure you have run "flutter build apk" at least once.''',
           });
         },
       );
+    });
+
+    group('version', () {
+      late Directory tempDir;
+
+      setUp(() {
+        when(() => platform.isLinux).thenReturn(true);
+        when(() => platform.isMacOS).thenReturn(false);
+        when(() => platform.isWindows).thenReturn(false);
+        tempDir = setUpAppTempDir();
+        File(
+          p.join(tempDir.path, 'android', 'gradlew'),
+        ).createSync(recursive: true);
+        const javaHome = 'test_java_home';
+        when(() => platform.environment).thenReturn({'JAVA_HOME': javaHome});
+
+        when(() => result.stdout).thenReturn('''
+
+------------------------------------------------------------
+Gradle 7.6.3
+------------------------------------------------------------
+
+Build time:   2023-10-04 15:59:47 UTC
+Revision:     1694251d59e0d4752d547e1fd5b5020b798a7e71
+
+Kotlin:       1.7.10
+Groovy:       3.0.13
+Ant:          Apache Ant(TM) version 1.10.11 compiled on July 10 2021
+JVM:          11.0.23 (Azul Systems, Inc. 11.0.23+9-LTS)
+OS:           Mac OS X 14.4.1 aarch64
+''');
+      });
+
+      test('returns the correct version', () async {
+        final version = await runWithOverrides(
+          () => gradlew.version(tempDir.path),
+        );
+        expect(version, '7.6.3');
+      });
     });
   });
 }

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -343,12 +343,34 @@ Make sure you have run "flutter build apk" at least once.''',
       });
 
       group('when gradlew exists', () {
-        test('returns true', () {
-          File(
-            p.join(tempDir.path, 'android', 'gradlew'),
-          ).createSync(recursive: true);
-          expect(gradlew.exists(tempDir.path), isTrue);
-        });
+        group(
+          'when on mac and linux',
+          () {
+            test('returns true', () {
+              File(
+                p.join(tempDir.path, 'android', 'gradlew'),
+              ).createSync(recursive: true);
+              expect(gradlew.exists(tempDir.path), isTrue);
+            });
+          },
+          onPlatform: {'windows': const Skip()},
+        );
+
+        group(
+          'when on windows',
+          () {
+            test('returns true', () {
+              File(
+                p.join(tempDir.path, 'android', 'gradlew.bat'),
+              ).createSync(recursive: true);
+              expect(gradlew.exists(tempDir.path), isTrue);
+            });
+          },
+          onPlatform: {
+            'mac-os': const Skip(),
+            'linux': const Skip(),
+          },
+        );
       });
     });
 


### PR DESCRIPTION
## Description

This PR is a first step in the path to Fix #1821.

It simply adds the version of the gradlew version in `shorebird doctor`.

In follow up PRs I plan to capture errors when running gradle, check if the error where a `Unsupported class file major version XX` one and if so, display a message to user explaining that this caused by the java version, that they can check the used java version and gralde version, and use the gradle compatibilty matrix to check which java version they should use.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
