### PR TITLE
fix: e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -144,5 +144,7 @@ jobs:
           cache: true
 
       - name: 🧪 Run Integration Tests
-        run: dart test integration_test
+        # Run a single test at a time to ensure that one test does not interfere with another
+        # since some commands might change the state of the cli installation.
+        run: dart test integration_test -j 1
         working-directory: packages/shorebird_cli

--- a/packages/shorebird_cli/integration_test/shorebird_cli_cache_test.dart
+++ b/packages/shorebird_cli/integration_test/shorebird_cli_cache_test.dart
@@ -24,13 +24,21 @@ R runWithOverrides<R>(R Function() body) {
 
 void main() {
   group('shorebird cache', () {
-    test('can clear the cache', () {
-      final result = runCommand(
-        'shorebird cache clear',
-        workingDirectory: '.',
-      );
+    group('clear', () {
+      tearDown(() {
+        // Run an arbritery, fast command, so cache will be restored
+        // for the next test.
+        runCommand('--version', workingDirectory: '.');
+      });
 
-      expect(result.exitCode, equals(ExitCode.success.code));
+      test('can clear the cache', () {
+        final result = runCommand(
+          'shorebird cache clear',
+          workingDirectory: '.',
+        );
+
+        expect(result.exitCode, equals(ExitCode.success.code));
+      });
     });
   });
 }

--- a/packages/shorebird_cli/integration_test/shorebird_cli_integration_test.dart
+++ b/packages/shorebird_cli/integration_test/shorebird_cli_integration_test.dart
@@ -32,11 +32,15 @@ R runWithOverrides<R>(R Function() body) {
 }
 
 void main() {
+  final shorebirdHostedURL = Platform.environment['SHOREBIRD_HOSTED_URL'];
+  if (shorebirdHostedURL == null || shorebirdHostedURL.isEmpty) {
+    throw Exception('SHOREBIRD_HOSTED_URL environment variable is not set.');
+  }
   final logger = Logger();
   final client = runWithOverrides(
     () => CodePushClient(
       httpClient: Auth().client,
-      hostedUri: Uri.parse(Platform.environment['SHOREBIRD_HOSTED_URL']!),
+      hostedUri: Uri.parse(shorebirdHostedURL),
     ),
   );
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

A while ago we added a [shorebird cache clear test](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_cli/integration_test/shorebird_cli_cache_test.dart), which like the name suggests, tests the `cache clear` command.

That test interfered with the other e2e tests though, since they expected that everything were pre-cached.

This PR splits the cli integration tests into two, running the cache related ones in an isolated step, in order for it to not break the main tests expectation.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
