### PR TITLE
fix: version should only log the version messages

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
@@ -195,6 +195,7 @@ ${lightCyan.wrap('shorebird release android -- --no-pub lib/main.dart')}''';
 Shorebird $packageVersion • git@github.com:shorebirdtech/shorebird.git
 $shorebirdFlutterPrefix • revision ${shorebirdEnv.flutterRevision}
 Engine • revision ${shorebirdEnv.shorebirdEngineRevision}''');
+      exitCode = ExitCode.success.code;
     } else {
       try {
         exitCode = await super.runCommand(topLevelResults);

--- a/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
@@ -196,6 +196,7 @@ ${lightCyan.wrap("shorebird release android '--' --no-pub lib/main.dart")}''',
           () => commandRunner.run(['--version']),
         );
         expect(result, equals(ExitCode.success.code));
+
         verify(
           () => logger.info(
             '''
@@ -204,6 +205,10 @@ Flutter $flutterVersion • revision $flutterRevision
 Engine • revision $shorebirdEngineRevision''',
           ),
         ).called(1);
+
+        // Making sure the only thing that was logged was the version info.
+        // https://github.com/shorebirdtech/shorebird/issues/2260
+        verifyNever(() => logger.info(any()));
       });
     });
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

`shorebird --version` was not properly setting the correct `ExitCode` and was being interpreted as failing, which would lead the CLI to print the open issue message.

This PR fixes that.

Fixes #2260 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
