### PR TITLE
fix: better error handling for release with no platforms provided

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -142,6 +142,12 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
 
   @override
   Future<int> run() async {
+    final platforms = results['platforms'] as List<String>;
+    if (platforms.isEmpty) {
+      logger.err('At least one platform must be specified.');
+      return ExitCode.usage.code;
+    }
+
     final releaserFutures =
         results.releaseTypes.map(_resolveReleaser).map(createRelease);
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -142,8 +142,7 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
 
   @override
   Future<int> run() async {
-    final platforms = results['platforms'] as List<String>;
-    if (platforms.isEmpty) {
+    if (results.releaseTypes.isEmpty) {
       logger.err('At least one platform must be specified.');
       return ExitCode.usage.code;
     }

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -143,7 +143,9 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
   @override
   Future<int> run() async {
     if (results.releaseTypes.isEmpty) {
-      logger.err('At least one platform must be specified.');
+      logger.err(
+        '''No platforms were provided, use the --platforms argument to provide one or more platforms''',
+      );
       return ExitCode.usage.code;
     }
 

--- a/packages/shorebird_cli/lib/src/release_type.dart
+++ b/packages/shorebird_cli/lib/src/release_type.dart
@@ -49,16 +49,22 @@ enum ReleaseType {
 
 extension ReleaseTypeArgs on ArgResults {
   Iterable<ReleaseType> get releaseTypes {
-    final List<String> releaseTypeCliNames;
+    List<String>? releaseTypeCliNames;
     if (wasParsed('platforms')) {
       releaseTypeCliNames = this['platforms'] as List<String>;
     } else {
-      final platformCliName = arguments.first;
-      if (ReleaseType.values
-          .none((target) => target.cliName == platformCliName)) {
-        throw ArgumentError('Invalid platform: $platformCliName');
+      if (arguments.isNotEmpty) {
+        final platformCliName = arguments.first;
+        if (ReleaseType.values
+            .none((target) => target.cliName == platformCliName)) {
+          throw ArgumentError('Invalid platform: $platformCliName');
+        }
+        releaseTypeCliNames = [platformCliName];
       }
-      releaseTypeCliNames = [platformCliName];
+    }
+
+    if (releaseTypeCliNames == null) {
+      return const [];
     }
 
     return releaseTypeCliNames.map(

--- a/packages/shorebird_cli/lib/src/release_type.dart
+++ b/packages/shorebird_cli/lib/src/release_type.dart
@@ -63,13 +63,11 @@ extension ReleaseTypeArgs on ArgResults {
       }
     }
 
-    if (releaseTypeCliNames == null) {
-      return const [];
-    }
-
-    return releaseTypeCliNames.map(
-      (cliName) =>
-          ReleaseType.values.firstWhere((target) => target.cliName == cliName),
-    );
+    return releaseTypeCliNames?.map(
+          (cliName) => ReleaseType.values.firstWhere(
+            (target) => target.cliName == cliName,
+          ),
+        ) ??
+        const [];
   }
 }

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -330,10 +330,10 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "40f592dd352890c3b60fec1b68e786cefb9603e05ff303dbc4dda49b304ecdf4"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.0"
   intl:
     dependency: "direct main"
     description:

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -534,7 +534,7 @@ $exception''',
 
         verify(
           () => logger.err(
-            'At least one platform must be specified.',
+            '''No platforms were provided, use the --platforms argument to provide one or more platforms''',
           ),
         ).called(1);
       });

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -521,5 +521,25 @@ $exception''',
         });
       });
     });
+
+    group('when no platform argument is provided', () {
+      // https://github.com/shorebirdtech/shorebird/issues/2261
+
+      setUp(() {
+        when(() => argResults['platforms']).thenReturn(const <String>[]);
+      });
+
+      test('fails and log the correct message', () async {
+        final exitCode = await runWithOverrides(command.run);
+
+        expect(exitCode, equals(ExitCode.usage.code));
+
+        verify(
+          () => logger.err(
+            'At least one platform must be specified.',
+          ),
+        ).called(1);
+      });
+    });
   });
 }

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -523,8 +523,6 @@ $exception''',
     });
 
     group('when no platform argument is provided', () {
-      // https://github.com/shorebirdtech/shorebird/issues/2261
-
       setUp(() {
         when(() => argResults['platforms']).thenReturn(const <String>[]);
       });

--- a/packages/shorebird_cli/test/src/release_type_test.dart
+++ b/packages/shorebird_cli/test/src/release_type_test.dart
@@ -29,6 +29,15 @@ void main() {
           );
       });
 
+      group('when nothing is provided', () {
+        test('parses and return empty', () {
+          expect(
+            parser.parse([]).releaseTypes.toList(),
+            isEmpty,
+          );
+        });
+      });
+
       group('when the platforms argument is provided', () {
         test('parses the release types', () {
           expect(
@@ -51,33 +60,33 @@ void main() {
             [ReleaseType.aar],
           );
         });
+      });
 
-        group('when the platforms is provided as a raw arg', () {
-          test('throws an ArgumentError if the platform is invalid', () {
-            expect(
-              () => parser.parse(['foo']).releaseTypes.toList(),
-              throwsArgumentError,
-            );
-          });
+      group('when the platforms is provided as a raw arg', () {
+        test('throws an ArgumentError if the platform is invalid', () {
+          expect(
+            () => parser.parse(['foo']).releaseTypes.toList(),
+            throwsArgumentError,
+          );
+        });
 
-          test('parses the release types', () {
-            expect(
-              parser.parse(['android', 'foo']).releaseTypes.toList(),
-              [ReleaseType.android],
-            );
-            expect(
-              parser.parse(['ios', 'foo']).releaseTypes.toList(),
-              [ReleaseType.ios],
-            );
-            expect(
-              parser.parse(['ios-framework', 'foo']).releaseTypes.toList(),
-              [ReleaseType.iosFramework],
-            );
-            expect(
-              parser.parse(['aar', 'foo']).releaseTypes.toList(),
-              [ReleaseType.aar],
-            );
-          });
+        test('parses the release types', () {
+          expect(
+            parser.parse(['android', 'foo']).releaseTypes.toList(),
+            [ReleaseType.android],
+          );
+          expect(
+            parser.parse(['ios', 'foo']).releaseTypes.toList(),
+            [ReleaseType.ios],
+          );
+          expect(
+            parser.parse(['ios-framework', 'foo']).releaseTypes.toList(),
+            [ReleaseType.iosFramework],
+          );
+          expect(
+            parser.parse(['aar', 'foo']).releaseTypes.toList(),
+            [ReleaseType.aar],
+          );
         });
       });
     });


### PR DESCRIPTION
## Description

Adds a better error handling for the release command when no platforms were provided.

Fixes #2261 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
