### PR TITLE
fix: don't do pub upgrade at shorebird executable

### DIFF
--- a/bin/shorebird.ps1
+++ b/bin/shorebird.ps1
@@ -132,7 +132,7 @@ function Update-Shorebird {
     Update-Flutter
 
     Push-Location $shorebirdCliDir
-    & $dart pub upgrade
+    & $dart pub get
     Pop-Location
 
     Write-Output "Compiling shorebird..."

--- a/third_party/flutter/bin/internal/shared.sh
+++ b/third_party/flutter/bin/internal/shared.sh
@@ -23,18 +23,18 @@ function update_flutter {
   FLUTTER_STORAGE_BASE_URL=https://download.shorebird.dev $FLUTTER_PATH/bin/flutter --version  
 }
 
-function pub_upgrade_with_retry {
+function pub_get_with_retry {
   local total_tries="10"
   local remaining_tries=$((total_tries - 1))
   while [[ "$remaining_tries" -gt 0 ]]; do
-    (cd "$SHOREBIRD_CLI_DIR" && $DART_PATH pub upgrade) && break
-    >&2 echo "Error: Unable to 'pub upgrade' shorebird. Retrying in five seconds... ($remaining_tries tries left)"
+    (cd "$SHOREBIRD_CLI_DIR" && $DART_PATH pub get) && break
+    >&2 echo "Error: Unable to 'pub get' shorebird. Retrying in five seconds... ($remaining_tries tries left)"
     remaining_tries=$((remaining_tries - 1))
     sleep 5
   done
 
   if [[ "$remaining_tries" == 0 ]]; then
-    >&2 echo "Command 'pub upgrade' still failed after $total_tries tries, giving up."
+    >&2 echo "Command 'pub get' still failed after $total_tries tries, giving up."
     return 1
   fi
   return 0
@@ -154,7 +154,7 @@ function upgrade_shorebird () (
     fi
 
     export PUB_ENVIRONMENT="$PUB_ENVIRONMENT:shorebird_install"
-    pub_upgrade_with_retry
+    pub_get_with_retry
 
     # Move the old snapshot - we can't just overwrite it as the VM might currently have it
     # memory mapped (e.g. on shorebird upgrade). For downloading a new dart sdk the folder is moved,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR changes shorebird's scripts to not run `dart pub upgrade`. The `upgrade` sub command were replaced to a `update` one to ensure that users will always get the dependencies versions that were checked into git in the pubspec.lock

Fixes #2263 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
