### PR TITLE
feat(shorebird_cli): improve output for gradle "unsupported file major version" errors

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_documentation.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_documentation.dart
@@ -1,0 +1,11 @@
+/// A class that holds a collection of Shorebird documentation links
+/// used throughout the Shorebird CLI.
+class ShorebirdDocumentation {
+  /// The base URL for the Shorebird documentation.
+  static const String baseUrl = 'https://docs.shorebird.dev';
+
+  /// URL to the troubshooting section which covers the Unsupported class
+  /// file major version
+  static const String unsupportedClassFileVersionUrl =
+      '$baseUrl/troubleshooting/#unsupported-class-file-major-version-65';
+}

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
+import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:test/test.dart';
 
@@ -218,7 +219,15 @@ BUILD FAILED in 3s
 
               await expectLater(
                 runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
-                throwsA(isA<IncompatibleGradleException>()),
+                throwsA(
+                  isA<IncompatibleGradleException>().having(
+                    (e) => e.toString(),
+                    'contains documentation link',
+                    contains(
+                      ShorebirdDocumentation.unsupportedClassFileVersionUrl,
+                    ),
+                  ),
+                ),
               );
             },
             testOn: 'linux || mac-os',

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -5,7 +5,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
-import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:test/test.dart';
 

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -218,15 +218,7 @@ BUILD FAILED in 3s
 
               await expectLater(
                 runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
-                throwsA(
-                  isA<GradleProcessException>().having(
-                    (e) => '$e',
-                    'message',
-                    equals(
-                      '''Gradle sub-process failed with error:\n${GradleHandedErrors.unsupportedClassFileVersion.toException().message}''',
-                    ),
-                  ),
-                ),
+                throwsA(isA<IncompatibleGradleException>()),
               );
             },
             testOn: 'linux || mac-os',

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
+import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:test/test.dart';
 
@@ -177,6 +178,63 @@ Make sure you have run "flutter build apk" at least once.''',
           ).called(1);
         },
         testOn: 'linux',
+      );
+
+      group(
+        '''when the process fails with the Unsupported class file major version error XX''',
+        () {
+          test(
+            'throws a GradleProcessException with the correct message',
+            () async {
+              final tempDir = setUpAppTempDir();
+              File(
+                p.join(tempDir.path, 'android', 'gradlew'),
+              ).createSync(recursive: true);
+              when(() => result.exitCode).thenReturn(1);
+              when(() => result.stderr).thenReturn('''
+BUILD FAILED in 3s
+
+✗ Detecting product flavors (3.6s)
+Unable to extract product flavors.
+Exception: > Task :gradle:compileJava NO-SOURCE
+> Task :gradle:compileGroovy FAILED
+1 actionable task: 1 executed
+
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':gradle:compileGroovy'.
+> BUG! exception in phase 'semantic analysis' in source unit '/home/user/flutter/packages/flutter_tools/gradle/src/main/groovy/app_plugin_loader.groovy' Unsupported class file major version 65
+
+* Try:
+> Run with --stacktrace option to get the stack trace.
+> Run with --info or --debug option to get more log output.
+> Run with --scan to get full insights.
+
+* Get more help at https://help.gradle.org
+
+BUILD FAILED in 3s
+''');
+
+              await expectLater(
+                runWithOverrides(() => gradlew.productFlavors(tempDir.path)),
+                throwsA(
+                  isA<GradleProcessException>().having(
+                    (e) => '$e',
+                    'message',
+                    equals(
+                      GradleHandedErrors.unsupportedClassFileVersion
+                          .toException()
+                          .message,
+                    ),
+                  ),
+                ),
+              );
+            },
+            testOn: 'linux',
+          );
+        },
       );
 
       test(

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -97,7 +97,7 @@ Make sure you have run "flutter build apk" at least once.''',
             ),
           );
         },
-        testOn: 'linux',
+        testOn: 'linux || mac-os',
       );
 
       test(
@@ -119,7 +119,7 @@ Make sure you have run "flutter build apk" at least once.''',
             ),
           );
         },
-        testOn: 'linux',
+        testOn: 'linux || mac-os',
       );
 
       test(
@@ -143,7 +143,7 @@ Make sure you have run "flutter build apk" at least once.''',
             ),
           ).called(1);
         },
-        testOn: 'linux',
+        testOn: 'linux || mac-os',
       );
 
       test(
@@ -176,7 +176,7 @@ Make sure you have run "flutter build apk" at least once.''',
             ),
           ).called(1);
         },
-        testOn: 'linux',
+        testOn: 'linux || mac-os',
       );
 
       group(
@@ -223,15 +223,13 @@ BUILD FAILED in 3s
                     (e) => '$e',
                     'message',
                     equals(
-                      GradleHandedErrors.unsupportedClassFileVersion
-                          .toException()
-                          .message,
+                      '''Gradle sub-process failed with error:\n${GradleHandedErrors.unsupportedClassFileVersion.toException().message}''',
                     ),
                   ),
                 ),
               );
             },
-            testOn: 'linux',
+            testOn: 'linux || mac-os',
           );
         },
       );
@@ -272,7 +270,7 @@ BUILD FAILED in 3s
             ),
           ).called(1);
         },
-        testOn: 'linux',
+        testOn: 'linux || mac-os',
       );
 
       group('when flavors are all upper case', () {
@@ -303,7 +301,7 @@ BUILD FAILED in 3s
               ),
             );
           },
-          testOn: 'linux',
+          testOn: 'linux || mac-os',
         );
       });
 
@@ -337,7 +335,7 @@ BUILD FAILED in 3s
                 ),
               );
             },
-            testOn: 'linux',
+            testOn: 'linux || mac-os',
           );
         },
       );
@@ -372,7 +370,7 @@ BUILD FAILED in 3s
                 ),
               );
             },
-            testOn: 'linux',
+            testOn: 'linux || mac-os',
           );
         },
       );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR adds a common error handling system in the gradlew executable class and adds a handler for the `Unsupported class file major version`, which will link the user to our trouble shooting section.

This PR introduces some new concepts to the CLI so it is mostly a proposal, none of the technical choices here are strong opinionated and I am happy to change if there are better approaches!

Before this PR, this were the output of the CLI when it broken:

```
⠼ Detecting product flavors... (3.5s)Exited with code 1

stdout:
> Task :gradle:compileJava NO-SOURCE
> Task :gradle:compileGroovy FAILED
1 actionable task: 1 executed


stderr:

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':gradle:compileGroovy'.
> BUG! exception in phase 'semantic analysis' in source unit '/home/kingwill101/flutter/packages/flutter_tools/gradle/src/main/groovy/app_plugin_loader.groovy' Unsupported class file major version 65

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 3s

✗ Detecting product flavors (3.6s)
Unable to extract product flavors.
Exception: > Task :gradle:compileJava NO-SOURCE
> Task :gradle:compileGroovy FAILED
1 actionable task: 1 executed


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':gradle:compileGroovy'.
> BUG! exception in phase 'semantic analysis' in source unit '/home/kingwill101/flutter/packages/flutter_tools/gradle/src/main/groovy/app_plugin_loader.groovy' Unsupported class file major version 65

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 3s
```

After the PR, this is the output
![Screenshot 2024-06-18 at 17 47 22](https://github.com/shorebirdtech/shorebird/assets/835641/1f85ffa3-665d-4de4-b558-9ec79a7386b0)


Fixes #1821 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
