### PR TITLE
fix(shorebird_cli): use Podfile.lock hash to detect native changes

### DIFF
--- a/packages/shorebird_cli/lib/src/archive_analysis/android_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/android_archive_differ.dart
@@ -2,6 +2,7 @@ import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 
+/// {@template android_archive_differ}
 /// Finds differences between two Android archives (either AABs or AARs).
 ///
 /// Types of changes we care about:
@@ -24,7 +25,11 @@ import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 /// /// https://developer.android.com/studio/projects/android-library.html#aar-contents
 /// for reference. Note that .aars produced by Flutter modules do not contain
 /// .jar files, so only asset and dart changes are possible.
+/// {@endtemplate}
 class AndroidArchiveDiffer extends ArchiveDiffer {
+  /// {@macro android_archive_differ}
+  const AndroidArchiveDiffer();
+
   @override
   bool containsPotentiallyBreakingNativeDiffs(FileSetDiff fileSetDiff) =>
       nativeFileSetDiff(fileSetDiff).isNotEmpty;

--- a/packages/shorebird_cli/lib/src/archive_analysis/archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/archive_differ.dart
@@ -9,8 +9,13 @@ import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 /// Thrown when an [ArchiveDiffer] fails to generate a [FileSetDiff].
 class DiffFailedException implements Exception {}
 
+/// {@template archive_differ}
 /// Computes content differences between two archives.
+/// {@endtemplate}
 abstract class ArchiveDiffer {
+  /// {@macro archive_differ}
+  const ArchiveDiffer();
+
   /// Asset files that are not considered to be breaking changes.
   static const assetFileNamesToIgnore = {
     'AssetManifest.bin',

--- a/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
@@ -11,6 +11,7 @@ import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/archive_analysis/file_set_diff.dart';
 import 'package:shorebird_cli/src/archive_analysis/macho.dart';
 
+/// {@template ios_archive_differ}
 /// Finds differences between two IPAs or zipped Xcframeworks.
 ///
 /// Asset changes will be in the `Assets.car` file (which is a combination of
@@ -21,7 +22,11 @@ import 'package:shorebird_cli/src/archive_analysis/macho.dart';
 ///   Flutter.framework or App.framework files.
 ///
 /// Dart changes will appear in the App.framework/App executable.
+/// {@endtemplate}
 class IosArchiveDiffer extends ArchiveDiffer {
+  /// {@macro ios_archive_differ}
+  const IosArchiveDiffer();
+
   String _hash(List<int> bytes) => sha256.convert(bytes).toString();
 
   static final _binaryFilePatterns = {

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -433,6 +433,7 @@ Looked in:
           platform: platform,
           hash: hash,
           canSideload: false,
+          podfileLockHash: null,
         );
       } on CodePushConflictException catch (_) {
         // Newlines are due to how logger.info interacts with logger.progress.
@@ -460,6 +461,7 @@ ${arch.arch} artifact already exists, continuing...''',
         platform: platform,
         hash: sha256.convert(await File(aabPath).readAsBytes()).toString(),
         canSideload: true,
+        podfileLockHash: null,
       );
     } on CodePushConflictException catch (_) {
       // Newlines are due to how logger.info interacts with logger.progress.
@@ -509,6 +511,7 @@ aab artifact already exists, continuing...''',
           platform: platform,
           hash: hash,
           canSideload: false,
+          podfileLockHash: null,
         );
       } on CodePushConflictException catch (_) {
         // Newlines are due to how logger.info interacts with logger.progress.
@@ -536,6 +539,7 @@ ${arch.arch} artifact already exists, continuing...''',
         platform: platform,
         hash: sha256.convert(await File(aarPath).readAsBytes()).toString(),
         canSideload: false,
+        podfileLockHash: null,
       );
     } on CodePushConflictException catch (_) {
       // Newlines are due to how logger.info interacts with logger.progress.
@@ -578,6 +582,7 @@ aar artifact already exists, continuing...''',
     required String xcarchivePath,
     required String runnerPath,
     required bool isCodesigned,
+    required String podfileLockHash,
   }) async {
     final createArtifactProgress = logger.progress('Creating artifacts');
     final thinnedArchiveDirectory =
@@ -592,6 +597,7 @@ aar artifact already exists, continuing...''',
         platform: ReleasePlatform.ios,
         hash: sha256.convert(await zippedArchive.readAsBytes()).toString(),
         canSideload: false,
+        podfileLockHash: podfileLockHash,
       );
     } catch (error) {
       _handleErrorAndExit(
@@ -611,6 +617,7 @@ aar artifact already exists, continuing...''',
         platform: ReleasePlatform.ios,
         hash: sha256.convert(await zippedRunner.readAsBytes()).toString(),
         canSideload: isCodesigned,
+        podfileLockHash: podfileLockHash,
       );
     } catch (error) {
       _handleErrorAndExit(
@@ -647,6 +654,7 @@ aar artifact already exists, continuing...''',
             .convert(await zippedAppFrameworkFile.readAsBytes())
             .toString(),
         canSideload: false,
+        podfileLockHash: null,
       );
     } catch (error) {
       _handleErrorAndExit(

--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -582,7 +582,7 @@ aar artifact already exists, continuing...''',
     required String xcarchivePath,
     required String runnerPath,
     required bool isCodesigned,
-    required String podfileLockHash,
+    required String? podfileLockHash,
   }) async {
     final createArtifactProgress = logger.progress('Creating artifacts');
     final thinnedArchiveDirectory =

--- a/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
@@ -71,7 +71,7 @@ class AarPatcher extends Patcher {
       patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
         localArchive: patchArchive,
         releaseArchive: releaseArchive,
-        archiveDiffer: AndroidArchiveDiffer(),
+        archiveDiffer: const AndroidArchiveDiffer(),
         allowAssetChanges: allowAssetDiffs,
         allowNativeChanges: allowNativeDiffs,
       );

--- a/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
@@ -6,7 +6,6 @@ import 'package:io/io.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/archive_analysis/android_archive_differ.dart';
-import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -41,9 +40,6 @@ class AarPatcher extends Patcher {
   String get buildNumber => argResults['build-number'] as String;
 
   @override
-  ArchiveDiffer get archiveDiffer => AndroidArchiveDiffer();
-
-  @override
   String get primaryReleaseArtifactArch => 'aar';
 
   @override
@@ -65,6 +61,20 @@ class AarPatcher extends Patcher {
       throw ProcessExit(ExitCode.config.code);
     }
   }
+
+  @override
+  Future<DiffStatus> assertUnpatchableDiffs({
+    required ReleaseArtifact releaseArtifact,
+    required File releaseArchive,
+    required File patchArchive,
+  }) =>
+      patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+        localArchive: patchArchive,
+        releaseArchive: releaseArchive,
+        archiveDiffer: AndroidArchiveDiffer(),
+        allowAssetChanges: allowAssetDiffs,
+        allowNativeChanges: allowNativeDiffs,
+      );
 
   @override
   Future<File> buildPatchArtifact() async {

--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -50,7 +50,7 @@ class AndroidPatcher extends Patcher {
       patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
         localArchive: patchArchive,
         releaseArchive: releaseArchive,
-        archiveDiffer: AndroidArchiveDiffer(),
+        archiveDiffer: const AndroidArchiveDiffer(),
         allowAssetChanges: allowAssetDiffs,
         allowNativeChanges: allowNativeDiffs,
       );

--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -4,7 +4,6 @@ import 'package:crypto/crypto.dart';
 import 'package:io/io.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/archive_analysis/android_archive_differ.dart';
-import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -43,7 +42,18 @@ class AndroidPatcher extends Patcher {
   String get primaryReleaseArtifactArch => 'aab';
 
   @override
-  ArchiveDiffer get archiveDiffer => AndroidArchiveDiffer();
+  Future<DiffStatus> assertUnpatchableDiffs({
+    required ReleaseArtifact releaseArtifact,
+    required File releaseArchive,
+    required File patchArchive,
+  }) =>
+      patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+        localArchive: patchArchive,
+        releaseArchive: releaseArchive,
+        archiveDiffer: AndroidArchiveDiffer(),
+        allowAssetChanges: allowAssetDiffs,
+        allowNativeChanges: allowNativeDiffs,
+      );
 
   @override
   Future<void> assertPreconditions() async {

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
@@ -87,7 +87,7 @@ class IosFrameworkPatcher extends Patcher {
       patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
         localArchive: patchArchive,
         releaseArchive: releaseArchive,
-        archiveDiffer: IosArchiveDiffer(),
+        archiveDiffer: const IosArchiveDiffer(),
         allowAssetChanges: allowAssetDiffs,
         allowNativeChanges: allowNativeDiffs,
       );

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
@@ -6,7 +6,6 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:shorebird_cli/src/archive/directory_archive.dart';
-import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/archive_analysis/ios_archive_differ.dart';
 import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
@@ -45,9 +44,6 @@ class IosFrameworkPatcher extends Patcher {
   String get _appDillCopyPath => p.join(buildDirectory.path, 'app.dill');
 
   @override
-  ArchiveDiffer get archiveDiffer => IosArchiveDiffer();
-
-  @override
   String get primaryReleaseArtifactArch => 'xcframework';
 
   @override
@@ -81,6 +77,20 @@ class IosFrameworkPatcher extends Patcher {
       throw ProcessExit(ExitCode.usage.code);
     }
   }
+
+  @override
+  Future<DiffStatus> assertUnpatchableDiffs({
+    required ReleaseArtifact releaseArtifact,
+    required File releaseArchive,
+    required File patchArchive,
+  }) =>
+      patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
+        localArchive: patchArchive,
+        releaseArchive: releaseArchive,
+        archiveDiffer: IosArchiveDiffer(),
+        allowAssetChanges: allowAssetDiffs,
+        allowNativeChanges: allowNativeDiffs,
+      );
 
   @override
   Future<File> buildPatchArtifact() async {

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -82,6 +82,26 @@ class IosPatcher extends Patcher {
   }
 
   @override
+  Future<void> checkPatchability({
+    required ReleaseArtifact releaseArtifact,
+  }) async {
+    final podfileLockHash = await ios.podfileLockHash();
+    if (podfileLockHash != releaseArtifact.podfileLockHash) {
+      logger
+        ..warn(
+          '''Your ios/Podfile.lock is different from the one used to build the release.''',
+        )
+        ..info(
+          yellow.wrap(
+            '''This may indicate that the patch contains native changes, which cannot be applied with a patch.''',
+          ),
+        );
+
+      // TODO
+    }
+  }
+
+  @override
   Future<File> buildPatchArtifact() async {
     final File exportOptionsPlist;
     try {

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -98,8 +98,6 @@ class IosPatcher extends Patcher {
       confirmNativeChanges: false,
     );
 
-    print('has native changes: ${diffStatus.hasNativeChanges}');
-
     if (!diffStatus.hasNativeChanges) {
       return diffStatus;
     }

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -109,7 +109,8 @@ class IosPatcher extends Patcher {
         .convert(shorebirdEnv.podfileLockFile.readAsBytesSync())
         .toString();
 
-    if (podfileLockHash != releaseArtifact.podfileLockHash) {
+    if (releaseArtifact.podfileLockHash != null &&
+        podfileLockHash != releaseArtifact.podfileLockHash) {
       logger
         ..warn(
           '''Your ios/Podfile.lock is different from the one used to build the release.''',

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -64,9 +64,6 @@ class IosPatcher extends Patcher {
   @override
   String get primaryReleaseArtifactArch => 'xcarchive';
 
-  // @override
-  // ArchiveDiffer get archiveDiffer => IosArchiveDiffer();
-
   @override
   Future<void> assertPreconditions() async {
     try {

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -113,15 +113,11 @@ class IosPatcher extends Patcher {
 
     if (releaseArtifact.podfileLockHash != null &&
         podfileLockHash != releaseArtifact.podfileLockHash) {
-      logger
-        ..warn(
-          '''Your ios/Podfile.lock is different from the one used to build the release.''',
-        )
-        ..info(
-          yellow.wrap(
-            '''This may indicate that the patch contains native changes, which cannot be applied with a patch. Proceeding may result in unexpected behavior or crashes.''',
-          ),
-        );
+      logger.warn(
+        '''
+Your ios/Podfile.lock is different from the one used to build the release.
+This may indicate that the patch contains native changes, which cannot be applied with a patch. Proceeding may result in unexpected behavior or crashes.''',
+      );
 
       if (!allowNativeDiffs) {
         if (!shorebirdEnv.canAcceptUserInput) {

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -98,13 +98,20 @@ class IosPatcher extends Patcher {
       confirmNativeChanges: false,
     );
 
+    print('has native changes: ${diffStatus.hasNativeChanges}');
+
     if (!diffStatus.hasNativeChanges) {
       return diffStatus;
     }
 
-    final podfileLockHash = sha256
-        .convert(shorebirdEnv.podfileLockFile.readAsBytesSync())
-        .toString();
+    final String? podfileLockHash;
+    if (shorebirdEnv.podfileLockFile.existsSync()) {
+      podfileLockHash = sha256
+          .convert(shorebirdEnv.podfileLockFile.readAsBytesSync())
+          .toString();
+    } else {
+      podfileLockHash = null;
+    }
 
     if (releaseArtifact.podfileLockHash != null &&
         podfileLockHash != releaseArtifact.podfileLockHash) {

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -84,13 +84,21 @@ class IosPatcher extends Patcher {
     required File releaseArchive,
     required File patchArchive,
   }) async {
-    final diffStatus =
-        await patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-      localArchive: patchArchive,
-      releaseArchive: releaseArchive,
-      archiveDiffer: IosArchiveDiffer(),
-      allowAssetChanges: allowAssetDiffs,
-      allowNativeChanges: allowNativeDiffs,
+    final progress =
+        logger.progress('Verifying patch can be applied to release');
+
+    final archiveDiffer = IosArchiveDiffer();
+    final contentDiffs = await archiveDiffer.changedFiles(
+      releaseArchive.path,
+      patchArchive.path,
+    );
+    progress.complete();
+
+    final diffStatus = DiffStatus(
+      hasAssetChanges:
+          archiveDiffer.containsPotentiallyBreakingAssetDiffs(contentDiffs),
+      hasNativeChanges:
+          archiveDiffer.containsPotentiallyBreakingNativeDiffs(contentDiffs),
     );
 
     if (!diffStatus.hasNativeChanges) {

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -361,7 +361,6 @@ Please re-run the release command for this version or create a new release.''');
     required ReleaseArtifact releaseArtifact,
     required File patchArchive,
     required File releaseArchive,
-    // required ArchiveDiffer archiveDiffer,
     required Patcher patcher,
   }) async {
     try {
@@ -370,12 +369,6 @@ Please re-run the release command for this version or create a new release.''');
         releaseArchive: releaseArchive,
         patchArchive: patchArchive,
       );
-      //   localArchive: patchArtifact,
-      //   releaseArchive: releaseArtifact,
-      //   archiveDiffer: archiveDiffer,
-      //   allowAssetChanges: allowAssetDiffs,
-      //   allowNativeChanges: allowNativeDiffs,
-      // );
     } on UserCancelledException {
       throw ProcessExit(ExitCode.success.code);
     } on UnpatchableChangeException {

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -195,9 +195,6 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
     }
   }
 
-  bool get allowAssetDiffs => results['allow-asset-diffs'] == true;
-  bool get allowNativeDiffs => results['allow-native-diffs'] == true;
-
   String? lastBuiltFlutterRevision;
 
   @visibleForTesting

--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -67,7 +67,8 @@ https://docs.shorebird.dev/status#link-percentage-ios
   /// Asserts that the combination arguments passed to the command are valid.
   Future<void> assertArgsAreValid() async {}
 
-  /// TODO
+  /// Compares the release and patch artifacts to determine if the patch can be
+  /// cleanly applied to the release.
   Future<DiffStatus> assertUnpatchableDiffs({
     required ReleaseArtifact releaseArtifact,
     required File releaseArchive,

--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -12,6 +12,7 @@ import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 
 /// {@template patcher}
 /// Platform-specific functionality to create a patch.
@@ -70,6 +71,12 @@ https://docs.shorebird.dev/status#link-percentage-ios
 
   /// Asserts that the combination arguments passed to the command are valid.
   Future<void> assertArgsAreValid() async {}
+
+  /// Checks whether the [releaseArtifact] can be patched by the current
+  /// project.
+  Future<void> checkPatchability({
+    required ReleaseArtifact releaseArtifact,
+  }) async {}
 
   /// Builds the release artifacts for the given platform. Returns the "primary"
   /// artifact for the platform (e.g. the AAB for Android, the IPA for iOS).

--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
-import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
@@ -55,10 +54,6 @@ https://docs.shorebird.dev/status#link-percentage-ios
   /// The type of artifact we are creating a release for.
   ReleaseType get releaseType;
 
-  /// Used to compare release and patch artifacts to determine if a patch can
-  /// be applied to a release.
-  ArchiveDiffer get archiveDiffer;
-
   /// The identifier used for the "primary" release artifact, usually a bundle.
   /// For example, 'aab' for Android, 'xcarchive' for iOS.
   String get primaryReleaseArtifactArch;
@@ -72,11 +67,12 @@ https://docs.shorebird.dev/status#link-percentage-ios
   /// Asserts that the combination arguments passed to the command are valid.
   Future<void> assertArgsAreValid() async {}
 
-  /// Checks whether the [releaseArtifact] can be patched by the current
-  /// project.
-  Future<void> checkPatchability({
+  /// TODO
+  Future<DiffStatus> assertUnpatchableDiffs({
     required ReleaseArtifact releaseArtifact,
-  }) async {}
+    required File releaseArchive,
+    required File patchArchive,
+  });
 
   /// Builds the release artifacts for the given platform. Returns the "primary"
   /// artifact for the platform (e.g. the AAB for Android, the IPA for iOS).

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
@@ -16,6 +17,7 @@ import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/ios.dart';
 import 'package:shorebird_cli/src/release_type.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
@@ -175,6 +177,9 @@ For more information see: $supportedVersionsLink''',
     required String appId,
   }) async {
     final xcarchiveDirectory = artifactManager.getXcarchiveDirectory()!;
+    final podfileLockHash = sha256
+        .convert(shorebirdEnv.podfileLockFile.readAsBytesSync())
+        .toString();
     await codePushClientWrapper.createIosReleaseArtifacts(
       appId: appId,
       releaseId: release.id,
@@ -183,7 +188,7 @@ For more information see: $supportedVersionsLink''',
           .getIosAppDirectory(xcarchiveDirectory: xcarchiveDirectory)!
           .path,
       isCodesigned: codesign,
-      podfileLockHash: await ios.podfileLockHash(),
+      podfileLockHash: podfileLockHash,
     );
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -183,6 +183,7 @@ For more information see: $supportedVersionsLink''',
           .getIosAppDirectory(xcarchiveDirectory: xcarchiveDirectory)!
           .path,
       isCodesigned: codesign,
+      podfileLockHash: await ios.podfileLockHash(),
     );
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -177,9 +177,14 @@ For more information see: $supportedVersionsLink''',
     required String appId,
   }) async {
     final xcarchiveDirectory = artifactManager.getXcarchiveDirectory()!;
-    final podfileLockHash = sha256
-        .convert(shorebirdEnv.podfileLockFile.readAsBytesSync())
-        .toString();
+    final String? podfileLockHash;
+    if (shorebirdEnv.podfileLockFile.existsSync()) {
+      podfileLockHash = sha256
+          .convert(shorebirdEnv.podfileLockFile.readAsBytesSync())
+          .toString();
+    } else {
+      podfileLockHash = null;
+    }
     await codePushClientWrapper.createIosReleaseArtifacts(
       appId: appId,
       releaseId: release.id,

--- a/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/upgrade_command.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:args/command_runner.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';

--- a/packages/shorebird_cli/lib/src/patch_diff_checker.dart
+++ b/packages/shorebird_cli/lib/src/patch_diff_checker.dart
@@ -42,10 +42,10 @@ PatchDiffChecker get patchDiffChecker => read(patchDiffCheckerRef);
 /// {@endtemplate}
 class PatchDiffChecker {
   /// Checks for differences that could cause issues when applying the
-  /// [localArtifact] patch to the [releaseArtifact].
+  /// [localArchive] patch to the [releaseArchive].
   Future<DiffStatus> confirmUnpatchableDiffsIfNecessary({
-    required File localArtifact,
-    required File releaseArtifact,
+    required File localArchive,
+    required File releaseArchive,
     required ArchiveDiffer archiveDiffer,
     required bool allowAssetChanges,
     required bool allowNativeChanges,
@@ -54,8 +54,8 @@ class PatchDiffChecker {
         logger.progress('Verifying patch can be applied to release');
 
     final contentDiffs = await archiveDiffer.changedFiles(
-      releaseArtifact.path,
-      localArtifact.path,
+      releaseArchive.path,
+      localArchive.path,
     );
     progress.complete();
 

--- a/packages/shorebird_cli/lib/src/patch_diff_checker.dart
+++ b/packages/shorebird_cli/lib/src/patch_diff_checker.dart
@@ -12,7 +12,7 @@ import 'package:shorebird_cli/src/shorebird_env.dart';
 /// {@endtemplate}
 class DiffStatus {
   /// {@macro diff_status}
-  DiffStatus({
+  const DiffStatus({
     required this.hasAssetChanges,
     required this.hasNativeChanges,
   });
@@ -49,6 +49,8 @@ class PatchDiffChecker {
     required ArchiveDiffer archiveDiffer,
     required bool allowAssetChanges,
     required bool allowNativeChanges,
+    bool checkAssetChanges = true,
+    bool confirmNativeChanges = true,
   }) async {
     final progress =
         logger.progress('Verifying patch can be applied to release');
@@ -66,7 +68,7 @@ class PatchDiffChecker {
           archiveDiffer.containsPotentiallyBreakingNativeDiffs(contentDiffs),
     );
 
-    if (status.hasNativeChanges) {
+    if (status.hasNativeChanges && confirmNativeChanges) {
       logger
         ..warn(
           '''Your app contains native changes, which cannot be applied with a patch.''',
@@ -93,7 +95,7 @@ If you don't know why you're seeing this error, visit our troublshooting page at
       }
     }
 
-    if (status.hasAssetChanges) {
+    if (status.hasAssetChanges && checkAssetChanges) {
       logger
         ..warn(
           '''Your app contains asset changes, which will not be included in the patch.''',

--- a/packages/shorebird_cli/lib/src/platform/ios.dart
+++ b/packages/shorebird_cli/lib/src/platform/ios.dart
@@ -3,14 +3,12 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
-import 'package:shorebird_cli/src/shorebird_env.dart';
 
 /// {@template export_method}
 /// The method used to export the IPA.
@@ -73,18 +71,6 @@ final iosRef = create(Ios.new);
 Ios get ios => read(iosRef);
 
 class Ios {
-  /// TODO
-  Future<String> podfileLockHash() async {
-    final podfileLockFile = File(
-      p.join(
-        shorebirdEnv.getShorebirdProjectRoot()!.path,
-        'ios',
-        'Podfile.lock',
-      ),
-    );
-    return sha256.convert(await podfileLockFile.readAsBytes()).toString();
-  }
-
   File exportOptionsPlistFromArgs(ArgResults results) {
     final exportPlistArg =
         results[CommonArguments.exportOptionsPlistArg.name] as String?;

--- a/packages/shorebird_cli/lib/src/platform/ios.dart
+++ b/packages/shorebird_cli/lib/src/platform/ios.dart
@@ -3,12 +3,14 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
 
 /// {@template export_method}
 /// The method used to export the IPA.
@@ -71,6 +73,18 @@ final iosRef = create(Ios.new);
 Ios get ios => read(iosRef);
 
 class Ios {
+  /// TODO
+  Future<String> podfileLockHash() async {
+    final podfileLockFile = File(
+      p.join(
+        shorebirdEnv.getShorebirdProjectRoot()!.path,
+        'ios',
+        'Podfile.lock',
+      ),
+    );
+    return sha256.convert(await podfileLockFile.readAsBytes()).toString();
+  }
+
   File exportOptionsPlistFromArgs(ArgResults results) {
     final exportPlistArg =
         results[CommonArguments.exportOptionsPlistArg.name] as String?;

--- a/packages/shorebird_cli/lib/src/shorebird_env.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_env.dart
@@ -102,6 +102,10 @@ class ShorebirdEnv {
     return File(p.join(flutterDirectory.path, 'bin', 'dart'));
   }
 
+  File get podfileLockFile {
+    return File(p.join(getFlutterProjectRoot()!.path, 'ios', 'Podfile.lock'));
+  }
+
   /// The `shorebird.yaml` file for this project.
   File getShorebirdYamlFile({required Directory cwd}) {
     return File(p.join(cwd.path, 'shorebird.yaml'));

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -330,10 +330,10 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "40f592dd352890c3b60fec1b68e786cefb9603e05ff303dbc4dda49b304ecdf4"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.0"
   intl:
     dependency: "direct main"
     description:

--- a/packages/shorebird_cli/test/src/archive_analysis/android_archive_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/android_archive_differ_test.dart
@@ -26,7 +26,7 @@ void main() {
     late AndroidArchiveDiffer differ;
 
     setUp(() {
-      differ = AndroidArchiveDiffer();
+      differ = const AndroidArchiveDiffer();
     });
 
     group('aab', () {

--- a/packages/shorebird_cli/test/src/archive_analysis/ios_archive_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/ios_archive_differ_test.dart
@@ -45,7 +45,7 @@ void main() {
       late IosArchiveDiffer differ;
 
       setUp(() {
-        differ = IosArchiveDiffer();
+        differ = const IosArchiveDiffer();
       });
 
       group('appRegex', () {

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -1558,6 +1558,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
     });
 
     group('createIosReleaseArtifacts', () {
+      const podfileLockHash = 'podfile-lock-hash';
       final xcarchivePath = p.join('path', 'to', 'app.xcarchive');
       final runnerPath = p.join('path', 'to', 'runner.app');
 
@@ -1611,7 +1612,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               xcarchivePath: p.join(projectRoot.path, xcarchivePath),
               runnerPath: p.join(projectRoot.path, runnerPath),
               isCodesigned: true,
-              podfileLockHash: 'TODO',
+              podfileLockHash: podfileLockHash,
             ),
           ),
           exitsWithCode(ExitCode.software),
@@ -1648,7 +1649,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               xcarchivePath: p.join(projectRoot.path, xcarchivePath),
               runnerPath: p.join(projectRoot.path, runnerPath),
               isCodesigned: false,
-              podfileLockHash: 'TODO',
+              podfileLockHash: podfileLockHash,
             ),
           ),
           exitsWithCode(ExitCode.software),
@@ -1685,7 +1686,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               xcarchivePath: p.join(projectRoot.path, xcarchivePath),
               runnerPath: p.join(projectRoot.path, runnerPath),
               isCodesigned: false,
-              podfileLockHash: 'TODO',
+              podfileLockHash: podfileLockHash,
             ),
           ),
           exitsWithCode(ExitCode.software),
@@ -1716,12 +1717,27 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
             xcarchivePath: p.join(projectRoot.path, xcarchivePath),
             runnerPath: p.join(projectRoot.path, runnerPath),
             isCodesigned: true,
-            podfileLockHash: 'TODO',
+            podfileLockHash: podfileLockHash,
           ),
         );
 
         verify(() => progress.complete()).called(1);
         verifyNever(() => progress.fail(any()));
+        verify(
+          () => codePushClient.createReleaseArtifact(
+            appId: app.appId,
+            artifactPath: any(
+              named: 'artifactPath',
+              that: endsWith('.xcarchive.zip'),
+            ),
+            releaseId: releaseId,
+            arch: any(named: 'arch'),
+            platform: releasePlatform,
+            hash: any(named: 'hash'),
+            canSideload: any(named: 'canSideload'),
+            podfileLockHash: podfileLockHash,
+          ),
+        ).called(1);
       });
     });
 

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -139,6 +139,7 @@ void main() {
       hash: 'asdf',
       size: 4,
       url: 'url',
+      podfileLockHash: 'podfile-lock-hash',
     );
 
     late CodePushClient codePushClient;
@@ -1050,6 +1051,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenAnswer((_) async {});
         });
@@ -1087,6 +1089,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenThrow(error);
           setUpProjectRoot();
@@ -1119,6 +1122,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenThrow(error);
           setUpProjectRoot();
@@ -1152,6 +1156,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenThrow(const CodePushConflictException(message: error));
           setUpProjectRoot();
@@ -1186,6 +1191,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenThrow(const CodePushConflictException(message: error));
           setUpProjectRoot();
@@ -1219,6 +1225,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenAnswer((_) async {});
           setUpProjectRoot();
@@ -1249,6 +1256,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenAnswer((_) async {});
           setUpProjectRoot(flavor: flavorName);
@@ -1277,6 +1285,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: releasePlatform,
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: null,
             ),
           ).called(Arch.values.length);
           verify(() => progress.complete()).called(1);
@@ -1325,6 +1334,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenAnswer((_) async {});
         });
@@ -1340,6 +1350,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenThrow(error);
           setUpProjectRoot();
@@ -1373,6 +1384,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenThrow(error);
           setUpProjectRoot();
@@ -1407,6 +1419,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenThrow(const CodePushConflictException(message: error));
           setUpProjectRoot();
@@ -1442,6 +1455,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenThrow(const CodePushConflictException(message: error));
           setUpProjectRoot();
@@ -1476,6 +1490,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenAnswer((_) async {});
           setUpProjectRoot();
@@ -1507,6 +1522,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenAnswer((_) async {});
           setUpProjectRoot(flavor: flavorName);
@@ -1532,6 +1548,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: releasePlatform,
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: null,
             ),
           ).called(Arch.values.length + 1);
           verify(() => progress.complete()).called(1);
@@ -1563,6 +1580,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
             platform: any(named: 'platform'),
             hash: any(named: 'hash'),
             canSideload: any(named: 'canSideload'),
+            podfileLockHash: any(named: 'podfileLockHash'),
           ),
         ).thenAnswer((_) async {});
       });
@@ -1580,6 +1598,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
             platform: any(named: 'platform'),
             hash: any(named: 'hash'),
             canSideload: any(named: 'canSideload'),
+            podfileLockHash: any(named: 'podfileLockHash'),
           ),
         ).thenThrow(error);
         setUpProjectRoot();
@@ -1592,6 +1611,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               xcarchivePath: p.join(projectRoot.path, xcarchivePath),
               runnerPath: p.join(projectRoot.path, runnerPath),
               isCodesigned: true,
+              podfileLockHash: 'TODO',
             ),
           ),
           exitsWithCode(ExitCode.software),
@@ -1615,6 +1635,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
             platform: any(named: 'platform'),
             hash: any(named: 'hash'),
             canSideload: any(named: 'canSideload'),
+            podfileLockHash: any(named: 'podfileLockHash'),
           ),
         ).thenThrow(const CodePushConflictException(message: error));
         setUpProjectRoot();
@@ -1627,6 +1648,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               xcarchivePath: p.join(projectRoot.path, xcarchivePath),
               runnerPath: p.join(projectRoot.path, runnerPath),
               isCodesigned: false,
+              podfileLockHash: 'TODO',
             ),
           ),
           exitsWithCode(ExitCode.software),
@@ -1650,6 +1672,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
             platform: any(named: 'platform'),
             hash: any(named: 'hash'),
             canSideload: any(named: 'canSideload'),
+            podfileLockHash: any(named: 'podfileLockHash'),
           ),
         ).thenThrow(error);
         setUpProjectRoot();
@@ -1662,6 +1685,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               xcarchivePath: p.join(projectRoot.path, xcarchivePath),
               runnerPath: p.join(projectRoot.path, runnerPath),
               isCodesigned: false,
+              podfileLockHash: 'TODO',
             ),
           ),
           exitsWithCode(ExitCode.software),
@@ -1680,6 +1704,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
             platform: any(named: 'platform'),
             hash: any(named: 'hash'),
             canSideload: any(named: 'canSideload'),
+            podfileLockHash: any(named: 'podfileLockHash'),
           ),
         ).thenAnswer((_) async {});
         setUpProjectRoot();
@@ -1691,6 +1716,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
             xcarchivePath: p.join(projectRoot.path, xcarchivePath),
             runnerPath: p.join(projectRoot.path, runnerPath),
             isCodesigned: true,
+            podfileLockHash: 'TODO',
           ),
         );
 
@@ -1720,6 +1746,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
               platform: any(named: 'platform'),
               hash: any(named: 'hash'),
               canSideload: any(named: 'canSideload'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenThrow(Exception('oh no'));
           setUpProjectRoot();
@@ -1747,6 +1774,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
             platform: any(named: 'platform'),
             hash: any(named: 'hash'),
             canSideload: any(named: 'canSideload'),
+            podfileLockHash: any(named: 'podfileLockHash'),
           ),
         ).thenAnswer((_) async {});
         setUpProjectRoot();

--- a/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
@@ -6,7 +6,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:scoped_deps/scoped_deps.dart';
-import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -124,12 +123,6 @@ void main() {
       });
     });
 
-    group('archiveDiffer', () {
-      test('is an AndroidArchiveDiffer', () {
-        expect(patcher.archiveDiffer, isA<AndroidArchiveDiffer>());
-      });
-    });
-
     group('releaseType', () {
       test('is aar', () {
         expect(patcher.releaseType, ReleaseType.aar);
@@ -218,6 +211,8 @@ void main() {
         });
       });
     });
+
+    group('assertUnpatchableDiffs', () {});
 
     group('buildPatchArtifact', () {
       const flutterVersionAndRevision = '3.10.6 (83305b5088)';

--- a/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
@@ -340,6 +340,7 @@ void main() {
         hash: '#',
         size: 42,
         url: 'https://example.com',
+        podfileLockHash: null,
       );
 
       late File releaseArtifactFile;

--- a/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
@@ -483,7 +483,7 @@ void main() {
       });
 
       test('returns correct metadata', () async {
-        final diffStatus = DiffStatus(
+        const diffStatus = DiffStatus(
           hasAssetChanges: false,
           hasNativeChanges: false,
         );

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -363,6 +363,7 @@ Looked in:
         hash: '#',
         size: 42,
         url: 'https://example.com',
+        podfileLockHash: null,
       );
 
       setUp(() {

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -582,7 +582,7 @@ Looked in:
       });
 
       test('returns correct metadata', () async {
-        final diffStatus = DiffStatus(
+        const diffStatus = DiffStatus(
           hasAssetChanges: false,
           hasNativeChanges: false,
         );

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -7,7 +7,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:scoped_deps/scoped_deps.dart';
-import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -146,12 +145,6 @@ void main() {
       );
     });
 
-    group('archiveDiffer', () {
-      test('is an AndroidArchiveDiffer', () {
-        expect(patcher.archiveDiffer, isA<AndroidArchiveDiffer>());
-      });
-    });
-
     group('primaryReleaseArtifactArch', () {
       test('is "aab"', () {
         expect(patcher.primaryReleaseArtifactArch, equals('aab'));
@@ -224,6 +217,8 @@ void main() {
         });
       });
     });
+
+    group('assertUnpatchableDiffs', () {});
 
     group('buildPatchArtifact', () {
       const flutterVersionAndRevision = '3.10.6 (83305b5088)';

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -6,7 +6,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:scoped_deps/scoped_deps.dart';
-import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -131,12 +130,6 @@ void main() {
           flavor: null,
           target: null,
         );
-      });
-
-      group('archiveDiffer', () {
-        test('is an IosArchiveDiffer', () {
-          expect(patcher.archiveDiffer, isA<IosArchiveDiffer>());
-        });
       });
 
       group('primaryReleaseArtifactArch', () {
@@ -278,6 +271,8 @@ void main() {
           });
         });
       });
+
+      group('assertUnpatchableDiffs', () {});
 
       group('buildPatchArtifact', () {
         const flutterVersionAndRevision = '3.10.6 (83305b5088)';

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -801,7 +801,7 @@ void main() {
 
         group('when linker is not enabled', () {
           test('returns correct metadata', () async {
-            final diffStatus = DiffStatus(
+            const diffStatus = DiffStatus(
               hasAssetChanges: false,
               hasNativeChanges: false,
             );
@@ -840,7 +840,7 @@ void main() {
           });
 
           test('returns correct metadata', () async {
-            final diffStatus = DiffStatus(
+            const diffStatus = DiffStatus(
               hasAssetChanges: false,
               hasNativeChanges: false,
             );

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -420,6 +420,7 @@ void main() {
           hash: '#',
           size: 42,
           url: 'https://example.com',
+          podfileLockHash: null,
         );
         late File releaseArtifactFile;
 

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -398,7 +398,9 @@ void main() {
                   expect(diffStatus, equals(nativeChangeDiffStatus));
                   verify(
                     () => logger.warn(
-                      '''Your ios/Podfile.lock is different from the one used to build the release.''',
+                      '''
+Your ios/Podfile.lock is different from the one used to build the release.
+This may indicate that the patch contains native changes, which cannot be applied with a patch. Proceeding may result in unexpected behavior or crashes.''',
                     ),
                   ).called(1);
                   verifyNever(() => logger.confirm(any()));

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -547,10 +547,11 @@ For more information see: $supportedVersionsLink''',
           id: 0,
           releaseId: releaseId,
           arch: arch,
-          platform: ReleasePlatform.android,
+          platform: ReleasePlatform.ios,
           hash: '#',
           size: 42,
           url: 'https://example.com',
+          podfileLockHash: 'podfile-lock-hash',
         );
         late File releaseArtifactFile;
 

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -7,7 +7,6 @@ import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
-import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -144,12 +143,6 @@ void main() {
         );
       });
 
-      group('archiveDiffer', () {
-        test('is an IosArchiveDiffer', () {
-          expect(patcher.archiveDiffer, isA<IosArchiveDiffer>());
-        });
-      });
-
       group('primaryReleaseArtifactArch', () {
         test('is "xcarchive"', () {
           expect(patcher.primaryReleaseArtifactArch, 'xcarchive');
@@ -264,6 +257,8 @@ void main() {
           });
         });
       });
+
+      group('assertUnpatchableDiffs', () {});
 
       group('buildPatchArtifact', () {
         const flutterVersionAndRevision = '3.22.2 (83305b5088)';

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -75,6 +75,7 @@ void main() {
       hash: '#',
       size: 42,
       url: 'https://example.com',
+      podfileLockHash: null,
     );
     const aabArtifact = ReleaseArtifact(
       id: 0,
@@ -84,6 +85,7 @@ void main() {
       hash: '#',
       size: 42,
       url: 'https://example.com/release.aab',
+      podfileLockHash: null,
     );
 
     late AotTools aotTools;

--- a/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
@@ -1,12 +1,12 @@
 import 'dart:io';
 
-import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_code_push_protocol/src/models/create_patch_metadata.dart';
+import 'package:shorebird_code_push_protocol/src/models/release_artifact.dart';
 import 'package:test/test.dart';
 
 import '../../mocks.dart';
@@ -49,10 +49,16 @@ class _TestPatcher extends Patcher {
   });
 
   @override
-  ArchiveDiffer get archiveDiffer => throw UnimplementedError();
+  Future<void> assertPreconditions() {
+    throw UnimplementedError();
+  }
 
   @override
-  Future<void> assertPreconditions() {
+  Future<DiffStatus> assertUnpatchableDiffs({
+    required ReleaseArtifact releaseArtifact,
+    required File releaseArchive,
+    required File patchArchive,
+  }) {
     throw UnimplementedError();
   }
 

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -714,6 +714,7 @@ To change the version of this release, change your app's version in your pubspec
               xcarchivePath: any(named: 'xcarchivePath'),
               runnerPath: any(named: 'runnerPath'),
               isCodesigned: any(named: 'isCodesigned'),
+              podfileLockHash: any(named: 'podfileLockHash'),
             ),
           ).thenAnswer((_) async => {});
         });
@@ -733,6 +734,7 @@ To change the version of this release, change your app's version in your pubspec
               xcarchivePath: xcarchiveDirectory.path,
               runnerPath: iosAppDirectory.path,
               isCodesigned: codesign,
+              podfileLockHash: 'TODO',
             ),
           ).called(1);
         });

--- a/packages/shorebird_cli/test/src/fakes.dart
+++ b/packages/shorebird_cli/test/src/fakes.dart
@@ -17,4 +17,6 @@ class FakeIOSink extends Fake implements IOSink {}
 
 class FakeRelease extends Fake implements Release {}
 
+class FakeReleaseArtifact extends Fake implements ReleaseArtifact {}
+
 class FakeShorebirdProcess extends Fake implements ShorebirdProcess {}

--- a/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
+++ b/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
@@ -94,8 +94,8 @@ void main() {
         test('logs warning', () async {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-              localArtifact: localArtifact,
-              releaseArtifact: releaseArtifact,
+              localArchive: localArtifact,
+              releaseArchive: releaseArtifact,
               archiveDiffer: archiveDiffer,
               allowAssetChanges: false,
               allowNativeChanges: false,
@@ -123,8 +123,8 @@ void main() {
         test('prompts user if allowNativeChanges is false', () async {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-              localArtifact: localArtifact,
-              releaseArtifact: releaseArtifact,
+              localArchive: localArtifact,
+              releaseArchive: releaseArtifact,
               archiveDiffer: archiveDiffer,
               allowAssetChanges: false,
               allowNativeChanges: false,
@@ -137,8 +137,8 @@ void main() {
         test('does not prompt user if allowNativeChanges is true', () async {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-              localArtifact: localArtifact,
-              releaseArtifact: releaseArtifact,
+              localArchive: localArtifact,
+              releaseArchive: releaseArtifact,
               archiveDiffer: archiveDiffer,
               allowAssetChanges: false,
               allowNativeChanges: true,
@@ -155,8 +155,8 @@ void main() {
           await expectLater(
             runWithOverrides(
               () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-                localArtifact: localArtifact,
-                releaseArtifact: releaseArtifact,
+                localArchive: localArtifact,
+                releaseArchive: releaseArtifact,
                 archiveDiffer: archiveDiffer,
                 allowAssetChanges: false,
                 allowNativeChanges: false,
@@ -176,8 +176,8 @@ void main() {
           await expectLater(
             () => runWithOverrides(
               () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-                localArtifact: localArtifact,
-                releaseArtifact: releaseArtifact,
+                localArchive: localArtifact,
+                releaseArchive: releaseArtifact,
                 archiveDiffer: archiveDiffer,
                 allowAssetChanges: false,
                 allowNativeChanges: false,
@@ -200,8 +200,8 @@ void main() {
         test('logs warning', () async {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-              localArtifact: localArtifact,
-              releaseArtifact: releaseArtifact,
+              localArchive: localArtifact,
+              releaseArchive: releaseArtifact,
               archiveDiffer: archiveDiffer,
               allowAssetChanges: false,
               allowNativeChanges: false,
@@ -221,8 +221,8 @@ void main() {
         test('prompts user if allowAssetChanges is false', () async {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-              localArtifact: localArtifact,
-              releaseArtifact: releaseArtifact,
+              localArchive: localArtifact,
+              releaseArchive: releaseArtifact,
               archiveDiffer: archiveDiffer,
               allowAssetChanges: false,
               allowNativeChanges: false,
@@ -235,8 +235,8 @@ void main() {
         test('does not prompt user if allowAssetChanges is true', () async {
           await runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-              localArtifact: localArtifact,
-              releaseArtifact: releaseArtifact,
+              localArchive: localArtifact,
+              releaseArchive: releaseArtifact,
               archiveDiffer: archiveDiffer,
               allowAssetChanges: true,
               allowNativeChanges: false,
@@ -253,8 +253,8 @@ void main() {
           await expectLater(
             runWithOverrides(
               () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-                localArtifact: localArtifact,
-                releaseArtifact: releaseArtifact,
+                localArchive: localArtifact,
+                releaseArchive: releaseArtifact,
                 archiveDiffer: archiveDiffer,
                 allowAssetChanges: false,
                 allowNativeChanges: false,
@@ -272,8 +272,8 @@ void main() {
           await expectLater(
             () => runWithOverrides(
               () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-                localArtifact: localArtifact,
-                releaseArtifact: releaseArtifact,
+                localArchive: localArtifact,
+                releaseArchive: releaseArtifact,
                 archiveDiffer: archiveDiffer,
                 allowAssetChanges: false,
                 allowNativeChanges: false,
@@ -291,8 +291,8 @@ void main() {
         await expectLater(
           runWithOverrides(
             () => patchDiffChecker.confirmUnpatchableDiffsIfNecessary(
-              localArtifact: localArtifact,
-              releaseArtifact: releaseArtifact,
+              localArchive: localArtifact,
+              releaseArchive: releaseArtifact,
               archiveDiffer: archiveDiffer,
               allowAssetChanges: false,
               allowNativeChanges: false,

--- a/packages/shorebird_cli/test/src/shorebird_env_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_env_test.dart
@@ -199,6 +199,23 @@ void main() {
       });
     });
 
+    group('podfileLockFile', () {
+      test('returns correct path', () {
+        final tempDir = Directory.systemTemp.createTempSync();
+        File(p.join(tempDir.path, 'pubspec.yaml')).createSync(recursive: true);
+        final podfileLockFile = IOOverrides.runZoned(
+          () => runWithOverrides(
+            () => shorebirdEnv.podfileLockFile,
+          ),
+          getCurrentDirectory: () => tempDir,
+        );
+        expect(
+          podfileLockFile.path,
+          equals(p.join(tempDir.path, 'ios', 'Podfile.lock')),
+        );
+      });
+    });
+
     group('flutterBinaryFile', () {
       test('returns correct path', () {
         expect(

--- a/packages/shorebird_code_push_client/example/main.dart
+++ b/packages/shorebird_code_push_client/example/main.dart
@@ -37,6 +37,7 @@ Future<void> main() async {
     arch: '<ARCHITECTURE>', // e.g. 'aarch64'
     hash: '<HASH>', // 'sha256 hash of the artifact'
     canSideload: true,
+    podfileLockHash: '<HASH>', // 'sha256 hash of ios/Podfile.lock'
   );
 
   // Create a new patch.

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -180,6 +180,7 @@ class CodePushClient {
     required ReleasePlatform platform,
     required String hash,
     required bool canSideload,
+    required String? podfileLockHash,
   }) async {
     final request = http.MultipartRequest(
       'POST',
@@ -194,6 +195,7 @@ class CodePushClient {
       size: file.length,
       canSideload: canSideload,
       filename: p.basename(artifactPath),
+      podfileLockHash: podfileLockHash,
     ).toJson().map((key, value) => MapEntry(key, '$value'));
     request.fields.addAll(payload);
 

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -28,6 +28,7 @@ void main() {
       ...CodePushClient.standardHeaders,
       ...customHeaders,
     };
+    const podfileLockHash = 'podfile-lock-hash';
 
     late http.Client httpClient;
     late CodePushClient codePushClient;
@@ -443,6 +444,7 @@ void main() {
           size: size,
           canSideload: canSideload,
           filename: 'release.txt',
+          podfileLockHash: podfileLockHash,
         );
 
         try {
@@ -454,6 +456,7 @@ void main() {
             platform: platform,
             hash: hash,
             canSideload: canSideload,
+            podfileLockHash: podfileLockHash,
           );
         } catch (_) {}
 
@@ -496,6 +499,7 @@ void main() {
             platform: platform,
             hash: hash,
             canSideload: canSideload,
+            podfileLockHash: null,
           ),
           throwsA(
             isA<CodePushException>().having(
@@ -530,6 +534,7 @@ void main() {
             platform: platform,
             hash: hash,
             canSideload: canSideload,
+            podfileLockHash: null,
           ),
           throwsA(isA<CodePushNotFoundException>()),
         );
@@ -558,6 +563,7 @@ void main() {
             platform: platform,
             hash: hash,
             canSideload: canSideload,
+            podfileLockHash: null,
           ),
           throwsA(isA<CodePushConflictException>()),
         );
@@ -584,6 +590,7 @@ void main() {
             platform: platform,
             hash: hash,
             canSideload: canSideload,
+            podfileLockHash: null,
           ),
           throwsA(
             isA<CodePushException>().having(
@@ -636,6 +643,7 @@ void main() {
             platform: platform,
             hash: hash,
             canSideload: canSideload,
+            podfileLockHash: null,
           ),
           throwsA(
             isA<CodePushException>().having(
@@ -696,6 +704,7 @@ void main() {
             platform: platform,
             hash: hash,
             canSideload: canSideload,
+            podfileLockHash: podfileLockHash,
           ),
           completes,
         );
@@ -1718,6 +1727,7 @@ void main() {
             url: 'https://example.com',
             hash: '#',
             size: 42,
+            podfileLockHash: null,
           ),
         ];
 

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_response.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_response.g.dart
@@ -14,8 +14,8 @@ CreatePatchResponse _$CreatePatchResponseFromJson(Map<String, dynamic> json) =>
       json,
       ($checkedConvert) {
         final val = CreatePatchResponse(
-          id: $checkedConvert('id', (v) => (v as num).toInt()),
-          number: $checkedConvert('number', (v) => (v as num).toInt()),
+          id: $checkedConvert('id', (v) => v as int),
+          number: $checkedConvert('number', (v) => v as int),
         );
         return val;
       },

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_artifact/create_patch_artifact_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_artifact/create_patch_artifact_request.dart
@@ -15,6 +15,7 @@ class CreatePatchArtifactRequest {
     required this.hash,
     required this.size,
     this.hashSignature,
+    this.podfileLockHash,
   });
 
   /// Converts a Map<String, dynamic> to a [CreatePatchArtifactRequest]
@@ -39,6 +40,9 @@ class CreatePatchArtifactRequest {
   /// the product, so when this field is null, the patch does not uses code
   /// signing.
   final String? hashSignature;
+
+  /// TODO
+  final String? podfileLockHash;
 
   /// The size of the artifact in bytes.
   @JsonKey(fromJson: _parseStringToInt, toJson: _parseIntToString)

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_artifact/create_patch_artifact_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_artifact/create_patch_artifact_request.dart
@@ -41,7 +41,8 @@ class CreatePatchArtifactRequest {
   /// signing.
   final String? hashSignature;
 
-  /// TODO
+  /// The sha256 hash of the Podfile.lock file, if a Podfile.lock file was
+  /// involved in the creation of the patch (iOS only).
   final String? podfileLockHash;
 
   /// The size of the artifact in bytes.

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_artifact/create_patch_artifact_request.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_artifact/create_patch_artifact_request.g.dart
@@ -22,10 +22,15 @@ CreatePatchArtifactRequest _$CreatePatchArtifactRequestFromJson(
           size: $checkedConvert(
               'size', (v) => CreatePatchArtifactRequest._parseStringToInt(v)),
           hashSignature: $checkedConvert('hash_signature', (v) => v as String?),
+          podfileLockHash:
+              $checkedConvert('podfile_lock_hash', (v) => v as String?),
         );
         return val;
       },
-      fieldKeyMap: const {'hashSignature': 'hash_signature'},
+      fieldKeyMap: const {
+        'hashSignature': 'hash_signature',
+        'podfileLockHash': 'podfile_lock_hash'
+      },
     );
 
 Map<String, dynamic> _$CreatePatchArtifactRequestToJson(
@@ -35,6 +40,7 @@ Map<String, dynamic> _$CreatePatchArtifactRequestToJson(
       'platform': _$ReleasePlatformEnumMap[instance.platform]!,
       'hash': instance.hash,
       'hash_signature': instance.hashSignature,
+      'podfile_lock_hash': instance.podfileLockHash,
       'size': CreatePatchArtifactRequest._parseIntToString(instance.size),
     };
 

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
@@ -19,6 +19,7 @@ class CreateReleaseArtifactRequest {
     required this.size,
     required this.canSideload,
     required this.filename,
+    required this.podfileLockHash,
   });
 
   /// Converts a Map<String, dynamic> to a [CreateReleaseArtifactRequest]
@@ -47,6 +48,9 @@ class CreateReleaseArtifactRequest {
   /// The size of the artifact in bytes.
   @JsonKey(fromJson: _parseStringToInt, toJson: _parseIntToString)
   final int size;
+
+  /// The hash of the Podfile.lock file used to create this artifact (iOS only).
+  final String? podfileLockHash;
 
   static int _parseStringToInt(dynamic value) => int.parse(value as String);
 

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.g.dart
@@ -24,10 +24,15 @@ CreateReleaseArtifactRequest _$CreateReleaseArtifactRequestFromJson(
           canSideload: $checkedConvert('can_sideload',
               (v) => CreateReleaseArtifactRequest._parseStringToBool(v)),
           filename: $checkedConvert('filename', (v) => v as String),
+          podfileLockHash:
+              $checkedConvert('podfile_lock_hash', (v) => v as String?),
         );
         return val;
       },
-      fieldKeyMap: const {'canSideload': 'can_sideload'},
+      fieldKeyMap: const {
+        'canSideload': 'can_sideload',
+        'podfileLockHash': 'podfile_lock_hash'
+      },
     );
 
 Map<String, dynamic> _$CreateReleaseArtifactRequestToJson(
@@ -40,6 +45,7 @@ Map<String, dynamic> _$CreateReleaseArtifactRequestToJson(
       'can_sideload':
           CreateReleaseArtifactRequest._parseBoolToString(instance.canSideload),
       'size': CreateReleaseArtifactRequest._parseIntToString(instance.size),
+      'podfile_lock_hash': instance.podfileLockHash,
     };
 
 const _$ReleasePlatformEnumMap = {

--- a/packages/shorebird_code_push_protocol/lib/src/messages/promote_patch/promote_patch_request.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/promote_patch/promote_patch_request.g.dart
@@ -14,8 +14,8 @@ PromotePatchRequest _$PromotePatchRequestFromJson(Map<String, dynamic> json) =>
       json,
       ($checkedConvert) {
         final val = PromotePatchRequest(
-          patchId: $checkedConvert('patch_id', (v) => (v as num).toInt()),
-          channelId: $checkedConvert('channel_id', (v) => (v as num).toInt()),
+          patchId: $checkedConvert('patch_id', (v) => v as int),
+          channelId: $checkedConvert('channel_id', (v) => v as int),
         );
         return val;
       },

--- a/packages/shorebird_code_push_protocol/lib/src/models/app_metadata.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/app_metadata.g.dart
@@ -21,8 +21,8 @@ AppMetadata _$AppMetadataFromJson(Map<String, dynamic> json) => $checkedCreate(
               $checkedConvert('updated_at', (v) => DateTime.parse(v as String)),
           latestReleaseVersion:
               $checkedConvert('latest_release_version', (v) => v as String?),
-          latestPatchNumber: $checkedConvert(
-              'latest_patch_number', (v) => (v as num?)?.toInt()),
+          latestPatchNumber:
+              $checkedConvert('latest_patch_number', (v) => v as int?),
         );
         return val;
       },

--- a/packages/shorebird_code_push_protocol/lib/src/models/channel.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/channel.g.dart
@@ -13,7 +13,7 @@ Channel _$ChannelFromJson(Map<String, dynamic> json) => $checkedCreate(
       json,
       ($checkedConvert) {
         final val = Channel(
-          id: $checkedConvert('id', (v) => (v as num).toInt()),
+          id: $checkedConvert('id', (v) => v as int),
           appId: $checkedConvert('app_id', (v) => v as String),
           name: $checkedConvert('name', (v) => v as String),
         );

--- a/packages/shorebird_code_push_protocol/lib/src/models/patch.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/patch.g.dart
@@ -13,8 +13,8 @@ Patch _$PatchFromJson(Map<String, dynamic> json) => $checkedCreate(
       json,
       ($checkedConvert) {
         final val = Patch(
-          id: $checkedConvert('id', (v) => (v as num).toInt()),
-          number: $checkedConvert('number', (v) => (v as num).toInt()),
+          id: $checkedConvert('id', (v) => v as int),
+          number: $checkedConvert('number', (v) => v as int),
         );
         return val;
       },

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_artifact.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_artifact.dart
@@ -18,6 +18,7 @@ class ReleaseArtifact {
     required this.hash,
     required this.size,
     required this.url,
+    required this.podfileLockHash,
   });
 
   /// Converts a Map<String, dynamic> to a [ReleaseArtifact]
@@ -47,6 +48,9 @@ class ReleaseArtifact {
 
   /// The url of the artifact.
   final String url;
+
+  /// The hash of the Podfile.lock file used to create the artifact (iOS only).
+  final String? podfileLockHash;
 
   @override
   String toString() => toJson().toString();

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_artifact.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_artifact.g.dart
@@ -22,10 +22,15 @@ ReleaseArtifact _$ReleaseArtifactFromJson(Map<String, dynamic> json) =>
           hash: $checkedConvert('hash', (v) => v as String),
           size: $checkedConvert('size', (v) => v as int),
           url: $checkedConvert('url', (v) => v as String),
+          podfileLockHash:
+              $checkedConvert('podfile_lock_hash', (v) => v as String?),
         );
         return val;
       },
-      fieldKeyMap: const {'releaseId': 'release_id'},
+      fieldKeyMap: const {
+        'releaseId': 'release_id',
+        'podfileLockHash': 'podfile_lock_hash'
+      },
     );
 
 Map<String, dynamic> _$ReleaseArtifactToJson(ReleaseArtifact instance) =>
@@ -37,6 +42,7 @@ Map<String, dynamic> _$ReleaseArtifactToJson(ReleaseArtifact instance) =>
       'hash': instance.hash,
       'size': instance.size,
       'url': instance.url,
+      'podfile_lock_hash': instance.podfileLockHash,
     };
 
 const _$ReleasePlatformEnumMap = {

--- a/packages/shorebird_code_push_protocol/lib/src/models/user.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/user.g.dart
@@ -13,7 +13,7 @@ User _$UserFromJson(Map<String, dynamic> json) => $checkedCreate(
       json,
       ($checkedConvert) {
         final val = User(
-          id: $checkedConvert('id', (v) => (v as num).toInt()),
+          id: $checkedConvert('id', (v) => v as int),
           email: $checkedConvert('email', (v) => v as String),
           jwtIssuer: $checkedConvert('jwt_issuer', (v) => v as String),
           hasActiveSubscription: $checkedConvert(

--- a/packages/shorebird_code_push_protocol/test/src/messages/create_release_artifact/create_release_artifact_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/create_release_artifact/create_release_artifact_request_test.dart
@@ -11,6 +11,7 @@ void main() {
         size: 9876,
         canSideload: true,
         filename: 'test.apk',
+        podfileLockHash: null,
       );
       expect(
         CreateReleaseArtifactRequest.fromJson(request.toJson()).toJson(),

--- a/packages/shorebird_code_push_protocol/test/src/messages/get_release_artifacts/get_release_artifacts_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/get_release_artifacts/get_release_artifacts_response_test.dart
@@ -14,6 +14,7 @@ void main() {
             hash: '#',
             size: 1337,
             url: 'https://example.com',
+            podfileLockHash: 'podfile-lock-hash',
           ),
         ],
       );

--- a/packages/shorebird_code_push_protocol/test/src/models/release_artifact_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/release_artifact_test.dart
@@ -34,7 +34,7 @@ void main() {
       final artifactString = artifact.toString();
       expect(
         artifactString,
-        '{id: 1, release_id: 1, arch: aarch64, platform: android, hash: sha256:1234567890, size: 42, url: https://example.com}',
+        '{id: 1, release_id: 1, arch: aarch64, platform: android, hash: sha256:1234567890, size: 42, url: https://example.com, podfile_lock_hash: podfile-lock-hash}',
       );
     });
   });

--- a/packages/shorebird_code_push_protocol/test/src/models/release_artifact_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/release_artifact_test.dart
@@ -12,6 +12,7 @@ void main() {
         url: 'https://example.com',
         size: 42,
         hash: 'sha256:1234567890',
+        podfileLockHash: 'podfile-lock-hash',
       );
       expect(
         ReleaseArtifact.fromJson(artifact.toJson()).toJson(),
@@ -28,6 +29,7 @@ void main() {
         url: 'https://example.com',
         size: 42,
         hash: 'sha256:1234567890',
+        podfileLockHash: 'podfile-lock-hash',
       );
       final artifactString = artifact.toString();
       expect(


### PR DESCRIPTION
## Description

Updates iOS patch diff checking to no longer warn if binary files differ, and instead compares the hash of the current Podfile.lock to what it was when the release was created, warning if the two are different. 

Part of https://github.com/shorebirdtech/shorebird/issues/2257

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
