### PR TITLE
fix: accurate message when patching a release that doesn't contains the platform

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -237,6 +237,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
       );
     }
 
+    assertReleaseContainsPlatform(release: release, patcher: patcher);
     assertReleaseIsActive(release: release, patcher: patcher);
 
     try {
@@ -321,6 +322,20 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
       choices: releases.sortedBy((r) => r.createdAt).reversed.toList(),
       display: (r) => r.version,
     );
+  }
+
+  void assertReleaseContainsPlatform({
+    required Release release,
+    required Patcher patcher,
+  }) {
+    final containsPlatform = release.platformStatuses
+        .containsKey(patcher.releaseType.releasePlatform);
+    if (!containsPlatform) {
+      logger.err(
+        '''No release exists for [platform]. Please run shorebird release [platform] to create one.''',
+      );
+      throw ProcessExit(ExitCode.software.code);
+    }
   }
 
   void assertReleaseIsActive({

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -333,7 +333,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
     if (!contains) {
       final platformName = releasePlatform.name;
       logger.err(
-        '''No release exists for $platformName in ${release.version}. Please run shorebird release --platform $platformName to create one.''',
+        '''No release exists for $platformName in release version ${release.version}. Please run shorebird release $platformName to create one.''',
       );
       throw ProcessExit(ExitCode.software.code);
     }

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -328,11 +328,12 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
     required Release release,
     required Patcher patcher,
   }) {
-    final containsPlatform = release.platformStatuses
-        .containsKey(patcher.releaseType.releasePlatform);
-    if (!containsPlatform) {
+    final releasePlatform = patcher.releaseType.releasePlatform;
+    final contains = release.platformStatuses.containsKey(releasePlatform);
+    if (!contains) {
+      final platformName = releasePlatform.name;
       logger.err(
-        '''No release exists for [platform]. Please run shorebird release [platform] to create one.''',
+        '''No release exists for $platformName in ${release.version}. Please run shorebird release --platform $platformName to create one.''',
       );
       throw ProcessExit(ExitCode.software.code);
     }

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -882,7 +882,7 @@ Please re-run the release command for this version or create a new release.''',
 
         verify(
           () => logger.err(
-            '''No release exists for android in $releaseVersion. Please run shorebird release --platform android to create one.''',
+            '''No release exists for android in release version ${release.version}. Please run shorebird release android to create one.''',
           ),
         ).called(1);
       });

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -882,7 +882,7 @@ Please re-run the release command for this version or create a new release.''',
 
         verify(
           () => logger.err(
-            '''No release exists for [platform]. Please run shorebird release [platform] to create one.''',
+            '''No release exists for android in $releaseVersion. Please run shorebird release --platform android to create one.''',
           ),
         ).called(1);
       });

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -853,6 +853,41 @@ Please re-run the release command for this version or create a new release.''',
       });
     });
 
+    group('when the target release does not contain the provided platform', () {
+      setUp(() {
+        when(
+          () => codePushClientWrapper.getRelease(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+          ),
+        ).thenAnswer(
+          (_) async => Release(
+            id: 0,
+            appId: appId,
+            version: releaseVersion,
+            flutterRevision: flutterRevision,
+            displayName: '1.2.3+1',
+            platformStatuses: {ReleasePlatform.ios: ReleaseStatus.active},
+            createdAt: DateTime(2023),
+            updatedAt: DateTime(2023),
+          ),
+        );
+      });
+
+      test('logs error and exits with code 70', () async {
+        await expectLater(
+          () => runWithOverrides(command.run),
+          exitsWithCode(ExitCode.software),
+        );
+
+        verify(
+          () => logger.err(
+            '''No release exists for [platform]. Please run shorebird release [platform] to create one.''',
+          ),
+        ).called(1);
+      });
+    });
+
     group('when primary release artifact fails to download', () {
       final error = Exception('Failed to download primary release artifact.');
 


### PR DESCRIPTION
## Description

From #2177 

> When a release exists for one platform (say, Android) but not for another (say, iOS) and one runs `shorebird patch ios --release-version 1.2.3`, the CLI prints:
> 
> ```
> Release 1.0.1+19 is in an incomplete state. It's possible that the original release was terminated or failed to complete.
> Please re-run the release command for this version or create a new release.
> ```
> 
> Which is not correct. The release is not in an incomplete state, it just does not exist for the given platform.

This PR adds an additional assertion to check if the release simply doesn't have a platform a logs a better message.

![Screenshot 2024-06-19 at 10 08 17](https://github.com/shorebirdtech/shorebird/assets/835641/3d708674-6c57-407f-a0ad-5935717be671)

Fix #2177 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
