### PR TITLE
feat: assert artifact is sideloadable on preview

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -19,8 +19,10 @@ import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
+import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
+import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:yaml/yaml.dart';
 import 'package:yaml_edit/yaml_edit.dart';
@@ -76,6 +78,17 @@ class PreviewCommand extends ShorebirdCommand {
 
   @override
   String get description => 'Preview a specific release on a device.';
+
+  void assertArtifactIsSideloable(ReleaseArtifact artifact) {
+    if (!artifact.canSideload) {
+      logger.err('''
+The choosen release is cannot be sideloaded.
+
+For more information, see ${link(uri: Uri.parse(ShorebirdDocumentation.nonSideloadableRelease))}
+''');
+      throw ProcessExit(ExitCode.unavailable.code);
+    }
+  }
 
   @override
   Future<int> run() async {
@@ -232,6 +245,8 @@ class PreviewCommand extends ShorebirdCommand {
       return ExitCode.software.code;
     }
 
+    assertArtifactIsSideloable(releaseAabArtifact);
+
     try {
       aabFile = File(
         getArtifactPath(
@@ -349,6 +364,8 @@ class PreviewCommand extends ShorebirdCommand {
         ..detail('Stack trace: $s');
       return ExitCode.software.code;
     }
+
+    assertArtifactIsSideloable(releaseRunnerArtifact);
 
     runnerDirectory = Directory(
       getArtifactPath(

--- a/packages/shorebird_cli/lib/src/shorebird_documentation.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_documentation.dart
@@ -8,4 +8,10 @@ class ShorebirdDocumentation {
   /// file major version
   static const String unsupportedClassFileVersionUrl =
       '$baseUrl/troubleshooting/#unsupported-class-file-major-version-65';
+
+  /// URL to the documentation section which explains what makes a release
+  /// not sideloadable.
+  static const String nonSideloadableRelease =
+      // TODO(erickzanardo): Add the real URL here.
+      '$baseUrl/faq/#non-sideloadable-release';
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Fixes #2154 

When previewing a release that cannot be side loaded, the user will face a hard to understand message.

This PR checks before previewing if the artifact can be side loaded, and will show a more meaningful message.

Maybe a better solution to this, would be to not even show non sideloadable releases for the user, but that will introduce a lot of complexness since it we will need to refactor the flow of the preview command, and we will need to handle it differently when the user provide the release version, and when they prompt.

So for the sake of simplicity and since this issue hasn't caused that much confusion since it is in a way, an edge case, I opted for a simple solution.

WIP: Still need to write docs and test it more.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
