### PR TITLE
feat: better messaging for the user when having non sideloadable releases

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -21,11 +21,10 @@ import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
+import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:yaml/yaml.dart';
 import 'package:yaml_edit/yaml_edit.dart';
-
-import '../third_party/flutter_tools/lib/flutter_tools.dart';
 
 /// {@template preview_command}
 /// `shorebird preview` command.
@@ -79,6 +78,14 @@ class PreviewCommand extends ShorebirdCommand {
   @override
   String get description => 'Preview a specific release on a device.';
 
+  /// Given two [Release]s, one with all the platforms, previewable or not,
+  /// and one with only the previewable platforms, this method will check for
+  /// platforms that are not previewable.
+  ///
+  /// If any is found, we will:
+  /// - Warn the user about the platform if that platform is not the one
+  /// the user provide on --platform
+  /// - Error out if the user provided the platform that is not previewable.
   void _assertPreviwableReleases({
     required Release releaseWithAllPlatforms,
     required Release release,

--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -82,10 +82,10 @@ class PreviewCommand extends ShorebirdCommand {
   /// and one with only the previewable platforms, this method will check for
   /// platforms that are not previewable.
   ///
-  /// If any is found, we will:
+  /// If any non-previewable platforms are found, we will:
   /// - Warn the user about the platform if that platform is not the one
-  /// the user provide on --platform
-  /// - Error out if the user provided the platform that is not previewable.
+  ///    the user specified with `--platform`.
+  /// - Error out if the user specified a platform that is not previewable.
   void _assertPreviwableReleases({
     required Release releaseWithAllPlatforms,
     required Release release,

--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -104,7 +104,8 @@ class PreviewCommand extends ShorebirdCommand {
       if (results['platform'] == platform.name) {
         logger.err(message);
         throw ProcessExit(ExitCode.software.code);
-      } else {
+        // We only WARN if the user didn't specify a platform.
+      } else if (results['platform'] == null) {
         logger.warn(message);
       }
     }

--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -97,7 +97,7 @@ class PreviewCommand extends ShorebirdCommand {
 
     for (final platform in nonPreviewablePlatforms) {
       final message =
-          '''${platform.displayName} is not previewable and can't be used.''';
+          '''The ${platform.displayName} artifact for this release is not previewable.''';
 
       // If the user explicitly specified a platform and it matches a non
       // previewable platform, we early exit to avoid duplicated warnings/errors.

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -92,7 +92,7 @@ void main() {
           ..createSync(recursive: true)
           ..writeAsStringSync('app_id: $appId', flush: true);
 
-    Future<void> createAndroidShorebirdYaml(Invocation invocation) async {
+    Future<void> setupAndroidShorebirdYaml(Invocation invocation) async {
       File(
         p.join(
           (invocation.namedArguments[#outputDirectory] as Directory).path,
@@ -424,7 +424,7 @@ void main() {
               zipFile: any(named: 'zipFile'),
               outputDirectory: any(named: 'outputDirectory'),
             ),
-          ).thenAnswer(createAndroidShorebirdYaml);
+          ).thenAnswer(setupAndroidShorebirdYaml);
 
           when(() => release.platformStatuses).thenReturn({
             ReleasePlatform.ios: ReleaseStatus.active,
@@ -597,7 +597,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
 
         final exception = Exception('oops');
         when(() => bundletool.getPackageName(any())).thenThrow(exception);
@@ -612,7 +612,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
 
         final exception = Exception('oops');
         when(
@@ -634,7 +634,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
 
         final exception = Exception('oops');
         when(
@@ -651,7 +651,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
 
         final exception = Exception('oops');
         when(
@@ -668,7 +668,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
 
         final exception = Exception('oops');
         when(() => adb.startApp(package: any(named: 'package')))
@@ -684,7 +684,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
 
         when(() => process.exitCode).thenAnswer((_) async => 1);
         final result = await runWithOverrides(command.run);
@@ -698,7 +698,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
 
         final completer = Completer<int>();
         when(() => process.exitCode).thenAnswer((_) => completer.future);
@@ -718,7 +718,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
 
         final completer = Completer<int>();
         when(() => process.exitCode).thenAnswer((_) => completer.future);
@@ -788,7 +788,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
 
         when(() => argResults.wasParsed('app-id')).thenReturn(false);
         when(() => argResults['app-id']).thenReturn(null);
@@ -818,7 +818,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
         // We only prompt when there are multiple platforms to choose from
         when(() => platform.isMacOS).thenReturn(true);
 
@@ -899,7 +899,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
 
         when(() => argResults['release-version']).thenReturn(null);
         when(
@@ -933,7 +933,7 @@ channel: ${track.channel}
             zipFile: any(named: 'zipFile'),
             outputDirectory: any(named: 'outputDirectory'),
           ),
-        ).thenAnswer(createAndroidShorebirdYaml);
+        ).thenAnswer(setupAndroidShorebirdYaml);
 
         const deviceId = '1234';
         when(() => argResults['device-id']).thenReturn(deviceId);
@@ -1281,10 +1281,10 @@ channel: ${DeploymentTrack.staging.channel}
 
       group('when the android release is not sideloadable', () {
         setUp(() {
-          final unfilteredRelease = MockRelease();
-          when(() => unfilteredRelease.id).thenReturn(releaseId);
-          when(() => unfilteredRelease.version).thenReturn(releaseVersion);
-          when(() => unfilteredRelease.platformStatuses).thenReturn({
+          final releatWithAllPlatforms = MockRelease();
+          when(() => releatWithAllPlatforms.id).thenReturn(releaseId);
+          when(() => releatWithAllPlatforms.version).thenReturn(releaseVersion);
+          when(() => releatWithAllPlatforms.platformStatuses).thenReturn({
             ReleasePlatform.ios: ReleaseStatus.active,
             ReleasePlatform.android: ReleaseStatus.active,
           });
@@ -1301,7 +1301,7 @@ channel: ${DeploymentTrack.staging.channel}
             () => codePushClientWrapper.getReleases(
               appId: any(named: 'appId'),
             ),
-          ).thenAnswer((_) async => [unfilteredRelease]);
+          ).thenAnswer((_) async => [releatWithAllPlatforms]);
         });
 
         test('err about the platform and exits', () async {
@@ -1318,10 +1318,10 @@ channel: ${DeploymentTrack.staging.channel}
 
       group('when the ios release is not sideloadable', () {
         setUp(() {
-          final unfilteredRelease = MockRelease();
-          when(() => unfilteredRelease.id).thenReturn(releaseId);
-          when(() => unfilteredRelease.version).thenReturn(releaseVersion);
-          when(() => unfilteredRelease.platformStatuses).thenReturn({
+          final releatWithAllPlatforms = MockRelease();
+          when(() => releatWithAllPlatforms.id).thenReturn(releaseId);
+          when(() => releatWithAllPlatforms.version).thenReturn(releaseVersion);
+          when(() => releatWithAllPlatforms.platformStatuses).thenReturn({
             ReleasePlatform.ios: ReleaseStatus.active,
             ReleasePlatform.android: ReleaseStatus.active,
           });
@@ -1338,7 +1338,7 @@ channel: ${DeploymentTrack.staging.channel}
             () => codePushClientWrapper.getReleases(
               appId: any(named: 'appId'),
             ),
-          ).thenAnswer((_) async => [unfilteredRelease]);
+          ).thenAnswer((_) async => [releatWithAllPlatforms]);
         });
 
         test('err about the platform and exits', () async {
@@ -1356,7 +1356,7 @@ channel: ${DeploymentTrack.staging.channel}
       });
     });
 
-    group('when no platform is informed', () {
+    group('when no platform is specified', () {
       const iosReleaseArtifactUrl = 'https://example.com/runner.app';
       late Devicectl devicectl;
       late IOSDeploy iosDeploy;
@@ -1402,6 +1402,9 @@ channel: ${DeploymentTrack.staging.channel}
         devicectl = MockDevicectl();
         iosDeploy = MockIOSDeploy();
 
+        iosReleaseArtifact = MockReleaseArtifact();
+        androidReleaseArtifact = MockReleaseArtifact();
+
         when(() => appleDevice.name).thenReturn('iPhone 12');
         when(() => appleDevice.udid).thenReturn('12345678-1234567890ABCDEF');
         when(
@@ -1433,9 +1436,6 @@ channel: ${DeploymentTrack.staging.channel}
           ReleasePlatform.android: ReleaseStatus.active,
           ReleasePlatform.ios: ReleaseStatus.active,
         });
-
-        iosReleaseArtifact = MockReleaseArtifact();
-        androidReleaseArtifact = MockReleaseArtifact();
 
         when(() => iosReleaseArtifact.id).thenReturn(iosArtifactId);
         when(() => iosReleaseArtifact.url).thenReturn(iosReleaseArtifactUrl);
@@ -1500,10 +1500,11 @@ channel: ${DeploymentTrack.staging.channel}
 
         group('when the android release is not sideloadable', () {
           setUp(() {
-            final unfilteredRelease = MockRelease();
-            when(() => unfilteredRelease.id).thenReturn(releaseId);
-            when(() => unfilteredRelease.version).thenReturn(releaseVersion);
-            when(() => unfilteredRelease.platformStatuses).thenReturn({
+            final releatWithAllPlatforms = MockRelease();
+            when(() => releatWithAllPlatforms.id).thenReturn(releaseId);
+            when(() => releatWithAllPlatforms.version)
+                .thenReturn(releaseVersion);
+            when(() => releatWithAllPlatforms.platformStatuses).thenReturn({
               ReleasePlatform.ios: ReleaseStatus.active,
               ReleasePlatform.android: ReleaseStatus.active,
             });
@@ -1520,7 +1521,7 @@ channel: ${DeploymentTrack.staging.channel}
               () => codePushClientWrapper.getReleases(
                 appId: any(named: 'appId'),
               ),
-            ).thenAnswer((_) async => [unfilteredRelease]);
+            ).thenAnswer((_) async => [releatWithAllPlatforms]);
           });
 
           test('warns about the platform and goes directly to iOS', () async {
@@ -1552,7 +1553,7 @@ channel: ${DeploymentTrack.staging.channel}
               zipFile: any(named: 'zipFile'),
               outputDirectory: any(named: 'outputDirectory'),
             ),
-          ).thenAnswer(createAndroidShorebirdYaml);
+          ).thenAnswer(setupAndroidShorebirdYaml);
 
           when(() => argResults['device-id']).thenReturn(deviceId);
 
@@ -1613,10 +1614,11 @@ channel: ${DeploymentTrack.staging.channel}
 
         group('when the ios release is not sideloadable', () {
           setUp(() {
-            final unfilteredRelease = MockRelease();
-            when(() => unfilteredRelease.id).thenReturn(releaseId);
-            when(() => unfilteredRelease.version).thenReturn(releaseVersion);
-            when(() => unfilteredRelease.platformStatuses).thenReturn({
+            final releatWithAllPlatforms = MockRelease();
+            when(() => releatWithAllPlatforms.id).thenReturn(releaseId);
+            when(() => releatWithAllPlatforms.version)
+                .thenReturn(releaseVersion);
+            when(() => releatWithAllPlatforms.platformStatuses).thenReturn({
               ReleasePlatform.ios: ReleaseStatus.active,
               ReleasePlatform.android: ReleaseStatus.active,
             });
@@ -1633,10 +1635,10 @@ channel: ${DeploymentTrack.staging.channel}
               () => codePushClientWrapper.getReleases(
                 appId: any(named: 'appId'),
               ),
-            ).thenAnswer((_) async => [unfilteredRelease]);
+            ).thenAnswer((_) async => [releatWithAllPlatforms]);
           });
 
-          test('warns about the platform and goes directly to iOS', () async {
+          test('warns about it not being previewable', () async {
             final exitCode = await runWithOverrides(command.run);
             expect(exitCode, equals(ExitCode.success.code));
 

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -1304,16 +1304,19 @@ channel: ${DeploymentTrack.staging.channel}
           ).thenAnswer((_) async => [releatWithAllPlatforms]);
         });
 
-        test('err about the platform and exits', () async {
-          final exitCode = await runWithOverrides(command.run);
-          expect(exitCode, equals(ExitCode.software.code));
+        test(
+          'does not warns since the user explicitly asked for iOS',
+          () async {
+            final exitCode = await runWithOverrides(command.run);
+            expect(exitCode, equals(ExitCode.software.code));
 
-          verify(
-            () => logger.warn(
-              '''${ReleasePlatform.android.displayName} is not previewable and can't be used.''',
-            ),
-          ).called(1);
-        });
+            verifyNever(
+              () => logger.warn(
+                '''${ReleasePlatform.android.displayName} is not previewable and can't be used.''',
+              ),
+            );
+          },
+        );
       });
 
       group('when the ios release is not sideloadable', () {

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -1404,7 +1404,6 @@ channel: ${DeploymentTrack.staging.channel}
         process = MockProcess();
         devicectl = MockDevicectl();
         iosDeploy = MockIOSDeploy();
-
         iosReleaseArtifact = MockReleaseArtifact();
         androidReleaseArtifact = MockReleaseArtifact();
 
@@ -1468,7 +1467,7 @@ channel: ${DeploymentTrack.staging.channel}
         when(() => platform.isMacOS).thenReturn(true);
       });
 
-      group('when the user choose ios', () {
+      group('when the user chooses ios at the prompt', () {
         setUp(() {
           when(
             () => logger.chooseOne<String>(
@@ -1540,7 +1539,7 @@ channel: ${DeploymentTrack.staging.channel}
         });
       });
 
-      group('when the user choose android', () {
+      group('when the user chooses android at the prompt', () {
         const deviceId = '1234';
 
         setUp(() {

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -26,6 +26,7 @@ import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
 
+import '../matchers.dart';
 import '../mocks.dart';
 
 void main() {
@@ -1330,8 +1331,10 @@ channel: ${DeploymentTrack.staging.channel}
         });
 
         test('err about the platform and exits', () async {
-          final exitCode = await runWithOverrides(command.run);
-          expect(exitCode, equals(ExitCode.software.code));
+          await expectLater(
+            () => runWithOverrides(command.run),
+            exitsWithCode(ExitCode.software),
+          );
 
           verify(
             () => logger.err(

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -1312,7 +1312,7 @@ channel: ${DeploymentTrack.staging.channel}
 
             verifyNever(
               () => logger.warn(
-                '''${ReleasePlatform.android.displayName} is not previewable and can't be used.''',
+                '''The ${ReleasePlatform.android.displayName} artifact for this release is not previewable.''',
               ),
             );
           },
@@ -1352,7 +1352,7 @@ channel: ${DeploymentTrack.staging.channel}
 
           verify(
             () => logger.err(
-              '''${ReleasePlatform.ios.displayName} is not previewable and can't be used.''',
+              '''The ${ReleasePlatform.ios.displayName} artifact for this release is not previewable.''',
             ),
           ).called(1);
         });
@@ -1533,7 +1533,7 @@ channel: ${DeploymentTrack.staging.channel}
 
             verify(
               () => logger.warn(
-                '''${ReleasePlatform.android.displayName} is not previewable and can't be used.''',
+                '''The ${ReleasePlatform.android.displayName} artifact for this release is not previewable.''',
               ),
             ).called(1);
           });
@@ -1647,7 +1647,7 @@ channel: ${DeploymentTrack.staging.channel}
 
             verify(
               () => logger.warn(
-                '''${ReleasePlatform.ios.displayName} is not previewable and can't be used.''',
+                '''The ${ReleasePlatform.ios.displayName} artifact for this release is not previewable.''',
               ),
             ).called(1);
           });

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -1305,7 +1305,7 @@ channel: ${DeploymentTrack.staging.channel}
         });
 
         test(
-          'does not warns since the user explicitly asked for iOS',
+          'does not warn since the user explicitly asked for iOS',
           () async {
             final exitCode = await runWithOverrides(command.run);
             expect(exitCode, equals(ExitCode.software.code));

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -1281,10 +1281,11 @@ channel: ${DeploymentTrack.staging.channel}
 
       group('when the android release is not sideloadable', () {
         setUp(() {
-          final releatWithAllPlatforms = MockRelease();
-          when(() => releatWithAllPlatforms.id).thenReturn(releaseId);
-          when(() => releatWithAllPlatforms.version).thenReturn(releaseVersion);
-          when(() => releatWithAllPlatforms.platformStatuses).thenReturn({
+          final releaseWithAllPlatforms = MockRelease();
+          when(() => releaseWithAllPlatforms.id).thenReturn(releaseId);
+          when(() => releaseWithAllPlatforms.version)
+              .thenReturn(releaseVersion);
+          when(() => releaseWithAllPlatforms.platformStatuses).thenReturn({
             ReleasePlatform.ios: ReleaseStatus.active,
             ReleasePlatform.android: ReleaseStatus.active,
           });
@@ -1301,7 +1302,7 @@ channel: ${DeploymentTrack.staging.channel}
             () => codePushClientWrapper.getReleases(
               appId: any(named: 'appId'),
             ),
-          ).thenAnswer((_) async => [releatWithAllPlatforms]);
+          ).thenAnswer((_) async => [releaseWithAllPlatforms]);
         });
 
         test(
@@ -1321,10 +1322,11 @@ channel: ${DeploymentTrack.staging.channel}
 
       group('when the ios release is not sideloadable', () {
         setUp(() {
-          final releatWithAllPlatforms = MockRelease();
-          when(() => releatWithAllPlatforms.id).thenReturn(releaseId);
-          when(() => releatWithAllPlatforms.version).thenReturn(releaseVersion);
-          when(() => releatWithAllPlatforms.platformStatuses).thenReturn({
+          final releaseWithAllPlatforms = MockRelease();
+          when(() => releaseWithAllPlatforms.id).thenReturn(releaseId);
+          when(() => releaseWithAllPlatforms.version)
+              .thenReturn(releaseVersion);
+          when(() => releaseWithAllPlatforms.platformStatuses).thenReturn({
             ReleasePlatform.ios: ReleaseStatus.active,
             ReleasePlatform.android: ReleaseStatus.active,
           });
@@ -1341,7 +1343,7 @@ channel: ${DeploymentTrack.staging.channel}
             () => codePushClientWrapper.getReleases(
               appId: any(named: 'appId'),
             ),
-          ).thenAnswer((_) async => [releatWithAllPlatforms]);
+          ).thenAnswer((_) async => [releaseWithAllPlatforms]);
         });
 
         test('err about the platform and exits', () async {
@@ -1502,11 +1504,11 @@ channel: ${DeploymentTrack.staging.channel}
 
         group('when the android release is not sideloadable', () {
           setUp(() {
-            final releatWithAllPlatforms = MockRelease();
-            when(() => releatWithAllPlatforms.id).thenReturn(releaseId);
-            when(() => releatWithAllPlatforms.version)
+            final releaseWithAllPlatforms = MockRelease();
+            when(() => releaseWithAllPlatforms.id).thenReturn(releaseId);
+            when(() => releaseWithAllPlatforms.version)
                 .thenReturn(releaseVersion);
-            when(() => releatWithAllPlatforms.platformStatuses).thenReturn({
+            when(() => releaseWithAllPlatforms.platformStatuses).thenReturn({
               ReleasePlatform.ios: ReleaseStatus.active,
               ReleasePlatform.android: ReleaseStatus.active,
             });
@@ -1523,7 +1525,7 @@ channel: ${DeploymentTrack.staging.channel}
               () => codePushClientWrapper.getReleases(
                 appId: any(named: 'appId'),
               ),
-            ).thenAnswer((_) async => [releatWithAllPlatforms]);
+            ).thenAnswer((_) async => [releaseWithAllPlatforms]);
           });
 
           test('warns about the platform and goes directly to iOS', () async {
@@ -1616,11 +1618,11 @@ channel: ${DeploymentTrack.staging.channel}
 
         group('when the ios release is not sideloadable', () {
           setUp(() {
-            final releatWithAllPlatforms = MockRelease();
-            when(() => releatWithAllPlatforms.id).thenReturn(releaseId);
-            when(() => releatWithAllPlatforms.version)
+            final releaseWithAllPlatforms = MockRelease();
+            when(() => releaseWithAllPlatforms.id).thenReturn(releaseId);
+            when(() => releaseWithAllPlatforms.version)
                 .thenReturn(releaseVersion);
-            when(() => releatWithAllPlatforms.platformStatuses).thenReturn({
+            when(() => releaseWithAllPlatforms.platformStatuses).thenReturn({
               ReleasePlatform.ios: ReleaseStatus.active,
               ReleasePlatform.android: ReleaseStatus.active,
             });
@@ -1637,7 +1639,7 @@ channel: ${DeploymentTrack.staging.channel}
               () => codePushClientWrapper.getReleases(
                 appId: any(named: 'appId'),
               ),
-            ).thenAnswer((_) async => [releatWithAllPlatforms]);
+            ).thenAnswer((_) async => [releaseWithAllPlatforms]);
           });
 
           test('warns about it not being previewable', () async {


### PR DESCRIPTION
## Description

When there were a release where one of the platforms were could not be sideloaded, that platform would simply not be show in the list.

This PR implements better messaging to the user regarding the non sideloadable platforms:
 - When no `platform`  is provided, we warn that a platform can't be side loaded
 - If the user provided a `platform`, and that platform can't be side loaded, we error instead

Fixes #2277 2154

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
