### PR TITLE
fix(shorebird_cli): use same asset diffing logic for iOS and Android

### DIFF
--- a/packages/shorebird_cli/lib/src/archive_analysis/android_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/android_archive_differ.dart
@@ -1,5 +1,4 @@
 import 'package:path/path.dart' as p;
-import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 
 /// {@template android_archive_differ}
@@ -29,10 +28,6 @@ import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 class AndroidArchiveDiffer extends ArchiveDiffer {
   /// {@macro android_archive_differ}
   const AndroidArchiveDiffer();
-
-  @override
-  bool containsPotentiallyBreakingNativeDiffs(FileSetDiff fileSetDiff) =>
-      nativeFileSetDiff(fileSetDiff).isNotEmpty;
 
   @override
   bool isAssetFilePath(String filePath) {

--- a/packages/shorebird_cli/lib/src/archive_analysis/archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/archive_differ.dart
@@ -29,6 +29,8 @@ abstract class ArchiveDiffer {
     final assetsDiff = assetsFileSetDiff(fileSetDiff);
 
     // If assets were added, we need to warn the user about asset differences.
+    // We don't care about removed assets, as they can't be removed by patch
+    // and won't cause issues.
     if (assetsDiff.addedPaths.isNotEmpty) {
       return true;
     }
@@ -43,7 +45,8 @@ abstract class ArchiveDiffer {
 
   /// Whether there are native code differences between the archives that may
   /// cause issues when patching a release.
-  bool containsPotentiallyBreakingNativeDiffs(FileSetDiff fileSetDiff);
+  bool containsPotentiallyBreakingNativeDiffs(FileSetDiff fileSetDiff) =>
+      nativeFileSetDiff(fileSetDiff).isNotEmpty;
 
   /// Whether the provided file path represents a changed asset.
   bool isAssetFilePath(String filePath);

--- a/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/ios_archive_differ.dart
@@ -157,14 +157,6 @@ class IosArchiveDiffer extends ArchiveDiffer {
   }
 
   @override
-  bool containsPotentiallyBreakingAssetDiffs(FileSetDiff fileSetDiff) =>
-      assetsFileSetDiff(fileSetDiff).isNotEmpty;
-
-  @override
-  bool containsPotentiallyBreakingNativeDiffs(FileSetDiff fileSetDiff) =>
-      nativeFileSetDiff(fileSetDiff).isNotEmpty;
-
-  @override
   bool isAssetFilePath(String filePath) {
     /// The flutter_assets directory contains the assets listed in the assets
     ///   section of the pubspec.yaml file.

--- a/packages/shorebird_cli/test/src/archive_analysis/ios_archive_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/ios_archive_differ_test.dart
@@ -98,6 +98,7 @@ void main() {
                 fileSetDiff.changedPaths,
                 {
                   'Products/Applications/Runner.app/Frameworks/App.framework/_CodeSignature/CodeResources',
+                  'Products/Applications/Runner.app/Frameworks/App.framework/flutter_assets/NOTICES.Z',
                   'Products/Applications/Runner.app/Frameworks/App.framework/flutter_assets/assets/asset.json',
                   'Info.plist',
                 },


### PR DESCRIPTION
## Description

Updates asset diff check to be the same on iOS and android. This causes iOS to ignore the same files Android ignores and cleans up the code a little bit. 

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
