### PR TITLE
chore(shorebird_cli): don't print error toString on command failure

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
@@ -202,7 +202,9 @@ Engine • revision ${shorebirdEnv.shorebirdEngineRevision}''');
       } on ProcessExit catch (error) {
         exitCode = error.exitCode;
       } catch (error, stackTrace) {
-        logger.detail('$stackTrace');
+        logger
+          ..detail('$error')
+          ..detail('$stackTrace');
         exitCode = ExitCode.software.code;
       }
     }

--- a/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
@@ -202,9 +202,7 @@ Engine • revision ${shorebirdEnv.shorebirdEngineRevision}''');
       } on ProcessExit catch (error) {
         exitCode = error.exitCode;
       } catch (error, stackTrace) {
-        logger
-          ..err('$error')
-          ..detail('$stackTrace');
+        logger.detail('$stackTrace');
         exitCode = ExitCode.software.code;
       }
     }

--- a/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
@@ -260,15 +260,16 @@ Engine • revision $shorebirdEngineRevision''',
     });
 
     group('on command failure', () {
-      test('logs a stack trace using detail', () async {
-        // This will fail due to the release android command missing scoped
-        // dependencies.
+      test('logs error and stack trace using detail', () async {
+        // This will fail with a StateError due to the release android command
+        // missing scoped dependencies.
         // Note: the --verbose flag is here for illustrative purposes only.
         // Because logger is a mock, setting the log level in code does
         // nothing.
         await runWithOverrides(
           () => commandRunner.run(['release', 'android', '--verbose']),
         );
+        verify(() => logger.detail(any(that: contains('Bad state')))).called(1);
         verify(() => logger.detail(any(that: contains('#0')))).called(1);
       });
 


### PR DESCRIPTION
## Description

When a command fails, print the `toString` of the error as a `detail` instead of as `err`. Most exceptions/errors don't provide an implementation of toString, and we already print more helpful error messages when errors occur.

Example of what this is fixing (with non-verbose logging):

Before:
![Screenshot 2024-06-24 at 11 08 16 AM](https://github.com/shorebirdtech/shorebird/assets/581764/d271b4c7-98f2-4538-8b6b-e0a7683b754b)

After:
![Screenshot 2024-06-24 at 11 10 30 AM](https://github.com/shorebirdtech/shorebird/assets/581764/09547d23-9229-45ee-96db-572faf0be698)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
