### PR TITLE
fix(shorebird_cli): ignore extension schemes with identifying iOS flavors

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -67,12 +67,8 @@ Please make sure you are running "shorebird init" from within your Flutter proje
     final projectRoot = shorebirdEnv.getFlutterProjectRoot()!;
     final detectFlavorsProgress = logger.progress('Detecting product flavors');
     try {
-      final flavors = await Future.wait([
-        _maybeGetAndroidFlavors(projectRoot.path),
-        Future.value(ios.flavors()),
-      ]);
-      androidFlavors = flavors[0];
-      iosFlavors = flavors[1];
+      androidFlavors = await _maybeGetAndroidFlavors(projectRoot.path);
+      iosFlavors = ios.flavors();
       productFlavors = <String>{
         if (androidFlavors != null) ...androidFlavors,
         if (iosFlavors != null) ...iosFlavors,

--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -1,14 +1,12 @@
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
-import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/logger.dart';
-import 'package:shorebird_cli/src/platform.dart';
+import 'package:shorebird_cli/src/platform/ios.dart';
 import 'package:shorebird_cli/src/pubspec_editor.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -71,7 +69,7 @@ Please make sure you are running "shorebird init" from within your Flutter proje
     try {
       final flavors = await Future.wait([
         _maybeGetAndroidFlavors(projectRoot.path),
-        _maybeGetiOSFlavors(projectRoot.path),
+        Future.value(ios.flavors()),
       ]);
       androidFlavors = flavors[0];
       iosFlavors = flavors[1];
@@ -241,42 +239,6 @@ For more information about Shorebird, visit ${link(uri: Uri.parse('https://shore
       return await gradlew.productFlavors(projectPath);
     } on MissingAndroidProjectException {
       return null;
-    }
-  }
-
-  Future<Set<String>?> _maybeGetiOSFlavors(String projectPath) async {
-    if (platform.isMacOS) {
-      try {
-        final info = await xcodeBuild.list(projectPath);
-        return info.schemes.whereNot((element) => element == 'Runner').toSet();
-      } on MissingIOSProjectException {
-        return null;
-      }
-    } else {
-      // When running on a non-macOS platform, we can't use `xcodebuild` to
-      // detect flavors so we fallback to looking for schemes in xcschemes.
-      // Note: this appears to be identical to the behavior of `xcodebuild`.
-      final iosDir = Directory(p.join(projectPath, 'ios'));
-      if (!iosDir.existsSync()) return null;
-      final xcschemesDir = Directory(
-        p.join(
-          iosDir.path,
-          'Runner.xcodeproj',
-          'xcshareddata',
-          'xcschemes',
-        ),
-      );
-      if (!xcschemesDir.existsSync()) {
-        throw Exception('Unable to detect iOS schemes in $xcschemesDir');
-      }
-      return xcschemesDir
-          .listSync()
-          .whereType<File>()
-          .where((e) => p.basename(e.path).endsWith('.xcscheme'))
-          .where((e) => p.basenameWithoutExtension(e.path) != 'Runner')
-          .map((file) => p.basename(file.path).split('.xcscheme').first)
-          .sorted()
-          .toSet();
     }
   }
 

--- a/packages/shorebird_cli/lib/src/executables/xcodebuild.dart
+++ b/packages/shorebird_cli/lib/src/executables/xcodebuild.dart
@@ -5,27 +5,6 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 
-/// {@template xcode_project_build_info}
-/// Xcode project build information returned by `xcodebuild -list`
-/// {@endtemplate}
-class XcodeProjectBuildInfo {
-  /// {@macro xcode_project_build_info}
-  const XcodeProjectBuildInfo({
-    this.targets = const {},
-    this.buildConfigurations = const {},
-    this.schemes = const {},
-  });
-
-  /// Set of targets configured for the project.
-  final Set<String> targets;
-
-  /// Set of build configurations configured for the project.
-  final Set<String> buildConfigurations;
-
-  /// Set of schemes configured for the project.
-  final Set<String> schemes;
-}
-
 /// A reference to a [XcodeBuild] instance.
 final xcodeBuildRef = create(XcodeBuild.new);
 

--- a/packages/shorebird_cli/test/fixtures/xcschemes/NotificationService.xcscheme
+++ b/packages/shorebird_cli/test/fixtures/xcschemes/NotificationService.xcscheme
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ED72C56C2C29D0FF00E1D409"
+               BuildableName = "NotificationService.appex"
+               BlueprintName = "NotificationService"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/shorebird_cli/test/fixtures/xcschemes/Runner.xcscheme
+++ b/packages/shorebird_cli/test/fixtures/xcschemes/Runner.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "331C8080294A63A400263BE5"
+               BuildableName = "RunnerTests.xctest"
+               BlueprintName = "RunnerTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Profile"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/shorebird_cli/test/fixtures/xcschemes/beta.xcscheme
+++ b/packages/shorebird_cli/test/fixtures/xcschemes/beta.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/shorebird_cli/test/fixtures/xcschemes/internal.xcscheme
+++ b/packages/shorebird_cli/test/fixtures/xcschemes/internal.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug-internal"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug-internal"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release-internal"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug-internal">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release-internal"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/shorebird_cli/test/fixtures/xcschemes/stable.xcscheme
+++ b/packages/shorebird_cli/test/fixtures/xcschemes/stable.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug-stable"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug-stable"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release-stable"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug-stable">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release-stable"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/shorebird_cli/test/src/executables/xcodebuild_test.dart
+++ b/packages/shorebird_cli/test/src/executables/xcodebuild_test.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:path/path.dart' as p;
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
@@ -24,113 +23,9 @@ void main() {
       );
     }
 
-    Directory setUpAppTempDir() {
-      final tempDir = Directory.systemTemp.createTempSync();
-      Directory(p.join(tempDir.path, 'ios')).createSync(recursive: true);
-      return tempDir;
-    }
-
     setUp(() {
       process = MockShorebirdProcess();
       xcodeBuild = runWithOverrides(XcodeBuild.new);
-    });
-
-    group(MissingIOSProjectException, () {
-      test('toString', () {
-        const exception = MissingIOSProjectException('test_project_path');
-        expect(
-          exception.toString(),
-          '''
-Could not find an iOS project in test_project_path.
-To add iOS, run "flutter create . --platforms ios"''',
-        );
-      });
-    });
-
-    group('list', () {
-      test('throws a MissingIOSProjectException if no iOS project is found',
-          () {
-        final tempDir = Directory.systemTemp.createTempSync();
-        expect(
-          () => xcodeBuild.list(tempDir.path),
-          throwsA(isA<MissingIOSProjectException>()),
-        );
-        verifyNever(
-          () => process.run(
-            any(),
-            any(),
-            workingDirectory: any(named: 'workingDirectory'),
-          ),
-        );
-      });
-
-      test('throws ProcessException when xcodebuild fails', () async {
-        final tempDir = setUpAppTempDir();
-        const message = 'oops';
-        when(
-          () => process.run(
-            any(),
-            any(),
-            workingDirectory: any(named: 'workingDirectory'),
-          ),
-        ).thenAnswer(
-          (_) async => ShorebirdProcessResult(
-            exitCode: ExitCode.software.code,
-            stdout: '',
-            stderr: message,
-          ),
-        );
-        expect(
-          () => runWithOverrides(() => xcodeBuild.list(tempDir.path)),
-          throwsA(isA<ProcessException>()),
-        );
-      });
-
-      test('returns correct XcodeProjectBuildInfo for an app', () async {
-        final tempDir = setUpAppTempDir();
-        when(
-          () => process.run(
-            any(),
-            any(),
-            workingDirectory: any(named: 'workingDirectory'),
-          ),
-        ).thenAnswer(
-          (_) async => ShorebirdProcessResult(
-            exitCode: ExitCode.success.code,
-            stdout: File(p.join('test', 'fixtures', 'xcodebuild_list.txt'))
-                .readAsStringSync(),
-            stderr: '',
-          ),
-        );
-        final info = await runWithOverrides(
-          () => xcodeBuild.list(tempDir.path),
-        );
-        expect(info.targets, equals({'Runner', 'RunnerTests'}));
-        expect(
-          info.buildConfigurations,
-          equals(
-            {
-              'Debug',
-              'Debug-stable',
-              'Debug-internal',
-              'Release',
-              'Release-stable',
-              'Release-internal',
-              'Profile',
-              'Profile-stable',
-              'Profile-internal',
-            },
-          ),
-        );
-        expect(info.schemes, equals({'Runner', 'stable', 'internal'}));
-        verify(
-          () => process.run(
-            'xcodebuild',
-            ['-list'],
-            workingDirectory: p.join(tempDir.path, 'ios'),
-          ),
-        ).called(1);
-      });
     });
 
     group('version', () {

--- a/packages/shorebird_cli/test/src/platform/ios_test.dart
+++ b/packages/shorebird_cli/test/src/platform/ios_test.dart
@@ -4,9 +4,11 @@ import 'package:args/args.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:propertylistserialization/propertylistserialization.dart';
+import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:test/test.dart';
 
 import '../mocks.dart';
@@ -20,10 +22,33 @@ void main() {
   });
 
   group(Ios, () {
+    late ShorebirdEnv shorebirdEnv;
     late Ios ios;
 
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        body,
+        values: {
+          shorebirdEnvRef.overrideWith(() => shorebirdEnv),
+        },
+      );
+    }
+
     setUp(() {
+      shorebirdEnv = MockShorebirdEnv();
       ios = Ios();
+    });
+
+    group(MissingIOSProjectException, () {
+      test('toString', () {
+        const exception = MissingIOSProjectException('test_project_path');
+        expect(
+          exception.toString(),
+          '''
+Could not find an iOS project in test_project_path.
+To add iOS, run "flutter create . --platforms ios"''',
+        );
+      });
     });
 
     group('exportOptionsPlistFromArgs', () {
@@ -179,6 +204,93 @@ void main() {
           verifyNever(
             () => argResults.wasParsed(CommonArguments.exportMethodArg.name),
           );
+        });
+      });
+    });
+
+    group('flavors', () {
+      final schemesPath = p.join(
+        'ios',
+        'Runner.xcodeproj',
+        'xcshareddata',
+        'xcschemes',
+      );
+      late Directory projectRoot;
+
+      void copyFixturesToProjectRoot() {
+        final fixturesDir = Directory(p.join('test', 'fixtures', 'xcschemes'));
+        for (final file in fixturesDir.listSync().whereType<File>()) {
+          final destination = File(
+            p.join(projectRoot.path, schemesPath, p.basename(file.path)),
+          )..createSync(recursive: true);
+          file.copySync(destination.path);
+        }
+      }
+
+      setUp(() {
+        projectRoot = Directory.systemTemp.createTempSync();
+        when(() => shorebirdEnv.getFlutterProjectRoot())
+            .thenReturn(projectRoot);
+      });
+
+      group('when ios directory does not exist', () {
+        test('returns null', () {
+          expect(runWithOverrides(() => ios.flavors()), isNull);
+        });
+      });
+
+      group('when xcodeproj does not exist', () {
+        setUp(() {
+          copyFixturesToProjectRoot();
+          Directory(
+            p.join(projectRoot.path, 'ios', 'Runner.xcodeproj'),
+          ).deleteSync(recursive: true);
+        });
+
+        test('throws exception', () {
+          expect(
+            () => runWithOverrides(ios.flavors),
+            throwsA(isA<MissingIOSProjectException>()),
+          );
+        });
+      });
+
+      group('when only Runner scheme exists', () {
+        setUp(() {
+          copyFixturesToProjectRoot();
+          final schemesDir = Directory(p.join(projectRoot.path, schemesPath));
+          for (final schemeFile in schemesDir.listSync().whereType<File>()) {
+            if (p.basenameWithoutExtension(schemeFile.path) != 'Runner') {
+              schemeFile.deleteSync();
+            }
+          }
+        });
+
+        test('returns no flavors', () {
+          expect(runWithOverrides(ios.flavors), isEmpty);
+        });
+      });
+
+      group('when extension and non-extension schemes exist', () {
+        setUp(copyFixturesToProjectRoot);
+
+        test('returns only non-extension schemes', () {
+          expect(runWithOverrides(ios.flavors), {'internal', 'beta', 'stable'});
+        });
+      });
+
+      group('when Runner has been renamed', () {
+        setUp(() {
+          copyFixturesToProjectRoot();
+          Directory(
+            p.join(projectRoot.path, 'ios', 'Runner.xcodeproj'),
+          ).renameSync(
+            p.join(projectRoot.path, 'ios', 'RenamedRunner.xcodeproj'),
+          );
+        });
+
+        test('returns only non-extension schemes', () {
+          expect(runWithOverrides(ios.flavors), {'internal', 'beta', 'stable'});
         });
       });
     });

--- a/packages/shorebird_cli/test/src/platform/ios_test.dart
+++ b/packages/shorebird_cli/test/src/platform/ios_test.dart
@@ -255,6 +255,19 @@ To add iOS, run "flutter create . --platforms ios"''',
         });
       });
 
+      group('when xcschemes directory does not exist', () {
+        setUp(() {
+          copyFixturesToProjectRoot();
+          Directory(
+            p.join(projectRoot.path, 'ios', 'Runner.xcodeproj', 'xcshareddata'),
+          ).deleteSync(recursive: true);
+        });
+
+        test('throws exception', () {
+          expect(() => runWithOverrides(ios.flavors), throwsException);
+        });
+      });
+
       group('when only Runner scheme exists', () {
         setUp(() {
           copyFixturesToProjectRoot();


### PR DESCRIPTION
## Description

When detecting iOS flavors, ignore schemes that were created for app extensions.

This also removes the now-unused `xcodebuild.list` method.

Fixes https://github.com/shorebirdtech/shorebird/issues/1703

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
