### PR TITLE
fix(shorebird_cli): update ios upload instructions to match Flutter

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -203,21 +203,15 @@ For more information see: $supportedVersionsLink''',
       artifactManager.getXcarchiveDirectory()!.path,
     );
     if (codesign) {
-      final ipa = artifactManager.getIpa();
-      if (ipa == null) {
-        logger.err('Could not find ipa file');
-        throw ProcessExit(ExitCode.software.code);
-      }
-
-      final relativeIpaPath = p.relative(ipa.path);
+      const ipaSearchString = 'build/ios/ipa/*.ipa';
       return '''
 
 Your next step is to upload your app to App Store Connect.
 
 To upload to the App Store, do one of the following:
     1. Open ${lightCyan.wrap(relativeArchivePath)} in Xcode and use the "Distribute App" flow.
-    2. Drag and drop the ${lightCyan.wrap(relativeIpaPath)} bundle into the Apple Transporter macOS app (https://apps.apple.com/us/app/transporter/id1450874784).
-    3. Run ${lightCyan.wrap('xcrun altool --upload-app --type ios -f $relativeIpaPath --apiKey your_api_key --apiIssuer your_issuer_id')}.
+    2. Drag and drop the ${lightCyan.wrap(ipaSearchString)} bundle into the Apple Transporter macOS app (https://apps.apple.com/us/app/transporter/id1450874784).
+    3. Run ${lightCyan.wrap('xcrun altool --upload-app --type ios -f $ipaSearchString --apiKey your_api_key --apiIssuer your_issuer_id')}.
        See "man altool" for details about how to authenticate with the App Store Connect API key.
 ''';
     } else {

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -802,44 +802,20 @@ To change the version of this release, change your app's version in your pubspec
             when(() => argResults['codesign']).thenReturn(true);
           });
 
-          group('when no ipa found', () {
-            test('logs error and exits', () async {
-              await expectLater(
-                () => runWithOverrides(
-                  () => iosReleaser.postReleaseInstructions,
-                ),
-                exitsWithCode(ExitCode.software),
-              );
-
-              verify(
-                () => logger.err('Could not find ipa file'),
-              ).called(1);
-            });
-          });
-
-          group('when ipa found', () {
-            late File ipa;
-            setUp(() {
-              final tempDir = Directory.systemTemp.createTempSync();
-              ipa = File(p.join(tempDir.path, 'ipa.ipa'))..createSync();
-              when(() => artifactManager.getIpa()).thenReturn(ipa);
-            });
-
-            test('prints ipa upload steps', () {
-              expect(
-                runWithOverrides(() => iosReleaser.postReleaseInstructions),
-                equals('''
+          test('prints ipa upload steps', () {
+            expect(
+              runWithOverrides(() => iosReleaser.postReleaseInstructions),
+              equals('''
 
 Your next step is to upload your app to App Store Connect.
 
 To upload to the App Store, do one of the following:
     1. Open ${lightCyan.wrap(p.relative(xcarchiveDirectory.path))} in Xcode and use the "Distribute App" flow.
-    2. Drag and drop the ${lightCyan.wrap(p.relative(ipa.path))} bundle into the Apple Transporter macOS app (https://apps.apple.com/us/app/transporter/id1450874784).
-    3. Run ${lightCyan.wrap('xcrun altool --upload-app --type ios -f ${p.relative(ipa.path)} --apiKey your_api_key --apiIssuer your_issuer_id')}.
+    2. Drag and drop the ${lightCyan.wrap('build/ios/ipa/*.ipa')} bundle into the Apple Transporter macOS app (https://apps.apple.com/us/app/transporter/id1450874784).
+    3. Run ${lightCyan.wrap('xcrun altool --upload-app --type ios -f ${p.relative('build/ios/ipa/*.ipa')} --apiKey your_api_key --apiIssuer your_issuer_id')}.
        See "man altool" for details about how to authenticate with the App Store Connect API key.
 '''),
-              );
-            });
+            );
           });
         });
 


### PR DESCRIPTION
## Description

Updates the post-release instructions for `shorebird release ios` to more closely match those of `flutter build ipa`.

Flutter:

```
To upload to the App Store either:
    1. Drag and drop the "build/ios/ipa/*.ipa" bundle into the Apple Transporter macOS app
    https://apps.apple.com/us/app/transporter/id1450874784
    2. Run "xcrun altool --upload-app --type ios -f build/ios/ipa/*.ipa --apiKey your_api_key --apiIssuer your_issuer_id".
       See "man altool" for details about how to authenticate with the App Store Connect API key.
```

Shorebird, with this PR:

```
Your next step is to upload your app to App Store Connect.

To upload to the App Store, do one of the following:
    1. Open build/ios/archive/Runner.xcarchive in Xcode and use the "Distribute App" flow.
    2. Drag and drop the build/ios/ipa/*.ipa bundle into the Apple Transporter macOS app (https://apps.apple.com/us/app/transporter/id1450874784).
    3. Run xcrun altool --upload-app --type ios -f build/ios/ipa/*.ipa --apiKey your_api_key --apiIssuer your_issuer_id.
       See "man altool" for details about how to authenticate with the App Store Connect API key.
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
