### PR TITLE
feat(shorebird_cli): add note about sharability of app_id to `shorebird init`

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -216,6 +216,9 @@ ${lightGreen.wrap('🐦 Shorebird initialized successfully!')}
 ✅ A "shorebird.yaml" has been created.
 ✅ The "pubspec.yaml" has been updated to include "shorebird.yaml" as an asset.
 
+shorebird.yaml does not contain any sensitive information and should be checked into version control.
+You can freely share your app_id with others.
+
 Reference the following commands to get started:
 
 📦 To create a new release use: "${lightCyan.wrap('shorebird release')}".

--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -216,9 +216,6 @@ ${lightGreen.wrap('🐦 Shorebird initialized successfully!')}
 ✅ A "shorebird.yaml" has been created.
 ✅ The "pubspec.yaml" has been updated to include "shorebird.yaml" as an asset.
 
-shorebird.yaml does not contain any sensitive information and should be checked into version control.
-You can freely share your app_id with others.
-
 Reference the following commands to get started:
 
 📦 To create a new release use: "${lightCyan.wrap('shorebird release')}".
@@ -249,11 +246,11 @@ For more information about Shorebird, visit ${link(uri: Uri.parse('https://shore
     const content = '''
 # This file is used to configure the Shorebird updater used by your app.
 # Learn more at https://docs.shorebird.dev
-# This file should be checked into version control.
+# This file does not contain any sensitive information and should be checked into version control.
 
-# This is the unique identifier assigned to your app.
-# Your app_id is not a secret and is just used to identify your app
-# when requesting patches from Shorebird's servers.
+# Your app_id is the unique identifier assigned to your app.
+# It is used to identify your app when requesting patches from Shorebird's servers.
+# It is not a secret and can be shared publicly.
 app_id:
 
 # auto_update controls if Shorebird should automatically update in the background on launch.

--- a/packages/shorebird_cli/test/src/commands/init_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/init_command_test.dart
@@ -894,8 +894,6 @@ flutter:
                 '✅ A shorebird app has been created.',
                 '✅ A "shorebird.yaml" has been created.',
                 '''✅ The "pubspec.yaml" has been updated to include "shorebird.yaml" as an asset.''',
-                '''shorebird.yaml does not contain any sensitive information and should be checked into version control.''',
-                'You can freely share your app_id with others.',
                 '''📦 To create a new release use: "${lightCyan.wrap('shorebird release')}".''',
                 '''🚀 To push an update use: "${lightCyan.wrap('shorebird patch')}".''',
                 '''👀 To preview a release use: "${lightCyan.wrap('shorebird preview')}".''',

--- a/packages/shorebird_cli/test/src/commands/init_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/init_command_test.dart
@@ -883,6 +883,31 @@ flutter:
       );
     });
 
+    test('logs success message on completion', () async {
+      await runWithOverrides(command.run);
+      verify(
+        () => logger.info(
+          any(
+            that: stringContainsInOrder(
+              [
+                lightGreen.wrap('🐦 Shorebird initialized successfully!')!,
+                '✅ A shorebird app has been created.',
+                '✅ A "shorebird.yaml" has been created.',
+                '''✅ The "pubspec.yaml" has been updated to include "shorebird.yaml" as an asset.''',
+                '''shorebird.yaml does not contain any sensitive information and should be checked into version control.''',
+                'You can freely share your app_id with others.',
+                '''📦 To create a new release use: "${lightCyan.wrap('shorebird release')}".''',
+                '''🚀 To push an update use: "${lightCyan.wrap('shorebird patch')}".''',
+                '''👀 To preview a release use: "${lightCyan.wrap('shorebird preview')}".''',
+                '''For more information about Shorebird, visit ${link(uri: Uri.parse('https://shorebird.dev'))}''',
+                ''
+              ],
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
     test('ensures that addShorebirdYamlToPubspecAssets is called', () async {
       when(() => shorebirdEnv.pubspecContainsShorebirdYaml).thenReturn(false);
       await runWithOverrides(command.run);


### PR DESCRIPTION
## Description

Adds a note in the `shorebird init` output telling users that the content of `shorebird.yaml` is shareable and should be checked in to version control.

Fixes https://github.com/shorebirdtech/shorebird/issues/969

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
