### PR TITLE
feat(artifact_proxy): add Dart SDK patterns to manifest

### DIFF
--- a/packages/artifact_proxy/tool/generate_manifest.sh
+++ b/packages/artifact_proxy/tool/generate_manifest.sh
@@ -48,6 +48,11 @@ artifact_overrides:
   - flutter_infra_release/flutter/\$engine/android-x64-release/symbols.zip
   - flutter_infra_release/flutter/\$engine/android-x64-release/windows-x64.zip
 
+  # Dart SDK
+  - flutter_infra_release/flutter/\$engine/dart-sdk-darwin-arm64.zip
+  - flutter_infra_release/flutter/\$engine/dart-sdk-linux-x64.zip
+  - flutter_infra_release/flutter/\$engine/dart-sdk-windows-x64.zip
+
   # embedding release
   - download.flutter.io/io/flutter/flutter_embedding_release/1.0.0-\$engine/flutter_embedding_release-1.0.0-\$engine.pom
   - download.flutter.io/io/flutter/flutter_embedding_release/1.0.0-\$engine/flutter_embedding_release-1.0.0-\$engine.jar

--- a/packages/artifact_proxy/tool/generate_manifest.sh
+++ b/packages/artifact_proxy/tool/generate_manifest.sh
@@ -50,6 +50,7 @@ artifact_overrides:
 
   # Dart SDK
   - flutter_infra_release/flutter/\$engine/dart-sdk-darwin-arm64.zip
+  - flutter_infra_release/flutter/\$engine/dart-sdk-darwin-x64.zip
   - flutter_infra_release/flutter/\$engine/dart-sdk-linux-x64.zip
   - flutter_infra_release/flutter/\$engine/dart-sdk-windows-x64.zip
 


### PR DESCRIPTION
## Description

Adds the paths to Dart SDK zips to the manifest file generated for our artifact proxy.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
