### PR TITLE
feat: adding Jetbrains Toolbox Android Studio detection for Linux

### DIFF
--- a/packages/shorebird_cli/lib/src/android_studio.dart
+++ b/packages/shorebird_cli/lib/src/android_studio.dart
@@ -91,7 +91,6 @@ class AndroidStudio {
       p.join('/', 'opt', 'android-studio'),
       p.join(home, '.AndroidStudio'),
       p.join(home, '.cache', 'Google', 'AndroidStudio'),
-      // Reference:
       // https://blog.jetbrains.com/toolbox-app/2023/08/toolbox-app-2-0-overhauls-installations-and-updates/#install-and-update-reworked-from-the-ground-up
       p.join(
         home,

--- a/packages/shorebird_cli/lib/src/android_studio.dart
+++ b/packages/shorebird_cli/lib/src/android_studio.dart
@@ -91,6 +91,17 @@ class AndroidStudio {
       p.join('/', 'opt', 'android-studio'),
       p.join(home, '.AndroidStudio'),
       p.join(home, '.cache', 'Google', 'AndroidStudio'),
+      // Reference:
+      // https://blog.jetbrains.com/toolbox-app/2023/08/toolbox-app-2-0-overhauls-installations-and-updates/#install-and-update-reworked-from-the-ground-up
+      p.join(
+        home,
+        '.local',
+        'share',
+        'JetBrains',
+        'Toolbox',
+        'apps',
+        'AndroidStudio',
+      ),
     ];
     return candidateLocations.firstWhereOrNull((location) {
       return Directory(location).existsSync();

--- a/packages/shorebird_cli/test/src/android_studio_test.dart
+++ b/packages/shorebird_cli/test/src/android_studio_test.dart
@@ -143,25 +143,25 @@ void main() {
       });
 
       group('on Linux', () {
-        late Directory mockedHome;
+        late Directory userHomeDir;
 
         setUp(() {
           when(() => platform.isWindows).thenReturn(false);
           when(() => platform.isMacOS).thenReturn(false);
           when(() => platform.isLinux).thenReturn(true);
 
-          mockedHome = Directory.systemTemp.createTempSync();
+          userHomeDir = Directory.systemTemp.createTempSync();
           when(() => platform.environment).thenReturn({
-            'HOME': mockedHome.path,
+            'HOME': userHomeDir.path,
           });
         });
 
-        group('when installed directly on home', () {
+        group('when installed at ~', () {
           late Directory androidStudioDir;
 
           setUp(() {
             androidStudioDir = Directory(
-              p.join(mockedHome.path, '.AndroidStudio'),
+              p.join(userHomeDir.path, '.AndroidStudio'),
             )..createSync(recursive: true);
           });
 
@@ -173,12 +173,12 @@ void main() {
           });
         });
 
-        group('when installed on the home cache', () {
+        group('when installed at ~/cache', () {
           late Directory androidStudioDir;
 
           setUp(() {
             androidStudioDir = Directory(
-              p.join(mockedHome.path, '.cache', 'Google', 'AndroidStudio'),
+              p.join(userHomeDir.path, '.cache', 'Google', 'AndroidStudio'),
             )..createSync(recursive: true);
           });
 
@@ -196,7 +196,7 @@ void main() {
           setUp(() {
             androidStudioDir = Directory(
               p.join(
-                mockedHome.path,
+                userHomeDir.path,
                 '.local',
                 'share',
                 'JetBrains',

--- a/packages/shorebird_cli/test/src/android_studio_test.dart
+++ b/packages/shorebird_cli/test/src/android_studio_test.dart
@@ -190,7 +190,7 @@ void main() {
           });
         });
 
-        group('when installed via the jetbrains toolbox app', () {
+        group('when installed in JetBrains Toolbox apps directory', () {
           late Directory androidStudioDir;
 
           setUp(() {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Improves the Android Studio detection on Linux by adding the default installation of the [Jetbrains Toolbox app](https://www.jetbrains.com/toolbox-app/).

On MacOS and Windows there is not need to change since Toolbox seems to install AS in directories that we already check.

Fixes #2297

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
