### PR TITLE
feat(shorebird_cli): add `--display-name` to `shorebird init`

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -22,12 +22,17 @@ import 'package:yaml_edit/yaml_edit.dart';
 class InitCommand extends ShorebirdCommand {
   /// {@macro init_command}
   InitCommand() {
-    argParser.addFlag(
-      'force',
-      abbr: 'f',
-      help: 'Initialize the app even if a "shorebird.yaml" already exists.',
-      negatable: false,
-    );
+    argParser
+      ..addFlag(
+        'force',
+        abbr: 'f',
+        help: 'Initialize the app even if a "shorebird.yaml" already exists.',
+        negatable: false,
+      )
+      ..addOption(
+        'display-name',
+        help: 'The display name of the app.',
+      );
   }
 
   @override
@@ -150,7 +155,8 @@ Please make sure you are running "shorebird init" from within your Flutter proje
     try {
       final needsConfirmation = !force && shorebirdEnv.canAcceptUserInput;
       final pubspecName = shorebirdEnv.getPubspecYaml()!.name;
-      final displayName = needsConfirmation
+      var displayName = results['display-name'] as String?;
+      displayName ??= needsConfirmation
           ? logger.prompt(
               '${lightGreen.wrap('?')} How should we refer to this app?',
               defaultValue: pubspecName,

--- a/packages/shorebird_cli/test/src/commands/init_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/init_command_test.dart
@@ -294,6 +294,29 @@ Please make sure you are running "shorebird init" from within your Flutter proje
         ).called(1);
       });
 
+      group('when --display-name is provided', () {
+        const displayName = 'custom-display-name';
+
+        setUp(() {
+          when(() => argResults['display-name']).thenReturn(displayName);
+        });
+
+        test('does not prompt for display name and uses correct display name',
+            () async {
+          final exitCode = await runWithOverrides(command.run);
+          expect(exitCode, equals(ExitCode.success.code));
+          verify(
+            () => shorebirdYamlFile.writeAsStringSync(
+              any(that: contains('app_id: $appId')),
+            ),
+          ).called(1);
+          verifyNever(() => logger.prompt(any()));
+          verify(
+            () => codePushClientWrapper.createApp(appName: displayName),
+          ).called(1);
+        });
+      });
+
       test('creates shorebird for an app without flavors', () async {
         when(
           () => gradlew.productFlavors(any()),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- feat(shorebird_cli): add `--display-name` to `shorebird init`
  - related to #2312
  
We already support using a custom display name for apps but this is limited to using the interactive prompt. Users should be able to skip the prompt and provide the display name via a command-line arg which is consistent with how other Shorebird CLI commands work already.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
