### PR TITLE
chore: move GetReleasePatchesResponse/Request to code_push_protocol

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches.dart
@@ -1,0 +1,1 @@
+export 'get_release_patches_response.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches_response.dart
@@ -1,0 +1,56 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+
+part 'get_release_patches_response.g.dart';
+
+/// {@template get_release_patches_response}
+/// The response to /api/v1/apps/$appId/releases/$releaseId/patches
+/// {@endtemplate}
+@JsonSerializable()
+class GetReleasePatchesResponse {
+  /// {@macro get_release_patches_response}
+  const GetReleasePatchesResponse({required this.patches});
+
+  /// Converts a Map<String, dynamic> to a [GetReleasePatchesResponse]
+  factory GetReleasePatchesResponse.fromJson(Map<String, dynamic> json) =>
+      _$GetReleasePatchesResponseFromJson(json);
+
+  /// Converts a [GetReleasePatchesResponse] to a Map<String, dynamic>
+  Json toJson() => _$GetReleasePatchesResponseToJson(this);
+
+  /// List of patches.
+  final List<ReleasePatch> patches;
+}
+
+/// {@template release_patch}
+/// A patch for a given release.
+/// {@endtemplate}
+@JsonSerializable()
+class ReleasePatch {
+  /// {@macro release_patch}
+  const ReleasePatch({
+    required this.id,
+    required this.number,
+    required this.channel,
+    required this.artifacts,
+  });
+
+  /// Converts a Map<String, dynamic> to a [ReleasePatch]
+  factory ReleasePatch.fromJson(Map<String, dynamic> json) =>
+      _$ReleasePatchFromJson(json);
+
+  /// Converts a [ReleasePatch] to a Map<String, dynamic>
+  Json toJson() => _$ReleasePatchToJson(this);
+
+  /// The patch id.
+  final int id;
+
+  /// The patch number.
+  final int number;
+
+  /// The channel associated with the patch.
+  final String? channel;
+
+  /// The associated patch artifacts.
+  final List<PatchArtifact> artifacts;
+}

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches_response.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches_response.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, require_trailing_commas, cast_nullable_to_non_nullable, lines_longer_than_80_chars
+
+part of 'get_release_patches_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+GetReleasePatchesResponse _$GetReleasePatchesResponseFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      'GetReleasePatchesResponse',
+      json,
+      ($checkedConvert) {
+        final val = GetReleasePatchesResponse(
+          patches: $checkedConvert(
+              'patches',
+              (v) => (v as List<dynamic>)
+                  .map((e) => ReleasePatch.fromJson(e as Map<String, dynamic>))
+                  .toList()),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$GetReleasePatchesResponseToJson(
+        GetReleasePatchesResponse instance) =>
+    <String, dynamic>{
+      'patches': instance.patches.map((e) => e.toJson()).toList(),
+    };
+
+ReleasePatch _$ReleasePatchFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      'ReleasePatch',
+      json,
+      ($checkedConvert) {
+        final val = ReleasePatch(
+          id: $checkedConvert('id', (v) => v as int),
+          number: $checkedConvert('number', (v) => v as int),
+          channel: $checkedConvert('channel', (v) => v as String?),
+          artifacts: $checkedConvert(
+              'artifacts',
+              (v) => (v as List<dynamic>)
+                  .map((e) => PatchArtifact.fromJson(e as Map<String, dynamic>))
+                  .toList()),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$ReleasePatchToJson(ReleasePatch instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'number': instance.number,
+      'channel': instance.channel,
+      'artifacts': instance.artifacts.map((e) => e.toJson()).toList(),
+    };

--- a/packages/shorebird_code_push_protocol/lib/src/messages/messages.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/messages.dart
@@ -8,6 +8,7 @@ export 'create_release_artifact/create_release_artifact.dart';
 export 'create_user/create_user.dart';
 export 'get_apps/get_apps.dart';
 export 'get_release_artifacts/get_release_artifacts.dart';
+export 'get_release_patches/get_release_patches.dart';
 export 'get_releases/get_releases.dart';
 export 'promote_patch/promote_patch.dart';
 export 'update_release/update_release.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/models.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/models.dart
@@ -6,6 +6,7 @@ export 'channel.dart';
 export 'create_patch_metadata.dart';
 export 'error_response.dart';
 export 'patch.dart';
+export 'patch_artifact.dart';
 export 'release.dart';
 export 'release_artifact.dart';
 export 'release_platform.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/patch_artifact.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/patch_artifact.dart
@@ -1,0 +1,50 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+
+part 'patch_artifact.g.dart';
+
+/// {@template patch_artifact}
+/// An artifact contains metadata about the contents of a specific patch
+/// for a specific platform and architecture.
+/// {@endtemplate}
+@JsonSerializable()
+class PatchArtifact {
+  /// {@macro patch_artifact}
+  const PatchArtifact({
+    required this.id,
+    required this.patchId,
+    required this.arch,
+    required this.platform,
+    required this.hash,
+    required this.size,
+    required this.createdAt,
+  });
+
+  /// Converts a Map<String, dynamic> to a [PatchArtifact]
+  factory PatchArtifact.fromJson(Map<String, dynamic> json) =>
+      _$PatchArtifactFromJson(json);
+
+  /// Converts a [PatchArtifact] to a Map<String, dynamic>
+  Map<String, dynamic> toJson() => _$PatchArtifactToJson(this);
+
+  /// The ID of the artifact;
+  final int id;
+
+  /// The ID of the patch.
+  final int patchId;
+
+  /// The arch of the artifact.
+  final String arch;
+
+  /// The platform of the artifact.
+  final ReleasePlatform platform;
+
+  /// The hash of the artifact.
+  final String hash;
+
+  /// The size of the artifact in bytes.
+  final int size;
+
+  /// The date and time the artifact was created.
+  final DateTime createdAt;
+}

--- a/packages/shorebird_code_push_protocol/lib/src/models/patch_artifact.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/patch_artifact.g.dart
@@ -2,50 +2,42 @@
 
 // ignore_for_file: implicit_dynamic_parameter, require_trailing_commas, cast_nullable_to_non_nullable, lines_longer_than_80_chars
 
-part of 'release_artifact.dart';
+part of 'patch_artifact.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-ReleaseArtifact _$ReleaseArtifactFromJson(Map<String, dynamic> json) =>
+PatchArtifact _$PatchArtifactFromJson(Map<String, dynamic> json) =>
     $checkedCreate(
-      'ReleaseArtifact',
+      'PatchArtifact',
       json,
       ($checkedConvert) {
-        final val = ReleaseArtifact(
+        final val = PatchArtifact(
           id: $checkedConvert('id', (v) => v as int),
-          releaseId: $checkedConvert('release_id', (v) => v as int),
+          patchId: $checkedConvert('patch_id', (v) => v as int),
           arch: $checkedConvert('arch', (v) => v as String),
           platform: $checkedConvert(
               'platform', (v) => $enumDecode(_$ReleasePlatformEnumMap, v)),
           hash: $checkedConvert('hash', (v) => v as String),
           size: $checkedConvert('size', (v) => v as int),
-          url: $checkedConvert('url', (v) => v as String),
-          podfileLockHash:
-              $checkedConvert('podfile_lock_hash', (v) => v as String?),
-          canSideload: $checkedConvert('can_sideload', (v) => v as bool),
+          createdAt:
+              $checkedConvert('created_at', (v) => DateTime.parse(v as String)),
         );
         return val;
       },
-      fieldKeyMap: const {
-        'releaseId': 'release_id',
-        'podfileLockHash': 'podfile_lock_hash',
-        'canSideload': 'can_sideload'
-      },
+      fieldKeyMap: const {'patchId': 'patch_id', 'createdAt': 'created_at'},
     );
 
-Map<String, dynamic> _$ReleaseArtifactToJson(ReleaseArtifact instance) =>
+Map<String, dynamic> _$PatchArtifactToJson(PatchArtifact instance) =>
     <String, dynamic>{
       'id': instance.id,
-      'release_id': instance.releaseId,
+      'patch_id': instance.patchId,
       'arch': instance.arch,
       'platform': _$ReleasePlatformEnumMap[instance.platform]!,
       'hash': instance.hash,
       'size': instance.size,
-      'url': instance.url,
-      'podfile_lock_hash': instance.podfileLockHash,
-      'can_sideload': instance.canSideload,
+      'created_at': instance.createdAt.toIso8601String(),
     };
 
 const _$ReleasePlatformEnumMap = {

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_patch.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_patch.dart
@@ -1,0 +1,37 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+
+part 'release_patch.g.dart';
+
+/// {@template release_patch}
+/// A patch for a given release.
+/// {@endtemplate}
+@JsonSerializable()
+class ReleasePatch {
+  /// {@macro release_patch}
+  const ReleasePatch({
+    required this.id,
+    required this.number,
+    required this.channel,
+    required this.artifacts,
+  });
+
+  /// Converts a Map<String, dynamic> to a [ReleasePatch]
+  factory ReleasePatch.fromJson(Map<String, dynamic> json) =>
+      _$ReleasePatchFromJson(json);
+
+  /// Converts a [ReleasePatch] to a Map<String, dynamic>
+  Json toJson() => _$ReleasePatchToJson(this);
+
+  /// The patch id.
+  final int id;
+
+  /// The patch number.
+  final int number;
+
+  /// The channel associated with the patch.
+  final String? channel;
+
+  /// The associated patch artifacts.
+  final List<PatchArtifact> artifacts;
+}

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_patch.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_patch.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, require_trailing_commas, cast_nullable_to_non_nullable, lines_longer_than_80_chars
+
+part of 'release_patch.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ReleasePatch _$ReleasePatchFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      'ReleasePatch',
+      json,
+      ($checkedConvert) {
+        final val = ReleasePatch(
+          id: $checkedConvert('id', (v) => v as int),
+          number: $checkedConvert('number', (v) => v as int),
+          channel: $checkedConvert('channel', (v) => v as String?),
+          artifacts: $checkedConvert(
+              'artifacts',
+              (v) => (v as List<dynamic>)
+                  .map((e) => PatchArtifact.fromJson(e as Map<String, dynamic>))
+                  .toList()),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$ReleasePatchToJson(ReleasePatch instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'number': instance.number,
+      'channel': instance.channel,
+      'artifacts': instance.artifacts.map((e) => e.toJson()).toList(),
+    };

--- a/packages/shorebird_code_push_protocol/test/src/messages/get_release_patches/get_release_patches_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/get_release_patches/get_release_patches_response_test.dart
@@ -1,0 +1,67 @@
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(GetReleasePatchesResponse, () {
+    test('can be (de)serialized', () {
+      final response = GetReleasePatchesResponse(
+        patches: [
+          ReleasePatch(
+            id: 42,
+            number: 1,
+            channel: 'stable',
+            artifacts: [
+              PatchArtifact(
+                id: 1,
+                patchId: 1,
+                arch: 'aarch64',
+                platform: ReleasePlatform.android,
+                size: 42,
+                hash: 'sha256:1234567890',
+                createdAt: DateTime(2023),
+              ),
+              PatchArtifact(
+                id: 2,
+                patchId: 1,
+                arch: 'aarch64',
+                platform: ReleasePlatform.android,
+                size: 42,
+                hash: 'sha256:1234567890',
+                createdAt: DateTime(2023),
+              ),
+            ],
+          ),
+          ReleasePatch(
+            id: 43,
+            number: 2,
+            channel: null,
+            artifacts: [
+              PatchArtifact(
+                id: 3,
+                patchId: 2,
+                arch: 'aarch64',
+                platform: ReleasePlatform.android,
+                size: 42,
+                hash: 'sha256:1234567890',
+                createdAt: DateTime(2023),
+              ),
+              PatchArtifact(
+                id: 4,
+                patchId: 3,
+                arch: 'aarch64',
+                platform: ReleasePlatform.android,
+                size: 42,
+                hash: 'sha256:1234567890',
+                createdAt: DateTime(2023),
+              ),
+            ],
+          ),
+        ],
+      );
+      expect(
+        GetReleasePatchesResponse.fromJson(response.toJson()).toJson(),
+        equals(response.toJson()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

Moves a formerly server-only message/model set to the code_push_protocol package for consumption by the CLI.

In support of https://github.com/shorebirdtech/shorebird/issues/2288

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
