### PR TITLE
chore(shorebird_cli): remove aot_tools exe artifact now that it is no longer needed

### DIFF
--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -1686,7 +1686,7 @@ void main() {
             id: 0,
             number: 1,
             channel: 'stable',
-            artifacts: [],
+            artifacts: const [],
           );
           response = GetReleasePatchesResponse(patches: [patch]);
           when(() => httpClient.send(any())).thenAnswer(


### PR DESCRIPTION
## Description

We no longer allow releasing or patching with any version of Flutter that uses the executable version of `aot_tools`. This also means that we no longer have any optional artifacts, and can remove that field as well.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
