### PR TITLE
fix(shorebird_cli): validate known checksums as part of cached artifact validation

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -56,7 +56,7 @@ class Cache {
 
   Future<void> updateAll() async {
     for (final artifact in _artifacts) {
-      if (await artifact.isUpToDate()) {
+      if (await artifact.isValid()) {
         continue;
       }
 
@@ -153,7 +153,7 @@ abstract class CachedArtifact {
   File get file =>
       File(p.join(cache.getArtifactDirectory(fileName).path, fileName));
 
-  Future<bool> isUpToDate() async {
+  Future<bool> isValid() async {
     if (!file.existsSync()) {
       return false;
     }

--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -153,7 +153,20 @@ abstract class CachedArtifact {
   File get file =>
       File(p.join(cache.getArtifactDirectory(fileName).path, fileName));
 
-  Future<bool> isUpToDate() async => file.existsSync();
+  Future<bool> isUpToDate() async {
+    if (!file.existsSync()) {
+      return false;
+    }
+
+    if (checksum == null) {
+      logger.detail(
+        '''No checksum provided for $fileName, skipping file corruption validation''',
+      );
+      return true;
+    }
+
+    return checksumChecker.checkFile(file, checksum!);
+  }
 
   Future<void> update() async {
     final request = http.Request('GET', Uri.parse(storageUrl));

--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -202,7 +202,7 @@ allowed to access $storageUrl.''',
         );
       } else {
         logger.detail(
-          'No checksum provided for $fileName, skipping file corruption validation',
+          '''No checksum provided for $fileName, skipping file corruption validation''',
         );
       }
     }

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -431,7 +431,7 @@ class _TestCachedArtifact extends CachedArtifact {
   String? checksumOverride;
 
   @override
-  String? get sha256Checksum => checksumOverride;
+  String? get checksum => checksumOverride;
 
   final Directory _location = Directory.systemTemp.createTempSync();
 

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -368,10 +368,10 @@ void main() {
       cachedArtifact = _TestCachedArtifact(cache: cache, platform: platform);
     });
 
-    group('isUpToDate', () {
+    group('isValid', () {
       group('when the artifact file does not exist', () {
         test('returns false', () async {
-          expect(await runWithOverrides(cachedArtifact.isUpToDate), isFalse);
+          expect(await runWithOverrides(cachedArtifact.isValid), isFalse);
         });
       });
 
@@ -386,7 +386,7 @@ void main() {
           });
 
           test('returns true', () async {
-            expect(await runWithOverrides(cachedArtifact.isUpToDate), isTrue);
+            expect(await runWithOverrides(cachedArtifact.isValid), isTrue);
           });
         });
 
@@ -402,7 +402,7 @@ void main() {
             });
 
             test('returns true', () async {
-              expect(await runWithOverrides(cachedArtifact.isUpToDate), isTrue);
+              expect(await runWithOverrides(cachedArtifact.isValid), isTrue);
             });
           });
 
@@ -414,7 +414,7 @@ void main() {
 
             test('returns false', () async {
               expect(
-                await runWithOverrides(cachedArtifact.isUpToDate),
+                await runWithOverrides(cachedArtifact.isValid),
                 isFalse,
               );
             });
@@ -431,7 +431,7 @@ class _TestCachedArtifact extends CachedArtifact {
   String? checksumOverride;
 
   @override
-  String? get checksum => checksumOverride;
+  String? get sha256Checksum => checksumOverride;
 
   final Directory _location = Directory.systemTemp.createTempSync();
 

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -338,4 +338,112 @@ void main() {
       });
     });
   });
+
+  group(CachedArtifact, () {
+    late Cache cache;
+    late ChecksumChecker checksumChecker;
+    late ShorebirdLogger logger;
+    late Platform platform;
+    late _TestCachedArtifact cachedArtifact;
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        () => body(),
+        values: {
+          checksumCheckerRef.overrideWith(() => checksumChecker),
+          loggerRef.overrideWith(() => logger),
+        },
+      );
+    }
+
+    setUpAll(() {
+      registerFallbackValue(File(''));
+    });
+
+    setUp(() {
+      cache = MockCache();
+      checksumChecker = MockChecksumChecker();
+      logger = MockShorebirdLogger();
+      platform = MockPlatform();
+      cachedArtifact = _TestCachedArtifact(cache: cache, platform: platform);
+    });
+
+    group('isUpToDate', () {
+      group('when the artifact file does not exist', () {
+        test('returns false', () async {
+          expect(await runWithOverrides(cachedArtifact.isUpToDate), isFalse);
+        });
+      });
+
+      group('when the artifact file exists', () {
+        setUp(() {
+          cachedArtifact.file.createSync(recursive: true);
+        });
+
+        group('when there is no expected checksum', () {
+          setUp(() {
+            cachedArtifact.checksumOverride = null;
+          });
+
+          test('returns true', () async {
+            expect(await runWithOverrides(cachedArtifact.isUpToDate), isTrue);
+          });
+        });
+
+        group('when there is an expected checksum', () {
+          setUp(() {
+            cachedArtifact.checksumOverride = 'some-checksum';
+          });
+
+          group('when the checksum matches', () {
+            setUp(() {
+              when(() => checksumChecker.checkFile(any(), any()))
+                  .thenReturn(true);
+            });
+
+            test('returns true', () async {
+              expect(await runWithOverrides(cachedArtifact.isUpToDate), isTrue);
+            });
+          });
+
+          group('when the checksum does not match', () {
+            setUp(() {
+              when(() => checksumChecker.checkFile(any(), any()))
+                  .thenReturn(false);
+            });
+
+            test('returns false', () async {
+              expect(
+                await runWithOverrides(cachedArtifact.isUpToDate),
+                isFalse,
+              );
+            });
+          });
+        });
+      });
+    });
+  });
+}
+
+class _TestCachedArtifact extends CachedArtifact {
+  _TestCachedArtifact({required super.cache, required super.platform});
+
+  String? checksumOverride;
+
+  @override
+  String? get checksum => checksumOverride;
+
+  final Directory _location = Directory.systemTemp.createTempSync();
+
+  @override
+  bool get isExecutable => throw UnimplementedError();
+
+  @override
+  String get fileName => 'test_artifact.exe';
+
+  @override
+  File get file => File(p.join(_location.path, fileName));
+
+  @override
+  String get storageUrl => throw UnimplementedError();
 }


### PR DESCRIPTION
## Description

The `CachedArtifact` `isUpToDate` method currently just checks whether the file exists and doesn't perform any integrity check. This renames `isUpToDate` to `isValid` and changes it to verify that the artifact on disk has the expected checksum if we know the artifact's checksum at build time.

Fixes https://github.com/shorebirdtech/shorebird/issues/2328
Fixes https://github.com/shorebirdtech/shorebird/issues/1006
Part of https://github.com/shorebirdtech/shorebird/issues/1771 (not yet fixed because we don't currently compute or store the checksum of the `aot_tools.dill` asset)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
