### PR TITLE
fix(shorebird_cli): make aot_tools.dill optional for backward compatibility

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -49,7 +49,7 @@ class Cache {
   Cache() {
     registerArtifact(PatchArtifact(cache: this, platform: platform));
     registerArtifact(BundleToolArtifact(cache: this, platform: platform));
-    registerArtifact(AotToolsDillArtifact(cache: this, platform: platform));
+    registerArtifact(AotToolsArtifact(cache: this, platform: platform));
   }
 
   void registerArtifact(CachedArtifact artifact) => _artifacts.add(artifact);
@@ -225,8 +225,8 @@ allowed to access $storageUrl.''',
   }
 }
 
-class AotToolsDillArtifact extends CachedArtifact {
-  AotToolsDillArtifact({required super.cache, required super.platform});
+class AotToolsArtifact extends CachedArtifact {
+  AotToolsArtifact({required super.cache, required super.platform});
 
   @override
   String get fileName => 'aot-tools.dill';

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -1686,7 +1686,7 @@ void main() {
             id: 0,
             number: 1,
             channel: 'stable',
-            artifacts: [],
+            artifacts: const [],
           );
           response = GetReleasePatchesResponse(patches: [patch]);
           when(() => httpClient.send(any())).thenAnswer(

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -1686,7 +1686,7 @@ void main() {
             id: 0,
             number: 1,
             channel: 'stable',
-            artifacts: const [],
+            artifacts: [],
           );
           response = GetReleasePatchesResponse(patches: [patch]);
           when(() => httpClient.send(any())).thenAnswer(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- Fixes a bug introduced in #2334 which broke releasing with older Flutter versions on Android

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
