### PR TITLE
feat: adding versions subcommand which

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_command.dart
@@ -9,6 +9,7 @@ class FlutterVersionsCommand extends ShorebirdCommand {
   /// {@macro flutter_versions_command}
   FlutterVersionsCommand() {
     addSubcommand(FlutterVersionsListCommand());
+    addSubcommand(FlutterVersionsWhichCommand());
   }
 
   @override

--- a/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_which_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_which_command.dart
@@ -1,0 +1,49 @@
+import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/shorebird_command.dart';
+import 'package:shorebird_cli/src/shorebird_flutter.dart';
+
+/// {@template flutter_versions_which_command}
+/// `shorebird flutter versions which [rev]`
+/// Based on the provided revision, determine the Flutter version.
+/// {@endtemplate}
+class FlutterVersionsWhichCommand extends ShorebirdCommand {
+  /// {@macro flutter_versions_which_command}
+  FlutterVersionsWhichCommand() {
+    argParser.addOption(
+      'rev',
+      help: 'The revision to determine the Flutter version.',
+    );
+  }
+
+  @override
+  String get description =>
+      '''Shows the flutter version string for a given revision.''';
+
+  @override
+  String get name => 'which';
+
+  @override
+  Future<int> run() async {
+    final revision = results['rev'] as String;
+    final progress = logger.progress(
+      'Finding Flutter Version based on revision: $revision',
+    );
+
+    try {
+      final version = await shorebirdFlutter.getVersionString(
+        revision: revision,
+      );
+
+      progress.complete(
+        'Flutter Version: ${version ?? 'Unknown'}',
+      );
+    } catch (error) {
+      progress.fail('Failed to determine Flutter version.');
+      logger.err('$error');
+      return ExitCode.software.code;
+    }
+
+    return ExitCode.success.code;
+  }
+}

--- a/packages/shorebird_cli/lib/src/commands/flutter/versions/versions.dart
+++ b/packages/shorebird_cli/lib/src/commands/flutter/versions/versions.dart
@@ -1,2 +1,3 @@
 export 'flutter_versions_command.dart';
 export 'flutter_versions_list_command.dart';
+export 'flutter_versions_which_command.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adds a new subcommand under `shorebird flutter versions`, which given a revision, returns the flutter version for that revision.

This command helped me build the update script for the recent added `flutter_version` field and figured it could help us quick have access to the flutter version calculation currently in the CLI which might help us on support when troubleshooting older app releases.

Opening this as a draft to gather feedback, will be implementing the tests once we decide if this is worth or not.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
