### PR TITLE
fix(shorebirdl_cli): add stamp file to cache artifacts to mark successful download

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -178,9 +178,7 @@ abstract class CachedArtifact {
 
   Future<void> update() async {
     // Clear any existing artifact files.
-    if (file.parent.existsSync()) {
-      await file.parent.delete(recursive: true);
-    }
+    await _delete();
 
     final request = http.Request('GET', Uri.parse(storageUrl));
     final http.StreamedResponse response;
@@ -239,6 +237,16 @@ allowed to access $storageUrl.''',
   // installed.
   void _writeStampFile() {
     stampFile.createSync(recursive: true);
+  }
+
+  Future<void> _delete() async {
+    if (file.existsSync()) {
+      await file.delete();
+    }
+
+    if (stampFile.existsSync()) {
+      await stampFile.delete();
+    }
   }
 }
 

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -480,10 +480,14 @@ void main() {
       group('when artifact exists on disk', () {
         setUp(() {
           cachedArtifact.file.createSync(recursive: true);
+          cachedArtifact.stampFile.createSync(recursive: true);
         });
 
-        test('deletes existing artifact before updating', () async {
+        test('deletes existing artifact and stamp file before updating',
+            () async {
           expect(cachedArtifact.file.existsSync(), isTrue);
+          expect(cachedArtifact.stampFile.existsSync(), isTrue);
+
           // This will fail due to the mock http client returning a 404.
           await expectLater(
             () => runWithOverrides(cachedArtifact.update),
@@ -491,6 +495,7 @@ void main() {
           );
 
           expect(cachedArtifact.file.existsSync(), isFalse);
+          expect(cachedArtifact.stampFile.existsSync(), isFalse);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -410,25 +410,20 @@ void main() {
           cachedArtifact.file.createSync(recursive: true);
         });
 
-        group('when there is no expected checksum', () {
-          setUp(() {
-            cachedArtifact.checksumOverride = null;
-          });
-
-          test('returns true', () async {
-            expect(await runWithOverrides(cachedArtifact.isValid), isTrue);
+        group('when the stamp file does not exist', () {
+          test('returns false', () async {
+            expect(await runWithOverrides(cachedArtifact.isValid), isFalse);
           });
         });
 
-        group('when there is an expected checksum', () {
+        group('when the stamp file exists', () {
           setUp(() {
-            cachedArtifact.checksumOverride = 'some-checksum';
+            cachedArtifact.stampFile.createSync();
           });
 
-          group('when the checksum matches', () {
+          group('when there is no expected checksum', () {
             setUp(() {
-              when(() => checksumChecker.checkFile(any(), any()))
-                  .thenReturn(true);
+              cachedArtifact.checksumOverride = null;
             });
 
             test('returns true', () async {
@@ -436,17 +431,34 @@ void main() {
             });
           });
 
-          group('when the checksum does not match', () {
+          group('when there is an expected checksum', () {
             setUp(() {
-              when(() => checksumChecker.checkFile(any(), any()))
-                  .thenReturn(false);
+              cachedArtifact.checksumOverride = 'some-checksum';
             });
 
-            test('returns false', () async {
-              expect(
-                await runWithOverrides(cachedArtifact.isValid),
-                isFalse,
-              );
+            group('when the checksum matches', () {
+              setUp(() {
+                when(() => checksumChecker.checkFile(any(), any()))
+                    .thenReturn(true);
+              });
+
+              test('returns true', () async {
+                expect(await runWithOverrides(cachedArtifact.isValid), isTrue);
+              });
+            });
+
+            group('when the checksum does not match', () {
+              setUp(() {
+                when(() => checksumChecker.checkFile(any(), any()))
+                    .thenReturn(false);
+              });
+
+              test('returns false', () async {
+                expect(
+                  await runWithOverrides(cachedArtifact.isValid),
+                  isFalse,
+                );
+              });
             });
           });
         });


### PR DESCRIPTION
## Description

Updates our cache management to write a zero-byte stamp file alongside the cache artifact when an artifact has successfully been downloaded and (optionally) extracted. We check for the existence of this file when determining that an artifact is valid. If this file does not exist, the artifact will be redownloaded.

Fixes https://github.com/shorebirdtech/shorebird/issues/1771

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
