### PR TITLE
fix: better handling usage exception on the CLI

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
@@ -202,6 +202,13 @@ Engine • revision ${shorebirdEnv.shorebirdEngineRevision}''');
         exitCode = await super.runCommand(topLevelResults);
       } on ProcessExit catch (error) {
         exitCode = error.exitCode;
+      } on UsageException catch (e) {
+        logger
+          ..err(e.message)
+          ..info(e.usage);
+        // When on an usage exception we don't need to show the "if you aren't
+        // sure" message, so we do an early return here.
+        return ExitCode.usage.code;
       } catch (error, stackTrace) {
         logger
           ..detail('$error')

--- a/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
@@ -113,20 +113,23 @@ void main() {
     });
 
     test('handles UsageException', () async {
-      final exception = UsageException('oops!', 'exception usage');
-      var isFirstInvocation = true;
-      when(() => logger.info(any())).thenAnswer((_) {
-        if (isFirstInvocation) {
-          isFirstInvocation = false;
-          throw exception;
-        }
-      });
       final result = await runWithOverrides(
-        () => commandRunner.run(['--version']),
+        // fly_to_the_moon is not a valid command.
+        () => commandRunner.run(['fly_to_the_moon']),
       );
       expect(result, equals(ExitCode.usage.code));
-      verify(() => logger.err(exception.message)).called(1);
-      verify(() => logger.info('exception usage')).called(1);
+      verify(
+        () => logger.err('Could not find a command named "fly_to_the_moon".'),
+      ).called(1);
+      verify(
+        () => logger.info(
+          any(
+            that: contains(
+              'Usage: shorebird <command> [arguments]',
+            ),
+          ),
+        ),
+      ).called(1);
     });
 
     test('handles missing option error', () async {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Before we were treating `UsageException` as a generic exception, which would lead to not show messages like "command foo doesn't exists".

This PR fixes that by adding a special catch exception for that specific error, and printing the correct message as well the CLI usage for quick reference.

Fixes #2341 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
