### PR TITLE
feat: enhanced error logging for patch errors on windows

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/patch_executable.dart
+++ b/packages/shorebird_cli/lib/src/executables/patch_executable.dart
@@ -51,7 +51,8 @@ class PatchExecutable {
 
     var messageDetails = '';
 
-    // A Windows-specific error code indicating that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.
+    // A Windows-specific error code indicating that the Microsoft C++ runtime
+    // (VCRUNTIME140.dll) could not be found.
     // More info: https://github.com/shorebirdtech/shorebird/issues/2329
     const vcRuntimeNotFoundExitCode = -1073741515;
     if (result.exitCode == vcRuntimeNotFoundExitCode && platform.isWindows) {

--- a/packages/shorebird_cli/lib/src/executables/patch_executable.dart
+++ b/packages/shorebird_cli/lib/src/executables/patch_executable.dart
@@ -2,6 +2,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/cache.dart';
+import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 
 /// A reference to a [PatchExecutable] instance.
@@ -49,9 +50,20 @@ class PatchExecutable {
     final result = await process.run(diffExecutable, diffArguments);
 
     if (result.exitCode != ExitCode.success.code) {
+      var messageDetails = '';
+
+      if (result.exitCode < 0 && platform.isWindows) {
+        messageDetails = '''
+This indicates that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.
+
+The C++ Runtime can be installed from microsoft at:
+${link(uri: Uri.parse('https://www.microsoft.com/en-us/download/details.aspx?id=52685'))}
+''';
+      }
+
       throw PatchFailedException(
         '''
-Failed to create diff (exit code ${result.exitCode}).
+Failed to create diff (exit code ${result.exitCode}).$messageDetails
   stdout: ${result.stdout}
   stderr: ${result.stderr}''',
       );

--- a/packages/shorebird_cli/lib/src/executables/patch_executable.dart
+++ b/packages/shorebird_cli/lib/src/executables/patch_executable.dart
@@ -52,7 +52,7 @@ class PatchExecutable {
     if (result.exitCode != ExitCode.success.code) {
       var messageDetails = '';
 
-      if (result.exitCode < 0 && platform.isWindows) {
+      if (result.exitCode == -1073741515 && platform.isWindows) {
         messageDetails = '''
 This indicates that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.
 

--- a/packages/shorebird_cli/lib/src/executables/patch_executable.dart
+++ b/packages/shorebird_cli/lib/src/executables/patch_executable.dart
@@ -51,23 +51,24 @@ class PatchExecutable {
 
     var messageDetails = '';
 
-    // This is a specific error exit code returned when the VC runtime is not
-    // found.
+    // A Windows-specific error code indicating that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.
     // More info: https://github.com/shorebirdtech/shorebird/issues/2329
     const vcRuntimeNotFoundExitCode = -1073741515;
     if (result.exitCode == vcRuntimeNotFoundExitCode && platform.isWindows) {
       messageDetails = '''
-This indicates that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.
+This error code indicates that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.
 
 The C++ Runtime can be installed from Microsoft at:
 ${link(uri: Uri.parse('https://www.microsoft.com/en-us/download/details.aspx?id=52685'))}
+
+Please try again once you have installed this software.
 ''';
     }
 
     if (result.exitCode != ExitCode.success.code) {
       throw PatchFailedException(
         '''
-Failed to create diff (exit code ${result.exitCode}).$messageDetails
+Failed to create diff (exit code ${result.exitCode}). $messageDetails
   stdout: ${result.stdout}
   stderr: ${result.stderr}''',
       );

--- a/packages/shorebird_cli/lib/src/executables/patch_executable.dart
+++ b/packages/shorebird_cli/lib/src/executables/patch_executable.dart
@@ -56,7 +56,7 @@ class PatchExecutable {
         messageDetails = '''
 This indicates that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.
 
-The C++ Runtime can be installed from microsoft at:
+The C++ Runtime can be installed from Microsoft at:
 ${link(uri: Uri.parse('https://www.microsoft.com/en-us/download/details.aspx?id=52685'))}
 ''';
       }

--- a/packages/shorebird_cli/lib/src/executables/patch_executable.dart
+++ b/packages/shorebird_cli/lib/src/executables/patch_executable.dart
@@ -49,18 +49,22 @@ class PatchExecutable {
 
     final result = await process.run(diffExecutable, diffArguments);
 
-    if (result.exitCode != ExitCode.success.code) {
-      var messageDetails = '';
+    var messageDetails = '';
 
-      if (result.exitCode == -1073741515 && platform.isWindows) {
-        messageDetails = '''
+    // This is a specific error exit code returned when the VC runtime is not
+    // found.
+    // More info: https://github.com/shorebirdtech/shorebird/issues/2329
+    const vcRuntimeNotFoundExitCode = -1073741515;
+    if (result.exitCode == vcRuntimeNotFoundExitCode && platform.isWindows) {
+      messageDetails = '''
 This indicates that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.
 
 The C++ Runtime can be installed from Microsoft at:
 ${link(uri: Uri.parse('https://www.microsoft.com/en-us/download/details.aspx?id=52685'))}
 ''';
-      }
+    }
 
+    if (result.exitCode != ExitCode.success.code) {
       throw PatchFailedException(
         '''
 Failed to create diff (exit code ${result.exitCode}).$messageDetails

--- a/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
+++ b/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
@@ -132,7 +132,7 @@ void main() {
       );
     });
 
-    group('when is on windows and we got a negative exit code', () {
+    group('when is on windows and we got a -1073741515 exit code', () {
       setUp(() {
         const stdout = 'uh oh';
         const stderr = 'oops something went wrong';

--- a/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
+++ b/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
@@ -132,7 +132,7 @@ void main() {
       );
     });
 
-    group('when is on windows and we got a -1073741515 exit code', () {
+    group('when running on windows and process exits with code -1073741515', () {
       setUp(() {
         const stdout = 'uh oh';
         const stderr = 'oops something went wrong';
@@ -150,7 +150,8 @@ void main() {
 
         when(() => platform.isWindows).thenReturn(true);
       });
-      test('enhances the message with additional details', () async {
+
+      test('throws a missing C++ runtime exception', () async {
         await expectLater(
           () => runWithOverrides(
             () => patchExecutable.run(

--- a/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
+++ b/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
@@ -132,44 +132,47 @@ void main() {
       );
     });
 
-    group('when running on windows and process exits with code -1073741515', () {
+    group('when on windows', () {
       setUp(() {
-        const stdout = 'uh oh';
-        const stderr = 'oops something went wrong';
-        when(() => patchProcessResult.exitCode).thenReturn(-1073741515);
-        when(() => patchProcessResult.stderr).thenReturn(stderr);
-        when(() => patchProcessResult.stdout).thenReturn(stdout);
-
-        when(
-          () => shorebirdProcess.run(
-            any(that: endsWith('patch')),
-            any(),
-            runInShell: any(named: 'runInShell'),
-          ),
-        ).thenAnswer((_) async => patchProcessResult);
-
         when(() => platform.isWindows).thenReturn(true);
       });
+      group('when the process exits with code -1073741515', () {
+        setUp(() {
+          const stdout = 'uh oh';
+          const stderr = 'oops something went wrong';
+          when(() => patchProcessResult.exitCode).thenReturn(-1073741515);
+          when(() => patchProcessResult.stderr).thenReturn(stderr);
+          when(() => patchProcessResult.stdout).thenReturn(stdout);
 
-      test('throws a missing C++ runtime exception', () async {
-        await expectLater(
-          () => runWithOverrides(
-            () => patchExecutable.run(
-              releaseArtifactPath: 'release',
-              patchArtifactPath: 'patch',
-              diffPath: 'diff',
+          when(
+            () => shorebirdProcess.run(
+              any(that: endsWith('patch')),
+              any(),
+              runInShell: any(named: 'runInShell'),
             ),
-          ),
-          throwsA(
-            isA<PatchFailedException>().having(
-              (e) => e.toString(),
-              'exception',
-              contains(
-                '''This indicates that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.''',
+          ).thenAnswer((_) async => patchProcessResult);
+        });
+
+        test('throws a missing C++ runtime exception', () async {
+          await expectLater(
+            () => runWithOverrides(
+              () => patchExecutable.run(
+                releaseArtifactPath: 'release',
+                patchArtifactPath: 'patch',
+                diffPath: 'diff',
               ),
             ),
-          ),
-        );
+            throwsA(
+              isA<PatchFailedException>().having(
+                (e) => e.toString(),
+                'exception',
+                contains(
+                  '''This indicates that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.''',
+                ),
+              ),
+            ),
+          );
+        });
       });
     });
   });

--- a/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
+++ b/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
@@ -181,7 +181,7 @@ void main() {
           when(() => platform.isWindows).thenReturn(false);
         });
 
-        test('does not adds the windows specific message', () async {
+        test('does not add the Windows specific message', () async {
           await expectLater(
             () => runWithOverrides(
               () => patchExecutable.run(

--- a/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
+++ b/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
@@ -124,7 +124,7 @@ void main() {
           isA<PatchFailedException>().having(
             (e) => e.toString(),
             'exception',
-            'Failed to create diff (exit code 1).\n'
+            'Failed to create diff (exit code 1). \n'
                 '  stdout: $stdout\n'
                 '  stderr: $stderr',
           ),
@@ -168,7 +168,7 @@ void main() {
                 (e) => e.toString(),
                 'exception',
                 contains(
-                  '''This indicates that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.''',
+                  '''This error code indicates that the Microsoft C++ runtime (VCRUNTIME140.dll) could not be found.''',
                 ),
               ),
             ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR enhances (in a similar approach used in the past for gradle errors https://github.com/shorebirdtech/shorebird/pull/2266) the error message when we get an error when running the patch command on windows platforms when we negative exit codes.

I weren't able to reproduce the error locally due lack of windows computer, so I couldn't test the approach other than on unit testing, but I guess the way this breaks, unit tests are good enough, but if someone could test this on a windows computer, I would appreciate!

Fixes #2329
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
