### PR TITLE
feat: improving versions on different release versions error

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -358,15 +358,14 @@ Use `shorebird flutter versions list` to list available versions.
       // All artifacts associated with a given release must be built
       // with the same Flutter revision.
       if (existingRelease.flutterRevision != flutterRevision) {
-        final existingReleaseStringVersion =
-            await shorebirdFlutter.humanReadableVersion(
+        final existingReleaseStringVersionString =
+            await shorebirdFlutter.getVersionAndRevision(
           flutterRevision: existingRelease.flutterRevision,
-          flutterVersion: existingRelease.flutterVersion,
         );
 
-        final stringVersion = await shorebirdFlutter.humanReadableVersion(
+        final releaseVersionString =
+            await shorebirdFlutter.getVersionAndRevision(
           flutterRevision: flutterRevision,
-          flutterVersion: flutterVersionArg,
         );
 
         logger
@@ -375,8 +374,8 @@ ${styleBold.wrap(lightRed.wrap('A release with version $version already exists b
 ''')
           ..info('''
 
-  Existing release built with: ${lightCyan.wrap(existingReleaseStringVersion)}
-  Current release built with: ${lightCyan.wrap(stringVersion)}
+  Existing release built with: ${lightCyan.wrap(existingReleaseStringVersionString)}
+  Current release built with: ${lightCyan.wrap(releaseVersionString)}
 
 ${styleBold.wrap(lightRed.wrap('All platforms for a given release must be built using the same Flutter revision.'))}
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -358,19 +358,30 @@ Use `shorebird flutter versions list` to list available versions.
       // All artifacts associated with a given release must be built
       // with the same Flutter revision.
       if (existingRelease.flutterRevision != flutterRevision) {
+        final existingReleaseStringVersion =
+            await shorebirdFlutter.humanReadableVersion(
+          flutterRevision: existingRelease.flutterRevision,
+          flutterVersion: existingRelease.flutterVersion,
+        );
+
+        final stringVersion = await shorebirdFlutter.humanReadableVersion(
+          flutterRevision: flutterRevision,
+          flutterVersion: flutterVersionArg,
+        );
+
         logger
           ..err('''
 ${styleBold.wrap(lightRed.wrap('A release with version $version already exists but was built using a different Flutter revision.'))}
 ''')
           ..info('''
 
-  Existing release built with: ${lightCyan.wrap(existingRelease.flutterRevision)}
-  Current release built with: ${lightCyan.wrap(flutterRevision)}
+  Existing release built with: ${lightCyan.wrap(existingReleaseStringVersion)}
+  Current release built with: ${lightCyan.wrap(stringVersion)}
 
 ${styleBold.wrap(lightRed.wrap('All platforms for a given release must be built using the same Flutter revision.'))}
 
 To resolve this issue, you can:
-  * Re-run the release command with "${lightCyan.wrap('--flutter-version=${existingRelease.flutterRevision}')}".
+  * Re-run the release command with "${lightCyan.wrap('--flutter-version=${existingRelease.flutterVersion ?? existingRelease.flutterRevision}')}".
   * Delete the existing release and re-run the release command with the desired Flutter version.
   * Bump the release version and re-run the release command with the desired Flutter version.''');
         throw ProcessExit(ExitCode.software.code);

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -224,7 +224,7 @@ class ShorebirdFlutter {
   ///
   /// If [flutterRevision] is null, the current revision will be used.
   /// If [flutterVersion] is null, it will be calculated from the current
-  /// revision using [getVersionString].
+  ///   revision using [getVersionString].
   Future<String> humanReadableVersion({
     String? flutterRevision,
     String? flutterVersion,

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -218,4 +218,31 @@ class ShorebirdFlutter {
     shorebirdEnv.flutterRevision = revision;
     useFlutterProgress.complete();
   }
+
+  /// Returns an human readable string from the received [flutterRevision] and
+  /// [flutterVersion].
+  ///
+  /// If [flutterRevision] is null, the current revision will be used.
+  /// If [flutterVersion] is null, it will be calculated from the current
+  /// revision using [getVersionString].
+  Future<String> humanReadableVersion({
+    String? flutterRevision,
+    String? flutterVersion,
+  }) async {
+    final revision = flutterRevision ?? shorebirdEnv.flutterRevision;
+    var version = 'unknown';
+
+    if (flutterVersion != null) {
+      version = flutterVersion;
+    } else {
+      try {
+        final calculatedValue = await getVersionString(revision: revision);
+        if (calculatedValue != null) {
+          version = calculatedValue;
+        }
+      } catch (_) {}
+    }
+
+    return '$version (${shortRevisionString(revision)})';
+  }
 }

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -135,13 +135,14 @@ class ShorebirdFlutter {
 
   /// Returns the current Shorebird Flutter version and revision.
   /// Returns unknown if the version check fails.
-  Future<String> getVersionAndRevision() async {
+  Future<String> getVersionAndRevision({String? flutterRevision}) async {
+    final revision = flutterRevision ?? shorebirdEnv.flutterRevision;
     String? version = 'unknown';
     try {
-      version = await getVersionString();
+      version = await getVersionString(revision: revision);
     } catch (_) {}
 
-    return '$version (${shortRevisionString(shorebirdEnv.flutterRevision)})';
+    return '$version (${shortRevisionString(revision)})';
   }
 
   /// Returns the current Shorebird Flutter version.
@@ -217,32 +218,5 @@ class ShorebirdFlutter {
     final useFlutterProgress = logger.progress('Using Flutter $version');
     shorebirdEnv.flutterRevision = revision;
     useFlutterProgress.complete();
-  }
-
-  /// Returns an human readable string from the received [flutterRevision] and
-  /// [flutterVersion].
-  ///
-  /// If [flutterRevision] is null, the current revision will be used.
-  /// If [flutterVersion] is null, it will be calculated from the current
-  ///   revision using [getVersionString].
-  Future<String> humanReadableVersion({
-    String? flutterRevision,
-    String? flutterVersion,
-  }) async {
-    final revision = flutterRevision ?? shorebirdEnv.flutterRevision;
-    var version = 'unknown';
-
-    if (flutterVersion != null) {
-      version = flutterVersion;
-    } else {
-      try {
-        final calculatedValue = await getVersionString(revision: revision);
-        if (calculatedValue != null) {
-          version = calculatedValue;
-        }
-      } catch (_) {}
-    }
-
-    return '$version (${shortRevisionString(revision)})';
   }
 }

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -372,13 +372,12 @@ Note: ${lightCyan.wrap('shorebird patch --platforms=android --flavor=$flavor --t
           );
 
           when(
-            () => shorebirdFlutter.humanReadableVersion(
+            () => shorebirdFlutter.getVersionAndRevision(
               flutterRevision: 'different',
-              flutterVersion: '3.12.1',
             ),
           ).thenAnswer((_) async => '3.12.1 (different)');
           when(
-            () => shorebirdFlutter.humanReadableVersion(
+            () => shorebirdFlutter.getVersionAndRevision(
               flutterRevision: flutterRevision,
             ),
           ).thenAnswer((_) async => '3.12.1 (different)');

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -370,6 +370,18 @@ Note: ${lightCyan.wrap('shorebird patch --platforms=android --flavor=$flavor --t
             createdAt: DateTime(2023),
             updatedAt: DateTime(2023),
           );
+
+          when(
+            () => shorebirdFlutter.humanReadableVersion(
+              flutterRevision: 'different',
+              flutterVersion: '3.12.1',
+            ),
+          ).thenAnswer((_) async => '3.12.1 (different)');
+          when(
+            () => shorebirdFlutter.humanReadableVersion(
+              flutterRevision: flutterRevision,
+            ),
+          ).thenAnswer((_) async => '3.12.1 (different)');
         });
 
         test('logs error and exits with code 70', () async {

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -236,6 +236,31 @@ Tools • Dart 3.0.6 • DevTools 2.23.1''');
           completion(equals('3.10.6 (${flutterRevision.substring(0, 10)})')),
         );
       });
+
+      group('when passing a revision', () {
+        const customRevision = '0123456789';
+        setUp(() {
+          when(
+            () => git.forEachRef(
+              directory: any(named: 'directory'),
+              contains: customRevision,
+              format: any(named: 'format'),
+              pattern: any(named: 'pattern'),
+            ),
+          ).thenAnswer((_) async => 'origin/flutter_release/3.10.8');
+        });
+
+        test('returns correct version and revision', () async {
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdFlutter.getVersionAndRevision(
+                flutterRevision: customRevision,
+              ),
+            ),
+            completion(equals('3.10.8 (${customRevision.substring(0, 10)})')),
+          );
+        });
+      });
     });
 
     group('getRevisionForVersion', () {
@@ -876,165 +901,6 @@ origin/flutter_release/3.10.6''';
           ),
         );
         verify(() => shorebirdEnv.flutterRevision = newRevision).called(1);
-      });
-    });
-
-    group('humanReadableVersion', () {
-      const envRevision = '012345678910112';
-      const envVersion = '3.10.6';
-
-      setUp(() {
-        when(() => shorebirdEnv.flutterRevision).thenReturn(envRevision);
-        when(
-          () => git.forEachRef(
-            directory: any(named: 'directory'),
-            contains: envRevision,
-            format: any(named: 'format'),
-            pattern: any(named: 'pattern'),
-          ),
-        ).thenAnswer((_) async => 'origin/flutter_release/$envVersion');
-      });
-
-      group('when no flutterRevision is provided', () {
-        test('returns the current version on env', () async {
-          final readableVersion = await runWithOverrides(
-            () => shorebirdFlutter.humanReadableVersion(),
-          );
-
-          expect(readableVersion, equals('3.10.6 (0123456789)'));
-        });
-
-        group('when searching for the version returns no results', () {
-          setUp(() {
-            when(
-              () => git.forEachRef(
-                directory: any(named: 'directory'),
-                contains: envRevision,
-                format: any(named: 'format'),
-                pattern: any(named: 'pattern'),
-              ),
-            ).thenAnswer((_) async => '');
-          });
-          test('uses "unknown" for the version', () async {
-            final readableVersion = await runWithOverrides(
-              () => shorebirdFlutter.humanReadableVersion(),
-            );
-
-            expect(readableVersion, equals('unknown (0123456789)'));
-          });
-        });
-
-        group('when searching for the version fails', () {
-          setUp(() {
-            when(
-              () => git.forEachRef(
-                directory: any(named: 'directory'),
-                contains: envRevision,
-                format: any(named: 'format'),
-                pattern: any(named: 'pattern'),
-              ),
-            ).thenThrow(Exception('oh no!'));
-          });
-          test('uses "unknown" for the version', () async {
-            final readableVersion = await runWithOverrides(
-              () => shorebirdFlutter.humanReadableVersion(),
-            );
-
-            expect(readableVersion, equals('unknown (0123456789)'));
-          });
-        });
-      });
-
-      group('when a revision is provided', () {
-        const providedRevision = '109876543210';
-        const providedVersion = '3.10.8';
-
-        setUp(() {
-          when(
-            () => git.forEachRef(
-              directory: any(named: 'directory'),
-              contains: providedRevision,
-              format: any(named: 'format'),
-              pattern: any(named: 'pattern'),
-            ),
-          ).thenAnswer((_) async => 'origin/flutter_release/$providedVersion');
-        });
-
-        test('returns the correct version', () async {
-          final readableVersion = await runWithOverrides(
-            () => shorebirdFlutter.humanReadableVersion(
-              flutterRevision: providedRevision,
-            ),
-          );
-
-          expect(readableVersion, equals('3.10.8 (1098765432)'));
-        });
-
-        group('when searching for the version returns no results', () {
-          setUp(() {
-            when(
-              () => git.forEachRef(
-                directory: any(named: 'directory'),
-                contains: providedRevision,
-                format: any(named: 'format'),
-                pattern: any(named: 'pattern'),
-              ),
-            ).thenAnswer((_) async => '');
-          });
-          test('uses "unknown" for the version', () async {
-            final readableVersion = await runWithOverrides(
-              () => shorebirdFlutter.humanReadableVersion(
-                flutterRevision: providedRevision,
-              ),
-            );
-
-            expect(readableVersion, equals('unknown (1098765432)'));
-          });
-        });
-
-        group('when searching for the version fails', () {
-          setUp(() {
-            when(
-              () => git.forEachRef(
-                directory: any(named: 'directory'),
-                contains: providedRevision,
-                format: any(named: 'format'),
-                pattern: any(named: 'pattern'),
-              ),
-            ).thenThrow(Exception('oh no!'));
-          });
-          test('uses "unknown" for the version', () async {
-            final readableVersion = await runWithOverrides(
-              () => shorebirdFlutter.humanReadableVersion(
-                flutterRevision: providedRevision,
-              ),
-            );
-
-            expect(readableVersion, equals('unknown (1098765432)'));
-          });
-        });
-
-        group('when passing a flutter version', () {
-          test('returns the correct version', () async {
-            final readableVersion = await runWithOverrides(
-              () => shorebirdFlutter.humanReadableVersion(
-                flutterRevision: providedRevision,
-                flutterVersion: providedVersion,
-              ),
-            );
-
-            expect(readableVersion, equals('3.10.8 (1098765432)'));
-            verifyNever(() => shorebirdEnv.flutterRevision);
-            verifyNever(
-              () => git.forEachRef(
-                directory: any(named: 'directory'),
-                contains: any(named: 'contains'),
-                format: any(named: 'format'),
-                pattern: any(named: 'pattern'),
-              ),
-            );
-          });
-        });
       });
     });
   });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

When doing a release for a platform whereas it's release version is the same as an already published release for a different platform with a different flutter version, we give an error messages saying that the flutter version must be the same.

In that message we use the flutter revision to identify the flutter versions, which is not the most user friendly value.

This PR changes so it will show the flutter version along side the shortened revision. Example:

```
A release with version 4.1.4+5 already exists but was built using a different Flutter revision.


  Existing release built with: 3.22.1 (2f366bd7c9)
  Current release built with: 3.22.2 (853d13d954)

All platforms for a given release must be built using the same Flutter revision.

To resolve this issue, you can:
  * Re-run the release command with "--flutter-version=3.22.1".
  * Delete the existing release and re-run the release command with the desired Flutter version.
  * Bump the release version and re-run the release command with the desired Flutter version.

If you aren't sure why this command failed, re-run with the --verbose flag to see more information.

You can also file an issue if you think this is a bug. Please include the following log file in your report:
/Users/erick/Library/Application Support/shorebird/logs/1720805902724_shorebird.log
```

Fixes #2349

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
