### PR TITLE
feat: better version message on existing flutter version error

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -261,8 +261,8 @@ Please create a release using "shorebird release" and try again.
     required ReleasePlatform platform,
   }) async {
     final createReleaseProgress = logger.progress('Creating release');
-    final flutterVersion = await shorebirdFlutter.getVersionString(
-      revision: flutterRevision,
+    final flutterVersion = await shorebirdFlutter.getVersionForRevision(
+      flutterRevision: flutterRevision,
     );
     try {
       final release = await codePushClient.createRelease(

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -358,8 +358,8 @@ Use `shorebird flutter versions list` to list available versions.
       // All artifacts associated with a given release must be built
       // with the same Flutter revision.
       if (existingRelease.flutterRevision != flutterRevision) {
-        final flutterVersion = await shorebirdFlutter.getVersionString(
-          revision: flutterRevision,
+        final flutterVersion = await shorebirdFlutter.getVersionForRevision(
+          flutterRevision: flutterRevision,
         );
 
         final formattedVersion = shorebirdFlutter.formatVersion(

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -358,19 +358,33 @@ Use `shorebird flutter versions list` to list available versions.
       // All artifacts associated with a given release must be built
       // with the same Flutter revision.
       if (existingRelease.flutterRevision != flutterRevision) {
+        final flutterVersion = await shorebirdFlutter.getVersionString(
+          revision: flutterRevision,
+        );
+
+        final formattedVersion = shorebirdFlutter.formatVersion(
+          revision: flutterRevision,
+          version: flutterVersion,
+        );
+
+        final formattedExistingReleaseVersion = shorebirdFlutter.formatVersion(
+          revision: existingRelease.flutterRevision,
+          version: existingRelease.flutterVersion,
+        );
+
         logger
           ..err('''
 ${styleBold.wrap(lightRed.wrap('A release with version $version already exists but was built using a different Flutter revision.'))}
 ''')
           ..info('''
 
-  Existing release built with: ${lightCyan.wrap(existingRelease.flutterRevision)}
-  Current release built with: ${lightCyan.wrap(flutterRevision)}
+  Existing release built with: ${lightCyan.wrap(formattedExistingReleaseVersion)}
+  Current release built with: ${lightCyan.wrap(formattedVersion)}
 
 ${styleBold.wrap(lightRed.wrap('All platforms for a given release must be built using the same Flutter revision.'))}
 
 To resolve this issue, you can:
-  * Re-run the release command with "${lightCyan.wrap('--flutter-version=${existingRelease.flutterRevision}')}".
+  * Re-run the release command with "${lightCyan.wrap('--flutter-version=${existingRelease.flutterVersion ?? existingRelease.flutterRevision}')}".
   * Delete the existing release and re-run the release command with the desired Flutter version.
   * Bump the release version and re-run the release command with the desired Flutter version.''');
         throw ProcessExit(ExitCode.software.code);

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -362,7 +362,7 @@ Use `shorebird flutter versions list` to list available versions.
           flutterRevision: flutterRevision,
         );
 
-        final formattedVersion = shorebirdFlutter.formatVersion(
+        final formattedCurrentReleaseVersion = shorebirdFlutter.formatVersion(
           revision: flutterRevision,
           version: flutterVersion,
         );
@@ -379,7 +379,7 @@ ${styleBold.wrap(lightRed.wrap('A release with version $version already exists b
           ..info('''
 
   Existing release built with: ${lightCyan.wrap(formattedExistingReleaseVersion)}
-  Current release built with: ${lightCyan.wrap(formattedVersion)}
+  Current release built with: ${lightCyan.wrap(formattedCurrentReleaseVersion)}
 
 ${styleBold.wrap(lightRed.wrap('All platforms for a given release must be built using the same Flutter revision.'))}
 

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -148,7 +148,7 @@ class ShorebirdFlutter {
 
     try {
       version = await getVersionString();
-    } on ProcessException {
+    } catch (_) {
       version = 'unknown';
     }
 

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -133,15 +133,21 @@ class ShorebirdFlutter {
   /// Converts a full git revision to a short revision string.
   String shortRevisionString(String revision) => revision.substring(0, 10);
 
+  /// Given a revision and a version, formats them into a single string.
+  ///
+  /// e.g. 3.16.3 and b9b2390296b9b2390296 -> 3.16.3 (b9b2390296)
+  String formatVersion({required String revision, required String? version}) {
+    version ??= 'unknown';
+    return '$version (${shortRevisionString(revision)})';
+  }
+
   /// Returns the current Shorebird Flutter version and revision.
   /// Returns unknown if the version check fails.
   Future<String> getVersionAndRevision() async {
-    String? version = 'unknown';
-    try {
-      version = await getVersionString();
-    } catch (_) {}
-
-    return '$version (${shortRevisionString(shorebirdEnv.flutterRevision)})';
+    return formatVersion(
+      version: await getVersionString(),
+      revision: shorebirdEnv.flutterRevision,
+    );
   }
 
   /// Returns the current Shorebird Flutter version.

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -55,8 +55,8 @@ void main() {
       when(() => logger.progress(any())).thenReturn(progress);
 
       when(
-        () => shorebirdFlutter.getVersionString(
-          revision: any(named: 'revision'),
+        () => shorebirdFlutter.getVersionForRevision(
+          flutterRevision: any(named: 'flutterRevision'),
         ),
       ).thenAnswer(
         (_) async => '3.22.0',
@@ -207,7 +207,9 @@ void main() {
       );
 
       when(
-        () => shorebirdFlutter.getVersionString(revision: flutterRevision),
+        () => shorebirdFlutter.getVersionForRevision(
+          flutterRevision: flutterRevision,
+        ),
       ).thenAnswer((_) async => flutterVersion);
     });
 

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -370,6 +370,25 @@ Note: ${lightCyan.wrap('shorebird patch --platforms=android --flavor=$flavor --t
             createdAt: DateTime(2023),
             updatedAt: DateTime(2023),
           );
+
+          when(
+            () => shorebirdFlutter.getVersionString(
+              revision: flutterRevision,
+            ),
+          ).thenAnswer((_) async => flutterVersion);
+
+          when(
+            () => shorebirdFlutter.formatVersion(
+              revision: flutterRevision,
+              version: flutterVersion,
+            ),
+          ).thenReturn('3.12.1');
+          when(
+            () => shorebirdFlutter.formatVersion(
+              revision: existingRelease.flutterRevision,
+              version: existingRelease.flutterVersion,
+            ),
+          ).thenReturn('3.12.1');
         });
 
         test('logs error and exits with code 70', () async {

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -372,8 +372,8 @@ Note: ${lightCyan.wrap('shorebird patch --platforms=android --flavor=$flavor --t
           );
 
           when(
-            () => shorebirdFlutter.getVersionString(
-              revision: flutterRevision,
+            () => shorebirdFlutter.getVersionForRevision(
+              flutterRevision: flutterRevision,
             ),
           ).thenAnswer((_) async => flutterVersion);
 

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -225,6 +225,7 @@ Tools • Dart 3.0.6 • DevTools 2.23.1''');
             ),
           );
         });
+
         test('returns unknown (<revision>)', () async {
           await expectLater(
             runWithOverrides(shorebirdFlutter.getVersionAndRevision),
@@ -254,6 +255,7 @@ Tools • Dart 3.0.6 • DevTools 2.23.1''');
             ),
           ).thenThrow(exception);
         });
+
         test('throws exception', () async {
           await expectLater(
             runWithOverrides(
@@ -279,6 +281,7 @@ Tools • Dart 3.0.6 • DevTools 2.23.1''');
             ),
           ).thenAnswer((_) async => '');
         });
+
         test('returns null', () async {
           await expectLater(
             runWithOverrides(
@@ -309,6 +312,7 @@ $revision
         ''',
           );
         });
+
         test('returns revision', () async {
           await expectLater(
             runWithOverrides(
@@ -352,6 +356,7 @@ $revision
             ),
           );
         });
+
         test('throws ProcessException', () async {
           await expectLater(
             runWithOverrides(shorebirdFlutter.getVersionString),
@@ -379,6 +384,7 @@ $revision
             ),
           ).thenAnswer((_) async => '');
         });
+
         test('returns null', () async {
           await expectLater(
             runWithOverrides(shorebirdFlutter.getVersionString),

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -201,33 +201,36 @@ Tools • Dart 3.0.6 • DevTools 2.23.1''');
     });
 
     group('getVersionAndRevision', () {
-      test('returns unknown (<revision>) when unable to determine version',
-          () async {
+      group('when unable to determine version', () {
         const error = 'oops';
-        when(
-          () => git.forEachRef(
-            directory: any(named: 'directory'),
-            contains: any(named: 'contains'),
-            format: any(named: 'format'),
-            pattern: any(named: 'pattern'),
-          ),
-        ).thenThrow(
-          ProcessException(
-            'git',
-            [
-              'for-each-ref',
-              '--format',
-              '%(refname:short)',
-              'refs/remotes/origin/flutter_release/*',
-            ],
-            error,
-            ExitCode.software.code,
-          ),
-        );
-        await expectLater(
-          runWithOverrides(shorebirdFlutter.getVersionAndRevision),
-          completion(equals('unknown (${flutterRevision.substring(0, 10)})')),
-        );
+        setUp(() {
+          when(
+            () => git.forEachRef(
+              directory: any(named: 'directory'),
+              contains: any(named: 'contains'),
+              format: any(named: 'format'),
+              pattern: any(named: 'pattern'),
+            ),
+          ).thenThrow(
+            ProcessException(
+              'git',
+              [
+                'for-each-ref',
+                '--format',
+                '%(refname:short)',
+                'refs/remotes/origin/flutter_release/*',
+              ],
+              error,
+              ExitCode.software.code,
+            ),
+          );
+        });
+        test('returns unknown (<revision>)', () async {
+          await expectLater(
+            runWithOverrides(shorebirdFlutter.getVersionAndRevision),
+            completion(equals('unknown (${flutterRevision.substring(0, 10)})')),
+          );
+        });
       });
 
       test('returns correct version and revision', () async {
@@ -409,7 +412,7 @@ $revision
         });
       });
 
-      group('when getVersionStringReturns an invalid string', () {
+      group('when getVersionString returns an invalid string', () {
         setUp(() {
           when(
             () => git.forEachRef(
@@ -429,7 +432,7 @@ $revision
         });
       });
 
-      group('when getVersionStringReturns a valid string', () {
+      group('when getVersionString returns a valid string', () {
         setUp(() {
           when(
             () => git.forEachRef(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description


When doing a release for a platform whereas it's release version is the same as an already published release for a different platform with a different flutter version, we give an error messages saying that the flutter version must be the same.

In that message we use the flutter revision to identify the flutter versions, which is not the most user friendly value.

This PR changes so it will show the flutter version along side the shortened revision. Example:

```
A release with version 4.1.4+5 already exists but was built using a different Flutter revision.


  Existing release built with: 3.22.1 (2f366bd7c9)
  Current release built with: 3.22.2 (853d13d954)

All platforms for a given release must be built using the same Flutter revision.

To resolve this issue, you can:
  * Re-run the release command with "--flutter-version=3.22.1".
  * Delete the existing release and re-run the release command with the desired Flutter version.
  * Bump the release version and re-run the release command with the desired Flutter version.

If you aren't sure why this command failed, re-run with the --verbose flag to see more information.

You can also file an issue if you think this is a bug. Please include the following log file in your report:
/Users/erick/Library/Application Support/shorebird/logs/1720805902724_shorebird.log
```

Additionally, this PR does a few small refactoring in the hope of improving the APIs:

 - Remove the optional `revision` argument from `getVersionString`. making this method consistent with the `getVersion` and `getVersionAndRevision`, which will always use the flutter version on `shorebirdEnv.flutterRevision`
 - Create a `getVersionForRevision` with a consistent API to `getRevisionForVersion`, which can be used to get a version from any given revision.

There might be additional refactoring that we could apply to these classes, but trying to not make too many changes in a single PR.

**WIP notes**
 - [x] Do some smoke testing on the affected places to make sure all is working
 - [x] Add additional unit tests specific for the added method.

Fixes #2349

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
