### PR TITLE
feat: add isRolledBack to ReleasePatch model

### DIFF
--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -619,7 +619,7 @@ packages:
       path: "../shorebird_code_push_client"
       relative: true
     source: path
-    version: "0.7.2+1"
+    version: "0.8.0+1"
   shorebird_code_push_protocol:
     dependency: "direct main"
     description:

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -769,6 +769,7 @@ You can manage this release in the ${link(uri: uri, message: 'Shorebird Console'
             id: 0,
             number: 1,
             channel: DeploymentTrack.production.channel,
+            isRolledBack: false,
             artifacts: const [],
           );
 

--- a/packages/shorebird_cli/test/src/commands/patches/promote_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patches/promote_command_test.dart
@@ -42,6 +42,7 @@ void main() {
       id: 0,
       number: 1,
       channel: DeploymentTrack.staging.channel,
+      isRolledBack: false,
       artifacts: const [],
     );
 
@@ -135,6 +136,7 @@ void main() {
           id: 0,
           number: 1,
           channel: DeploymentTrack.production.channel,
+          isRolledBack: false,
           artifacts: const [],
         );
         when(

--- a/packages/shorebird_code_push_client/lib/src/version.dart
+++ b/packages/shorebird_code_push_client/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.7.2+1';
+const packageVersion = '0.8.0+1';

--- a/packages/shorebird_code_push_client/pubspec.yaml
+++ b/packages/shorebird_code_push_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_code_push_client
 description: Library which allows Dart applications to interact with the Shorebird CodePush API
-version: 0.7.2+1
+version: 0.8.0+1
 repository: https://github.com/shorebirdtech/shorebird
 
 publish_to: none

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -1686,6 +1686,7 @@ void main() {
             id: 0,
             number: 1,
             channel: 'stable',
+            isRolledBack: false,
             artifacts: const [],
           );
           response = GetReleasePatchesResponse(patches: [patch]);

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_patch.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_patch.dart
@@ -7,6 +7,7 @@ part 'release_patch.g.dart';
 /// {@template release_patch}
 /// A patch for a given release.
 /// {@endtemplate}
+// TODO(bryanoltman): consolidate this with [Patch]
 @JsonSerializable()
 class ReleasePatch extends Equatable {
   /// {@macro release_patch}

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_patch.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_patch.dart
@@ -15,6 +15,7 @@ class ReleasePatch extends Equatable {
     required this.number,
     required this.channel,
     required this.artifacts,
+    required this.isRolledBack,
   });
 
   /// Converts a Map<String, dynamic> to a [ReleasePatch]
@@ -36,6 +37,9 @@ class ReleasePatch extends Equatable {
   /// The associated patch artifacts.
   final List<PatchArtifact> artifacts;
 
+  /// Whether the patch has been rolled back.
+  final bool isRolledBack;
+
   @override
-  List<Object?> get props => [id, number, channel, artifacts];
+  List<Object?> get props => [id, number, channel, artifacts, isRolledBack];
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_patch.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_patch.g.dart
@@ -22,9 +22,11 @@ ReleasePatch _$ReleasePatchFromJson(Map<String, dynamic> json) =>
               (v) => (v as List<dynamic>)
                   .map((e) => PatchArtifact.fromJson(e as Map<String, dynamic>))
                   .toList()),
+          isRolledBack: $checkedConvert('is_rolled_back', (v) => v as bool),
         );
         return val;
       },
+      fieldKeyMap: const {'isRolledBack': 'is_rolled_back'},
     );
 
 Map<String, dynamic> _$ReleasePatchToJson(ReleasePatch instance) =>
@@ -33,4 +35,5 @@ Map<String, dynamic> _$ReleasePatchToJson(ReleasePatch instance) =>
       'number': instance.number,
       'channel': instance.channel,
       'artifacts': instance.artifacts.map((e) => e.toJson()).toList(),
+      'is_rolled_back': instance.isRolledBack,
     };

--- a/packages/shorebird_code_push_protocol/test/src/messages/get_release_patches/get_release_patches_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/get_release_patches/get_release_patches_response_test.dart
@@ -10,6 +10,7 @@ void main() {
             id: 42,
             number: 1,
             channel: 'stable',
+            isRolledBack: true,
             artifacts: [
               PatchArtifact(
                 id: 1,
@@ -35,6 +36,7 @@ void main() {
             id: 43,
             number: 2,
             channel: null,
+            isRolledBack: false,
             artifacts: [
               PatchArtifact(
                 id: 3,

--- a/packages/shorebird_code_push_protocol/test/src/models/release_patch_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/release_patch_test.dart
@@ -11,6 +11,7 @@ void main() {
           id: 0,
           number: 1,
           channel: 'channel',
+          isRolledBack: false,
           artifacts: const [],
         ),
         equals(
@@ -18,6 +19,7 @@ void main() {
             id: 0,
             number: 1,
             channel: 'channel',
+            isRolledBack: false,
             artifacts: const [],
           ),
         ),


### PR DESCRIPTION
## Description

Adds `isRolledBack` to the ReleasePatch model. This will be used to display rolled back patches in the console.

Supports https://github.com/shorebirdtech/_shorebird/pull/741.
Part of https://github.com/shorebirdtech/shorebird/issues/126

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
