### PR TITLE
fix(shorebird_cli): allow git hashes to be passed as flutter-version arg for release

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -393,7 +393,7 @@ ${styleBold.wrap(lightRed.wrap('A release with version $version already exists b
 ${styleBold.wrap(lightRed.wrap('All platforms for a given release must be built using the same Flutter revision.'))}
 
 To resolve this issue, you can:
-  * Re-run the release command with "${lightCyan.wrap('--flutter-version=${existingRelease.flutterVersion ?? existingRelease.flutterRevision}')}".
+  * Re-run the release command with "${lightCyan.wrap('--flutter-version=${existingRelease.flutterRevision}')}".
   * Delete the existing release and re-run the release command with the desired Flutter version.
   * Bump the release version and re-run the release command with the desired Flutter version.''');
         throw ProcessExit(ExitCode.software.code);

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -9,6 +9,7 @@ import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
+import 'package:shorebird_cli/src/extensions/version.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
@@ -85,7 +86,8 @@ class ReleaseCommand extends ShorebirdCommand {
       )
       ..addOption(
         'flutter-version',
-        help: 'The Flutter version to use when building the app (e.g: 3.16.3).',
+        help:
+            '''The Flutter version to use when building the app (e.g: 3.16.3). This option also accepts Flutter commit hashes.''',
       )
       ..addOption(
         'artifact',
@@ -297,41 +299,48 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
   /// [shorebirdEnv]. Will exit with [ExitCode.software] if the version
   /// specified by the user is not found/supported.
   Future<String> resolveTargetFlutterRevision() async {
-    if (flutterVersionArg != null) {
-      final String? revision;
-      try {
-        revision = await shorebirdFlutter.getRevisionForVersion(
-          flutterVersionArg!,
-        );
-      } catch (error) {
-        logger.err(
-          '''
+    if (flutterVersionArg == null) {
+      return shorebirdEnv.flutterRevision;
+    }
+
+    final parsedVersion = tryParseVersion(flutterVersionArg!);
+    if (parsedVersion == null) {
+      // If we fail to parse flutterVersionArg as a semver version, attempt to
+      // use the provided value as a revision.
+      return flutterVersionArg!;
+    }
+
+    final String? revision;
+    try {
+      revision = await shorebirdFlutter.getRevisionForVersion(
+        flutterVersionArg!,
+      );
+    } catch (error) {
+      logger.err(
+        '''
 Unable to determine revision for Flutter version: $flutterVersionArg.
 $error''',
-        );
-        throw ProcessExit(ExitCode.software.code);
-      }
+      );
+      throw ProcessExit(ExitCode.software.code);
+    }
 
-      if (revision == null) {
-        final openIssueLink = link(
-          uri: Uri.parse(
-            'https://github.com/shorebirdtech/shorebird/issues/new?assignees=&labels=feature&projects=&template=feature_request.md&title=feat%3A+',
-          ),
-          message: 'open an issue',
-        );
-        logger.err(
-          '''
+    if (revision == null) {
+      final openIssueLink = link(
+        uri: Uri.parse(
+          'https://github.com/shorebirdtech/shorebird/issues/new?assignees=&labels=feature&projects=&template=feature_request.md&title=feat%3A+',
+        ),
+        message: 'open an issue',
+      );
+      logger.err(
+        '''
 Version $flutterVersionArg not found. Please $openIssueLink to request a new version.
 Use `shorebird flutter versions list` to list available versions.
 ''',
-        );
-        throw ProcessExit(ExitCode.software.code);
-      }
-
-      return revision;
+      );
+      throw ProcessExit(ExitCode.software.code);
     }
 
-    return shorebirdEnv.flutterRevision;
+    return revision;
   }
 
   /// Asserts that a release with version [version] can be released using

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -520,6 +520,28 @@ $exception''',
             ).called(1);
           });
         });
+
+        group('when flutter-verison is a git hash', () {
+          const revision = 'deadbeef';
+          setUp(() {
+            when(() => argResults['flutter-version']).thenReturn(revision);
+          });
+
+          test(
+              '''installs the flutter version with the provided revision and completes''',
+              () async {
+            await runWithOverrides(command.run);
+
+            verify(() => shorebirdFlutter.installRevision(revision: revision))
+                .called(1);
+            // We should never attempt to treat this as a semver version.
+            verifyNever(
+              () => shorebirdFlutter.getVersionForRevision(
+                flutterRevision: any(named: 'flutterRevision'),
+              ),
+            );
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## Description

Updates the `--flutter-version` arg handling to allow both semver version numbers and git hashes in the release command.

Fixes https://github.com/shorebirdtech/shorebird/issues/2382

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
