### PR TITLE
fix(shorebird_cli): fix app.dill parsing from flutter build output

### DIFF
--- a/packages/shorebird_cli/lib/src/extensions/shorebird_process_result.dart
+++ b/packages/shorebird_cli/lib/src/extensions/shorebird_process_result.dart
@@ -14,6 +14,14 @@ extension FindAppDill on ShorebirdProcessResult {
     final appDillLine = stdout.toString().split('\n').firstWhereOrNull(
           (l) => l.contains('gen_snapshot') && l.endsWith('app.dill'),
         );
-    return appDillLine?.split(' ').last;
+
+    if (appDillLine == null) return null;
+
+    // The last argument in the line is the path to app.dill. Because
+    //   1) paths can contain spaces and
+    //   2) the path to the app.dill is absolute (i.e., it starts with a '/')
+    // we can grab the last space-separated part of the line that starts with
+    // a '/' and assume everything after it is the path to app.dill.
+    return '/${appDillLine.split(' /').last}';
   }
 }

--- a/packages/shorebird_cli/test/src/extensions/shorebird_process_result_test.dart
+++ b/packages/shorebird_cli/test/src/extensions/shorebird_process_result_test.dart
@@ -42,6 +42,30 @@ void main() {
           ),
         );
       });
+
+      group('when path to app.dill contains a space', () {
+        test('returns full path to app.dill, including the space(s)', () {
+          const result = ShorebirdProcessResult(
+            stdout: '''
+            [   +3 ms] targetingApplePlatform = true
+            [        ] extractAppleDebugSymbols = true
+            [        ] Will strip AOT snapshot manually after build and dSYM generation.
+            [        ] executing: /Users/bryanoltman/shorebirdtech/_shorebird/shorebird/bin/cache/flutter/9015e1b42a1ba41d97176e22b502b0e0e8ad28af/bin/cache/artifacts/engine/ios-release/gen_snapshot_arm64 --deterministic --snapshot_kind=app-aot-assembly --assembly=/Users/bryanoltman/Documents/sandbox/folder with space/ios_patcher/.dart_tool/flutter_build/cd4f4aa272817365910648606e3e4164/arm64/snapshot_assembly.S /Users/bryanoltman/Documents/sandbox/folder with space/ios_patcher/.dart_tool/flutter_build/cd4f4aa272817365910648606e3e4164/app.dill
+            [+3395 ms] executing: sysctl hw.optional.arm64
+            [   +3 ms] Exit code 0 from: sysctl hw.optional.arm64
+''',
+            stderr: '',
+            exitCode: 0,
+          );
+
+          expect(
+            result.findAppDill(),
+            equals(
+              '/Users/bryanoltman/Documents/sandbox/folder with space/ios_patcher/.dart_tool/flutter_build/cd4f4aa272817365910648606e3e4164/app.dill',
+            ),
+          );
+        });
+      });
     });
 
     group('when gen_snapshot is not invoked with app.dill', () {


### PR DESCRIPTION
## Description

Fixes our parsing of the Flutter build output that detects an `app.dill` file.

Fixes https://github.com/shorebirdtech/shorebird/issues/2386

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
