### PR TITLE
refactor(shorebird_cli): update how command metadata is populated

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
@@ -13,7 +13,6 @@ import 'package:shorebird_cli/src/commands/patch/patch.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
-import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_android_artifacts.dart';
@@ -21,7 +20,6 @@ import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
-import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// {@template aar_patcher}
@@ -182,21 +180,8 @@ class AarPatcher extends Patcher {
   }
 
   @override
-  Future<CreatePatchMetadata> createPatchMetadata(DiffStatus diffStatus) async {
-    return CreatePatchMetadata(
-      releasePlatform: releaseType.releasePlatform,
-      usedIgnoreAssetChangesFlag: allowAssetDiffs,
-      hasAssetChanges: diffStatus.hasAssetChanges,
-      usedIgnoreNativeChangesFlag: allowNativeDiffs,
-      hasNativeChanges: diffStatus.hasNativeChanges,
-      linkPercentage: null,
-      environment: BuildEnvironmentMetadata(
-        flutterRevision: shorebirdEnv.flutterRevision,
-        operatingSystem: platform.operatingSystem,
-        operatingSystemVersion: platform.operatingSystemVersion,
-        shorebirdVersion: packageVersion,
-        xcodeVersion: null,
-      ),
-    );
-  }
+  Future<CreatePatchMetadata> updatedCreatePatchMetadata(
+    CreatePatchMetadata metadata,
+  ) async =>
+      metadata;
 }

--- a/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
@@ -178,10 +178,4 @@ class AarPatcher extends Patcher {
       'Release version must be specified using --release-version.',
     );
   }
-
-  @override
-  Future<CreatePatchMetadata> updatedCreatePatchMetadata(
-    CreatePatchMetadata metadata,
-  ) async =>
-      metadata;
 }

--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -14,15 +14,12 @@ import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
-import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_android_artifacts.dart';
-import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
-import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// {@template android_patcher}
@@ -206,21 +203,8 @@ Looked in:
   }
 
   @override
-  Future<CreatePatchMetadata> createPatchMetadata(DiffStatus diffStatus) async {
-    return CreatePatchMetadata(
-      releasePlatform: releaseType.releasePlatform,
-      usedIgnoreAssetChangesFlag: allowAssetDiffs,
-      hasAssetChanges: diffStatus.hasAssetChanges,
-      usedIgnoreNativeChangesFlag: allowNativeDiffs,
-      hasNativeChanges: diffStatus.hasNativeChanges,
-      linkPercentage: null,
-      environment: BuildEnvironmentMetadata(
-        flutterRevision: shorebirdEnv.flutterRevision,
-        operatingSystem: platform.operatingSystem,
-        operatingSystemVersion: platform.operatingSystemVersion,
-        shorebirdVersion: packageVersion,
-        xcodeVersion: null,
-      ),
-    );
-  }
+  Future<CreatePatchMetadata> updatedCreatePatchMetadata(
+    CreatePatchMetadata metadata,
+  ) async =>
+      metadata;
 }

--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -201,10 +201,4 @@ Looked in:
       artifact.path,
     );
   }
-
-  @override
-  Future<CreatePatchMetadata> updatedCreatePatchMetadata(
-    CreatePatchMetadata metadata,
-  ) async =>
-      metadata;
 }

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
@@ -17,7 +17,6 @@ import 'package:shorebird_cli/src/executables/xcodebuild.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
-import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
@@ -25,7 +24,6 @@ import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
-import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// {@template ios_framework_patcher}
@@ -228,23 +226,15 @@ class IosFrameworkPatcher extends Patcher {
   }
 
   @override
-  Future<CreatePatchMetadata> createPatchMetadata(DiffStatus diffStatus) async {
-    return CreatePatchMetadata(
-      releasePlatform: releaseType.releasePlatform,
-      usedIgnoreAssetChangesFlag: allowAssetDiffs,
-      hasAssetChanges: diffStatus.hasAssetChanges,
-      usedIgnoreNativeChangesFlag: allowNativeDiffs,
-      hasNativeChanges: diffStatus.hasNativeChanges,
-      linkPercentage: lastBuildLinkPercentage,
-      environment: BuildEnvironmentMetadata(
-        flutterRevision: shorebirdEnv.flutterRevision,
-        operatingSystem: platform.operatingSystem,
-        operatingSystemVersion: platform.operatingSystemVersion,
-        shorebirdVersion: packageVersion,
-        xcodeVersion: await xcodeBuild.version(),
-      ),
-    );
-  }
+  Future<CreatePatchMetadata> updatedCreatePatchMetadata(
+    CreatePatchMetadata metadata,
+  ) async =>
+      metadata.copyWith(
+        linkPercentage: lastBuildLinkPercentage,
+        environment: metadata.environment.copyWith(
+          xcodeVersion: await xcodeBuild.version(),
+        ),
+      );
 
   Future<void> _runLinker({
     required File aotSnapshot,

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -21,7 +21,6 @@ import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
-import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
@@ -30,7 +29,6 @@ import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
-import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 
@@ -339,23 +337,15 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
   }
 
   @override
-  Future<CreatePatchMetadata> createPatchMetadata(DiffStatus diffStatus) async {
-    return CreatePatchMetadata(
-      releasePlatform: releaseType.releasePlatform,
-      usedIgnoreAssetChangesFlag: allowAssetDiffs,
-      hasAssetChanges: diffStatus.hasAssetChanges,
-      usedIgnoreNativeChangesFlag: allowNativeDiffs,
-      hasNativeChanges: diffStatus.hasNativeChanges,
-      linkPercentage: lastBuildLinkPercentage,
-      environment: BuildEnvironmentMetadata(
-        flutterRevision: shorebirdEnv.flutterRevision,
-        operatingSystem: platform.operatingSystem,
-        operatingSystemVersion: platform.operatingSystemVersion,
-        shorebirdVersion: packageVersion,
-        xcodeVersion: await xcodeBuild.version(),
-      ),
-    );
-  }
+  Future<CreatePatchMetadata> updatedCreatePatchMetadata(
+    CreatePatchMetadata metadata,
+  ) async =>
+      metadata.copyWith(
+        linkPercentage: lastBuildLinkPercentage,
+        environment: metadata.environment.copyWith(
+          xcodeVersion: await xcodeBuild.version(),
+        ),
+      );
 
   Future<_LinkResult> _runLinker({
     required File releaseArtifact,

--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -92,9 +92,10 @@ ${iOSLinkPercentageUrl.toLink()}
     required File releaseArtifact,
   });
 
-  /// Metadata to attach to the patch when creating it, used for debugging
-  /// and support.
-  Future<CreatePatchMetadata> createPatchMetadata(DiffStatus diffStatus);
+  /// Updates the provided metadata to include patcher-specific fields.
+  Future<CreatePatchMetadata> updatedCreatePatchMetadata(
+    CreatePatchMetadata metadata,
+  );
 
   /// Whether to allow changes in assets (--allow-asset-diffs).
   bool get allowAssetDiffs => argResults['allow-asset-diffs'] == true;

--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -95,7 +95,9 @@ ${iOSLinkPercentageUrl.toLink()}
   /// Updates the provided metadata to include patcher-specific fields.
   Future<CreatePatchMetadata> updatedCreatePatchMetadata(
     CreatePatchMetadata metadata,
-  );
+  ) async {
+    return metadata;
+  }
 
   /// Whether to allow changes in assets (--allow-asset-diffs).
   bool get allowAssetDiffs => argResults['allow-asset-diffs'] == true;

--- a/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
@@ -143,12 +143,6 @@ class AarReleaser extends Releaser {
   }
 
   @override
-  Future<UpdateReleaseMetadata> updatedReleaseMetadata(
-    UpdateReleaseMetadata metadata,
-  ) async =>
-      metadata;
-
-  @override
   String get postReleaseInstructions {
     final targetLibraryDirectory = Directory(
       p.join(shorebirdEnv.getShorebirdProjectRoot()!.path, 'release'),

--- a/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
@@ -9,7 +9,6 @@ import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/release/releaser.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logger.dart';
-import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_android_artifacts.dart';
@@ -17,7 +16,6 @@ import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
-import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// {@template aar_releaser}
@@ -145,19 +143,10 @@ class AarReleaser extends Releaser {
   }
 
   @override
-  Future<UpdateReleaseMetadata> releaseMetadata() async =>
-      UpdateReleaseMetadata(
-        releasePlatform: releaseType.releasePlatform,
-        flutterVersionOverride: argResults['flutter-version'] as String?,
-        generatedApks: false,
-        environment: BuildEnvironmentMetadata(
-          flutterRevision: shorebirdEnv.flutterRevision,
-          operatingSystem: platform.operatingSystem,
-          operatingSystemVersion: platform.operatingSystemVersion,
-          shorebirdVersion: packageVersion,
-          xcodeVersion: null,
-        ),
-      );
+  Future<UpdateReleaseMetadata> updatedReleaseMetadata(
+    UpdateReleaseMetadata metadata,
+  ) async =>
+      metadata;
 
   @override
   String get postReleaseInstructions {

--- a/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/android_releaser.dart
@@ -8,15 +8,12 @@ import 'package:shorebird_cli/src/commands/release/releaser.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logger.dart';
-import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_android_artifacts.dart';
-import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
-import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// {@template android_releaser}
@@ -188,19 +185,10 @@ Please comment and upvote ${link(uri: Uri.parse('https://github.com/shorebirdtec
   }
 
   @override
-  Future<UpdateReleaseMetadata> releaseMetadata() async =>
-      UpdateReleaseMetadata(
-        releasePlatform: releaseType.releasePlatform,
-        flutterVersionOverride: argResults['flutter-version'] as String?,
-        generatedApks: generateApk,
-        environment: BuildEnvironmentMetadata(
-          flutterRevision: shorebirdEnv.flutterRevision,
-          operatingSystem: platform.operatingSystem,
-          operatingSystemVersion: platform.operatingSystemVersion,
-          shorebirdVersion: packageVersion,
-          xcodeVersion: null,
-        ),
-      );
+  Future<UpdateReleaseMetadata> updatedReleaseMetadata(
+    UpdateReleaseMetadata metadata,
+  ) async =>
+      metadata.copyWith(generatedApks: generateApk);
 
   @override
   String get postReleaseInstructions {

--- a/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
@@ -12,13 +12,11 @@ import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/xcodebuild.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logger.dart';
-import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
-import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// {@template ios_framework_releaser}
@@ -133,6 +131,16 @@ class IosFrameworkReleaser extends Releaser {
   }
 
   @override
+  Future<UpdateReleaseMetadata> updatedReleaseMetadata(
+    UpdateReleaseMetadata metadata,
+  ) async =>
+      metadata.copyWith(
+        environment: metadata.environment.copyWith(
+          xcodeVersion: await xcodeBuild.version(),
+        ),
+      );
+
+  @override
   String get postReleaseInstructions {
     final relativeFrameworkDirectoryPath = p.relative(releaseDirectory.path);
     return '''
@@ -146,19 +154,4 @@ To do this:
 Instructions for these steps can be found at https://docs.flutter.dev/add-to-app/ios/project-setup#option-b---embed-frameworks-in-xcode.
 ''';
   }
-
-  @override
-  Future<UpdateReleaseMetadata> releaseMetadata() async =>
-      UpdateReleaseMetadata(
-        releasePlatform: releaseType.releasePlatform,
-        flutterVersionOverride: argResults['flutter-version'] as String?,
-        generatedApks: false,
-        environment: BuildEnvironmentMetadata(
-          flutterRevision: shorebirdEnv.flutterRevision,
-          operatingSystem: platform.operatingSystem,
-          operatingSystemVersion: platform.operatingSystemVersion,
-          shorebirdVersion: packageVersion,
-          xcodeVersion: await xcodeBuild.version(),
-        ),
-      );
 }

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -14,7 +14,6 @@ import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/xcodebuild.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logger.dart';
-import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/ios.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_documentation.dart';
@@ -22,7 +21,6 @@ import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
-import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// {@template ios_releaser}
@@ -199,6 +197,16 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
   }
 
   @override
+  Future<UpdateReleaseMetadata> updatedReleaseMetadata(
+    UpdateReleaseMetadata metadata,
+  ) async =>
+      metadata.copyWith(
+        environment: metadata.environment.copyWith(
+          xcodeVersion: await xcodeBuild.version(),
+        ),
+      );
+
+  @override
   String get postReleaseInstructions {
     final relativeArchivePath = p.relative(
       artifactManager.getXcarchiveDirectory()!.path,
@@ -227,19 +235,4 @@ ${styleBold.wrap('Make sure to uncheck "Manage Version and Build Number", or els
 ''';
     }
   }
-
-  @override
-  Future<UpdateReleaseMetadata> releaseMetadata() async =>
-      UpdateReleaseMetadata(
-        releasePlatform: releaseType.releasePlatform,
-        flutterVersionOverride: argResults['flutter-version'] as String?,
-        generatedApks: false,
-        environment: BuildEnvironmentMetadata(
-          flutterRevision: shorebirdEnv.flutterRevision,
-          operatingSystem: platform.operatingSystem,
-          operatingSystemVersion: platform.operatingSystemVersion,
-          shorebirdVersion: packageVersion,
-          xcodeVersion: await xcodeBuild.version(),
-        ),
-      );
 }

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -11,6 +11,7 @@ import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/extensions/version.dart';
 import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
@@ -18,6 +19,7 @@ import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
+import 'package:shorebird_cli/src/version.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 
@@ -476,12 +478,23 @@ ${summary.join('\n')}
     required Release release,
     required Releaser releaser,
   }) async {
+    final baseMetadata = UpdateReleaseMetadata(
+      releasePlatform: releaser.releaseType.releasePlatform,
+      flutterVersionOverride: results['flutter-version'] as String?,
+      environment: BuildEnvironmentMetadata(
+        flutterRevision: shorebirdEnv.flutterRevision,
+        operatingSystem: platform.operatingSystem,
+        operatingSystemVersion: platform.operatingSystemVersion,
+        shorebirdVersion: packageVersion,
+      ),
+    );
+
     await codePushClientWrapper.updateReleaseStatus(
       appId: appId,
       releaseId: release.id,
       platform: releaser.releaseType.releasePlatform,
       status: ReleaseStatus.active,
-      metadata: await releaser.releaseMetadata(),
+      metadata: await releaser.updatedReleaseMetadata(baseMetadata),
     );
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -57,7 +57,9 @@ abstract class Releaser {
   /// Creates a copy of [metadata] with releaser-specific fields updated.
   Future<UpdateReleaseMetadata> updatedReleaseMetadata(
     UpdateReleaseMetadata metadata,
-  );
+  ) async {
+    return metadata;
+  }
 
   /// Instructions explaining next steps after running `shorebird release`. This
   /// could include how to upload the generated artifact to a store and how to

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -54,9 +54,10 @@ abstract class Releaser {
     required String appId,
   });
 
-  /// Metadata to attach to the release when creating it, used for debugging
-  /// and support.
-  Future<UpdateReleaseMetadata> releaseMetadata();
+  /// Creates a copy of [metadata] with releaser-specific fields updated.
+  Future<UpdateReleaseMetadata> updatedReleaseMetadata(
+    UpdateReleaseMetadata metadata,
+  );
 
   /// Instructions explaining next steps after running `shorebird release`. This
   /// could include how to upload the generated artifact to a store and how to

--- a/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
@@ -515,10 +515,6 @@ void main() {
       const operatingSystem = 'Mac OS X';
       const operatingSystemVersion = '10.15.7';
 
-      setUp(() {
-        when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
-      });
-
       test('returns correct metadata', () async {
         const metadata = CreatePatchMetadata(
           releasePlatform: ReleasePlatform.android,

--- a/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
@@ -4,7 +4,6 @@ import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
-import 'package:platform/platform.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/archive_analysis/android_archive_differ.dart';
 import 'package:shorebird_cli/src/artifact_builder.dart';
@@ -41,7 +40,6 @@ void main() {
     late Directory projectRoot;
     late ShorebirdLogger logger;
     late PatchDiffChecker patchDiffChecker;
-    late Platform platform;
     late Progress progress;
     late ShorebirdEnv shorebirdEnv;
     late ShorebirdFlutter shorebirdFlutter;
@@ -98,7 +96,6 @@ void main() {
       artifactManager = MockArtifactManager();
       codePushClientWrapper = MockCodePushClientWrapper();
       patchDiffChecker = MockPatchDiffChecker();
-      platform = MockPlatform();
       progress = MockProgress();
       projectRoot = Directory.systemTemp.createTempSync();
       logger = MockShorebirdLogger();
@@ -511,7 +508,7 @@ void main() {
       });
     });
 
-    group('createPatchMetadata', () {
+    group('updatedCreatePatchMetadata', () {
       const allowAssetDiffs = false;
       const allowNativeDiffs = true;
       const flutterRevision = '853d13d954df3b6e9c2f07b72062f33c52a9a64b';
@@ -519,46 +516,27 @@ void main() {
       const operatingSystemVersion = '10.15.7';
 
       setUp(() {
-        when(() => argResults['allow-asset-diffs']).thenReturn(allowAssetDiffs);
-        when(
-          () => argResults['allow-native-diffs'],
-        ).thenReturn(allowNativeDiffs);
-        when(() => platform.operatingSystem).thenReturn(operatingSystem);
-        when(
-          () => platform.operatingSystemVersion,
-        ).thenReturn(operatingSystemVersion);
         when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
       });
 
       test('returns correct metadata', () async {
-        const diffStatus = DiffStatus(
+        const metadata = CreatePatchMetadata(
+          releasePlatform: ReleasePlatform.android,
+          usedIgnoreAssetChangesFlag: allowAssetDiffs,
           hasAssetChanges: false,
+          usedIgnoreNativeChangesFlag: allowNativeDiffs,
           hasNativeChanges: false,
-        );
-
-        final metadata = await runWithOverrides(
-          () => patcher.createPatchMetadata(diffStatus),
+          environment: BuildEnvironmentMetadata(
+            flutterRevision: flutterRevision,
+            operatingSystem: operatingSystem,
+            operatingSystemVersion: operatingSystemVersion,
+            shorebirdVersion: packageVersion,
+          ),
         );
 
         expect(
-          metadata,
-          equals(
-            CreatePatchMetadata(
-              releasePlatform: ReleasePlatform.android,
-              usedIgnoreAssetChangesFlag: allowAssetDiffs,
-              hasAssetChanges: diffStatus.hasAssetChanges,
-              usedIgnoreNativeChangesFlag: allowNativeDiffs,
-              hasNativeChanges: diffStatus.hasNativeChanges,
-              linkPercentage: null,
-              environment: const BuildEnvironmentMetadata(
-                flutterRevision: flutterRevision,
-                operatingSystem: operatingSystem,
-                operatingSystemVersion: operatingSystemVersion,
-                shorebirdVersion: packageVersion,
-                xcodeVersion: null,
-              ),
-            ),
-          ),
+          runWithOverrides(() => patcher.updatedCreatePatchMetadata(metadata)),
+          completion(metadata),
         );
       });
     });

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -625,7 +625,7 @@ Looked in:
       });
     });
 
-    group('createPatchMetadata', () {
+    group('updatedCreatePatchMetadata', () {
       const allowAssetDiffs = false;
       const allowNativeDiffs = true;
       const flutterRevision = '853d13d954df3b6e9c2f07b72062f33c52a9a64b';

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -815,7 +815,7 @@ void main() {
         });
       });
 
-      group('createPatchMetadata', () {
+      group('updatedCreatePatchMetadata', () {
         const allowAssetDiffs = false;
         const allowNativeDiffs = true;
         const flutterRevision = '853d13d954df3b6e9c2f07b72062f33c52a9a64b';
@@ -824,7 +824,6 @@ void main() {
         const xcodeVersion = '11';
 
         setUp(() {
-          when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
           when(
             () => xcodeBuild.version(),
           ).thenAnswer((_) async => xcodeVersion);

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -1580,7 +1580,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
         });
       });
 
-      group('createPatchMetadata', () {
+      group('updatedCreatePatchMetadata', () {
         const allowAssetDiffs = false;
         const allowNativeDiffs = true;
         const flutterRevision = '853d13d954df3b6e9c2f07b72062f33c52a9a64b';

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -49,6 +49,10 @@ void main() {
       ),
     };
     const shorebirdYaml = ShorebirdYaml(appId: appId);
+    const diffStatus = DiffStatus(
+      hasAssetChanges: false,
+      hasNativeChanges: false,
+    );
     final patchMetadata = CreatePatchMetadata.forTest();
 
     final appMetadata = AppMetadata(
@@ -241,7 +245,7 @@ void main() {
         ),
       ).thenAnswer((_) async => patchArtifactBundles);
       when(
-        () => patcher.createPatchMetadata(any()),
+        () => patcher.updatedCreatePatchMetadata(any()),
       ).thenAnswer((_) async => patchMetadata);
       when(
         () => patcher.assertUnpatchableDiffs(
@@ -249,7 +253,7 @@ void main() {
           releaseArchive: any(named: 'releaseArchive'),
           patchArchive: any(named: 'patchArchive'),
         ),
-      ).thenAnswer((_) async => FakeDiffStatus());
+      ).thenAnswer((_) async => diffStatus);
 
       when(() => shorebirdEnv.getShorebirdYaml()).thenReturn(shorebirdYaml);
       when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
@@ -596,7 +600,7 @@ void main() {
                 releaseArtifact: any(named: 'releaseArtifact'),
               ),
           () => logger.confirm('Would you like to continue?'),
-          () => patcher.createPatchMetadata(any()),
+          () => patcher.updatedCreatePatchMetadata(any()),
           () => codePushClientWrapper.publishPatch(
                 appId: appId,
                 releaseId: release.id,

--- a/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
@@ -193,7 +193,9 @@ class _TestPatcher extends Patcher {
   }
 
   @override
-  Future<CreatePatchMetadata> createPatchMetadata(DiffStatus diffStatus) {
+  Future<CreatePatchMetadata> updatedCreatePatchMetadata(
+    CreatePatchMetadata metadata,
+  ) {
     throw UnimplementedError();
   }
 

--- a/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
@@ -418,13 +418,7 @@ void main() {
       });
     });
 
-    group('releaseMetadata', () {
-      const flutterRevision = '853d13d954df3b6e9c2f07b72062f33c52a9a64b';
-
-      setUp(() {
-        when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
-      });
-
+    group('updatedReleaseMetadata', () {
       test('returns expected metadata', () async {
         final metadata = UpdateReleaseMetadata.forTest();
         expect(

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -4,7 +4,6 @@ import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
-import 'package:platform/platform.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
@@ -15,7 +14,6 @@ import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
-import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_android_artifacts.dart';
@@ -38,7 +36,6 @@ void main() {
     late CodePushClientWrapper codePushClientWrapper;
     late CodeSigner codeSigner;
     late Doctor doctor;
-    late Platform platform;
     late Directory projectRoot;
     late ShorebirdLogger logger;
     late OperatingSystemInterface operatingSystemInterface;
@@ -62,7 +59,6 @@ void main() {
           engineConfigRef.overrideWith(() => const EngineConfig.empty()),
           loggerRef.overrideWith(() => logger),
           osInterfaceRef.overrideWith(() => operatingSystemInterface),
-          platformRef.overrideWith(() => platform),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
           shorebirdFlutterRef.overrideWith(() => shorebirdFlutter),
@@ -86,7 +82,6 @@ void main() {
       codeSigner = MockCodeSigner();
       doctor = MockDoctor();
       operatingSystemInterface = MockOperatingSystemInterface();
-      platform = MockPlatform();
       progress = MockProgress();
       projectRoot = Directory.systemTemp.createTempSync();
       logger = MockShorebirdLogger();
@@ -647,16 +642,22 @@ To change the version of this release, change your app's version in your pubspec
       });
     });
 
-    group('releaseMetadata', () {
+    group('updatedReleaseMetadata', () {
       const flutterRevision = '853d13d954df3b6e9c2f07b72062f33c52a9a64b';
       const operatingSystem = 'macos';
       const operatingSystemVersion = '11.0.0';
+      const metadata = UpdateReleaseMetadata(
+        releasePlatform: ReleasePlatform.android,
+        flutterVersionOverride: null,
+        environment: BuildEnvironmentMetadata(
+          flutterRevision: flutterRevision,
+          operatingSystem: operatingSystem,
+          operatingSystemVersion: operatingSystemVersion,
+          shorebirdVersion: packageVersion,
+        ),
+      );
 
       setUp(() {
-        when(() => platform.operatingSystem).thenReturn(operatingSystem);
-        when(
-          () => platform.operatingSystemVersion,
-        ).thenReturn(operatingSystemVersion);
         when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
       });
 
@@ -667,17 +668,20 @@ To change the version of this release, change your app's version in your pubspec
 
         test('returns expected metadata', () async {
           expect(
-            await runWithOverrides(() => androidReleaser.releaseMetadata()),
-            const UpdateReleaseMetadata(
-              releasePlatform: ReleasePlatform.android,
-              flutterVersionOverride: null,
-              generatedApks: true,
-              environment: BuildEnvironmentMetadata(
-                flutterRevision: flutterRevision,
-                operatingSystem: operatingSystem,
-                operatingSystemVersion: operatingSystemVersion,
-                shorebirdVersion: packageVersion,
-                xcodeVersion: null,
+            runWithOverrides(
+              () => androidReleaser.updatedReleaseMetadata(metadata),
+            ),
+            completion(
+              const UpdateReleaseMetadata(
+                releasePlatform: ReleasePlatform.android,
+                flutterVersionOverride: null,
+                generatedApks: true,
+                environment: BuildEnvironmentMetadata(
+                  flutterRevision: flutterRevision,
+                  operatingSystem: operatingSystem,
+                  operatingSystemVersion: operatingSystemVersion,
+                  shorebirdVersion: packageVersion,
+                ),
               ),
             ),
           );
@@ -691,17 +695,20 @@ To change the version of this release, change your app's version in your pubspec
 
         test('returns expected metadata', () async {
           expect(
-            await runWithOverrides(() => androidReleaser.releaseMetadata()),
-            const UpdateReleaseMetadata(
-              releasePlatform: ReleasePlatform.android,
-              flutterVersionOverride: null,
-              generatedApks: false,
-              environment: BuildEnvironmentMetadata(
-                flutterRevision: flutterRevision,
-                operatingSystem: operatingSystem,
-                operatingSystemVersion: operatingSystemVersion,
-                shorebirdVersion: packageVersion,
-                xcodeVersion: null,
+            runWithOverrides(
+              () => androidReleaser.updatedReleaseMetadata(metadata),
+            ),
+            completion(
+              const UpdateReleaseMetadata(
+                releasePlatform: ReleasePlatform.android,
+                flutterVersionOverride: null,
+                generatedApks: false,
+                environment: BuildEnvironmentMetadata(
+                  flutterRevision: flutterRevision,
+                  operatingSystem: operatingSystem,
+                  operatingSystemVersion: operatingSystemVersion,
+                  shorebirdVersion: packageVersion,
+                ),
               ),
             ),
           );

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -657,10 +657,6 @@ To change the version of this release, change your app's version in your pubspec
         ),
       );
 
-      setUp(() {
-        when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
-      });
-
       group('when an apk is generated', () {
         setUp(() {
           when(() => argResults['artifact']).thenReturn('apk');

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -81,6 +81,7 @@ void main() {
       registerFallbackValue(release);
       registerFallbackValue(ReleasePlatform.android);
       registerFallbackValue(ReleaseStatus.draft);
+      registerFallbackValue(UpdateReleaseMetadata.forTest());
     });
 
     setUp(() {
@@ -153,7 +154,7 @@ void main() {
       ).thenReturn(postReleaseInstructions);
       when(() => releaser.releaseType).thenReturn(ReleaseType.android);
       when(
-        () => releaser.releaseMetadata(),
+        () => releaser.updatedReleaseMetadata(any()),
       ).thenAnswer((_) async => UpdateReleaseMetadata.forTest());
       when(() => releaser.requiresReleaseVersionArg).thenReturn(false);
 

--- a/packages/shorebird_cli/test/src/commands/release/releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/releaser_test.dart
@@ -46,7 +46,10 @@ class FakeReleaser extends Releaser {
   String get postReleaseInstructions => throw UnimplementedError();
 
   @override
-  Future<UpdateReleaseMetadata> releaseMetadata() => throw UnimplementedError();
+  Future<UpdateReleaseMetadata> updatedReleaseMetadata(
+    UpdateReleaseMetadata metadata,
+  ) =>
+      throw UnimplementedError();
 
   @override
   ReleaseType get releaseType => throw UnimplementedError();

--- a/packages/shorebird_code_push_client/example/main.dart
+++ b/packages/shorebird_code_push_client/example/main.dart
@@ -50,13 +50,11 @@ Future<void> main() async {
       hasAssetChanges: false,
       usedIgnoreNativeChangesFlag: false,
       hasNativeChanges: false,
-      linkPercentage: null,
       environment: BuildEnvironmentMetadata(
         flutterRevision: '<FLUTTER_REVISION>', // e.g. '83305b5088e6'
         operatingSystem: 'Windows',
         operatingSystemVersion: '10',
         shorebirdVersion: '1.2.3',
-        xcodeVersion: null,
       ),
     ).toJson(),
   );

--- a/packages/shorebird_code_push_protocol/lib/src/models/build_environment_metadata.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/build_environment_metadata.dart
@@ -21,7 +21,7 @@ class BuildEnvironmentMetadata extends Equatable {
     required this.shorebirdVersion,
     required this.operatingSystem,
     required this.operatingSystemVersion,
-    required this.xcodeVersion,
+    this.xcodeVersion,
   });
 
   /// coverage:ignore-start
@@ -49,6 +49,24 @@ class BuildEnvironmentMetadata extends Equatable {
 
   /// Converts a [BuildEnvironmentMetadata] to a Map<String, dynamic>
   Map<String, dynamic> toJson() => _$BuildEnvironmentMetadataToJson(this);
+
+  /// Creates a copy of this [BuildEnvironmentMetadata] with the given fields
+  /// replaced by the new values.
+  BuildEnvironmentMetadata copyWith({
+    String? flutterRevision,
+    String? shorebirdVersion,
+    String? operatingSystem,
+    String? operatingSystemVersion,
+    String? xcodeVersion,
+  }) =>
+      BuildEnvironmentMetadata(
+        flutterRevision: flutterRevision ?? this.flutterRevision,
+        shorebirdVersion: shorebirdVersion ?? this.shorebirdVersion,
+        operatingSystem: operatingSystem ?? this.operatingSystem,
+        operatingSystemVersion:
+            operatingSystemVersion ?? this.operatingSystemVersion,
+        xcodeVersion: xcodeVersion ?? this.xcodeVersion,
+      );
 
   /// The revision of Flutter used to run the command.
   ///

--- a/packages/shorebird_code_push_protocol/lib/src/models/create_patch_metadata.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/create_patch_metadata.dart
@@ -23,8 +23,8 @@ class CreatePatchMetadata extends Equatable {
     required this.hasAssetChanges,
     required this.usedIgnoreNativeChangesFlag,
     required this.hasNativeChanges,
-    required this.linkPercentage,
     required this.environment,
+    this.linkPercentage,
   });
 
   // coverage:ignore-start
@@ -56,6 +56,29 @@ class CreatePatchMetadata extends Equatable {
 
   /// Converts a [CreatePatchMetadata] to a Map<String, dynamic>
   Map<String, dynamic> toJson() => _$CreatePatchMetadataToJson(this);
+
+  /// Returns a copy of this [CreatePatchMetadata] with the given fields
+  /// replaced by the new values.
+  CreatePatchMetadata copyWith({
+    ReleasePlatform? releasePlatform,
+    bool? usedIgnoreAssetChangesFlag,
+    bool? hasAssetChanges,
+    bool? usedIgnoreNativeChangesFlag,
+    bool? hasNativeChanges,
+    double? linkPercentage,
+    BuildEnvironmentMetadata? environment,
+  }) =>
+      CreatePatchMetadata(
+        releasePlatform: releasePlatform ?? this.releasePlatform,
+        usedIgnoreAssetChangesFlag:
+            usedIgnoreAssetChangesFlag ?? this.usedIgnoreAssetChangesFlag,
+        hasAssetChanges: hasAssetChanges ?? this.hasAssetChanges,
+        usedIgnoreNativeChangesFlag:
+            usedIgnoreNativeChangesFlag ?? this.usedIgnoreNativeChangesFlag,
+        hasNativeChanges: hasNativeChanges ?? this.hasNativeChanges,
+        linkPercentage: linkPercentage ?? this.linkPercentage,
+        environment: environment ?? this.environment,
+      );
 
   /// The platform for which the patch was created.
   final ReleasePlatform releasePlatform;

--- a/packages/shorebird_code_push_protocol/lib/src/models/update_release_metadata.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/update_release_metadata.dart
@@ -20,8 +20,8 @@ class UpdateReleaseMetadata extends Equatable {
   const UpdateReleaseMetadata({
     required this.releasePlatform,
     required this.flutterVersionOverride,
-    required this.generatedApks,
     required this.environment,
+    this.generatedApks,
   });
 
   // coverage:ignore-start
@@ -47,6 +47,22 @@ class UpdateReleaseMetadata extends Equatable {
 
   /// Converts a [UpdateReleaseMetadata] to a Map<String, dynamic>.
   Map<String, dynamic> toJson() => _$UpdateReleaseMetadataToJson(this);
+
+  /// Returns a copy of this [UpdateReleaseMetadata] with the given fields
+  /// replaced by the new values.
+  UpdateReleaseMetadata copyWith({
+    ReleasePlatform? releasePlatform,
+    String? flutterVersionOverride,
+    bool? generatedApks,
+    BuildEnvironmentMetadata? environment,
+  }) =>
+      UpdateReleaseMetadata(
+        releasePlatform: releasePlatform ?? this.releasePlatform,
+        flutterVersionOverride:
+            flutterVersionOverride ?? this.flutterVersionOverride,
+        generatedApks: generatedApks ?? this.generatedApks,
+        environment: environment ?? this.environment,
+      );
 
   /// The platform for which the patch was created.
   final ReleasePlatform releasePlatform;

--- a/packages/shorebird_code_push_protocol/test/src/models/build_environment_metadata_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/build_environment_metadata_test.dart
@@ -19,6 +19,18 @@ void main() {
     });
 
     group('copyWith', () {
+      test('creates a copy with the same fields', () {
+        const metadata = BuildEnvironmentMetadata(
+          flutterRevision: '853d13d954df3b6e9c2f07b72062f33c52a9a64b',
+          operatingSystem: 'macos',
+          operatingSystemVersion: '1.2.3',
+          shorebirdVersion: '4.5.6',
+          xcodeVersion: '15.0',
+        );
+
+        expect(metadata.copyWith(), equals(metadata));
+      });
+
       test('returns a new instance with the given fields replaced', () {
         const metadata = BuildEnvironmentMetadata(
           flutterRevision: '853d13d954df3b6e9c2f07b72062f33c52a9a64b',

--- a/packages/shorebird_code_push_protocol/test/src/models/build_environment_metadata_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/build_environment_metadata_test.dart
@@ -28,18 +28,21 @@ void main() {
           xcodeVersion: '15.0',
         );
         final newMetadata = metadata.copyWith(
+          flutterRevision: 'asdf',
           operatingSystem: 'windows',
           operatingSystemVersion: '11',
+          shorebirdVersion: '1.2.3',
+          xcodeVersion: '14.0',
         );
         expect(
           newMetadata,
           equals(
-            BuildEnvironmentMetadata(
-              flutterRevision: metadata.flutterRevision,
-              shorebirdVersion: metadata.shorebirdVersion,
+            const BuildEnvironmentMetadata(
+              flutterRevision: 'asdf',
               operatingSystem: 'windows',
               operatingSystemVersion: '11',
-              xcodeVersion: metadata.xcodeVersion,
+              shorebirdVersion: '1.2.3',
+              xcodeVersion: '14.0',
             ),
           ),
         );

--- a/packages/shorebird_code_push_protocol/test/src/models/build_environment_metadata_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/build_environment_metadata_test.dart
@@ -18,6 +18,34 @@ void main() {
       );
     });
 
+    group('copyWith', () {
+      test('returns a new instance with the given fields replaced', () {
+        const metadata = BuildEnvironmentMetadata(
+          flutterRevision: '853d13d954df3b6e9c2f07b72062f33c52a9a64b',
+          operatingSystem: 'macos',
+          operatingSystemVersion: '1.2.3',
+          shorebirdVersion: '4.5.6',
+          xcodeVersion: '15.0',
+        );
+        final newMetadata = metadata.copyWith(
+          operatingSystem: 'windows',
+          operatingSystemVersion: '11',
+        );
+        expect(
+          newMetadata,
+          equals(
+            BuildEnvironmentMetadata(
+              flutterRevision: metadata.flutterRevision,
+              shorebirdVersion: metadata.shorebirdVersion,
+              operatingSystem: 'windows',
+              operatingSystemVersion: '11',
+              xcodeVersion: metadata.xcodeVersion,
+            ),
+          ),
+        );
+      });
+    });
+
     group('equatable', () {
       test('two metadatas with the same properties are equal', () {
         const metadata = BuildEnvironmentMetadata(

--- a/packages/shorebird_code_push_protocol/test/src/models/create_patch_metadata_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/create_patch_metadata_test.dart
@@ -26,6 +26,26 @@ void main() {
     });
 
     group('copyWith', () {
+      test('creates a copy with the same fields', () {
+        const metadata = CreatePatchMetadata(
+          releasePlatform: ReleasePlatform.android,
+          usedIgnoreAssetChangesFlag: false,
+          hasAssetChanges: false,
+          usedIgnoreNativeChangesFlag: false,
+          hasNativeChanges: false,
+          linkPercentage: 99.9,
+          environment: BuildEnvironmentMetadata(
+            flutterRevision: '853d13d954df3b6e9c2f07b72062f33c52a9a64b',
+            operatingSystem: 'macos',
+            operatingSystemVersion: '1.2.3',
+            shorebirdVersion: '4.5.6',
+            xcodeVersion: '15.0',
+          ),
+        );
+
+        expect(metadata.copyWith(), equals(metadata));
+      });
+
       test('creates a copy with the given fields replaced', () {
         const metadata = CreatePatchMetadata(
           releasePlatform: ReleasePlatform.android,

--- a/packages/shorebird_code_push_protocol/test/src/models/create_patch_metadata_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/create_patch_metadata_test.dart
@@ -25,6 +25,63 @@ void main() {
       );
     });
 
+    group('copyWith', () {
+      test('creates a copy with the given fields replaced', () {
+        const metadata = CreatePatchMetadata(
+          releasePlatform: ReleasePlatform.android,
+          usedIgnoreAssetChangesFlag: false,
+          hasAssetChanges: false,
+          usedIgnoreNativeChangesFlag: false,
+          hasNativeChanges: false,
+          linkPercentage: 99.9,
+          environment: BuildEnvironmentMetadata(
+            flutterRevision: '853d13d954df3b6e9c2f07b72062f33c52a9a64b',
+            operatingSystem: 'macos',
+            operatingSystemVersion: '1.2.3',
+            shorebirdVersion: '4.5.6',
+            xcodeVersion: '15.0',
+          ),
+        );
+
+        final newMetadata = metadata.copyWith(
+          releasePlatform: ReleasePlatform.ios,
+          usedIgnoreAssetChangesFlag: true,
+          hasAssetChanges: true,
+          usedIgnoreNativeChangesFlag: true,
+          hasNativeChanges: true,
+          linkPercentage: 99.8,
+          environment: const BuildEnvironmentMetadata(
+            flutterRevision: 'asdf',
+            operatingSystem: 'windows',
+            operatingSystemVersion: '11',
+            shorebirdVersion: '1.2.3',
+            xcodeVersion: '14.0',
+          ),
+        );
+
+        expect(
+          newMetadata,
+          equals(
+            const CreatePatchMetadata(
+              releasePlatform: ReleasePlatform.ios,
+              usedIgnoreAssetChangesFlag: true,
+              hasAssetChanges: true,
+              usedIgnoreNativeChangesFlag: true,
+              hasNativeChanges: true,
+              linkPercentage: 99.8,
+              environment: BuildEnvironmentMetadata(
+                flutterRevision: 'asdf',
+                operatingSystem: 'windows',
+                operatingSystemVersion: '11',
+                shorebirdVersion: '1.2.3',
+                xcodeVersion: '14.0',
+              ),
+            ),
+          ),
+        );
+      });
+    });
+
     group('equatable', () {
       test('two metadatas with the same properties are equal', () {
         const metadata = CreatePatchMetadata(

--- a/packages/shorebird_code_push_protocol/test/src/models/update_release_metadata_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/update_release_metadata_test.dart
@@ -23,6 +23,23 @@ void main() {
     });
 
     group('copyWith', () {
+      test('creates a copy with the same fields', () {
+        const metadata = UpdateReleaseMetadata(
+          releasePlatform: ReleasePlatform.android,
+          flutterVersionOverride: '1.2.3',
+          generatedApks: false,
+          environment: BuildEnvironmentMetadata(
+            flutterRevision: '853d13d954df3b6e9c2f07b72062f33c52a9a64b',
+            operatingSystem: 'macos',
+            operatingSystemVersion: '1.2.3',
+            shorebirdVersion: '4.5.6',
+            xcodeVersion: '15.0',
+          ),
+        );
+
+        expect(metadata.copyWith(), equals(metadata));
+      });
+
       test('creates a copy with the given fields replaced', () {
         const metadata = UpdateReleaseMetadata(
           releasePlatform: ReleasePlatform.android,

--- a/packages/shorebird_code_push_protocol/test/src/models/update_release_metadata_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/update_release_metadata_test.dart
@@ -22,6 +22,54 @@ void main() {
       );
     });
 
+    group('copyWith', () {
+      test('creates a copy with the given fields replaced', () {
+        const metadata = UpdateReleaseMetadata(
+          releasePlatform: ReleasePlatform.android,
+          flutterVersionOverride: '1.2.3',
+          generatedApks: false,
+          environment: BuildEnvironmentMetadata(
+            flutterRevision: '853d13d954df3b6e9c2f07b72062f33c52a9a64b',
+            operatingSystem: 'macos',
+            operatingSystemVersion: '1.2.3',
+            shorebirdVersion: '4.5.6',
+            xcodeVersion: '15.0',
+          ),
+        );
+
+        final newMetadata = metadata.copyWith(
+          releasePlatform: ReleasePlatform.ios,
+          flutterVersionOverride: '1.2.4',
+          generatedApks: true,
+          environment: const BuildEnvironmentMetadata(
+            flutterRevision: 'asdf',
+            operatingSystem: 'windows',
+            operatingSystemVersion: '11',
+            shorebirdVersion: '1.2.3',
+            xcodeVersion: '14.0',
+          ),
+        );
+
+        expect(
+          newMetadata,
+          equals(
+            const UpdateReleaseMetadata(
+              releasePlatform: ReleasePlatform.ios,
+              flutterVersionOverride: '1.2.4',
+              generatedApks: true,
+              environment: BuildEnvironmentMetadata(
+                flutterRevision: 'asdf',
+                operatingSystem: 'windows',
+                operatingSystemVersion: '11',
+                shorebirdVersion: '1.2.3',
+                xcodeVersion: '14.0',
+              ),
+            ),
+          ),
+        );
+      });
+    });
+
     group('equatable', () {
       test('two metadatas with the same properties are equal', () {
         const metadata = UpdateReleaseMetadata(


### PR DESCRIPTION
## Description

Shifts most of release and patch command metadata creation into the release and patch commands and away from the releasers and patchers.

Clears the way for https://github.com/shorebirdtech/shorebird/issues/2418

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
