### PR TITLE
feat: show progress when updating cache artifacts

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -213,7 +213,12 @@ allowed to access $storageUrl.''',
 
     final extractProgress = logger.progress('Extracting $fileName...');
     final artifactDirectory = Directory(p.dirname(file.path));
-    await extractArtifact(response.stream, artifactDirectory.path);
+    try {
+      await extractArtifact(response.stream, artifactDirectory.path);
+    } catch (_) {
+      extractProgress.fail();
+      rethrow;
+    }
 
     final expectedChecksum = checksum;
     if (expectedChecksum != null) {

--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -196,7 +196,6 @@ allowed to access $storageUrl.''',
     }
 
     if (response.statusCode != HttpStatus.ok) {
-      updateProgress.fail();
       if (!required && response.statusCode == HttpStatus.notFound) {
         logger.detail(
           '[cache] optional artifact: "$fileName" was not found, skipping...',
@@ -204,6 +203,7 @@ allowed to access $storageUrl.''',
         return;
       }
 
+      updateProgress.fail();
       throw CacheUpdateFailure(
         '''Failed to download $fileName: ${response.statusCode} ${response.reasonPhrase}''',
       );

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -32,6 +32,7 @@ void main() {
     late ShorebirdLogger logger;
     late Platform platform;
     late Process chmodProcess;
+    late Progress progress;
     late ShorebirdEnv shorebirdEnv;
     late ShorebirdProcess shorebirdProcess;
 
@@ -77,6 +78,7 @@ void main() {
       httpClient = MockHttpClient();
       logger = MockShorebirdLogger();
       platform = MockPlatform();
+      progress = MockProgress();
       shorebirdEnv = MockShorebirdEnv();
       shorebirdProcess = MockShorebirdProcess();
 
@@ -90,6 +92,7 @@ void main() {
         (invocation.namedArguments[#outputDirectory] as Directory)
             .createSync(recursive: true);
       });
+      when(() => logger.progress(any())).thenReturn(progress);
       when(
         () => shorebirdEnv.shorebirdEngineRevision,
       ).thenReturn(shorebirdEngineRevision);
@@ -375,6 +378,7 @@ void main() {
     late http.Client httpClient;
     late ShorebirdLogger logger;
     late Platform platform;
+    late Progress progress;
     late _TestCachedArtifact cachedArtifact;
 
     R runWithOverrides<R>(R Function() body) {
@@ -399,6 +403,7 @@ void main() {
       httpClient = MockHttpClient();
       logger = MockShorebirdLogger();
       platform = MockPlatform();
+      progress = MockProgress();
 
       when(() => httpClient.send(any())).thenAnswer(
         (_) async => http.StreamedResponse(
@@ -406,6 +411,9 @@ void main() {
           HttpStatus.notFound,
         ),
       );
+
+      when(() => logger.progress(any())).thenReturn(progress);
+
       cachedArtifact = _TestCachedArtifact(cache: cache, platform: platform);
     });
 

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -279,11 +279,31 @@ void main() {
           expect(patchArtifactDirectory.existsSync(), isTrue);
         });
 
+        group('when extraction fails', () {
+          setUp(() {
+            when(
+              () => artifactManager.extractZip(
+                zipFile: any(named: 'zipFile'),
+                outputDirectory: any(named: 'outputDirectory'),
+              ),
+            ).thenThrow(Exception('test'));
+          });
+
+          test('throws exception, logs failure', () async {
+            await expectLater(
+              () => runWithOverrides(cache.updateAll),
+              throwsException,
+            );
+            verify(() => progress.fail()).called(3);
+          });
+        });
+
         group('when checksum validation fails', () {
           setUp(() {
             when(() => checksumChecker.checkFile(any(), any()))
                 .thenReturn(false);
           });
+
           test('fails with the correct message', () async {
             await expectLater(
               () => runWithOverrides(cache.updateAll),
@@ -297,6 +317,8 @@ void main() {
                 ),
               ),
             );
+
+            verify(() => progress.fail()).called(3);
           });
         });
 


### PR DESCRIPTION
## Description

Shows output when updating cached artifacts to make the CLI instead of looking unresponsive.

![Screenshot 2024-08-27 at 11 37 33 AM](https://github.com/user-attachments/assets/0eacd655-74fb-4e7b-969c-d289741398c3)

Fixes https://github.com/shorebirdtech/shorebird/issues/2422

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
