### PR TITLE
chore: add settable delayFactor on cache.updateAll for tests

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -54,7 +54,14 @@ class Cache {
 
   void registerArtifact(CachedArtifact artifact) => _artifacts.add(artifact);
 
-  Future<void> updateAll() async {
+  /// Update all artifacts in the cache.
+  ///
+  /// [retryDelayFactor] is the delay between retries that doubles after every
+  /// attempt. The default from the retry package is 200ms. This is settable for
+  /// testing.
+  Future<void> updateAll([
+    Duration retryDelayFactor = const Duration(milliseconds: 200),
+  ]) async {
     for (final artifact in _artifacts) {
       if (await artifact.isValid()) {
         continue;
@@ -63,6 +70,7 @@ class Cache {
       await retry(
         artifact.update,
         maxAttempts: 3,
+        delayFactor: retryDelayFactor,
         onRetry: (e) {
           logger
             ..detail('Failed to update ${artifact.fileName}, retrying...')

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -193,7 +193,7 @@ void main() {
             const exception = SocketException('test');
             when(() => httpClient.send(any())).thenThrow(exception);
             await expectLater(
-              runWithOverrides(cache.updateAll),
+              runWithOverrides(() => cache.updateAll(Duration.zero)),
               throwsA(
                 isA<CacheUpdateFailure>().having(
                   (e) => e.message,
@@ -209,7 +209,7 @@ void main() {
             when(() => httpClient.send(any())).thenThrow(exception);
 
             await expectLater(
-              runWithOverrides(cache.updateAll),
+              runWithOverrides(() => cache.updateAll(Duration.zero)),
               throwsA(
                 isA<CacheUpdateFailure>(),
               ),
@@ -229,7 +229,7 @@ void main() {
             ),
           );
           await expectLater(
-            runWithOverrides(cache.updateAll),
+            runWithOverrides(() => cache.updateAll(Duration.zero)),
             throwsA(
               isA<CacheUpdateFailure>().having(
                 (e) => e.message,
@@ -260,7 +260,7 @@ void main() {
             },
           );
           await expectLater(
-            runWithOverrides(cache.updateAll),
+            runWithOverrides(() => cache.updateAll(Duration.zero)),
             completes,
           );
           verify(
@@ -275,7 +275,10 @@ void main() {
             () => cache.getArtifactDirectory('patch'),
           );
           expect(patchArtifactDirectory.existsSync(), isFalse);
-          await expectLater(runWithOverrides(cache.updateAll), completes);
+          await expectLater(
+            runWithOverrides(() => cache.updateAll(Duration.zero)),
+            completes,
+          );
           expect(patchArtifactDirectory.existsSync(), isTrue);
         });
 
@@ -291,7 +294,7 @@ void main() {
 
           test('throws exception, logs failure', () async {
             await expectLater(
-              () => runWithOverrides(cache.updateAll),
+              () => runWithOverrides(() => cache.updateAll(Duration.zero)),
               throwsException,
             );
             verify(() => progress.fail()).called(3);
@@ -306,7 +309,7 @@ void main() {
 
           test('fails with the correct message', () async {
             await expectLater(
-              () => runWithOverrides(cache.updateAll),
+              () => runWithOverrides(() => cache.updateAll(Duration.zero)),
               throwsA(
                 isA<CacheUpdateFailure>().having(
                   (e) => e.message,
@@ -325,7 +328,10 @@ void main() {
         test('pull correct artifact for MacOS', () async {
           setMockPlatform(Platform.macOS);
 
-          await expectLater(runWithOverrides(cache.updateAll), completes);
+          await expectLater(
+            runWithOverrides(() => cache.updateAll(Duration.zero)),
+            completes,
+          );
 
           final requests = verify(() => httpClient.send(captureAny()))
               .captured
@@ -348,7 +354,10 @@ void main() {
         test('pull correct artifact for Windows', () async {
           setMockPlatform(Platform.windows);
 
-          await expectLater(runWithOverrides(cache.updateAll), completes);
+          await expectLater(
+            runWithOverrides(() => cache.updateAll(Duration.zero)),
+            completes,
+          );
 
           final requests = verify(() => httpClient.send(captureAny()))
               .captured
@@ -371,7 +380,10 @@ void main() {
         test('pull correct artifact for Linux', () async {
           setMockPlatform(Platform.linux);
 
-          await expectLater(runWithOverrides(cache.updateAll), completes);
+          await expectLater(
+            runWithOverrides(() => cache.updateAll(Duration.zero)),
+            completes,
+          );
 
           final requests = verify(() => httpClient.send(captureAny()))
               .captured


### PR DESCRIPTION
## Description

This was making the cache tests very slow.

Before:

```
⑆ time dart run test test/src/cache_test.dart
00:06 +22: All tests passed!                                                                                                                                                                                                                     
dart run test test/src/cache_test.dart  1.35s user 0.24s system 21% cpu 7.527 total
```

After:

```
⑆ time dart run test test/src/cache_test.dart
00:00 +22: All tests passed!                                                                                                                                                                                                                     
dart run test test/src/cache_test.dart  1.35s user 0.25s system 121% cpu 1.318 total
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
