### PR TITLE
fix(shorebird_cli): fix an issue where ios releases could not properly parse a flutter hash

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -4,7 +4,6 @@ import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:shorebird_cli/src/archive_analysis/plist.dart';
 import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
@@ -82,8 +81,9 @@ To change the version of this release, change your app's version in your pubspec
 
     final flutterVersionArg = argResults['flutter-version'] as String?;
     if (flutterVersionArg != null) {
-      if (Version.parse(flutterVersionArg) <
-          minimumSupportedIosFlutterVersion) {
+      final version =
+          await shorebirdFlutter.resolveFlutterVersion(flutterVersionArg);
+      if (version != null && version < minimumSupportedIosFlutterVersion) {
         logger.err(
           '''
 iOS releases are not supported with Flutter versions older than $minimumSupportedIosFlutterVersion.

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -9,7 +9,6 @@ import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
-import 'package:shorebird_cli/src/extensions/version.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/platform.dart';
@@ -306,16 +305,9 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
       return shorebirdEnv.flutterRevision;
     }
 
-    final parsedVersion = tryParseVersion(flutterVersionArg!);
-    if (parsedVersion == null) {
-      // If we fail to parse flutterVersionArg as a semver version, attempt to
-      // use the provided value as a revision.
-      return flutterVersionArg!;
-    }
-
     final String? revision;
     try {
-      revision = await shorebirdFlutter.getRevisionForVersion(
+      revision = await shorebirdFlutter.resolveFlutterRevision(
         flutterVersionArg!,
       );
     } catch (error) {

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -217,9 +217,14 @@ class ShorebirdFlutter {
     }
 
     // If we were unable to parse the version, assume it's a revision hash.
-    final version = await getVersionForRevision(flutterRevision: versionOrHash);
-    if (version != null) {
-      return versionOrHash;
+    try {
+      final version =
+          await getVersionForRevision(flutterRevision: versionOrHash);
+      if (version != null) {
+        return versionOrHash;
+      }
+    } catch (_) {
+      return null;
     }
 
     return null;
@@ -235,10 +240,14 @@ class ShorebirdFlutter {
       return parsedVersion;
     }
 
-    // If we were unable to parse the version, assume it's a revision hash.
-    final versionString =
-        await getVersionForRevision(flutterRevision: versionOrHash);
-    return versionString != null ? tryParseVersion(versionString) : null;
+    try {
+      // If we were unable to parse the version, assume it's a revision hash.
+      final versionString =
+          await getVersionForRevision(flutterRevision: versionOrHash);
+      return versionString != null ? tryParseVersion(versionString) : null;
+    } catch (_) {
+      return null;
+    }
   }
 
   /// Returns the git revision for the provided [version].

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -7,6 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
+import 'package:shorebird_cli/src/extensions/version.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -203,6 +204,41 @@ class ShorebirdFlutter {
         .map((e) => e.replaceFirst('origin/flutter_release/', ''))
         .toList()
         .firstOrNull;
+  }
+
+  /// Translates [versionOrHash] into a Flutter revision. If this is a semver
+  /// version, it will simply parse that into a [Version]. If not, it will
+  /// attempt to look up the Flutter version for the provided revision hash and
+  /// return the hash if a version is found, or null if not.
+  Future<String?> resolveFlutterRevision(String versionOrHash) async {
+    final parsedVersion = tryParseVersion(versionOrHash);
+    if (parsedVersion != null) {
+      return getRevisionForVersion(versionOrHash);
+    }
+
+    // If we were unable to parse the version, assume it's a revision hash.
+    final version = await getVersionForRevision(flutterRevision: versionOrHash);
+    if (version != null) {
+      return versionOrHash;
+    }
+
+    return null;
+  }
+
+  /// Translates [versionOrHash] into a Flutter [Version]. If [versionOrHash]
+  /// is semver version string, it will simply parse that into a [Version]. If
+  /// not, it will assume that the input is a git commit hash and attempt to
+  /// map it to a Flutter version.
+  Future<Version?> resolveFlutterVersion(String versionOrHash) async {
+    final parsedVersion = tryParseVersion(versionOrHash);
+    if (parsedVersion != null) {
+      return parsedVersion;
+    }
+
+    // If we were unable to parse the version, assume it's a revision hash.
+    final versionString =
+        await getVersionForRevision(flutterRevision: versionOrHash);
+    return versionString != null ? tryParseVersion(versionString) : null;
   }
 
   /// Returns the git revision for the provided [version].

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -7,6 +7,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
@@ -123,9 +124,13 @@ void main() {
       });
 
       group('assertPreconditions', () {
+        final flutterVersion = Version(3, 0, 0);
+
         setUp(() {
           when(() => doctor.iosCommandValidators)
               .thenReturn([flutterValidator]);
+          when(() => shorebirdFlutter.resolveFlutterVersion(any()))
+              .thenAnswer((_) async => flutterVersion);
           when(flutterValidator.validate).thenAnswer((_) async => []);
         });
 

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -441,7 +441,7 @@ Note: ${lightCyan.wrap('shorebird patch --platforms=android --flavor=$flavor --t
         final exception = Exception('oops');
         setUp(() {
           when(
-            () => shorebirdFlutter.getRevisionForVersion(any()),
+            () => shorebirdFlutter.resolveFlutterRevision(any()),
           ).thenThrow(exception);
         });
 
@@ -463,7 +463,7 @@ $exception''',
       group('when flutter version is not supported', () {
         setUp(() {
           when(
-            () => shorebirdFlutter.getRevisionForVersion(any()),
+            () => shorebirdFlutter.resolveFlutterRevision(any()),
           ).thenAnswer((_) async => null);
         });
 
@@ -484,7 +484,7 @@ $exception''',
         const revision = '771d07b2cf';
         setUp(() {
           when(
-            () => shorebirdFlutter.getRevisionForVersion(any()),
+            () => shorebirdFlutter.resolveFlutterRevision(any()),
           ).thenAnswer((_) async => revision);
         });
 
@@ -520,28 +520,6 @@ $exception''',
             verify(
               () => shorebirdFlutter.installRevision(revision: revision),
             ).called(1);
-          });
-        });
-
-        group('when flutter-version is a git hash', () {
-          const revision = 'deadbeef';
-          setUp(() {
-            when(() => argResults['flutter-version']).thenReturn(revision);
-          });
-
-          test(
-              '''installs the flutter version with the provided revision and completes''',
-              () async {
-            await runWithOverrides(command.run);
-
-            verify(() => shorebirdFlutter.installRevision(revision: revision))
-                .called(1);
-            // We should never attempt to treat this as a semver version.
-            verifyNever(
-              () => shorebirdFlutter.getVersionForRevision(
-                flutterRevision: any(named: 'flutterRevision'),
-              ),
-            );
           });
         });
       });


### PR DESCRIPTION
## Description

Updates `IosReleaser` to accept either a Flutter semver version or a git commit hash for the `flutter-version` arg. 

Fixes the issue reported in https://discord.com/channels/1030243211995791380/1280434876813938749

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
