### PR TITLE
chore: remove unused arg to confirmUnpatchableDiffsIfNecessary

### DIFF
--- a/packages/shorebird_cli/lib/src/patch_diff_checker.dart
+++ b/packages/shorebird_cli/lib/src/patch_diff_checker.dart
@@ -50,7 +50,6 @@ class PatchDiffChecker {
     required ArchiveDiffer archiveDiffer,
     required bool allowAssetChanges,
     required bool allowNativeChanges,
-    bool checkAssetChanges = true,
     bool confirmNativeChanges = true,
   }) async {
     final progress =
@@ -96,7 +95,7 @@ If you don't know why you're seeing this error, visit our troubleshooting page a
       }
     }
 
-    if (status.hasAssetChanges && checkAssetChanges) {
+    if (status.hasAssetChanges) {
       logger
         ..warn(
           '''Your app contains asset changes, which will not be included in the patch.''',


### PR DESCRIPTION
## Description

The `checkAssetChanges` arg isn't used anywhere, removing it.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
