### PR TITLE
feat(shorebird_code_push_client): add support for fetching organization memberships

### DIFF
--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -477,6 +477,22 @@ class CodePushClient {
     }
   }
 
+  /// Gets the list of organizations the user is a member of, along with the
+  /// user's role in each organization.
+  Future<List<OrganizationMembership>> getOrganizationMemberships() async {
+    final response = await _httpClient.get(
+      Uri.parse('$_v1/organizations'),
+    );
+
+    if (!response.isSuccess) {
+      throw _parseErrorResponse(response.statusCode, response.body);
+    }
+
+    return GetOrganizationsResponse.fromJson(
+      json.decode(response.body) as Map<String, dynamic>,
+    ).organizations;
+  }
+
   /// Closes the client.
   void close() => _httpClient.close();
 

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -1914,7 +1914,7 @@ void main() {
     });
 
     group('getOrganizationMemberships', () {
-      group('when repsonse is not success', () {
+      group('when response is not success', () {
         setUp(() {
           when(() => httpClient.send(any())).thenAnswer(
             (_) async => http.StreamedResponse(

--- a/packages/shorebird_code_push_protocol/lib/src/models/organization.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/organization.dart
@@ -1,3 +1,4 @@
+import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
@@ -35,7 +36,7 @@ enum OrganizationType {
 /// [stripeCustomerId] may have a subscription.
 /// {@endtemplate}
 @JsonSerializable()
-class Organization {
+class Organization extends Equatable {
   /// {@macro organization}
   const Organization({
     required this.id,
@@ -91,4 +92,14 @@ class Organization {
 
   /// When this organization was last updated.
   final DateTime updatedAt;
+
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        organizationType,
+        stripeCustomerId,
+        createdAt,
+        updatedAt,
+      ];
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/organization_membership.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/organization_membership.dart
@@ -1,3 +1,4 @@
+import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:shorebird_code_push_protocol/src/models/organization.dart';
 
@@ -7,9 +8,9 @@ part 'organization_membership.g.dart';
 /// An organization and the current user's role in that organization.
 /// {@endtemplate}
 @JsonSerializable()
-class OrganizationMembership {
+class OrganizationMembership extends Equatable {
   /// {@macro organization_membership}
-  OrganizationMembership({
+  const OrganizationMembership({
     required this.organization,
     required this.role,
   });
@@ -26,4 +27,10 @@ class OrganizationMembership {
 
   /// The user's role in the organization.
   final OrganizationRole role;
+
+  @override
+  List<Object?> get props => [
+        organization,
+        role,
+      ];
 }

--- a/packages/shorebird_code_push_protocol/test/src/models/organization_membership_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/organization_membership_test.dart
@@ -13,5 +13,49 @@ void main() {
         equals(membership.toJson()),
       );
     });
+
+    group('Equatable', () {
+      final date = DateTime.now();
+
+      group('when two instances are equal', () {
+        test('returns true', () {
+          final membership = OrganizationMembership(
+            organization: Organization.forTest(
+              createdAt: date,
+              updatedAt: date,
+            ),
+            role: OrganizationRole.member,
+          );
+          final otherMembership = OrganizationMembership(
+            organization: Organization.forTest(
+              createdAt: date,
+              updatedAt: date,
+            ),
+            role: OrganizationRole.member,
+          );
+          expect(membership, equals(otherMembership));
+        });
+      });
+
+      group('when two instances are not equal', () {
+        test('returns false', () {
+          final membership = OrganizationMembership(
+            organization: Organization.forTest(
+              createdAt: date,
+              updatedAt: date,
+            ),
+            role: OrganizationRole.member,
+          );
+          final otherMembership = OrganizationMembership(
+            organization: Organization.forTest(
+              createdAt: date,
+              updatedAt: date,
+            ),
+            role: OrganizationRole.admin,
+          );
+          expect(membership, isNot(equals(otherMembership)));
+        });
+      });
+    });
   });
 }

--- a/packages/shorebird_code_push_protocol/test/src/models/organization_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/organization_test.dart
@@ -17,5 +17,53 @@ void main() {
         equals(organization.toJson()),
       );
     });
+
+    group('Equatable', () {
+      final date = DateTime.now();
+
+      group('when two instances are equal', () {
+        test('returns true', () {
+          final organization = Organization(
+            id: 1,
+            name: 'name',
+            createdAt: date,
+            updatedAt: date,
+            organizationType: OrganizationType.team,
+            stripeCustomerId: 'cus_123',
+          );
+          final otherOrganization = Organization(
+            id: 1,
+            name: 'name',
+            createdAt: date,
+            updatedAt: date,
+            organizationType: OrganizationType.team,
+            stripeCustomerId: 'cus_123',
+          );
+          expect(organization, equals(otherOrganization));
+        });
+      });
+
+      group('when two instances are not equal', () {
+        test('returns false', () {
+          final organization = Organization(
+            id: 1,
+            name: 'name',
+            createdAt: date,
+            updatedAt: date,
+            organizationType: OrganizationType.team,
+            stripeCustomerId: 'cus_123',
+          );
+          final otherOrganization = Organization(
+            id: 1,
+            name: 'name',
+            createdAt: date,
+            updatedAt: date,
+            organizationType: OrganizationType.team,
+            stripeCustomerId: 'cus_456',
+          );
+          expect(organization, isNot(equals(otherOrganization)));
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

Adds the `getOrganizationMemberships` function to `CodePushClient`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
