### PR TITLE
feat: add optional organization id field to create app request

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_app/create_app_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_app/create_app_request.dart
@@ -8,7 +8,10 @@ part 'create_app_request.g.dart';
 @JsonSerializable()
 class CreateAppRequest {
   /// {@macro create_app_request}
-  const CreateAppRequest({required this.displayName});
+  const CreateAppRequest({
+    required this.displayName,
+    this.organizationId,
+  });
 
   /// Converts a Map<String, dynamic> to a [CreateAppRequest]
   factory CreateAppRequest.fromJson(Map<String, dynamic> json) =>
@@ -19,4 +22,8 @@ class CreateAppRequest {
 
   /// The display name of the app.
   final String displayName;
+
+  /// The id of organization that this app will belong to. If no id is provided,
+  /// this app will belong to the user's personal organization.
+  final int? organizationId;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_app/create_app_request.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_app/create_app_request.g.dart
@@ -15,13 +15,19 @@ CreateAppRequest _$CreateAppRequestFromJson(Map<String, dynamic> json) =>
       ($checkedConvert) {
         final val = CreateAppRequest(
           displayName: $checkedConvert('display_name', (v) => v as String),
+          organizationId:
+              $checkedConvert('organization_id', (v) => (v as num?)?.toInt()),
         );
         return val;
       },
-      fieldKeyMap: const {'displayName': 'display_name'},
+      fieldKeyMap: const {
+        'displayName': 'display_name',
+        'organizationId': 'organization_id'
+      },
     );
 
 Map<String, dynamic> _$CreateAppRequestToJson(CreateAppRequest instance) =>
     <String, dynamic>{
       'display_name': instance.displayName,
+      'organization_id': instance.organizationId,
     };


### PR DESCRIPTION
## Description

Adds an optional `organizationId` field to `CreateAppRequest`. If unspecified, the newly created app will belong to the creating user's personal organization.

`organizationId` is optional to keep this from being a breaking change.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
