### PR TITLE
fix: change "Creating Artifacts" to "Uploading Artifacts"

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -412,7 +412,7 @@ Please create a release using "shorebird release" and try again.
     required Iterable<Arch> architectures,
     String? flavor,
   }) async {
-    final createArtifactProgress = logger.progress('Creating artifacts');
+    final createArtifactProgress = logger.progress('Uploading artifacts');
     final archsDir = ArtifactManager.androidArchsDirectory(
       projectRoot: Directory(projectRoot),
       flavor: flavor,
@@ -511,7 +511,7 @@ aab artifact already exists, continuing...''',
     required String extractedAarDir,
     required Iterable<Arch> architectures,
   }) async {
-    final createArtifactProgress = logger.progress('Creating artifacts');
+    final createArtifactProgress = logger.progress('Uploading artifacts');
 
     for (final arch in architectures) {
       final artifactPath = p.join(
@@ -606,7 +606,7 @@ aar artifact already exists, continuing...''',
     required bool isCodesigned,
     required String? podfileLockHash,
   }) async {
-    final createArtifactProgress = logger.progress('Creating artifacts');
+    final createArtifactProgress = logger.progress('Uploading artifacts');
     final thinnedArchiveDirectory =
         await _thinXcarchive(xcarchivePath: xcarchivePath);
     final zippedArchive = await thinnedArchiveDirectory.zipToTempFile();
@@ -658,7 +658,7 @@ aar artifact already exists, continuing...''',
     required int releaseId,
     required String appFrameworkPath,
   }) async {
-    final createArtifactProgress = logger.progress('Creating artifacts');
+    final createArtifactProgress = logger.progress('Uploading artifacts');
     final appFrameworkDirectory = Directory(appFrameworkPath);
     await Isolate.run(
       () => ZipFileEncoder().zipDirectory(appFrameworkDirectory),

--- a/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
@@ -138,7 +138,7 @@ class AarPatcher extends Patcher {
     );
     final patchArtifactBundles = <Arch, PatchArtifactBundle>{};
 
-    final createDiffProgress = logger.progress('Creating artifacts');
+    final createDiffProgress = logger.progress('Uploading artifacts');
     for (final releaseArtifactPath in releaseArtifactPaths.entries) {
       final arch = releaseArtifactPath.key;
       final artifactPath = p.join(

--- a/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
@@ -121,7 +121,7 @@ class AarReleaser extends Releaser {
     required Release release,
     required String appId,
   }) async {
-    final extractAarProgress = logger.progress('Creating artifacts');
+    final extractAarProgress = logger.progress('Uploading artifacts');
     final extractedAarDir = await shorebirdAndroidArtifacts.extractAar(
       packageName: shorebirdEnv.androidPackageName!,
       buildNumber: buildNumber,


### PR DESCRIPTION
Customers sometimes get stuck on the "Creating Artifacts" step
which I believe to be due to networking issues.  Saying
"Uploading" instead of Creating might help customers understand
that the network is involved in the "creation".
