### PR TITLE
fix: add CDN and google storage to network checker

### DIFF
--- a/packages/shorebird_cli/lib/src/network_checker.dart
+++ b/packages/shorebird_cli/lib/src/network_checker.dart
@@ -18,6 +18,8 @@ class NetworkChecker {
     'https://api.shorebird.dev',
     'https://console.shorebird.dev',
     'https://oauth2.googleapis.com',
+    'https://storage.googleapis.com',
+    'https://cdn.shorebird.cloud',
   ].map(Uri.parse).toList();
 
   /// Verify that each of [urlsToCheck] responds to an HTTP GET request.


### PR DESCRIPTION
Followup on https://github.com/shorebirdtech/shorebird/pull/2537