### PR TITLE
fix(shorebird_cli): use exe extension for patch executable on Windows

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -305,7 +305,7 @@ class PatchArtifact extends CachedArtifact {
   PatchArtifact({required super.cache, required super.platform});
 
   @override
-  String get fileName => 'patch';
+  String get fileName => platform.isWindows ? 'patch.exe' : 'patch';
 
   @override
   bool get isExecutable => true;

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -354,7 +354,7 @@ void main() {
           });
         });
 
-        test('pull correct artifact for MacOS', () async {
+        test('pulls correct artifact for MacOS', () async {
           setMockPlatform(Platform.macOS);
 
           await expectLater(
@@ -380,7 +380,7 @@ void main() {
           expect(requests, equals(expected));
         });
 
-        test('pull correct artifact for Windows', () async {
+        test('pulls correct artifact for Windows', () async {
           setMockPlatform(Platform.windows);
 
           await expectLater(
@@ -406,7 +406,7 @@ void main() {
           expect(requests, equals(expected));
         });
 
-        test('pull correct artifact for Linux', () async {
+        test('pulls correct artifact for Linux', () async {
           setMockPlatform(Platform.linux);
 
           await expectLater(

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -188,6 +188,34 @@ void main() {
 
     group('updateAll', () {
       group('patch', () {
+        group('fileName', () {
+          group(
+            'when on Windows',
+            () {
+              test('has exe extension', () {
+                final artifact =
+                    PatchArtifact(cache: cache, platform: platform);
+                expect(artifact.fileName, equals('patch.exe'));
+              });
+            },
+            testOn: 'windows',
+          );
+
+          group(
+            'when not on Windows',
+            () {
+              test('does not have exe extension', () {
+                final artifact =
+                    PatchArtifact(cache: cache, platform: platform);
+                expect(artifact.fileName, equals('patch'));
+              });
+            },
+            onPlatform: {
+              'windows': const Skip(),
+            },
+          );
+        });
+
         group('when an exception happens', () {
           test('throws CacheUpdateFailure', () async {
             const exception = SocketException('test');

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -189,31 +189,31 @@ void main() {
     group('updateAll', () {
       group('patch', () {
         group('fileName', () {
-          group(
-            'when on Windows',
-            () {
-              test('has exe extension', () {
-                final artifact =
-                    PatchArtifact(cache: cache, platform: platform);
-                expect(artifact.fileName, equals('patch.exe'));
-              });
-            },
-            testOn: 'windows',
-          );
+          group('when on Windows', () {
+            setUp(() {
+              setMockPlatform(Platform.windows);
+            });
 
-          group(
-            'when not on Windows',
-            () {
-              test('does not have exe extension', () {
-                final artifact =
-                    PatchArtifact(cache: cache, platform: platform);
-                expect(artifact.fileName, equals('patch'));
-              });
-            },
-            onPlatform: {
-              'windows': const Skip(),
-            },
-          );
+            test('has exe extension', () {
+              final fileName = runWithOverrides(
+                () => PatchArtifact(cache: cache, platform: platform).fileName,
+              );
+              expect(fileName, equals('patch.exe'));
+            });
+          });
+
+          group('when not on Windows', () {
+            setUp(() {
+              setMockPlatform(Platform.linux);
+            });
+
+            test('does not have exe extension', () {
+              final fileName = runWithOverrides(
+                () => PatchArtifact(cache: cache, platform: platform).fileName,
+              );
+              expect(fileName, equals('patch'));
+            });
+          });
         });
 
         group('when an exception happens', () {


### PR DESCRIPTION
## Description

The patch artifact has an exe extension on Windows, which is causing the artifact's existence check to always fail. This change conditionally adds `.exe` to the file name when running on Windows.

Fixes https://github.com/shorebirdtech/shorebird/issues/2546

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
