### PR TITLE
fix: enforce minimum iOS version on iOS framework release

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
@@ -13,7 +13,9 @@ import 'package:shorebird_cli/src/executables/xcodebuild.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logger.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
+import 'package:shorebird_cli/src/platform/ios.dart';
 import 'package:shorebird_cli/src/release_type.dart';
+import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
@@ -61,6 +63,20 @@ class IosFrameworkReleaser extends Releaser {
       );
     } on PreconditionFailedException catch (e) {
       throw ProcessExit(e.exitCode.code);
+    }
+
+    final flutterVersionArg = argResults['flutter-version'] as String?;
+    if (flutterVersionArg != null) {
+      final version =
+          await shorebirdFlutter.resolveFlutterVersion(flutterVersionArg);
+      if (version != null && version < minimumSupportedIosFlutterVersion) {
+        logger.err(
+          '''
+iOS releases are not supported with Flutter versions older than $minimumSupportedIosFlutterVersion.
+For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
+        );
+        throw ProcessExit(ExitCode.usage.code);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

We are not currently enforcing the minimum supported iOS version for iOS framework releases. This PR fixes that.

Fixes https://github.com/shorebirdtech/shorebird/issues/2559

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
