### PR TITLE
fix: close IO sink after download finishes or fails

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_manager.dart
+++ b/packages/shorebird_cli/lib/src/artifact_manager.dart
@@ -79,7 +79,12 @@ class ArtifactManager {
       outFile.createSync();
     }
 
-    await outFile.openWrite().addStream(response.stream);
+    final ioSink = outFile.openWrite();
+    try {
+      await ioSink.addStream(response.stream);
+    } finally {
+      await ioSink.close();
+    }
     return outFile;
   }
 


### PR DESCRIPTION
## Description

Close the IOSink we create in `ArtifactManager.downloadFile` after the write either completes or fails.

Fixes this issue when running `shorebird doctor -v`:

```
Network Speed
✓ GCP Upload Speed: 7.08 MB/s (0.9s)
✗ GCP download speed test failed: PathAccessException: Cannot delete file, path = 'C:\Users\bryan\AppData\Local\Temp\71835ee1\speed_test_file' (OS Error: The process cannot access the file because it is being used by another process.
, errno = 32) (1.3s)

✓ Shorebird is up-to-date (1.5s)
✓ Flutter install is correct (2.4s)
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
