### PR TITLE
feat: show download progress when downloading patch artifacts

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_manager.dart
+++ b/packages/shorebird_cli/lib/src/artifact_manager.dart
@@ -18,6 +18,9 @@ final artifactManagerRef = create(ArtifactManager.new);
 /// The [ArtifactManager] instance available in the current zone.
 ArtifactManager get artifactManager => read(artifactManagerRef);
 
+/// A callback that reports progress as a double between 0 and 1.
+typedef ProgressCallback = void Function(double progress);
+
 /// Manages artifacts for the Shorebird CLI.
 class ArtifactManager {
   /// Generates a binary diff between two files and returns the path to the
@@ -59,7 +62,7 @@ class ArtifactManager {
   Future<File> downloadFile(
     Uri uri, {
     String? outputPath,
-    void Function(double)? onProgress,
+    ProgressCallback? onProgress,
   }) async {
     final request = http.Request('GET', uri);
     final response = await httpClient.send(request);

--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -127,11 +127,19 @@ Looked in:
     final downloadReleaseArtifactProgress = logger.progress(
       'Downloading release artifacts',
     );
+    final numArtifacts = releaseArtifacts.length;
 
-    for (final releaseArtifact in releaseArtifacts.entries) {
+    for (final (i, releaseArtifact) in releaseArtifacts.entries.indexed) {
+      final baseMessage = 'Downloading release artifact ${i + 1}/$numArtifacts';
       try {
+        downloadReleaseArtifactProgress.update(baseMessage);
         final releaseArtifactFile = await artifactManager.downloadFile(
           Uri.parse(releaseArtifact.value.url),
+          onProgress: (progress) {
+            downloadReleaseArtifactProgress.update(
+              '$baseMessage (${(progress * 100).toStringAsFixed(0)}%)',
+            );
+          },
         );
         releaseArtifactPaths[releaseArtifact.key] = releaseArtifactFile.path;
       } catch (error) {

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -451,12 +451,18 @@ ${summary.join('\n')}
     required ReleaseArtifact releaseArtifact,
     required Patcher patcher,
   }) async {
-    final downloadProgress =
-        logger.progress('Downloading ${patcher.primaryReleaseArtifactArch}');
+    final downloadMessage = 'Downloading ${patcher.primaryReleaseArtifactArch}';
+    final downloadProgress = logger.progress(downloadMessage);
     final File artifactFile;
     try {
-      artifactFile =
-          await artifactManager.downloadFile(Uri.parse(releaseArtifact.url));
+      artifactFile = await artifactManager.downloadFile(
+        Uri.parse(releaseArtifact.url),
+        onProgress: (progress) {
+          downloadProgress.update(
+            '$downloadMessage (${(progress * 100).toStringAsFixed(0)}%)',
+          );
+        },
+      );
     } catch (e) {
       downloadProgress.fail(e.toString());
       throw ProcessExit(ExitCode.software.code);

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -439,14 +439,21 @@ Looked in:
             Arch.x86_64: releaseArtifact,
           },
         );
-        when(() => artifactManager.downloadFile(any()))
-            .thenAnswer((_) async => File(''));
+        when(
+          () => artifactManager.downloadFile(
+            any(),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer((_) async => File(''));
       });
 
       group('when release artifact fails to download', () {
         setUp(() {
           when(
-            () => artifactManager.downloadFile(any()),
+            () => artifactManager.downloadFile(
+              any(),
+              onProgress: any(named: 'onProgress'),
+            ),
           ).thenThrow(Exception('error'));
         });
 

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -551,6 +551,31 @@ Looked in:
           }
         });
 
+        test('updates progress with download percentage', () async {
+          await runWithOverrides(
+            () => patcher.createPatchArtifacts(
+              appId: 'appId',
+              releaseId: 0,
+              releaseArtifact: File('release.aab'),
+            ),
+          );
+
+          final capturedOnProgress = verify(
+            () => artifactManager.downloadFile(
+              any(),
+              onProgress: captureAny(named: 'onProgress'),
+            ),
+          ).captured.first as ProgressCallback;
+
+          capturedOnProgress(0.5);
+
+          verify(
+            () => progress.update(
+              'Downloading release artifact 1/3 (50%)',
+            ),
+          ).called(1);
+        });
+
         group('when a private key is provided', () {
           setUp(() {
             final privateKey = File(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -975,5 +975,32 @@ Please re-run the release command for this version or create a new release.''',
         ).called(1);
       });
     });
+
+    group('downloadPrimaryReleaseArtifact', () {
+      setUp(() {
+        final releaseArtifact = MockReleaseArtifact();
+        when(() => releaseArtifact.url).thenReturn('http://example.com');
+      });
+
+      test('updates progress with download percentage', () async {
+        await runWithOverrides(
+          () => command.downloadPrimaryReleaseArtifact(
+            releaseArtifact: releaseArtifact,
+            patcher: patcher,
+          ),
+        );
+
+        final capturedOnProgress = verify(
+          () => artifactManager.downloadFile(
+            Uri.parse(releaseArtifact.url),
+            onProgress: captureAny(named: 'onProgress'),
+          ),
+        ).captured.single as ProgressCallback;
+
+        capturedOnProgress(0.5);
+
+        verify(() => progress.update('Downloading aab (50%)')).called(1);
+      });
+    });
   });
 }

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -169,7 +169,10 @@ void main() {
       when(aotTools.isLinkDebugInfoSupported).thenAnswer((_) async => true);
 
       when(
-        () => artifactManager.downloadFile(any()),
+        () => artifactManager.downloadFile(
+          any(),
+          onProgress: any(named: 'onProgress'),
+        ),
       ).thenAnswer((_) async => File(''));
 
       when(() => cache.updateAll()).thenAnswer((_) async => {});
@@ -888,7 +891,12 @@ Please re-run the release command for this version or create a new release.''',
       final error = Exception('Failed to download primary release artifact.');
 
       setUp(() {
-        when(() => artifactManager.downloadFile(any())).thenThrow(error);
+        when(
+          () => artifactManager.downloadFile(
+            any(),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenThrow(error);
       });
 
       test('logs error and exits with code 70', () async {


### PR DESCRIPTION
## Description

Updates `ArtifactManager.downloadFile` to accept an `onProgress` callback, which is used by the patch command and the android patcher to display download progress.

I hope for this to be helpful in diagnosing https://github.com/shorebirdtech/shorebird/issues/2532

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
