### PR TITLE
fix: changes download progress printing to update less frequently

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_manager.dart
+++ b/packages/shorebird_cli/lib/src/artifact_manager.dart
@@ -133,7 +133,9 @@ class ArtifactManager {
           }
         }
       } finally {
-        await progressStreamController.close();
+        // Don't await, as this future will never complete if there are no
+        // listeners.
+        unawaited(progressStreamController.close());
         await ioSink.close();
       }
 

--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -124,31 +124,20 @@ Looked in:
       platform: releaseType.releasePlatform,
     );
     final releaseArtifactPaths = <Arch, String>{};
-    final downloadReleaseArtifactProgress = logger.progress(
-      'Downloading release artifacts',
-    );
     final numArtifacts = releaseArtifacts.length;
 
     for (final (i, releaseArtifact) in releaseArtifacts.entries.indexed) {
-      final baseMessage = 'Downloading release artifact ${i + 1}/$numArtifacts';
       try {
-        downloadReleaseArtifactProgress.update(baseMessage);
-        final releaseArtifactFile = await artifactManager.downloadFile(
+        final releaseArtifactFile =
+            await artifactManager.downloadWithProgressUpdates(
           Uri.parse(releaseArtifact.value.url),
-          onProgress: (progress) {
-            downloadReleaseArtifactProgress.update(
-              '$baseMessage (${(progress * 100).toStringAsFixed(0)}%)',
-            );
-          },
+          message: 'Downloading release artifact ${i + 1}/$numArtifacts',
         );
         releaseArtifactPaths[releaseArtifact.key] = releaseArtifactFile.path;
       } catch (error) {
-        downloadReleaseArtifactProgress.fail('$error');
         throw ProcessExit(ExitCode.software.code);
       }
     }
-
-    downloadReleaseArtifactProgress.complete();
 
     final patchArchsBuildDir = ArtifactManager.androidArchsDirectory(
       projectRoot: projectRoot,

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -451,24 +451,16 @@ ${summary.join('\n')}
     required ReleaseArtifact releaseArtifact,
     required Patcher patcher,
   }) async {
-    final downloadMessage = 'Downloading ${patcher.primaryReleaseArtifactArch}';
-    final downloadProgress = logger.progress(downloadMessage);
     final File artifactFile;
     try {
-      artifactFile = await artifactManager.downloadFile(
+      artifactFile = await artifactManager.downloadWithProgressUpdates(
         Uri.parse(releaseArtifact.url),
-        onProgress: (progress) {
-          downloadProgress.update(
-            '$downloadMessage (${(progress * 100).toStringAsFixed(0)}%)',
-          );
-        },
+        message: 'Downloading ${patcher.primaryReleaseArtifactArch}',
       );
-    } catch (e) {
-      downloadProgress.fail(e.toString());
+    } catch (_) {
       throw ProcessExit(ExitCode.software.code);
     }
 
-    downloadProgress.complete();
     return artifactFile;
   }
 }

--- a/packages/shorebird_cli/pubspec.lock
+++ b/packages/shorebird_cli/pubspec.lock
@@ -695,7 +695,7 @@ packages:
     source: hosted
     version: "2.1.2"
   stream_transform:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: stream_transform
       sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
     path: ../shorebird_code_push_client
   shorebird_code_push_protocol:
     path: ../shorebird_code_push_protocol
+  stream_transform: ^2.1.0
   uuid: ^4.5.1
   xml: ^6.5.0
   yaml: ^3.1.2

--- a/packages/shorebird_cli/test/src/artifact_manager_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_manager_test.dart
@@ -366,10 +366,10 @@ void main() {
             ..add([1])
             ..add([1])
             ..add([1]);
-          await Future<void>.delayed(const Duration(milliseconds: 60));
+          await Future<void>.delayed(const Duration(milliseconds: 70));
           // Download the last 2/5, bringing the total to 5/5
           responseStreamController.add([1, 1]);
-          await Future<void>.delayed(const Duration(milliseconds: 60));
+          await Future<void>.delayed(const Duration(milliseconds: 70));
           verifyInOrder([
             () => progress.update('hello (20%)'),
             () => progress.update('hello (60%)'),

--- a/packages/shorebird_cli/test/src/artifact_manager_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_manager_test.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
+import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped_deps/scoped_deps.dart';
@@ -229,20 +231,9 @@ void main() {
 
         expect(result.path, endsWith('artifact'));
       });
+    });
 
-      test('returns provided output path when specified', () async {
-        final tempDir = Directory.systemTemp.createTempSync();
-        final outFile = File(p.join(tempDir.path, 'file.out'));
-        final result = await runWithOverrides(
-          () async => artifactManager.downloadFile(
-            Uri.parse('https://example.com'),
-            outputPath: outFile.path,
-          ),
-        );
-
-        expect(result.path, equals(outFile.path));
-      });
-
+    group('downloadFileWithProgress', () {
       group('with progress update', () {
         group('when response contentLength is null', () {
           setUp(() {
@@ -258,17 +249,14 @@ void main() {
             );
           });
 
-          test('does not call onProgress callback', () async {
-            await runWithOverrides(
-              () => artifactManager.downloadFile(
+          test('does not add to stream', () async {
+            final download = await runWithOverrides(
+              () => artifactManager.startFileDownload(
                 Uri.parse('https://example.com'),
-                onProgress: (progress) {
-                  fail(
-                    '''onProgress should not be called when the response does not have a contentLength''',
-                  );
-                },
               ),
             );
+
+            expect(await download.progress.toList(), isEmpty);
           });
         });
 
@@ -288,16 +276,110 @@ void main() {
           });
 
           test('calls onProgress with correct percentage', () async {
-            final progressUpdates = <double>[];
-            await runWithOverrides(
-              () => artifactManager.downloadFile(
+            final download = await runWithOverrides(
+              () => artifactManager.startFileDownload(
                 Uri.parse('https://example.com'),
-                onProgress: progressUpdates.add,
               ),
             );
 
-            expect(progressUpdates, equals([1 / 3, 2 / 3, 3 / 3]));
+            expect(download.progress, emitsInOrder([1 / 3, 2 / 3, 3 / 3]));
           });
+        });
+      });
+    });
+
+    group('downloadWithProgressUpdates', () {
+      late Progress progress;
+
+      setUp(() {
+        progress = MockProgress();
+        when(() => logger.progress(any())).thenReturn(progress);
+      });
+
+      group('when download fails', () {
+        setUp(() {
+          const error = 'Not Found';
+          when(() => httpClient.send(any())).thenAnswer(
+            (_) async => http.StreamedResponse(
+              const Stream.empty(),
+              HttpStatus.notFound,
+              reasonPhrase: error,
+            ),
+          );
+        });
+
+        test('progress fails with error message', () async {
+          await expectLater(
+            runWithOverrides(
+              () => artifactManager.downloadWithProgressUpdates(
+                Uri.parse('https://example.com'),
+                message: 'hello',
+              ),
+            ),
+            throwsA(
+              isA<Exception>().having(
+                (e) => e.toString(),
+                'exception',
+                'Exception: Failed to download file: 404 Not Found',
+              ),
+            ),
+          );
+
+          verify(
+            () => progress.fail(
+              '''hello failed: Exception: Failed to download file: 404 Not Found''',
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when download succeeds', () {
+        late StreamController<List<int>> responseStreamController;
+
+        setUp(() {
+          responseStreamController = StreamController<List<int>>();
+          when(() => httpClient.send(any())).thenAnswer(
+            (_) async => http.StreamedResponse(
+              responseStreamController.stream,
+              HttpStatus.ok,
+              contentLength: 5,
+            ),
+          );
+        });
+
+        test('progress updates with a throttled ', () async {
+          // Awaiting this will cause the test to hang
+          unawaited(
+            runWithOverrides(
+              () => artifactManager.downloadWithProgressUpdates(
+                Uri.parse('https://example.com'),
+                message: 'hello',
+                throttleDuration: const Duration(milliseconds: 50),
+              ),
+            ),
+          );
+          // Download the first 3/5. The first addition will trigger the first
+          // progress update, the second addition will be throttled, and the
+          // third addition will trigger the second progress update after the
+          // delay.
+          responseStreamController
+            ..add([1])
+            ..add([1])
+            ..add([1]);
+          await Future<void>.delayed(const Duration(milliseconds: 60));
+          // Download the last 2/5, bringing the total to 5/5
+          responseStreamController.add([1, 1]);
+          await Future<void>.delayed(const Duration(milliseconds: 60));
+          verifyInOrder([
+            () => progress.update('hello (20%)'),
+            () => progress.update('hello (60%)'),
+            () => progress.update('hello (100%)'),
+          ]);
+          verifyNever(() => progress.update('hello (0%)'));
+          verifyNever(() => progress.update('hello (20%)'));
+          verifyNever(() => progress.update('hello (80%)'));
+          verifyNoMoreInteractions(progress);
+          await responseStreamController.close();
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -440,9 +440,9 @@ Looked in:
           },
         );
         when(
-          () => artifactManager.downloadFile(
+          () => artifactManager.downloadWithProgressUpdates(
             any(),
-            onProgress: any(named: 'onProgress'),
+            message: any(named: 'message'),
           ),
         ).thenAnswer((_) async => File(''));
       });
@@ -450,9 +450,9 @@ Looked in:
       group('when release artifact fails to download', () {
         setUp(() {
           when(
-            () => artifactManager.downloadFile(
+            () => artifactManager.downloadWithProgressUpdates(
               any(),
-              onProgress: any(named: 'onProgress'),
+              message: any(named: 'message'),
             ),
           ).thenThrow(Exception('error'));
         });
@@ -468,8 +468,6 @@ Looked in:
             ),
             exitsWithCode(ExitCode.software),
           );
-
-          verify(() => progress.fail('Exception: error')).called(1);
         });
       });
 
@@ -549,31 +547,6 @@ Looked in:
           for (final bundle in result.values) {
             expect(bundle.hashSignature, isNull);
           }
-        });
-
-        test('updates progress with download percentage', () async {
-          await runWithOverrides(
-            () => patcher.createPatchArtifacts(
-              appId: 'appId',
-              releaseId: 0,
-              releaseArtifact: File('release.aab'),
-            ),
-          );
-
-          final capturedOnProgress = verify(
-            () => artifactManager.downloadFile(
-              any(),
-              onProgress: captureAny(named: 'onProgress'),
-            ),
-          ).captured.first as ProgressCallback;
-
-          capturedOnProgress(0.5);
-
-          verify(
-            () => progress.update(
-              'Downloading release artifact 1/3 (50%)',
-            ),
-          ).called(1);
         });
 
         group('when a private key is provided', () {

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -169,9 +169,9 @@ void main() {
       when(aotTools.isLinkDebugInfoSupported).thenAnswer((_) async => true);
 
       when(
-        () => artifactManager.downloadFile(
+        () => artifactManager.downloadWithProgressUpdates(
           any(),
-          onProgress: any(named: 'onProgress'),
+          message: any(named: 'message'),
         ),
       ).thenAnswer((_) async => File(''));
 
@@ -892,9 +892,9 @@ Please re-run the release command for this version or create a new release.''',
 
       setUp(() {
         when(
-          () => artifactManager.downloadFile(
+          () => artifactManager.downloadWithProgressUpdates(
             any(),
-            onProgress: any(named: 'onProgress'),
+            message: any(named: 'message'),
           ),
         ).thenThrow(error);
       });
@@ -904,12 +904,6 @@ Please re-run the release command for this version or create a new release.''',
           () => runWithOverrides(command.run),
           exitsWithCode(ExitCode.software),
         );
-
-        verify(
-          () => progress.fail(
-            'Exception: Failed to download primary release artifact.',
-          ),
-        ).called(1);
       });
     });
 
@@ -973,33 +967,6 @@ Please re-run the release command for this version or create a new release.''',
             track: DeploymentTrack.staging,
           ),
         ).called(1);
-      });
-    });
-
-    group('downloadPrimaryReleaseArtifact', () {
-      setUp(() {
-        final releaseArtifact = MockReleaseArtifact();
-        when(() => releaseArtifact.url).thenReturn('http://example.com');
-      });
-
-      test('updates progress with download percentage', () async {
-        await runWithOverrides(
-          () => command.downloadPrimaryReleaseArtifact(
-            releaseArtifact: releaseArtifact,
-            patcher: patcher,
-          ),
-        );
-
-        final capturedOnProgress = verify(
-          () => artifactManager.downloadFile(
-            Uri.parse(releaseArtifact.url),
-            onProgress: captureAny(named: 'onProgress'),
-          ),
-        ).captured.single as ProgressCallback;
-
-        capturedOnProgress(0.5);
-
-        verify(() => progress.update('Downloading aab (50%)')).called(1);
       });
     });
   });


### PR DESCRIPTION
## Description

This change refactors [ArtifactManager]'s file download logic to expose a progress stream (which is ignored by the default `downloadFile` method, whose signature has not changed). This also adds `downloadWithProgressUpdates` to `ArtifactManager`, which creates a progress logger and updates with a download percentage. The updates are throttled so as to avoid the flickering effect mentioned in https://github.com/shorebirdtech/shorebird/pull/2563#issuecomment-2427308291.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
