### PR TITLE
fix: write shorebird command to top of log file

### DIFF
--- a/packages/shorebird_cli/bin/shorebird.dart
+++ b/packages/shorebird_cli/bin/shorebird.dart
@@ -36,6 +36,15 @@ Future<void> main(List<String> args) async {
     values: {shorebirdEnvRef},
   );
 
+  // Write the current command to the top of the log file.
+  currentRunLogFile.writeAsStringSync(
+    '''
+Command: shorebird ${args.join(' ')}
+
+''',
+    mode: FileMode.append,
+  );
+
   await IOOverrides.runZoned(
     () async => _flushThenExit(
       await runScoped(


### PR DESCRIPTION
## Description

Writes the full shorebird invocation to the top of the log file.

Example:

```
Command: shorebird release android --artifact=apk

2024-10-22T16:36:23.406279 No checksum provided for patch, skipping file corruption validation
2024-10-22T16:36:23.737249 No checksum provided for aot-tools.dill, skipping file corruption validation
2024-10-22T16:36:23.744691 [HTTP] GET https://api.shorebird.dev/api/v1/apps
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
