### PR TITLE
fix(shorebird_cli): support `--split-debug-info`

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder.dart
@@ -406,11 +406,13 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
   Future<File> buildElfAotSnapshot({
     required String appDillPath,
     required String outFilePath,
+    List<String> additionalArgs = const [],
   }) async {
     final arguments = [
       '--deterministic',
       '--snapshot-kind=app-aot-elf',
       '--elf=$outFilePath',
+      ...additionalArgs,
       appDillPath,
     ];
 

--- a/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/aar_patcher.dart
@@ -29,6 +29,7 @@ class AarPatcher extends Patcher {
   /// {@macro aar_patcher}
   AarPatcher({
     required super.argResults,
+    required super.argParser,
     required super.flavor,
     required super.target,
   });

--- a/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/android_patcher.dart
@@ -29,6 +29,7 @@ class AndroidPatcher extends Patcher {
   /// {@macro android_patcher}
   AndroidPatcher({
     required super.argResults,
+    required super.argParser,
     required super.flavor,
     required super.target,
   });

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
@@ -11,7 +11,6 @@ import 'package:shorebird_cli/src/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/patch/patch.dart';
-import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/aot_tools.dart';
 import 'package:shorebird_cli/src/executables/xcodebuild.dart';
@@ -35,6 +34,7 @@ class IosFrameworkPatcher extends Patcher {
   /// {@macro ios_framework_patcher}
   IosFrameworkPatcher({
     required super.argResults,
+    required super.argParser,
     required super.flavor,
     required super.target,
   });
@@ -52,14 +52,6 @@ class IosFrameworkPatcher extends Patcher {
   @override
   double? get linkPercentage => lastBuildLinkPercentage;
 
-  /// The value of --split-debug-info-path if specified.
-  String? get splitDebugInfoPath =>
-      argResults[CommonArguments.splitDebugInfoArg.name] as String?;
-
-  // TODO(felangel): make this dynamic based on the platform and arch.
-  /// The name of the split debug info file.
-  static const splitDebugInfoFileName = 'app.ios-arm64.symbols';
-
   /// The additional gen_snapshot arguments to use when building the patch with
   /// `--split-debug-info`.
   List<String> get splitDebugInfoArgs {
@@ -67,14 +59,10 @@ class IosFrameworkPatcher extends Patcher {
         ? [
             '--dwarf-stack-traces',
             '--resolve-dwarf-paths',
-            '''--save-debugging-info=${saveDebuggingInfoPath(splitDebugInfoPath!)}''',
+            '''--save-debugging-info=${IosPatcher.saveDebuggingInfoPath(splitDebugInfoPath!)}''',
           ]
         : <String>[];
   }
-
-  /// The path to save the split debug info file.
-  String saveDebuggingInfoPath(String directory) =>
-      p.join(p.absolute(directory), splitDebugInfoFileName);
 
   /// The last build link percentage.
   @visibleForTesting

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
@@ -52,18 +52,6 @@ class IosFrameworkPatcher extends Patcher {
   @override
   double? get linkPercentage => lastBuildLinkPercentage;
 
-  /// The additional gen_snapshot arguments to use when building the patch with
-  /// `--split-debug-info`.
-  List<String> get splitDebugInfoArgs {
-    return splitDebugInfoPath != null
-        ? [
-            '--dwarf-stack-traces',
-            '--resolve-dwarf-paths',
-            '''--save-debugging-info=${IosPatcher.saveDebuggingInfoPath(splitDebugInfoPath!)}''',
-          ]
-        : <String>[];
-  }
-
   /// The last build link percentage.
   @visibleForTesting
   double? lastBuildLinkPercentage;
@@ -131,7 +119,7 @@ class IosFrameworkPatcher extends Patcher {
           'build',
           'out.aot',
         ),
-        additionalArgs: splitDebugInfoArgs,
+        additionalArgs: IosPatcher.splitDebugInfoArgs(splitDebugInfoPath),
       );
     } catch (error) {
       buildProgress.fail('$error');
@@ -288,7 +276,7 @@ class IosFrameworkPatcher extends Patcher {
         kernel: _appDillCopyPath,
         outputPath: _vmcodeOutputPath,
         workingDirectory: buildDirectory.path,
-        additionalArgs: splitDebugInfoArgs,
+        additionalArgs: IosPatcher.splitDebugInfoArgs(splitDebugInfoPath),
       );
     } catch (error) {
       linkProgress.fail('Failed to link AOT files: $error');

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_framework_patcher.dart
@@ -131,7 +131,7 @@ class IosFrameworkPatcher extends Patcher {
           'build',
           'out.aot',
         ),
-        additionalArgs: [...splitDebugInfoArgs],
+        additionalArgs: splitDebugInfoArgs,
       );
     } catch (error) {
       buildProgress.fail('$error');
@@ -288,7 +288,7 @@ class IosFrameworkPatcher extends Patcher {
         kernel: _appDillCopyPath,
         outputPath: _vmcodeOutputPath,
         workingDirectory: buildDirectory.path,
-        additionalArgs: [...splitDebugInfoArgs],
+        additionalArgs: splitDebugInfoArgs,
       );
     } catch (error) {
       linkProgress.fail('Failed to link AOT files: $error');

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -59,12 +59,12 @@ class IosPatcher extends Patcher {
 
   /// The additional gen_snapshot arguments to use when building the patch with
   /// `--split-debug-info`.
-  List<String> get splitDebugInfoArgs {
+  static List<String> splitDebugInfoArgs(String? splitDebugInfoPath) {
     return splitDebugInfoPath != null
         ? [
             '--dwarf-stack-traces',
             '--resolve-dwarf-paths',
-            '''--save-debugging-info=${saveDebuggingInfoPath(splitDebugInfoPath!)}''',
+            '''--save-debugging-info=${saveDebuggingInfoPath(splitDebugInfoPath)}''',
           ]
         : <String>[];
   }
@@ -214,7 +214,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
         await artifactBuilder.buildElfAotSnapshot(
           appDillPath: ipaBuildResult.kernelFile.path,
           outFilePath: _aotOutputPath,
-          additionalArgs: splitDebugInfoArgs,
+          additionalArgs: splitDebugInfoArgs(splitDebugInfoPath),
         );
       } catch (error) {
         buildProgress.fail('$error');
@@ -424,7 +424,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
         workingDirectory: buildDirectory.path,
         kernel: kernelFile.path,
         dumpDebugInfoPath: dumpDebugInfoDir?.path,
-        additionalArgs: splitDebugInfoArgs,
+        additionalArgs: splitDebugInfoArgs(splitDebugInfoPath),
       );
     } catch (error) {
       linkProgress.fail('Failed to link AOT files: $error');

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -214,7 +214,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
         await artifactBuilder.buildElfAotSnapshot(
           appDillPath: ipaBuildResult.kernelFile.path,
           outFilePath: _aotOutputPath,
-          additionalArgs: [...splitDebugInfoArgs],
+          additionalArgs: splitDebugInfoArgs,
         );
       } catch (error) {
         buildProgress.fail('$error');
@@ -424,7 +424,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
         workingDirectory: buildDirectory.path,
         kernel: kernelFile.path,
         dumpDebugInfoPath: dumpDebugInfoDir?.path,
-        additionalArgs: [...splitDebugInfoArgs],
+        additionalArgs: splitDebugInfoArgs,
       );
     } catch (error) {
       linkProgress.fail('Failed to link AOT files: $error');

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -42,6 +42,7 @@ class IosPatcher extends Patcher {
   /// {@macro ios_patcher}
   IosPatcher({
     required super.argResults,
+    required super.argParser,
     required super.flavor,
     required super.target,
   });
@@ -51,10 +52,6 @@ class IosPatcher extends Patcher {
   String get _vmcodeOutputPath => p.join(buildDirectory.path, 'out.vmcode');
 
   String get _appDillCopyPath => p.join(buildDirectory.path, 'app.dill');
-
-  /// The value of --split-debug-info-path if specified.
-  String? get splitDebugInfoPath =>
-      argResults[CommonArguments.splitDebugInfoArg.name] as String?;
 
   // TODO(felangel): make this dynamic based on the platform and arch.
   /// The name of the split debug info file.
@@ -73,8 +70,9 @@ class IosPatcher extends Patcher {
   }
 
   /// The path to save the split debug info file.
-  String saveDebuggingInfoPath(String directory) =>
-      p.join(p.absolute(directory), splitDebugInfoFileName);
+  static String saveDebuggingInfoPath(String directory) {
+    return p.join(p.absolute(directory), splitDebugInfoFileName);
+  }
 
   @visibleForTesting
   double? lastBuildLinkPercentage;

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -53,8 +53,7 @@ class IosPatcher extends Patcher {
 
   String get _appDillCopyPath => p.join(buildDirectory.path, 'app.dill');
 
-  // TODO(felangel): make this dynamic based on the platform and arch.
-  /// The name of the split debug info file.
+  /// The name of the split debug info file when the target is iOS.
   static const splitDebugInfoFileName = 'app.ios-arm64.symbols';
 
   /// The additional gen_snapshot arguments to use when building the patch with

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -123,6 +123,10 @@ of the iOS app that is using this module.''',
       ..addOption(
         CommonArguments.publicKeyArg.name,
         help: CommonArguments.publicKeyArg.description,
+      )
+      ..addOption(
+        CommonArguments.splitDebugInfoArg.name,
+        help: CommonArguments.splitDebugInfoArg.description,
       );
   }
 
@@ -159,6 +163,14 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
   bool get allowNativeDiffs => results['allow-native-diffs'] == true;
 
   bool get isStaging => results['staging'] == true;
+
+  /// The value of the --split-debug-info option.
+  String? get splitDebugInfoPath {
+    return results.findOption(
+      CommonArguments.splitDebugInfoArg.name,
+      argParser: argParser,
+    );
+  }
 
   @override
   Future<int> run() async {

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -164,14 +164,6 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
 
   bool get isStaging => results['staging'] == true;
 
-  /// The value of the --split-debug-info option.
-  String? get splitDebugInfoPath {
-    return results.findOption(
-      CommonArguments.splitDebugInfoArg.name,
-      argParser: argParser,
-    );
-  }
-
   @override
   Future<int> run() async {
     final patcherFutures =
@@ -190,24 +182,28 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
       case ReleaseType.android:
         return AndroidPatcher(
           argResults: results,
+          argParser: argParser,
           flavor: flavor,
           target: target,
         );
       case ReleaseType.ios:
         return IosPatcher(
           argResults: results,
+          argParser: argParser,
           flavor: flavor,
           target: target,
         );
       case ReleaseType.iosFramework:
         return IosFrameworkPatcher(
           argResults: results,
+          argParser: argParser,
           flavor: flavor,
           target: target,
         );
       case ReleaseType.aar:
         return AarPatcher(
           argResults: results,
+          argParser: argParser,
           flavor: flavor,
           target: target,
         );

--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -129,7 +129,7 @@ ${iOSLinkPercentageUrl.toLink()}
   /// step has not yet been run.
   double? get linkPercentage => null;
 
-  /// The value of --split-debug-info-path if specified.
+  /// The value of `--split-debug-info-path` if specified.
   String? get splitDebugInfoPath {
     return argResults.findOption(
       CommonArguments.splitDebugInfoArg.name,

--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
+import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/extensions/iterable.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
@@ -24,6 +25,7 @@ import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 abstract class Patcher {
   /// {@macro patcher}
   Patcher({
+    required this.argParser,
     required this.argResults,
     required this.flavor,
     required this.target,
@@ -40,6 +42,9 @@ This means the patched code may execute slower than expected.
 ${iOSLinkPercentageUrl.toLink()}
 ''';
   }
+
+  /// The parser for the arguments passed to the command.
+  final ArgParser argParser;
 
   /// The arguments passed to the command.
   final ArgResults argResults;
@@ -123,6 +128,14 @@ ${iOSLinkPercentageUrl.toLink()}
   /// Returns `null` if the platform does not use a linker or if the linking
   /// step has not yet been run.
   double? get linkPercentage => null;
+
+  /// The value of --split-debug-info-path if specified.
+  String? get splitDebugInfoPath {
+    return argResults.findOption(
+      CommonArguments.splitDebugInfoArg.name,
+      argParser: argParser,
+    );
+  }
 
   /// The build directory of the respective shorebird project.
   Directory get buildDirectory {

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -132,6 +132,10 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
       ..addOption(
         CommonArguments.publicKeyArg.name,
         help: CommonArguments.publicKeyArg.description,
+      )
+      ..addOption(
+        CommonArguments.splitDebugInfoArg.name,
+        help: CommonArguments.splitDebugInfoArg.description,
       );
   }
 

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -102,8 +102,8 @@ The path for a private key .pem file that will be used to sign the patch artifac
 ''',
   );
 
-  /// An argument that allows the user to specify a file where program symbols
-  /// are stored.
+  /// An argument that allows the user to specify a directory where program
+  /// symbols are stored.
   static const splitDebugInfoArg = ArgumentDescriber(
     name: 'split-debug-info',
     description: '''

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -101,4 +101,16 @@ The path for a public key .pem file that will be used to validate patch signatur
 The path for a private key .pem file that will be used to sign the patch artifact.
 ''',
   );
+
+  /// An argument that allows the user to specify a file where program symbols
+  /// are stored.
+  static const splitDebugInfoArg = ArgumentDescriber(
+    name: 'split-debug-info',
+    description: '''
+In a release build, this flag reduces application size by storing Dart program symbols in a separate file on the host rather than
+                                                             in the application. The value of the flag should be a directory where program symbol files can be stored for later use. These
+                                                             symbol files contain the information needed to symbolize Dart stack traces. For an app built with this flag, the "flutter
+                                                             symbolize" command with the right program symbol file is required to obtain a human readable stack trace.
+''',
+  );
 }

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -108,9 +108,9 @@ The path for a private key .pem file that will be used to sign the patch artifac
     name: 'split-debug-info',
     description: '''
 In a release build, this flag reduces application size by storing Dart program symbols in a separate file on the host rather than
-                                                             in the application. The value of the flag should be a directory where program symbol files can be stored for later use. These
-                                                             symbol files contain the information needed to symbolize Dart stack traces. For an app built with this flag, the "flutter
-                                                             symbolize" command with the right program symbol file is required to obtain a human readable stack trace.
+in the application. The value of the flag should be a directory where program symbol files can be stored for later use. These
+symbol files contain the information needed to symbolize Dart stack traces. For an app built with this flag, the "flutter
+symbolize" command with the right program symbol file is required to obtain a human readable stack trace.
 ''',
   );
 }

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -243,6 +243,7 @@ class AotTools {
     required String outputPath,
     String? workingDirectory,
     String? dumpDebugInfoPath,
+    List<String> additionalArgs = const [],
   }) async {
     // We use the json lines format. https://jsonlines.org
     const linkJson = 'link.jsonl';
@@ -263,6 +264,10 @@ class AotTools {
           '--redirect-to=${p.join(outputDir, linkJson)}',
         ],
         if (dumpDebugInfoPath != null) '--dump-debug-info=$dumpDebugInfoPath',
+        if (additionalArgs.isNotEmpty) ...[
+          '--',
+          ...additionalArgs,
+        ]
       ],
       workingDirectory: workingDirectory,
     );

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -137,6 +137,7 @@ extension ForwardedArgs on ArgResults {
         ..._argsNamed(CommonArguments.dartDefineFromFileArg.name),
         ..._argsNamed(CommonArguments.buildNameArg.name),
         ..._argsNamed(CommonArguments.buildNumberArg.name),
+        ..._argsNamed(CommonArguments.splitDebugInfoArg.name),
       ],
     );
 

--- a/packages/shorebird_cli/test/src/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder_test.dart
@@ -999,10 +999,35 @@ Please file a bug at https://github.com/shorebirdtech/shorebird/issues/new with 
             ).thenReturn('gen_snapshot');
           });
 
+          test('passes additional args to gen_snapshot', () async {
+            await runWithOverrides(
+              () => builder.buildElfAotSnapshot(
+                appDillPath: '/app/dill/path',
+                outFilePath: '/path/to/out',
+                additionalArgs: ['--foo', 'bar'],
+              ),
+            );
+
+            verify(
+              () => shorebirdProcess.run(
+                'gen_snapshot',
+                [
+                  '--deterministic',
+                  '--snapshot-kind=app-aot-elf',
+                  '--elf=/path/to/out',
+                  '--foo',
+                  'bar',
+                  '/app/dill/path',
+                ],
+              ),
+            ).called(1);
+          });
+
           group('when build fails', () {
             setUp(() {
-              when(() => buildProcessResult.exitCode)
-                  .thenReturn(ExitCode.software.code);
+              when(
+                () => buildProcessResult.exitCode,
+              ).thenReturn(ExitCode.software.code);
             });
 
             test('throws ArtifactBuildException', () {

--- a/packages/shorebird_cli/test/src/artifact_manager_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_manager_test.dart
@@ -284,6 +284,20 @@ void main() {
 
             expect(download.progress, emitsInOrder([1 / 3, 2 / 3, 3 / 3]));
           });
+
+          test('uses outputPath when specified', () async {
+            final tempDir = Directory.systemTemp.createTempSync();
+            final outputPath = p.join(tempDir.path, 'output-file.txt');
+            final download = await runWithOverrides(
+              () => artifactManager.startFileDownload(
+                Uri.parse('https://example.com'),
+                outputPath: outputPath,
+              ),
+            );
+            final file = await download.file;
+            expect(file.path, equals(outputPath));
+            expect(file.lengthSync(), equals(3));
+          });
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
@@ -35,6 +35,7 @@ void main() {
     const packageName = 'com.example.my_flutter_module';
     const buildNumber = '1.0';
 
+    late ArgParser argParser;
     late ArgResults argResults;
     late ArtifactBuilder artifactBuilder;
     late ArtifactManager artifactManager;
@@ -93,6 +94,7 @@ void main() {
     });
 
     setUp(() {
+      argParser = MockArgParser();
       argResults = MockArgResults();
       artifactBuilder = MockArtifactBuilder();
       artifactManager = MockArtifactManager();
@@ -117,7 +119,12 @@ void main() {
         () => shorebirdEnv.getShorebirdProjectRoot(),
       ).thenReturn(projectRoot);
 
-      patcher = AarPatcher(argResults: argResults, flavor: null, target: null);
+      patcher = AarPatcher(
+        argParser: argParser,
+        argResults: argResults,
+        flavor: null,
+        target: null,
+      );
     });
 
     group('buildNumber', () {

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -37,6 +37,7 @@ import '../../mocks.dart';
 
 void main() {
   group(AndroidPatcher, () {
+    late ArgParser argParser;
     late ArgResults argResults;
     late ArtifactBuilder artifactBuilder;
     late ArtifactManager artifactManager;
@@ -116,6 +117,7 @@ void main() {
     });
 
     setUp(() {
+      argParser = MockArgParser();
       argResults = MockArgResults();
       artifactBuilder = MockArtifactBuilder();
       artifactManager = MockArtifactManager();
@@ -144,6 +146,7 @@ void main() {
       ).thenReturn(projectRoot);
 
       patcher = AndroidPatcher(
+        argParser: argParser,
         argResults: argResults,
         flavor: null,
         target: null,

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -42,6 +42,7 @@ void main() {
     IosFrameworkPatcher,
     () {
       late AotTools aotTools;
+      late ArgParser argParser;
       late ArgResults argResults;
       late ArtifactBuilder artifactBuilder;
       late ArtifactManager artifactManager;
@@ -96,6 +97,7 @@ void main() {
 
       setUp(() {
         aotTools = MockAotTools();
+        argParser = MockArgParser();
         argResults = MockArgResults();
         artifactBuilder = MockArtifactBuilder();
         artifactManager = MockArtifactManager();
@@ -115,13 +117,11 @@ void main() {
         shorebirdValidator = MockShorebirdValidator();
         xcodeBuild = MockXcodeBuild();
 
+        when(() => argParser.options).thenReturn({});
+
         when(() => argResults['build-number']).thenReturn('1.0');
         when(() => argResults.rest).thenReturn([]);
         when(() => argResults.wasParsed(any())).thenReturn(false);
-        when(() => argResults.wasParsed(CommonArguments.privateKeyArg.name))
-            .thenReturn(false);
-        when(() => argResults.wasParsed(CommonArguments.publicKeyArg.name))
-            .thenReturn(false);
 
         when(() => logger.progress(any())).thenReturn(progress);
 
@@ -130,6 +130,7 @@ void main() {
         ).thenReturn(projectRoot);
 
         patcher = IosFrameworkPatcher(
+          argParser: argParser,
           argResults: argResults,
           flavor: null,
           target: null,
@@ -356,6 +357,7 @@ void main() {
               () => artifactBuilder.buildElfAotSnapshot(
                 appDillPath: any(named: 'appDillPath'),
                 outFilePath: any(named: 'outFilePath'),
+                additionalArgs: any(named: 'additionalArgs'),
               ),
             ).thenThrow(const FileSystemException('error'));
           });
@@ -413,6 +415,11 @@ void main() {
               p.join(splitDebugInfoPath, 'app.ios-arm64.symbols'),
             );
             setUp(() {
+              when(
+                () => argResults.wasParsed(
+                  CommonArguments.splitDebugInfoArg.name,
+                ),
+              ).thenReturn(true);
               when(
                 () => argResults['split-debug-info'],
               ).thenReturn(splitDebugInfoPath);
@@ -670,7 +677,12 @@ void main() {
               );
               setUp(() {
                 when(
-                  () => argResults['split-debug-info'],
+                  () => argResults.wasParsed(
+                    CommonArguments.splitDebugInfoArg.name,
+                  ),
+                ).thenReturn(true);
+                when(
+                  () => argResults[CommonArguments.splitDebugInfoArg.name],
                 ).thenReturn(splitDebugInfoPath);
                 setUpProjectRootArtifacts();
               });

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -48,6 +48,7 @@ void main() {
     IosPatcher,
     () {
       late AotTools aotTools;
+      late ArgParser argParser;
       late ArgResults argResults;
       late ArtifactBuilder artifactBuilder;
       late ArtifactManager artifactManager;
@@ -107,6 +108,7 @@ void main() {
 
       setUp(() {
         aotTools = MockAotTools();
+        argParser = MockArgParser();
         argResults = MockArgResults();
         artifactBuilder = MockArtifactBuilder();
         artifactManager = MockArtifactManager();
@@ -128,6 +130,8 @@ void main() {
         shorebirdValidator = MockShorebirdValidator();
         xcodeBuild = MockXcodeBuild();
 
+        when(() => argParser.options).thenReturn({});
+
         when(() => argResults.options).thenReturn([]);
         when(() => argResults.rest).thenReturn([]);
         when(() => argResults.wasParsed(any())).thenReturn(false);
@@ -143,6 +147,7 @@ void main() {
         when(aotTools.isLinkDebugInfoSupported).thenAnswer((_) async => false);
 
         patcher = IosPatcher(
+          argParser: argParser,
           argResults: argResults,
           flavor: null,
           target: null,
@@ -682,7 +687,12 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
             );
             setUp(() {
               when(
-                () => argResults['split-debug-info'],
+                () => argResults.wasParsed(
+                  CommonArguments.splitDebugInfoArg.name,
+                ),
+              ).thenReturn(true);
+              when(
+                () => argResults[CommonArguments.splitDebugInfoArg.name],
               ).thenReturn(splitDebugInfoPath);
             });
 
@@ -1122,7 +1132,12 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
               );
               setUp(() {
                 when(
-                  () => argResults['split-debug-info'],
+                  () => argResults.wasParsed(
+                    CommonArguments.splitDebugInfoArg.name,
+                  ),
+                ).thenReturn(true);
+                when(
+                  () => argResults[CommonArguments.splitDebugInfoArg.name],
                 ).thenReturn(splitDebugInfoPath);
                 setUpProjectRootArtifacts();
               });

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -299,6 +299,19 @@ void main() {
       expect(command.description, isNotEmpty);
     });
 
+    group('splitDebugInfoPath', () {
+      test('returns null when --split-debug-info is not provided', () {
+        when(() => argResults['split-debug-info']).thenReturn(null);
+        expect(command.splitDebugInfoPath, isNull);
+      });
+
+      test('returns the path when --split-debug-info is provided', () {
+        const path = './build/symbols';
+        when(() => argResults['split-debug-info']).thenReturn(path);
+        expect(command.splitDebugInfoPath, equals(path));
+      });
+    });
+
     group('createPatch', () {
       test('publishes the patch', () async {
         await runWithOverrides(() => command.createPatch(patcher));
@@ -319,8 +332,9 @@ void main() {
           test('validates successfully', () async {
             await runWithOverrides(() => command.createPatch(patcher));
 
-            verify(() => shorebirdValidator.validateFlavors(flavorArg: null))
-                .called(1);
+            verify(
+              () => shorebirdValidator.validateFlavors(flavorArg: null),
+            ).called(1);
           });
         });
 
@@ -333,8 +347,9 @@ void main() {
           test('validates successfully', () async {
             await runWithOverrides(() => command.createPatch(patcher));
 
-            verify(() => shorebirdValidator.validateFlavors(flavorArg: flavor))
-                .called(1);
+            verify(
+              () => shorebirdValidator.validateFlavors(flavorArg: flavor),
+            ).called(1);
           });
         });
       });
@@ -382,8 +397,9 @@ void main() {
               when(
                 () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
               ).thenReturn(false);
-              when(() => argResults[CommonArguments.privateKeyArg.name])
-                  .thenReturn(createTempFile('private.pem').path);
+              when(
+                () => argResults[CommonArguments.privateKeyArg.name],
+              ).thenReturn(createTempFile('private.pem').path);
 
               await expectLater(
                 runWithOverrides(() => command.createPatch(patcher)),
@@ -408,8 +424,9 @@ void main() {
               when(
                 () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
               ).thenReturn(true);
-              when(() => argResults[CommonArguments.publicKeyArg.name])
-                  .thenReturn(createTempFile('public.pem').path);
+              when(
+                () => argResults[CommonArguments.publicKeyArg.name],
+              ).thenReturn(createTempFile('public.pem').path);
 
               await expectLater(
                 runWithOverrides(() => command.createPatch(patcher)),

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -299,19 +299,6 @@ void main() {
       expect(command.description, isNotEmpty);
     });
 
-    group('splitDebugInfoPath', () {
-      test('returns null when --split-debug-info is not provided', () {
-        when(() => argResults['split-debug-info']).thenReturn(null);
-        expect(command.splitDebugInfoPath, isNull);
-      });
-
-      test('returns the path when --split-debug-info is provided', () {
-        const path = './build/symbols';
-        when(() => argResults['split-debug-info']).thenReturn(path);
-        expect(command.splitDebugInfoPath, equals(path));
-      });
-    });
-
     group('createPatch', () {
       test('publishes the patch', () async {
         await runWithOverrides(() => command.createPatch(patcher));

--- a/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
@@ -26,6 +26,7 @@ void main() {
       test('defaults to null', () {
         expect(
           _TestPatcher(
+            argParser: MockArgParser(),
             argResults: MockArgResults(),
             flavor: null,
             target: null,
@@ -39,6 +40,7 @@ void main() {
       test('has no validations by default', () {
         expect(
           _TestPatcher(
+            argParser: MockArgParser(),
             argResults: MockArgResults(),
             flavor: null,
             target: null,
@@ -59,6 +61,7 @@ void main() {
         test('returns an empty list', () {
           expect(
             _TestPatcher(
+              argParser: MockArgParser(),
               argResults: MockArgResults(),
               flavor: null,
               target: null,
@@ -72,6 +75,7 @@ void main() {
         test('returns an empty list', () {
           expect(
             _TestPatcher(
+              argParser: MockArgParser(),
               argResults: argResults,
               flavor: null,
               target: null,
@@ -90,6 +94,7 @@ void main() {
           test('returns an empty list', () {
             expect(
               _TestPatcher(
+                argParser: MockArgParser(),
                 argResults: argResults,
                 flavor: null,
                 target: null,
@@ -107,6 +112,7 @@ void main() {
           test('returns an empty list', () {
             expect(
               _TestPatcher(
+                argParser: MockArgParser(),
                 argResults: argResults,
                 flavor: null,
                 target: null,
@@ -122,6 +128,7 @@ void main() {
 
             expect(
               _TestPatcher(
+                argParser: MockArgParser(),
                 argResults: argResults,
                 flavor: null,
                 target: null,
@@ -150,6 +157,7 @@ void main() {
           test('returns an empty list', () {
             expect(
               _TestPatcher(
+                argParser: MockArgParser(),
                 argResults: argResults,
                 flavor: null,
                 target: null,
@@ -167,6 +175,7 @@ void main() {
           'with correct args', () async {
         final args = MockArgResults();
         final patcher = _TestPatcher(
+          argParser: MockArgParser(),
           argResults: args,
           flavor: null,
           target: null,
@@ -219,6 +228,7 @@ void main() {
 
 class _TestPatcher extends Patcher {
   _TestPatcher({
+    required super.argParser,
     required super.argResults,
     required super.flavor,
     required super.target,

--- a/packages/shorebird_cli/test/src/extensions/arg_results_test.dart
+++ b/packages/shorebird_cli/test/src/extensions/arg_results_test.dart
@@ -107,6 +107,10 @@ void main() {
           CommonArguments.buildNumberArg.name,
           help: CommonArguments.buildNumberArg.description,
         )
+        ..addOption(
+          CommonArguments.splitDebugInfoArg.name,
+          help: CommonArguments.splitDebugInfoArg.description,
+        )
         ..addMultiOption(
           'platforms',
           allowed: ReleaseType.values.map((e) => e.cliName),
@@ -227,6 +231,37 @@ void main() {
               '--build-number=4',
             ],
           ),
+        );
+      });
+    });
+
+    group('when split-debug-info is provided before the --', () {
+      test('forwards it', () {
+        final args = [
+          '--verbose',
+          '--split-debug-info=build/symbols',
+        ];
+        final result = parser.parse(args);
+        expect(result.forwardedArgs, hasLength(1));
+        expect(
+          result.forwardedArgs,
+          contains('--split-debug-info=build/symbols'),
+        );
+      });
+    });
+
+    group('when split-debug-info is provided after the --', () {
+      test('forwards it', () {
+        final args = [
+          '--verbose',
+          '--',
+          '--split-debug-info=build/symbols',
+        ];
+        final result = parser.parse(args);
+        expect(result.forwardedArgs, hasLength(1));
+        expect(
+          result.forwardedArgs,
+          contains('--split-debug-info=build/symbols'),
         );
       });
     });

--- a/packages/shorebird_cli/test/src/mocks.dart
+++ b/packages/shorebird_cli/test/src/mocks.dart
@@ -59,6 +59,8 @@ class MockAppleDevice extends Mock implements AppleDevice {}
 
 class MockArchiveDiffer extends Mock implements ArchiveDiffer {}
 
+class MockArgParser extends Mock implements ArgParser {}
+
 class MockArgResults extends Mock implements ArgResults {}
 
 class MockArtifactBuilder extends Mock implements ArtifactBuilder {}

--- a/scripts/patch_e2e.sh
+++ b/scripts/patch_e2e.sh
@@ -37,7 +37,7 @@ echo "base_url: https://api-dev.shorebird.dev" >> shorebird.yaml
 APP_ID=$(cat shorebird.yaml | grep 'app_id:' | awk '{print $2}')
 
 # Create a new release on Android
-shorebird release android --flutter-version=$FLUTTER_VERSION -v
+shorebird release android --flutter-version=$FLUTTER_VERSION --split-debug-info=./build/symbols -v
 
 # Run the app on Android and ensure that the print statement is printed.
 while IFS= read line; do
@@ -55,7 +55,7 @@ echo "lib/main.dart is now:"
 cat lib/main.dart
 
 # Create a patch
-shorebird patch android -v
+shorebird patch android --split-debug-info=./build/symbols -v
 
 # Run the app on Android and ensure that the original print statement is printed.
 while IFS= read line; do


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- fix(shorebird_cli): support `--split-debug-info` (closes #2480)
  - when passing the `--split-debug-info` flag to the `flutter_tool`, the resulting `gen_snapshot` execution includes additional flags ('--dwarf-stack-traces', '--resolve-dwarf-paths', '--save-debugging-info') previously, we were proxying this flag when building the release but when building the optimized aot snapshot (as part of the linking step) we were not supplying the additional flags which would result in different vm sections of the generated snapshot.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
