### PR TITLE
fix: don't print failure message when -h flag is passed

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
@@ -216,7 +216,10 @@ Engine • revision ${shorebirdEnv.shorebirdEngineRevision}''');
       }
     }
 
-    if (exitCode != ExitCode.success.code && logger.level != Level.verbose) {
+    // `runCommand` returns null in when the --help flag is passed.
+    if (exitCode != null &&
+        exitCode != ExitCode.success.code &&
+        logger.level != Level.verbose) {
       final fileAnIssue = link(
         uri: Uri.parse(
           'https://github.com/shorebirdtech/shorebird/issues/new/choose',

--- a/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
@@ -112,6 +112,20 @@ void main() {
       verify(() => logger.info(commandRunner.usage)).called(1);
     });
 
+    group('when runCommand returns null exitCode', () {
+      test('does not print failure text', () async {
+        final result = await runWithOverrides(
+          () => commandRunner.run(['--help']),
+        );
+        expect(result, equals(ExitCode.success.code));
+        verifyNever(
+          () => logger.info(
+            any(that: contains("If you aren't sure why this command failed")),
+          ),
+        );
+      });
+    });
+
     test('handles UsageException', () async {
       final result = await runWithOverrides(
         // fly_to_the_moon is not a valid command.


### PR DESCRIPTION
## Description

Fixes https://github.com/shorebirdtech/shorebird/issues/2571

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
