### PR TITLE
feat: print message directing users to github issue if windows download takes too long

### DIFF
--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -605,6 +605,40 @@ Looked in:
             expect(signatures, equals(expectedSignatures));
           });
         });
+
+        group('when artifacts download takes longer than provided timeout', () {
+          setUp(() {
+            when(
+              () => artifactManager.downloadWithProgressUpdates(
+                any(),
+                message: any(named: 'message'),
+              ),
+            ).thenAnswer((_) async {
+              await Future<void>.delayed(const Duration(milliseconds: 100));
+              return File('');
+            });
+          });
+
+          test('prints message directing users to github issue', () async {
+            await runWithOverrides(
+              () => patcher.createPatchArtifacts(
+                appId: 'appId',
+                releaseId: 0,
+                releaseArtifact: File('release.aab'),
+                downloadMessageTimeout: const Duration(milliseconds: 50),
+              ),
+            );
+
+            verify(
+              () => logger.info(
+                any(
+                  that: contains(
+                      'https://github.com/shorebirdtech/shorebird/issues/2532'),
+                ),
+              ),
+            ).called(1);
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## Description

If a user's release artifacts (libapp.so files) take longer than a minute to download, print a message directing them to https://github.com/shorebirdtech/shorebird/issues/2532. This timeout can be adjusted (my experience is probably skewed due to mostly using the counter demo app for testing and having a relatively fast internet connection).

This is to help address https://github.com/shorebirdtech/shorebird/issues/2532

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
