### PR TITLE
fix: handle gradle version strings missing a patch version

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/gradlew.dart
+++ b/packages/shorebird_cli/lib/src/executables/gradlew.dart
@@ -128,7 +128,7 @@ class Gradlew {
 
     // Tries to match version string in the output (e.g. "Gradle 7.6.3" or
     // "Grade 8.3")
-    final versionPattern = RegExp(r'Gradle (\d+\.\d+\.?\d?)');
+    final versionPattern = RegExp(r'Gradle (\d+\.\d+(\.\d+)?)');
     final match = versionPattern.firstMatch(result.stdout.toString());
 
     return match?.group(1) ?? 'unknown';

--- a/packages/shorebird_cli/lib/src/executables/gradlew.dart
+++ b/packages/shorebird_cli/lib/src/executables/gradlew.dart
@@ -126,8 +126,9 @@ class Gradlew {
   Future<String> version(String projectRoot) async {
     final result = await _run(['--version'], projectRoot);
 
-    // Tries to match version string in the output (e.g. "Gradle 7.6.3")
-    final versionPattern = RegExp(r'Gradle (\d+\.\d+\.\d+)');
+    // Tries to match version string in the output (e.g. "Gradle 7.6.3" or
+    // "Grade 8.3")
+    final versionPattern = RegExp(r'Gradle (\d+\.\d+\.?\d?)');
     final match = versionPattern.firstMatch(result.stdout.toString());
 
     return match?.group(1) ?? 'unknown';

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -436,7 +436,11 @@ BUILD FAILED in 3s
         File(
           p.join(tempDir.path, 'android', 'gradlew'),
         ).createSync(recursive: true);
-        when(() => result.stdout).thenReturn('''
+      });
+
+      group('when version string has a patch version', () {
+        setUp(() {
+          when(() => result.stdout).thenReturn('''
 
 ------------------------------------------------------------
 Gradle 7.6.3
@@ -451,18 +455,50 @@ Ant:          Apache Ant(TM) version 1.10.11 compiled on July 10 2021
 JVM:          11.0.23 (Azul Systems, Inc. 11.0.23+9-LTS)
 OS:           Mac OS X 14.4.1 aarch64
 ''');
+        });
+
+        test(
+          'returns the correct version',
+          () async {
+            final version = await runWithOverrides(
+              () => gradlew.version(tempDir.path),
+            );
+            expect(version, equals('7.6.3'));
+          },
+          testOn: 'linux || mac-os',
+        );
       });
 
-      test(
-        'returns the correct version',
-        () async {
-          final version = await runWithOverrides(
-            () => gradlew.version(tempDir.path),
-          );
-          expect(version, '7.6.3');
-        },
-        testOn: 'linux || mac-os',
-      );
+      group('when version string has only major and minor versions', () {
+        setUp(() {
+          when(() => result.stdout).thenReturn('''
+
+------------------------------------------------------------
+Gradle 8.3
+------------------------------------------------------------
+
+Build time:   2023-10-04 15:59:47 UTC
+Revision:     1694251d59e0d4752d547e1fd5b5020b798a7e71
+
+Kotlin:       1.7.10
+Groovy:       3.0.13
+Ant:          Apache Ant(TM) version 1.10.11 compiled on July 10 2021
+JVM:          11.0.23 (Azul Systems, Inc. 11.0.23+9-LTS)
+OS:           Mac OS X 14.4.1 aarch64
+''');
+        });
+
+        test(
+          'returns the correct version',
+          () async {
+            final version = await runWithOverrides(
+              () => gradlew.version(tempDir.path),
+            );
+            expect(version, equals('8.3'));
+          },
+          testOn: 'linux || mac-os',
+        );
+      });
 
       group('when the output cannot be parsed', () {
         setUp(() {

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -443,7 +443,7 @@ BUILD FAILED in 3s
           when(() => result.stdout).thenReturn('''
 
 ------------------------------------------------------------
-Gradle 7.6.3
+Gradle 12.34.56
 ------------------------------------------------------------
 
 Build time:   2023-10-04 15:59:47 UTC
@@ -463,7 +463,7 @@ OS:           Mac OS X 14.4.1 aarch64
             final version = await runWithOverrides(
               () => gradlew.version(tempDir.path),
             );
-            expect(version, equals('7.6.3'));
+            expect(version, equals('12.34.56'));
           },
           testOn: 'linux || mac-os',
         );
@@ -474,7 +474,7 @@ OS:           Mac OS X 14.4.1 aarch64
           when(() => result.stdout).thenReturn('''
 
 ------------------------------------------------------------
-Gradle 8.3
+Gradle 12.34
 ------------------------------------------------------------
 
 Build time:   2023-10-04 15:59:47 UTC
@@ -494,7 +494,7 @@ OS:           Mac OS X 14.4.1 aarch64
             final version = await runWithOverrides(
               () => gradlew.version(tempDir.path),
             );
-            expect(version, equals('8.3'));
+            expect(version, equals('12.34'));
           },
           testOn: 'linux || mac-os',
         );


### PR DESCRIPTION
## Description

Updates Gradle version parsing to handle cases where the Gradle version string is missing a patch version (e.g., '8.3' instead of '8.3.0')

Fixes https://github.com/shorebirdtech/shorebird/issues/2451

Thanks to @SunlightBro for the catch!

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
