### PR TITLE
feat: replace --staging with --channel in patch command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -87,16 +87,16 @@ of the iOS app that is using this module.''',
         negatable: false,
       )
       ..addOption(
-        'channel',
+        'track',
         allowed: DeploymentTrack.values.map((v) => v.channel),
-        help: 'The channel to publish the patch to.',
+        help: 'The track to publish the patch to.',
         defaultsTo: DeploymentTrack.production.channel,
       )
       ..addFlag(
         'staging',
         negatable: false,
         help: '''
-[DEPRECATED] Whether to publish the patch to the staging environment. Use --channel=staging instead.''',
+[DEPRECATED] Whether to publish the patch to the staging environment. Use --track=staging instead.''',
         hide: true,
       )
       ..addOption(
@@ -173,7 +173,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
   bool get isStaging => track == DeploymentTrack.staging;
 
   DeploymentTrack get track {
-    final channel = results['channel'] as String;
+    final channel = results['track'] as String;
     return DeploymentTrack.values.firstWhere((t) => t.channel == channel);
   }
 
@@ -181,7 +181,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
   Future<int> run() async {
     if (results.wasParsed('staging')) {
       logger.err(
-        '''The --staging flag is deprecated and will be removed in a future release. Use --channel=staging instead.''',
+        '''The --staging flag is deprecated and will be removed in a future release. Use --track=staging instead.''',
       );
       return ExitCode.usage.code;
     }

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -158,7 +158,11 @@ void main() {
       when(() => argResults['dry-run']).thenReturn(false);
       when(() => argResults['platforms']).thenReturn(['android']);
       when(() => argResults['release-version']).thenReturn(releaseVersion);
+      when(
+        () => argResults['channel'],
+      ).thenReturn(DeploymentTrack.production.channel);
       when(() => argResults.wasParsed(any())).thenReturn(true);
+      when(() => argResults.wasParsed('staging')).thenReturn(false);
       when(
         () => argResults.wasParsed(CommonArguments.privateKeyArg.name),
       ).thenReturn(false);
@@ -297,6 +301,28 @@ void main() {
 
     test('has non-empty description', () {
       expect(command.description, isNotEmpty);
+    });
+
+    group('run', () {
+      group('when --staging is passed', () {
+        setUp(() {
+          when(() => argResults.wasParsed('staging')).thenReturn(true);
+        });
+
+        test(
+            '''warns that staging flag will be deprecated and exits with usage code''',
+            () async {
+          await expectLater(
+            runWithOverrides(command.run),
+            completion(equals(ExitCode.usage.code)),
+          );
+          verify(
+            () => logger.err(
+              '''The --staging flag is deprecated and will be removed in a future release. Use --channel=staging instead.''',
+            ),
+          ).called(1);
+        });
+      });
     });
 
     group('createPatch', () {
@@ -487,7 +513,9 @@ void main() {
 
       group('when is staging', () {
         setUp(() {
-          when(() => argResults['staging']).thenReturn(true);
+          when(
+            () => argResults['channel'],
+          ).thenReturn(DeploymentTrack.staging.channel);
         });
 
         test('logs correct summary', () async {
@@ -955,7 +983,9 @@ Please re-run the release command for this version or create a new release.''',
 
     group('when patching to the staging track', () {
       setUp(() {
-        when(() => argResults['staging']).thenReturn(true);
+        when(
+          () => argResults['channel'],
+        ).thenReturn(DeploymentTrack.staging.channel);
       });
 
       test('publishes to the staging track', () async {

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -159,7 +159,7 @@ void main() {
       when(() => argResults['platforms']).thenReturn(['android']);
       when(() => argResults['release-version']).thenReturn(releaseVersion);
       when(
-        () => argResults['channel'],
+        () => argResults['track'],
       ).thenReturn(DeploymentTrack.production.channel);
       when(() => argResults.wasParsed(any())).thenReturn(true);
       when(() => argResults.wasParsed('staging')).thenReturn(false);
@@ -318,7 +318,7 @@ void main() {
           );
           verify(
             () => logger.err(
-              '''The --staging flag is deprecated and will be removed in a future release. Use --channel=staging instead.''',
+              '''The --staging flag is deprecated and will be removed in a future release. Use --track=staging instead.''',
             ),
           ).called(1);
         });
@@ -514,7 +514,7 @@ void main() {
       group('when is staging', () {
         setUp(() {
           when(
-            () => argResults['channel'],
+            () => argResults['track'],
           ).thenReturn(DeploymentTrack.staging.channel);
         });
 
@@ -984,7 +984,7 @@ Please re-run the release command for this version or create a new release.''',
     group('when patching to the staging track', () {
       setUp(() {
         when(
-          () => argResults['channel'],
+          () => argResults['track'],
         ).thenReturn(DeploymentTrack.staging.channel);
       });
 


### PR DESCRIPTION
## Description

Updates the patch command to accept the `--channel` argument (which defaults to `stable`). Currently accepted values are `staging` and `stable`. This replaces `--staging`, which now prints a deprecation error.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
