### PR TITLE
chore: prep release 1.4.12

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,16 @@ cspell:words pubspec erickzanardo xcframeworks Cupertino codesign codecov rkisha
 
 This section contains past updates we've sent to customers.
 
+## 1.4.12 (November 14, 2024)
+
+- 🍎 Remove logic to provide custom ExportOptions.plist to iOS builds. This was
+  in place to prevent Xcode from changing build numbers post-build, which
+  confuses Shorebird. This no longer seems to be an issue, and the
+  ExportOptions.plist behavior was causing issues with apps using extensions
+  (see https://github.com/shorebirdtech/shorebird/issues/1956). If you see
+  a different version of your app in App Store Connect than in your Shorebird
+  release, this is likely caused by this change, and you should let us know.
+
 ## 1.4.11 (November 14, 2024)
 
 - 🐦 Support for Flutter 3.24.5

--- a/packages/shorebird_cli/lib/src/version.dart
+++ b/packages/shorebird_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.4.11';
+const packageVersion = '1.4.12';

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_cli
 description: Command-line tool to interact with Shorebird's services.
-version: 1.4.11
+version: 1.4.12
 repository: https://github.com/shorebirdtech/shorebird
 
 publish_to: none


### PR DESCRIPTION
Exactly the same as 1.4.11, except for https://github.com/shorebirdtech/shorebird/pull/2620