### PR TITLE
fix(shorebird_cli): delete stale `build/ios/shorebird` directory

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
@@ -87,11 +87,10 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
     // Delete the Shorebird supplement directory if it exists.
     // This is to ensure that we don't accidentally upload stale artifacts
     // when building with older versions of Flutter.
-    final shorebirdSupplementDir = Directory(
-      p.canonicalize(p.join('build', 'ios', 'shorebird')),
-    );
-    if (shorebirdSupplementDir.existsSync()) {
-      shorebirdSupplementDir.deleteSync(recursive: true);
+    final shorebirdSupplementDir =
+        artifactManager.getIosReleaseSupplementDirectory();
+    if (shorebirdSupplementDir?.existsSync() ?? false) {
+      shorebirdSupplementDir!.deleteSync(recursive: true);
     }
 
     final buildProgress = logger.progress(

--- a/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
@@ -84,6 +84,16 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
   Future<FileSystemEntity> buildReleaseArtifacts() async {
     final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
 
+    // Delete the Shorebird supplement directory if it exists.
+    // This is to ensure that we don't accidentally upload stale artifacts
+    // when building with older versions of Flutter.
+    final shorebirdSupplementDir = Directory(
+      p.canonicalize(p.join('build', 'ios', 'shorebird')),
+    );
+    if (shorebirdSupplementDir.existsSync()) {
+      shorebirdSupplementDir.deleteSync(recursive: true);
+    }
+
     final buildProgress = logger.progress(
       'Building iOS framework with Flutter $flutterVersionString',
     );

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -109,11 +109,10 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
     // Delete the Shorebird supplement directory if it exists.
     // This is to ensure that we don't accidentally upload stale artifacts
     // when building with older versions of Flutter.
-    final shorebirdSupplementDir = Directory(
-      p.canonicalize(p.join('build', 'ios', 'shorebird')),
-    );
-    if (shorebirdSupplementDir.existsSync()) {
-      shorebirdSupplementDir.deleteSync(recursive: true);
+    final shorebirdSupplementDir =
+        artifactManager.getIosReleaseSupplementDirectory();
+    if (shorebirdSupplementDir?.existsSync() ?? false) {
+      shorebirdSupplementDir!.deleteSync(recursive: true);
     }
 
     final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -106,6 +106,16 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
         );
     }
 
+    // Delete the Shorebird supplement directory if it exists.
+    // This is to ensure that we don't accidentally upload stale artifacts
+    // when building with older versions of Flutter.
+    final shorebirdSupplementDir = Directory(
+      p.canonicalize(p.join('build', 'ios', 'shorebird')),
+    );
+    if (shorebirdSupplementDir.existsSync()) {
+      shorebirdSupplementDir.deleteSync(recursive: true);
+    }
+
     final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
     final buildProgress = logger.detailProgress(
       'Building app bundle with Flutter $flutterVersionString',

--- a/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
@@ -309,23 +309,22 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
         group('when build succeeds', () {
           group('when stale build/ios/shorebird directory exists', () {
             late Directory shorebirdSupplementDir;
+
             setUp(() {
               shorebirdSupplementDir = Directory(
                 p.join(projectRoot.path, 'build', 'ios', 'shorebird'),
               )..createSync(recursive: true);
+              when(
+                () => artifactManager.getIosReleaseSupplementDirectory(),
+              ).thenReturn(shorebirdSupplementDir);
             });
 
             test('deletes the directory', () async {
-              await IOOverrides.runZoned(
-                () async {
-                  expect(shorebirdSupplementDir.existsSync(), isTrue);
-                  await runWithOverrides(
-                    iosFrameworkReleaser.buildReleaseArtifacts,
-                  );
-                  expect(shorebirdSupplementDir.existsSync(), isFalse);
-                },
-                getCurrentDirectory: () => projectRoot,
+              expect(shorebirdSupplementDir.existsSync(), isTrue);
+              await runWithOverrides(
+                iosFrameworkReleaser.buildReleaseArtifacts,
               );
+              expect(shorebirdSupplementDir.existsSync(), isFalse);
             });
           });
 

--- a/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
@@ -307,6 +307,28 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
         });
 
         group('when build succeeds', () {
+          group('when stale build/ios/shorebird directory exists', () {
+            late Directory shorebirdSupplementDir;
+            setUp(() {
+              shorebirdSupplementDir = Directory(
+                p.join(projectRoot.path, 'build', 'ios', 'shorebird'),
+              )..createSync(recursive: true);
+            });
+
+            test('deletes the directory', () async {
+              await IOOverrides.runZoned(
+                () async {
+                  expect(shorebirdSupplementDir.existsSync(), isTrue);
+                  await runWithOverrides(
+                    iosFrameworkReleaser.buildReleaseArtifacts,
+                  );
+                  expect(shorebirdSupplementDir.existsSync(), isFalse);
+                },
+                getCurrentDirectory: () => projectRoot,
+              );
+            });
+          });
+
           group('when platform was specified via arg results rest', () {
             setUp(() {
               when(() => argResults.rest).thenReturn(['ios', '--verbose']);

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -462,21 +462,20 @@ To change the version of this release, change your app's version in your pubspec
         group('when build succeeds', () {
           group('when stale build/ios/shorebird directory exists', () {
             late Directory shorebirdSupplementDir;
+
             setUp(() {
               shorebirdSupplementDir = Directory(
                 p.join(projectRoot.path, 'build', 'ios', 'shorebird'),
               )..createSync(recursive: true);
+              when(
+                () => artifactManager.getIosReleaseSupplementDirectory(),
+              ).thenReturn(shorebirdSupplementDir);
             });
 
             test('deletes the directory', () async {
-              await IOOverrides.runZoned(
-                () async {
-                  expect(shorebirdSupplementDir.existsSync(), isTrue);
-                  await runWithOverrides(iosReleaser.buildReleaseArtifacts);
-                  expect(shorebirdSupplementDir.existsSync(), isFalse);
-                },
-                getCurrentDirectory: () => projectRoot,
-              );
+              expect(shorebirdSupplementDir.existsSync(), isTrue);
+              await runWithOverrides(iosReleaser.buildReleaseArtifacts);
+              expect(shorebirdSupplementDir.existsSync(), isFalse);
             });
           });
 

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -348,14 +348,17 @@ To change the version of this release, change your app's version in your pubspec
               xcarchiveDirectory: any(named: 'xcarchiveDirectory'),
             ),
           ).thenReturn(iosAppDirectory);
-          when(() => artifactManager.getXcarchiveDirectory())
-              .thenReturn(xcarchiveDirectory);
+          when(
+            () => artifactManager.getXcarchiveDirectory(),
+          ).thenReturn(xcarchiveDirectory);
 
-          when(() => codeSigner.base64PublicKey(any()))
-              .thenReturn(base64PublicKey);
+          when(
+            () => codeSigner.base64PublicKey(any()),
+          ).thenReturn(base64PublicKey);
 
-          when(() => shorebirdEnv.getShorebirdProjectRoot())
-              .thenReturn(projectRoot);
+          when(
+            () => shorebirdEnv.getShorebirdProjectRoot(),
+          ).thenReturn(projectRoot);
           when(
             () => shorebirdFlutter.getVersionAndRevision(),
           ).thenAnswer((_) async => flutterVersionAndRevision);
@@ -369,8 +372,9 @@ To change the version of this release, change your app's version in your pubspec
                 'patch-signing-public-key.pem',
               ),
             )..createSync(recursive: true);
-            when(() => argResults[CommonArguments.publicKeyArg.name])
-                .thenReturn(patchSigningPublicKeyFile.path);
+            when(
+              () => argResults[CommonArguments.publicKeyArg.name],
+            ).thenReturn(patchSigningPublicKeyFile.path);
 
             when(
               () => artifactBuilder.buildIpa(
@@ -456,6 +460,26 @@ To change the version of this release, change your app's version in your pubspec
         });
 
         group('when build succeeds', () {
+          group('when stale build/ios/shorebird directory exists', () {
+            late Directory shorebirdSupplementDir;
+            setUp(() {
+              shorebirdSupplementDir = Directory(
+                p.join(projectRoot.path, 'build', 'ios', 'shorebird'),
+              )..createSync(recursive: true);
+            });
+
+            test('deletes the directory', () async {
+              await IOOverrides.runZoned(
+                () async {
+                  expect(shorebirdSupplementDir.existsSync(), isTrue);
+                  await runWithOverrides(iosReleaser.buildReleaseArtifacts);
+                  expect(shorebirdSupplementDir.existsSync(), isFalse);
+                },
+                getCurrentDirectory: () => projectRoot,
+              );
+            });
+          });
+
           group('when platform was specified via arg results rest', () {
             setUp(() {
               when(() => argResults.rest).thenReturn(['ios', '--verbose']);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- fix(shorebird_cli): delete stale `build/ios/shorebird` directory
  - This fixes a bug which could happen if someone built an app with a newer flutter revision and then downgraded to an older flutter revision (we'd incorrectly upload stale class table link information)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
