### PR TITLE
fix: remove __MACOSX directories from ditto archives

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/ditto.dart
+++ b/packages/shorebird_cli/lib/src/executables/ditto.dart
@@ -44,9 +44,20 @@ class Ditto {
       source,
       destination,
     ];
-    final result = await _exec(args.join(' '));
-    if (result.exitCode != 0) {
-      throw Exception('Failed to archive: ${result.stderr}');
+    final dittoResult = await _exec(args.join(' '));
+    if (dittoResult.exitCode != 0) {
+      throw Exception('Failed to archive: ${dittoResult.stderr}');
+    }
+
+    // ditto includes __MACOSX directories in the archive, which we don't want.
+    // Use the `zip` command to remove them. More on these directories:
+    // https://superuser.com/questions/104500/what-is-macosx-folder-i-keep-seeing-in-zip-files-made-by-people-on-os-x
+    final zipResult = await process.run(
+      'zip',
+      ['-d', destination, r'__MACOSX\/*'],
+    );
+    if (zipResult.exitCode != 0) {
+      throw Exception('Failed to archive: ${zipResult.stderr}');
     }
   }
 }


### PR DESCRIPTION
## Description

`ditto` archives include a lot of `__MACOSX` directories, which we don't need and confuse our archive differ. This change updates `ditto.archive` to remove those directories after zipping (there doesn't seem to be a flag we can pass to ditto that will keep them from being zipped in the first place).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
