### PR TITLE
fix: ignore null fields when converting CreateReleaseArtifactRequest to json

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
@@ -9,7 +9,7 @@ part 'create_release_artifact_request.g.dart';
 /// Because this request is sent as a http.MultipartRequest, all fields
 /// serialize to strings.
 /// {@endtemplate}
-@JsonSerializable()
+@JsonSerializable(includeIfNull: false)
 class CreateReleaseArtifactRequest {
   /// {@macro create_release_artifact_request}
   const CreateReleaseArtifactRequest({

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.g.dart
@@ -36,26 +36,18 @@ CreateReleaseArtifactRequest _$CreateReleaseArtifactRequestFromJson(
     );
 
 Map<String, dynamic> _$CreateReleaseArtifactRequestToJson(
-    CreateReleaseArtifactRequest instance) {
-  final val = <String, dynamic>{
-    'arch': instance.arch,
-    'platform': _$ReleasePlatformEnumMap[instance.platform]!,
-    'hash': instance.hash,
-    'filename': instance.filename,
-    'can_sideload':
-        CreateReleaseArtifactRequest._parseBoolToString(instance.canSideload),
-    'size': CreateReleaseArtifactRequest._parseIntToString(instance.size),
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('podfile_lock_hash', instance.podfileLockHash);
-  return val;
-}
+        CreateReleaseArtifactRequest instance) =>
+    <String, dynamic>{
+      'arch': instance.arch,
+      'platform': _$ReleasePlatformEnumMap[instance.platform]!,
+      'hash': instance.hash,
+      'filename': instance.filename,
+      'can_sideload':
+          CreateReleaseArtifactRequest._parseBoolToString(instance.canSideload),
+      'size': CreateReleaseArtifactRequest._parseIntToString(instance.size),
+      if (instance.podfileLockHash case final value?)
+        'podfile_lock_hash': value,
+    };
 
 const _$ReleasePlatformEnumMap = {
   ReleasePlatform.android: 'android',

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.g.dart
@@ -36,17 +36,26 @@ CreateReleaseArtifactRequest _$CreateReleaseArtifactRequestFromJson(
     );
 
 Map<String, dynamic> _$CreateReleaseArtifactRequestToJson(
-        CreateReleaseArtifactRequest instance) =>
-    <String, dynamic>{
-      'arch': instance.arch,
-      'platform': _$ReleasePlatformEnumMap[instance.platform]!,
-      'hash': instance.hash,
-      'filename': instance.filename,
-      'can_sideload':
-          CreateReleaseArtifactRequest._parseBoolToString(instance.canSideload),
-      'size': CreateReleaseArtifactRequest._parseIntToString(instance.size),
-      'podfile_lock_hash': instance.podfileLockHash,
-    };
+    CreateReleaseArtifactRequest instance) {
+  final val = <String, dynamic>{
+    'arch': instance.arch,
+    'platform': _$ReleasePlatformEnumMap[instance.platform]!,
+    'hash': instance.hash,
+    'filename': instance.filename,
+    'can_sideload':
+        CreateReleaseArtifactRequest._parseBoolToString(instance.canSideload),
+    'size': CreateReleaseArtifactRequest._parseIntToString(instance.size),
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('podfile_lock_hash', instance.podfileLockHash);
+  return val;
+}
 
 const _$ReleasePlatformEnumMap = {
   ReleasePlatform.android: 'android',


### PR DESCRIPTION
## Description

This was causing us to send the string "null" as the value for the `podfileLockHash` when creating release artifacts.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
