### PR TITLE
fix: use correct gen_snapshot path on ios

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
@@ -128,7 +128,7 @@ class ShorebirdCachedArtifacts implements ShorebirdArtifacts {
         'artifacts',
         'engine',
         'ios-release',
-        'gen_snapshot',
+        'gen_snapshot_arm64',
       ),
     );
   }

--- a/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
@@ -119,7 +119,7 @@ void main() {
               'artifacts',
               'engine',
               'ios-release',
-              'gen_snapshot',
+              'gen_snapshot_arm64',
             ),
           ),
         );


### PR DESCRIPTION
## Description

This was incorrectly changed as part of the previous release.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
