### PR TITLE
fix(shorebird_cli): print shorebird checkout output on windows, verify longpaths

### DIFF
--- a/bin/shorebird.ps1
+++ b/bin/shorebird.ps1
@@ -23,18 +23,25 @@ $dart = [IO.Path]::Combine($flutterPath, "bin", "cache", "dart-sdk", "bin", "dar
 # This is fixed in Powershell 7.1.
 # 
 # See https://github.com/PowerShell/PowerShell/issues/4002 for more info.
-function Invoke-SilentlyIfPossible($command) {
+function Invoke-SilentlyIfNeeded($command) {
     $psVersion = $PSVersionTable.PSVersion
-    $shouldRedirectStdErr = $psVersion.Major -ge 7 -and $psVersion.Minor -ge 1
-    if ($shouldRedirectStdErr) {
-        # Redirect everything to $null.
-        & $command *> $null
+    $isErrorStreamIssueFixed = $psVersion.Major -ge 7 -and $psVersion.Minor -ge 1
+    if ($isErrorStreamIssueFixed) {
+        & $command
     }
     else {
         # Otherwise redirect everything _but_ the Error stream to $null. See
         # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_output_streams?view=powershell-7.3#long-description
         # for a description of these streams.
         & $command  1> $null 3> $null 4> $null 5> $null 6> $null
+    }
+}
+
+function Test-GitConfigLongpaths {
+    $longpathsEnabled = git config --system core.longpaths
+    if ($longpathsEnabled -ne "true") {
+        Write-Output "Git is not configured to allow long paths. This can cause issues with Shorebird's Flutter checkout. Please run 'git config --system core.longpaths true' to enable long paths."
+        exit 1
     }
 }
 
@@ -100,17 +107,17 @@ function Update-Flutter {
     Write-Output "Updating Flutter..."
 
     if (!(Test-Path $flutterPath)) {
-        Invoke-SilentlyIfPossible {
+        Invoke-SilentlyIfNeeded {
             git clone --filter=tree:0 https://github.com/shorebirdtech/flutter.git --no-checkout "$flutterPath" 
         }
     }
     else {
-        Invoke-SilentlyIfPossible {
+        Invoke-SilentlyIfNeeded {
             git -C "$flutterPath" fetch
         }
     }
 
-    Invoke-SilentlyIfPossible {
+    Invoke-SilentlyIfNeeded {
         # -c to avoid printing a warning about being in a detached head state.
         git -C "$flutterPath" -c advice.detachedHead=false checkout "$flutterVersion"
     }
@@ -151,6 +158,8 @@ function Update-Shorebird {
 }
 
 Test-GitInstalled
+
+Test-GitConfigLongpaths
 
 if (Test-ShorebirdNeedsUpdate) {
     Update-Shorebird

--- a/bin/shorebird.ps1
+++ b/bin/shorebird.ps1
@@ -27,6 +27,7 @@ function Invoke-SilentlyIfNeeded($command) {
     $psVersion = $PSVersionTable.PSVersion
     $isErrorStreamIssueFixed = $psVersion.Major -ge 7 -and $psVersion.Minor -ge 1
     if ($isErrorStreamIssueFixed) {
+        # Execute the command with no redirection.
         & $command
     }
     else {

--- a/bin/shorebird.ps1
+++ b/bin/shorebird.ps1
@@ -42,7 +42,6 @@ function Test-GitConfigLongpaths {
     $longpathsEnabled = git config --system core.longpaths
     if ($longpathsEnabled -ne "true") {
         Write-Output "Git is not configured to allow long paths. This can cause issues with Shorebird's Flutter checkout. Please run 'git config --system core.longpaths true' to enable long paths."
-        exit 1
     }
 }
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -63,6 +63,7 @@ words:
   - libplist
   - lldb
   - logcat
+  - longpaths
   - lproj
   - metadatas
   - mktemp


### PR DESCRIPTION
## Description

Updates shorebird.ps1 to print git output when we check out our fork of Flutter and to verify that git's core.longpaths config property is true. 

Fixes https://github.com/shorebirdtech/shorebird/issues/2709

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
