### PR TITLE
feat(shorebird_cli): add custom keystore support to `shorebird preview`

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -396,7 +396,7 @@ This is only applicable when previewing Android releases.''',
     final keyPassword = results['ks-key-pass'] as String?;
     final keyAlias = results['ks-key-alias'] as String?;
 
-    // Validate the keystore flags.
+    // Ensure keystore options are valid.
     if (keystore != null) {
       if (keystorePassword == null) {
         logger.err('You must provide a keystore password.');

--- a/packages/shorebird_cli/lib/src/executables/bundletool.dart
+++ b/packages/shorebird_cli/lib/src/executables/bundletool.dart
@@ -45,6 +45,10 @@ class Bundletool {
     required String bundle,
     required String output,
     bool universal = true,
+    String? keystore,
+    String? keystorePassword,
+    String? keyPassword,
+    String? keyAlias,
   }) async {
     final result = await _exec(
       [
@@ -53,6 +57,10 @@ class Bundletool {
         '--bundle=$bundle',
         '--output=$output',
         if (universal) '--mode=universal',
+        if (keystore != null) '--ks=$keystore',
+        if (keystorePassword != null) '--ks-pass=$keystorePassword',
+        if (keyPassword != null) '--key-pass=$keyPassword',
+        if (keyAlias != null) '--ks-key-alias=$keyAlias',
       ],
     );
     if (result.exitCode != 0) {

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -403,6 +403,10 @@ void main() {
           () => bundletool.buildApks(
             bundle: any(named: 'bundle'),
             output: any(named: 'output'),
+            keystore: any(named: 'keystore'),
+            keystorePassword: any(named: 'keystorePassword'),
+            keyPassword: any(named: 'keyPassword'),
+            keyAlias: any(named: 'keyAlias'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -482,6 +486,165 @@ void main() {
               display: any(named: 'display'),
             ),
           );
+        });
+
+        group('when valid keystore is specified', () {
+          const keystore = 'keystore.jks';
+          const keystorePassword = 'pass:keystorePassword';
+          const keyPassword = 'pass:keyPassword';
+          const keyAlias = 'keyAlias';
+
+          setUp(() {
+            when(() => argResults['ks']).thenReturn(keystore);
+            when(() => argResults['ks-pass']).thenReturn(keystorePassword);
+            when(() => argResults['ks-key-pass']).thenReturn(keyPassword);
+            when(() => argResults['ks-key-alias']).thenReturn(keyAlias);
+          });
+
+          test('builds apks with keystore', () async {
+            await runWithOverrides(command.run);
+
+            verify(
+              () => bundletool.buildApks(
+                bundle: aabPath(),
+                output: apksPath(),
+                keystore: keystore,
+                keystorePassword: keystorePassword,
+                keyPassword: keyPassword,
+                keyAlias: keyAlias,
+              ),
+            ).called(1);
+          });
+        });
+
+        group('when keystorePassword is missing', () {
+          const keystore = 'keystore.jks';
+
+          setUp(() {
+            when(() => argResults['ks']).thenReturn(keystore);
+          });
+
+          test('exits with usage error', () async {
+            final result = await runWithOverrides(command.run);
+            expect(result, equals(ExitCode.usage.code));
+
+            verify(
+              () => logger.err('You must provide a keystore password.'),
+            ).called(1);
+
+            verifyNever(
+              () => bundletool.buildApks(
+                bundle: aabPath(),
+                output: apksPath(),
+                keystore: any(named: 'keystore'),
+                keystorePassword: any(named: 'keystorePassword'),
+                keyPassword: any(named: 'keyPassword'),
+                keyAlias: any(named: 'keyAlias'),
+              ),
+            );
+          });
+        });
+
+        group('when keyAlias is missing', () {
+          const keystore = 'keystore.jks';
+          const keystorePassword = 'keystorePassword';
+
+          setUp(() {
+            when(() => argResults['ks']).thenReturn(keystore);
+            when(() => argResults['ks-pass']).thenReturn(keystorePassword);
+          });
+
+          test('exits with usage error', () async {
+            final result = await runWithOverrides(command.run);
+            expect(result, equals(ExitCode.usage.code));
+
+            verify(
+              () => logger.err('You must provide a key alias.'),
+            ).called(1);
+
+            verifyNever(
+              () => bundletool.buildApks(
+                bundle: aabPath(),
+                output: apksPath(),
+                keystore: any(named: 'keystore'),
+                keystorePassword: any(named: 'keystorePassword'),
+                keyPassword: any(named: 'keyPassword'),
+                keyAlias: any(named: 'keyAlias'),
+              ),
+            );
+          });
+        });
+
+        group('when keystorePassword is invalid', () {
+          const keystore = 'keystore.jks';
+          const keystorePassword = 'keystorePassword';
+          const keyPassword = 'pass:keyPassword';
+          const keyAlias = 'keyAlias';
+
+          setUp(() {
+            when(() => argResults['ks']).thenReturn(keystore);
+            when(() => argResults['ks-pass']).thenReturn(keystorePassword);
+            when(() => argResults['ks-key-pass']).thenReturn(keyPassword);
+            when(() => argResults['ks-key-alias']).thenReturn(keyAlias);
+          });
+
+          test('exits with usage error', () async {
+            final result = await runWithOverrides(command.run);
+            expect(result, equals(ExitCode.usage.code));
+
+            verify(
+              () => logger.err(
+                'Keystore password must start with "pass:" or "file:".',
+              ),
+            ).called(1);
+
+            verifyNever(
+              () => bundletool.buildApks(
+                bundle: aabPath(),
+                output: apksPath(),
+                keystore: any(named: 'keystore'),
+                keystorePassword: any(named: 'keystorePassword'),
+                keyPassword: any(named: 'keyPassword'),
+                keyAlias: any(named: 'keyAlias'),
+              ),
+            );
+          });
+        });
+
+        group('when keyPassword is invalid', () {
+          const keystore = 'keystore.jks';
+          const keystorePassword = 'file:keystorePasswordFile';
+          const keyPassword = 'keyPassword';
+          const keyAlias = 'keyAlias';
+
+          setUp(() {
+            when(() => argResults['ks']).thenReturn(keystore);
+            when(() => argResults['ks-pass']).thenReturn(keystorePassword);
+            when(() => argResults['ks-key-pass']).thenReturn(keyPassword);
+            when(() => argResults['ks-key-alias']).thenReturn(keyAlias);
+          });
+
+          test('exits with usage error', () async {
+            final result = await runWithOverrides(command.run);
+            expect(result, equals(ExitCode.usage.code));
+
+            verify(
+              () => logger.err(
+                'Key password must start with "pass:" or "file:".',
+              ),
+            ).called(1);
+
+            verifyNever(
+              () => bundletool.buildApks(
+                bundle: aabPath(),
+                output: apksPath(),
+                keystore: any(named: 'keystore'),
+                keystorePassword: any(named: 'keystorePassword'),
+                keyPassword: any(named: 'keyPassword'),
+                keyAlias: any(named: 'keyAlias'),
+              ),
+            );
+          });
         });
       });
 

--- a/packages/shorebird_cli/test/src/executables/bundletool_test.dart
+++ b/packages/shorebird_cli/test/src/executables/bundletool_test.dart
@@ -129,6 +129,68 @@ void main() {
         ).called(1);
       });
 
+      group('when keystore configuration is passed', () {
+        const keystore = 'keystore.jks';
+        const keystorePassword = 'pass:keystorePassword';
+        const keyPassword = 'pass:keyPassword';
+        const keyAlias = 'keyAlias';
+
+        setUp(() {
+          when(
+            () => process.run(
+              any(),
+              any(),
+              environment: any(named: 'environment'),
+            ),
+          ).thenAnswer(
+            (_) async => const ShorebirdProcessResult(
+              exitCode: 0,
+              stdout: '',
+              stderr: '',
+            ),
+          );
+        });
+
+        test('sets correct flags', () async {
+          await expectLater(
+            runWithOverrides(
+              () => bundletool.buildApks(
+                bundle: appBundlePath,
+                output: output,
+                keystore: keystore,
+                keystorePassword: keystorePassword,
+                keyPassword: keyPassword,
+                keyAlias: keyAlias,
+              ),
+            ),
+            completes,
+          );
+
+          verify(
+            () => process.run(
+              'java',
+              [
+                '-jar',
+                p.join(workingDirectory.path, 'bundletool.jar'),
+                'build-apks',
+                '--overwrite',
+                '--bundle=$appBundlePath',
+                '--output=$output',
+                '--mode=universal',
+                '--ks=$keystore',
+                '--ks-pass=$keystorePassword',
+                '--key-pass=$keyPassword',
+                '--ks-key-alias=$keyAlias',
+              ],
+              environment: {
+                'ANDROID_HOME': androidSdkPath,
+                'JAVA_HOME': javaHome,
+              },
+            ),
+          ).called(1);
+        });
+      });
+
       group('when universal is set to false', () {
         setUp(() {
           when(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- This PR makes it possible to pass a custom keystore configuration when previewing android releases.

**Sample Usage**

```sh
shorebird preview --platform android --release-version 1.0.0+1 --ks=./my_keystore.jks --ks-pass=pass:top-secret --ks-alias=keyAlias
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
