### PR TITLE
fix: ensure windows releases include build number

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/powershell.dart
+++ b/packages/shorebird_cli/lib/src/executables/powershell.dart
@@ -47,6 +47,10 @@ class Powershell {
       runInShell: true,
     );
 
-    return (result.stdout as String).trim();
+    var versionString = (result.stdout as String).trim();
+    if (!versionString.contains('+')) {
+      versionString += '+0';
+    }
+    return versionString;
   }
 }

--- a/packages/shorebird_cli/test/src/executables/powershell_test.dart
+++ b/packages/shorebird_cli/test/src/executables/powershell_test.dart
@@ -56,16 +56,33 @@ void main() {
       });
 
       group('when exit code is success', () {
-        setUp(() {
-          when(() => processResult.exitCode).thenReturn(0);
-          when(() => processResult.stdout).thenReturn('1.0.0');
+        group('when version code includes a build number', () {
+          setUp(() {
+            when(() => processResult.exitCode).thenReturn(0);
+            when(() => processResult.stdout).thenReturn('1.0.0+1');
+          });
+
+          test('returns unaltered version string', () async {
+            final version = await runWithOverrides(
+              () => powershell.getExeVersionString(File('')),
+            );
+            expect(version, '1.0.0+1');
+          });
         });
 
-        test('returns the version string', () async {
-          final version = await runWithOverrides(
-            () => powershell.getExeVersionString(File('')),
-          );
-          expect(version, '1.0.0');
+        group('when version code does not include a build number', () {
+          setUp(() {
+            when(() => processResult.exitCode).thenReturn(0);
+            when(() => processResult.stdout).thenReturn('1.0.0');
+          });
+
+          test('returns the version string with build number 0 added',
+              () async {
+            final version = await runWithOverrides(
+              () => powershell.getExeVersionString(File('')),
+            );
+            expect(version, '1.0.0+0');
+          });
         });
       });
     });


### PR DESCRIPTION
## Description

If a flutter app's pubspec.yaml contains a version without a build number (e.g., `1.0.0`), our engine logic will parse that as `1.0.0+0`. This change updates the CLI's version parsing logic to append `+0` if no build number is present.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
