### PR TITLE
fix: improve flutter minimum support version check for windows

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
@@ -66,10 +66,10 @@ To change the version of this release, change your app's version in your pubspec
       final version =
           await shorebirdFlutter.resolveFlutterVersion(flutterVersionArg);
       final gitHash =
-          await shorebirdFlutter.resolveFlutterRevision(flutterVersionArg);
+          await shorebirdFlutter.getRevisionForVersion(flutterVersionArg);
       if ((version != null &&
-              version < minimumSupportedWindowsFlutterVersion) ||
-          !flutter_3_27_1_windowsHashes.contains(gitHash)) {
+              version < minimumSupportedWindowsFlutterVersion) &&
+          !windowsFlutterGitHashesBelowMinVersion.contains(gitHash)) {
         logger.err(
           '''
 Windows releases are not supported with Flutter versions older than $minimumSupportedWindowsFlutterVersion.

--- a/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
@@ -67,8 +67,8 @@ To change the version of this release, change your app's version in your pubspec
           await shorebirdFlutter.resolveFlutterVersion(flutterVersionArg);
       final gitHash =
           await shorebirdFlutter.getRevisionForVersion(flutterVersionArg);
-      if ((version != null &&
-              version < minimumSupportedWindowsFlutterVersion) &&
+      if (version != null &&
+          version < minimumSupportedWindowsFlutterVersion &&
           !windowsFlutterGitHashesBelowMinVersion.contains(gitHash)) {
         logger.err(
           '''

--- a/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
@@ -65,7 +65,11 @@ To change the version of this release, change your app's version in your pubspec
     if (flutterVersionArg != null) {
       final version =
           await shorebirdFlutter.resolveFlutterVersion(flutterVersionArg);
-      if (version != null && version < minimumSupportedWindowsFlutterVersion) {
+      final gitHash =
+          await shorebirdFlutter.resolveFlutterRevision(flutterVersionArg);
+      if ((version != null &&
+              version < minimumSupportedWindowsFlutterVersion) ||
+          !flutter_3_27_1_windowsHashes.contains(gitHash)) {
         logger.err(
           '''
 Windows releases are not supported with Flutter versions older than $minimumSupportedWindowsFlutterVersion.

--- a/packages/shorebird_cli/lib/src/platform/windows.dart
+++ b/packages/shorebird_cli/lib/src/platform/windows.dart
@@ -13,7 +13,7 @@ const primaryWindowsReleaseArtifactArch = 'win_archive';
 final minimumSupportedWindowsFlutterVersion = Version(3, 27, 2);
 
 /// Revisions of Flutter 3.27.1 that support windows.
-const flutter_3_27_1_windowsHashes = {
+const windowsFlutterGitHashesBelowMinVersion = {
   '56228c343d6c7fd3e1e548dbb290f9713bb22aa9'
 };
 

--- a/packages/shorebird_cli/lib/src/platform/windows.dart
+++ b/packages/shorebird_cli/lib/src/platform/windows.dart
@@ -10,7 +10,12 @@ import 'package:pub_semver/pub_semver.dart';
 const primaryWindowsReleaseArtifactArch = 'win_archive';
 
 /// The minimum allowed Flutter version for creating Windows releases.
-final minimumSupportedWindowsFlutterVersion = Version(3, 27, 1);
+final minimumSupportedWindowsFlutterVersion = Version(3, 27, 2);
+
+/// Revisions of Flutter 3.27.1 that support windows.
+const flutter_3_27_1_windowsHashes = {
+  '56228c343d6c7fd3e1e548dbb290f9713bb22aa9'
+};
 
 /// A warning message printed at the start of `shorebird release windows` and
 /// `shorebird patch windows` commands.

--- a/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
@@ -222,11 +222,12 @@ To change the version of this release, change your app's version in your pubspec
             ),
           ).thenAnswer((_) async {});
           when(() => argResults['flutter-version'] as String?)
-              .thenReturn('1.2.3');
-          when(() => shorebirdFlutter.resolveFlutterVersion('1.2.3'))
-              .thenAnswer((_) async => Version(1, 2, 3));
-          when(() => shorebirdFlutter.getVersionAndRevision())
-              .thenAnswer((_) async => '3.27.1');
+              .thenReturn('3.27.1');
+          when(() => shorebirdFlutter.resolveFlutterVersion('3.27.1'))
+              .thenAnswer((_) async => Version(3, 27, 1));
+          when(
+            () => shorebirdFlutter.getRevisionForVersion(any()),
+          ).thenAnswer((_) async => 'deadbeef');
         });
 
         test('logs error and exits with usage err', () async {
@@ -242,6 +243,22 @@ Windows releases are not supported with Flutter versions older than $minimumSupp
 For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
             ),
           ).called(1);
+        });
+
+        group('when flutter version is 3.27.1 but hash is supported', () {
+          setUp(() {
+            when(
+              () => shorebirdFlutter.getRevisionForVersion(any()),
+            ).thenAnswer(
+                (_) async => windowsFlutterGitHashesBelowMinVersion.first);
+          });
+
+          test('completes normally', () async {
+            await expectLater(
+              runWithOverrides(releaser.assertPreconditions),
+              completes,
+            );
+          });
         });
       });
     });


### PR DESCRIPTION
## Description

Make the minimum Flutter revision that supports Windows 3.27.2 (not released yet) and mark our currently Flutter revision as supporting windows.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
