### PR TITLE
fix: remove quotes from ditto files

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/ditto.dart
+++ b/packages/shorebird_cli/lib/src/executables/ditto.dart
@@ -21,7 +21,7 @@ class Ditto {
     required String source,
     required String destination,
   }) async {
-    final result = await _exec(['-x', '-k', '"$source"', '"$destination"']);
+    final result = await _exec(['-x', '-k', source, destination]);
     if (result.exitCode != 0) {
       throw Exception('Failed to extract: ${result.stderr}');
     }

--- a/packages/shorebird_cli/test/src/executables/ditto_test.dart
+++ b/packages/shorebird_cli/test/src/executables/ditto_test.dart
@@ -52,7 +52,7 @@ void main() {
           verify(
             () => process.run(
               'ditto',
-              ['-x', '-k', '"$source"', '"$destination"'],
+              ['-x', '-k', source, destination],
             ),
           ).called(1);
         });
@@ -88,7 +88,7 @@ void main() {
           verify(
             () => process.run(
               'ditto',
-              ['-x', '-k', '"$source"', '"$destination"'],
+              ['-x', '-k', source, destination],
             ),
           ).called(1);
         });


### PR DESCRIPTION
## Description

These were making `shorebird preview` unhappy – I think simply moving from a string split by spaces to an arg array (so we aren't splitting `/my/path/with spaces/somedir` into two separate args) is sufficient to resolve https://github.com/shorebirdtech/shorebird/issues/2764

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
