### PR TITLE
refactor(shorebird_cli): remove unnecessary `removeAnsiEscapes`

### DIFF
--- a/packages/shorebird_cli/lib/src/extensions/string.dart
+++ b/packages/shorebird_cli/lib/src/extensions/string.dart
@@ -4,31 +4,6 @@ extension NullOrEmpty on String? {
   bool get isNullOrEmpty => this == null || this!.isEmpty;
 }
 
-/// Extension on [String] to provide Ansi escape code helpers.
-extension AnsiEscapes on String {
-  /// Removes ANSI escape codes (usually the result of a lightCyan.wrap or
-  /// similar) from this string. Used to clean up
-  String removeAnsiEscapes() {
-    // Convert ansi escape links to markdown links. This assumes the string is
-    // well-formed and that there are no nested links.
-    //
-    // Links are in the form of '\x1B]8;;<uri>\x1B\\<text>\x1B]8;;\x1B\\'
-    //
-    // See https://github.com/felangel/mason/blob/38a525b0607d8723df3b5b3fcc2c087efd9e1c93/packages/mason_logger/lib/src/link.dart
-    final hyperlinkRegex = RegExp(
-      r'\x1B\]8;;(.+)\x1B\\(.+)\x1B\]8;;\x1B\\',
-    );
-    final ansiEscapeRegex = RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]');
-
-    // Replace all links with markdown links
-    // Remove all other ANSI escape codes
-    return replaceAllMapped(
-      hyperlinkRegex,
-      (match) => '[${match.group(2)!}](${match.group(1)!})',
-    ).replaceAll(ansiEscapeRegex, '');
-  }
-}
-
 /// Extension on [String] to provide an `isUpperCase` getter.
 extension IsUpperCase on String {
   /// Returns `true` if this string is in uppercase.

--- a/packages/shorebird_cli/lib/src/logging/shorebird_logger.dart
+++ b/packages/shorebird_cli/lib/src/logging/shorebird_logger.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped_deps/scoped_deps.dart';
-import 'package:shorebird_cli/src/extensions/string.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 
 /// A reference to a [Logger] instance.

--- a/packages/shorebird_cli/lib/src/logging/shorebird_logger.dart
+++ b/packages/shorebird_cli/lib/src/logging/shorebird_logger.dart
@@ -61,7 +61,7 @@ void writeToLogFile(Object? message, {required File logFile}) {
   }
 
   final timestampString = DateTime.now().toIso8601String();
-  final messageString = message.toString().removeAnsiEscapes();
+  final messageString = message.toString();
   logFile.writeAsStringSync(
     '$timestampString $messageString\n',
     mode: FileMode.append,

--- a/packages/shorebird_cli/test/src/extensions/string_test.dart
+++ b/packages/shorebird_cli/test/src/extensions/string_test.dart
@@ -1,4 +1,3 @@
-import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/extensions/string.dart';
 import 'package:test/test.dart';
 
@@ -20,21 +19,6 @@ void main() {
       test('returns false', () {
         expect('test'.isNullOrEmpty, false);
       });
-    });
-  });
-
-  group('AnsiEscapes', () {
-    test('removes ansi escape codes from string', () {
-      expect(
-        styleUnderlined.wrap(
-          '''This ${red.wrap('is')} ${styleBlink.wrap('a')} ${lightCyan.wrap('test')}''',
-        )!.removeAnsiEscapes(),
-        equals('This is a test'),
-      );
-    });
-
-    test('returns string unchanged if no ansi escape codes are present', () {
-      expect('test'.removeAnsiEscapes(), equals('test'));
     });
   });
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- refactor(shorebird_cli): remove unnecessary `removeAnsiEscapes`
  - this was fixed in `mason_logger` directly as part of https://github.com/felangel/mason/pull/1505
  - https://github.com/shorebirdtech/shorebird/pull/2754

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
