### PR TITLE
fix: remove faulty native change detection from Windows

### DIFF
--- a/packages/shorebird_cli/lib/src/archive_analysis/portable_executable.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/portable_executable.dart
@@ -4,6 +4,11 @@ import 'dart:typed_data';
 import 'package:shorebird_cli/src/archive_analysis/byte_utils.dart';
 
 /// Utilities for interacting with Windows Portable Executable files.
+///
+/// .exe and .dll files are examples of PE files. .dll files specifically "are
+/// considered executable files for almost all purposes, although they cannot be
+/// directly run."
+/// (https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#coff-file-header-object-and-image)
 class PortableExecutable {
   /// Zeroes out the timestamps in the provided PE file to enable comparison of
   /// binaries with different build times.

--- a/packages/shorebird_cli/test/src/archive_analysis/windows_archive_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/windows_archive_differ_test.dart
@@ -43,25 +43,8 @@ void main() {
     });
 
     group('isNativeFilePath', () {
-      group('when file extension is .dll', () {
-        test('returns true', () {
-          final result = differ.isNativeFilePath('foo.dll');
-          expect(result, isTrue);
-        });
-      });
-
-      group('when file extension is .exe', () {
-        test('returns true', () {
-          final result = differ.isNativeFilePath('foo.exe');
-          expect(result, isTrue);
-        });
-      });
-
-      group('when file extension is not .dll or .exe', () {
-        test('returns false', () {
-          final result = differ.isNativeFilePath('foo.so');
-          expect(result, isFalse);
-        });
+      test('returns false', () {
+        expect(differ.isNativeFilePath(r'C:\path\to\file.exe'), isFalse);
       });
     });
 
@@ -77,9 +60,18 @@ void main() {
         'patch.zip',
       );
 
-      test('returns an empty FileSetDiff', () async {
+      test('returns a FileSetDiff containing only the .exe', () async {
         final result = await differ.changedFiles(releasePath, patchPath);
-        expect(result, equals(FileSetDiff.empty()));
+        expect(
+          result,
+          equals(
+            const FileSetDiff(
+              addedPaths: {},
+              removedPaths: {},
+              changedPaths: {'hello_windows.exe'},
+            ),
+          ),
+        );
       });
     });
   });


### PR DESCRIPTION
## Description

Because Windows does not always produce stable outputs (the same inputs may produce exes and dlls that are very different at the bit level), we can't reliably detect native changes. This PR backs out our earlier native change detection.

Fixes https://github.com/shorebirdtech/shorebird/issues/2794

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
