### PR TITLE
feat: add validator to check that macOS app allows unsigned executable memory

### DIFF
--- a/packages/shorebird_cli/lib/src/doctor.dart
+++ b/packages/shorebird_cli/lib/src/doctor.dart
@@ -26,7 +26,7 @@ class Doctor {
 
   /// Validators that verify shorebird will work on macOS.
   final List<Validator> macosCommandValidators = [
-    MacosNetworkEntitlementValidator(),
+    MacosEntitlementsValidator(),
   ];
 
   /// Validators that verify shorebird will work on Windows.
@@ -38,7 +38,7 @@ class Doctor {
   List<Validator> generalValidators = [
     ShorebirdVersionValidator(),
     AndroidInternetPermissionValidator(),
-    MacosNetworkEntitlementValidator(),
+    MacosEntitlementsValidator(),
     ShorebirdYamlAssetValidator(),
     TrackedLockFilesValidator(),
   ];


### PR DESCRIPTION
## Description

Validate that the project's macOS app is configured to allow unsigned executable memory, which is required for macOS patches.

Part of https://github.com/shorebirdtech/shorebird/issues/2711

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
