### PR TITLE
feat: remove `--split-debug-symbols` handling from macOS patching

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/macos_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/macos_patcher.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:shorebird_cli/src/archive_analysis/apple_archive_differ.dart';
@@ -55,42 +54,6 @@ class MacosPatcher extends Patcher {
       );
 
   String get _appDillCopyPath => p.join(buildDirectory.path, 'app.dill');
-
-  /// The name of the split debug info file when the target is macOS and the
-  /// target platform is arm64.
-  static const splitDebugInfoArm64FileName = 'app.darwin-arm64.symbols';
-
-  /// The name of the split debug info file when the target is macOS and the
-  /// target platform is x64.
-  static const splitDebugInfoX64FileName = 'app.darwin-x86_64.symbols';
-
-  /// The additional gen_snapshot arguments to use when building the patch with
-  /// `--split-debug-info`.
-  static List<String> splitDebugInfoArgs(
-    String? splitDebugInfoPath,
-    Arch arch,
-  ) {
-    final fileName = switch (arch) {
-      Arch.arm64 => splitDebugInfoArm64FileName,
-      Arch.x86_64 => splitDebugInfoX64FileName,
-      _ => throw Exception('no split debug info file for $arch'),
-    };
-
-    return splitDebugInfoPath != null
-        ? [
-            '--dwarf-stack-traces',
-            '--resolve-dwarf-paths',
-            '''--save-debugging-info=${p.join(p.absolute(splitDebugInfoPath), fileName)}''',
-          ]
-        : <String>[];
-  }
-
-  /// The link percentage from the most recent patch build.
-  @visibleForTesting
-  double? lastBuildLinkPercentage;
-
-  @override
-  double? get linkPercentage => lastBuildLinkPercentage;
 
   @override
   ReleaseType get releaseType => ReleaseType.macos;
@@ -223,7 +186,6 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
           appDillPath: macosBuildResult.kernelFile.path,
           outFilePath: _arm64AotOutputPath,
           genSnapshotArtifact: ShorebirdArtifact.genSnapshotMacosArm64,
-          additionalArgs: splitDebugInfoArgs(splitDebugInfoPath, Arch.arm64),
         );
 
         if (!File(_arm64AotOutputPath).existsSync()) {
@@ -234,7 +196,6 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
           appDillPath: macosBuildResult.kernelFile.path,
           outFilePath: _x64AotOutputPath,
           genSnapshotArtifact: ShorebirdArtifact.genSnapshotMacosX64,
-          additionalArgs: splitDebugInfoArgs(splitDebugInfoPath, Arch.x86_64),
         );
 
         if (!File(_x64AotOutputPath).existsSync()) {
@@ -375,7 +336,6 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
     CreatePatchMetadata metadata,
   ) async =>
       metadata.copyWith(
-        linkPercentage: lastBuildLinkPercentage,
         environment: metadata.environment.copyWith(
           xcodeVersion: await xcodeBuild.version(),
         ),

--- a/packages/shorebird_cli/test/src/commands/patch/macos_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/macos_patcher_test.dart
@@ -46,7 +46,6 @@ void main() {
   group(
     MacosPatcher,
     () {
-      late AotTools aotTools;
       late ArgParser argParser;
       late ArgResults argResults;
       late ArtifactBuilder artifactBuilder;
@@ -75,7 +74,6 @@ void main() {
         return runScoped(
           body,
           values: {
-            aotToolsRef.overrideWith(() => aotTools),
             artifactBuilderRef.overrideWith(() => artifactBuilder),
             artifactManagerRef.overrideWith(() => artifactManager),
             codePushClientWrapperRef.overrideWith(() => codePushClientWrapper),
@@ -106,7 +104,6 @@ void main() {
       });
 
       setUp(() {
-        aotTools = MockAotTools();
         argParser = MockArgParser();
         argResults = MockArgResults();
         artifactBuilder = MockArtifactBuilder();

--- a/packages/shorebird_cli/test/src/commands/patch/macos_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/macos_patcher_test.dart
@@ -530,7 +530,7 @@ This may indicate that the patch contains native changes, which cannot be applie
           ).thenAnswer((_) async => flutterVersionAndRevision);
           when(
             () => shorebirdFlutter.getVersion(),
-          ).thenAnswer((_) async => Version(3, 27, 0));
+          ).thenAnswer((_) async => Version(3, 27, 3));
         });
 
         group('when specified flutter version is less than minimum', () {
@@ -807,8 +807,11 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
           group('when --split-debug-info is provided', () {
             final tempDir = Directory.systemTemp.createTempSync();
             final splitDebugInfoPath = p.join(tempDir.path, 'symbols');
-            final splitDebugInfoFile = File(
+            final splitDebugInfoArm64File = File(
               p.join(splitDebugInfoPath, 'app.darwin-arm64.symbols'),
+            );
+            final splitDebugInfoX64File = File(
+              p.join(splitDebugInfoPath, 'app.darwin-x86_64.symbols'),
             );
             setUp(() {
               when(
@@ -835,10 +838,22 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
                   additionalArgs: [
                     '--dwarf-stack-traces',
                     '--resolve-dwarf-paths',
-                    '--save-debugging-info=${splitDebugInfoFile.path}',
+                    '--save-debugging-info=${splitDebugInfoArm64File.path}',
                   ],
                 ),
-              ).called(2);
+              ).called(1);
+              verify(
+                () => artifactBuilder.buildElfAotSnapshot(
+                  appDillPath: any(named: 'appDillPath'),
+                  outFilePath: any(named: 'outFilePath'),
+                  genSnapshotArtifact: any(named: 'genSnapshotArtifact'),
+                  additionalArgs: [
+                    '--dwarf-stack-traces',
+                    '--resolve-dwarf-paths',
+                    '--save-debugging-info=${splitDebugInfoX64File.path}',
+                  ],
+                ),
+              ).called(1);
             });
           });
 


### PR DESCRIPTION
## Description

The `--split-debug-symbols` flag requires special handling on iOS due to linking considerations (see https://github.com/shorebirdtech/shorebird/pull/2570). macOS no longer has these considerations, so we can remove this code.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
