### PR TITLE
fix: tighten Flutter revisions for macOS releasing and patching

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -68,6 +68,7 @@ words:
   - nserror
   - Oltman
   - orri # Arm64 instruction, Or Register with Immediate
+  - patchability
   - pana
   - pkcs
   - podfile
@@ -107,6 +108,7 @@ words:
   - unmockable
   - Unpatchable
   - unsets
+  - unskipped
   - upvote
   - usbmuxd
   - USERPROFILE

--- a/packages/shorebird_cli/lib/src/commands/patch/macos_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/macos_patcher.dart
@@ -143,8 +143,11 @@ This may indicate that the patch contains native changes, which cannot be applie
         shorebirdFlutter.getVersion(),
       ).wait;
 
-      if ((flutterVersion ?? minimumSupportedMacosFlutterVersion) <
-          minimumSupportedMacosFlutterVersion) {
+      // TODO(bryanoltman): revert this to checking the flutter version once
+      // the minimum supported version is updated.
+      if (!patchableMacosFlutterRevisions.contains(
+        shorebirdEnv.flutterRevision,
+      )) {
         logger.err(
           '''
 macOS patches are not supported with Flutter versions older than $minimumSupportedMacosFlutterVersion.

--- a/packages/shorebird_cli/lib/src/platform/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple.dart
@@ -99,7 +99,17 @@ Please report issues at https://github.com/shorebirdtech/shorebird/issues/new
 final minimumSupportedIosFlutterVersion = Version(3, 22, 2);
 
 /// The minimum allowed Flutter version for creating macOS releases.
-final minimumSupportedMacosFlutterVersion = Version(3, 27, 0);
+final minimumSupportedMacosFlutterVersion = Version(3, 27, 3);
+
+/// Flutter revisions that support macOS patching.
+/// This is a temporary workaround. Some revisions of 3.27.3 (those included
+/// here) support our current (unlinked) method of patching macOS releases,
+/// while the rest do not.
+// TODO(bryanoltman): remove this when we can bump the minimum macOS version to
+// 3.27.4 or higher.
+const patchableMacosFlutterRevisions = {
+  '5c1dcc19ebcee3565c65262dd95970186e4d81cc',
+};
 
 /// A reference to a [Apple] instance.
 final appleRef = create(Apple.new);


### PR DESCRIPTION
## Description

Because we changed the macOS patching method in https://github.com/shorebirdtech/engine/pull/96, older macOS releases are no longer patchable. This change increases the minimum supported Flutter version to 3.27.3 (the latest stable version) and allowlists revisions of that version for patching to filter out previous 3.27.3 revisions that do not support the new patching mechanism. This allowlist should be removed when we can increase the minimum supported macOS Flutter version to 3.27.4 or higher.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
