### PR TITLE
fix: support staging patches on windows

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -474,6 +474,11 @@ This is only applicable when previewing Android releases.''',
       }
     }
 
+    await setChannelOnWindowsApp(
+      appDirectory: appDirectory,
+      channel: track.name,
+    );
+
     final exeFile = appDirectory
         .listSync()
         .whereType<File>()
@@ -836,6 +841,27 @@ This is only applicable when previewing Android releases.''',
     return p.join(
       previewDirectory.path,
       '${platform.name}_${release.version}_${artifact.id}$ext',
+    );
+  }
+
+  /// Sets the channel property in the shorebird.yaml file inside the Windows
+  /// app whose root directory is [appDirectory].
+  Future<void> setChannelOnWindowsApp({
+    required Directory appDirectory,
+    required String channel,
+  }) async {
+    final shorebirdYamlFile = File(
+      p.join(
+        appDirectory.path,
+        'data',
+        'flutter_assets',
+        'shorebird.yaml',
+      ),
+    );
+
+    await _maybeSetChannelInShorebirdYaml(
+      channel: channel,
+      shorebirdYamlFile: shorebirdYamlFile,
     );
   }
 


### PR DESCRIPTION
## Description

Adds support for the `shorebird preview --staging` command on windows.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
