### PR TITLE
fix: allow previewing of staged patches on macos

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -545,6 +545,8 @@ This is only applicable when previewing Android releases.''',
       }
     }
 
+    await setChannelOnMacosApp(appDirectory: appDirectory, channel: track.name);
+
     final logs = await open.newApplication(path: appDirectory.path);
     final completer = Completer<void>();
 
@@ -890,6 +892,29 @@ This is only applicable when previewing Android releases.''',
         shorebirdYamlFile: shorebirdYaml,
       );
     });
+  }
+
+  /// Sets the channel property in the shorebird.yaml file inside a macOS app.
+  Future<void> setChannelOnMacosApp({
+    required Directory appDirectory,
+    required String channel,
+  }) async {
+    final shorebirdYamlFile = File(
+      p.join(
+        appDirectory.path,
+        'Contents',
+        'Frameworks',
+        'App.framework',
+        'Resources',
+        'flutter_assets',
+        'shorebird.yaml',
+      ),
+    );
+
+    await _maybeSetChannelInShorebirdYaml(
+      channel: channel,
+      shorebirdYamlFile: shorebirdYamlFile,
+    );
   }
 
   /// Unzips the `.aab` and sets the channel property in the shorebird.yaml

--- a/packages/shorebird_cli/lib/src/platform/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple.dart
@@ -109,6 +109,7 @@ final minimumSupportedMacosFlutterVersion = Version(3, 27, 3);
 // 3.27.4 or higher.
 const patchableMacosFlutterRevisions = {
   '5c1dcc19ebcee3565c65262dd95970186e4d81cc',
+  '3d75b30b181d1d4ce66c426c64aca2498529f2e0',
 };
 
 /// A reference to a [Apple] instance.


### PR DESCRIPTION
## Description

Update `shorebird preview` to support `--staging` for macOS apps.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
