### PR TITLE
chore: clean up macOS preview log output

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -561,14 +561,13 @@ This is only applicable when previewing Android releases.''',
       RegExp('^Filtering the log data'),
     ];
 
-    final prefixRegex = RegExp(
-      r'^[\d-]+\W+[\d:\.]+\W+\w+\W+\w+\[[\da-f]+:[\da-f]+\]',
-    );
-
     // Removes the log prefix from the log line.
     // Example log line:
     // ignore: lines_longer_than_80_chars
     // 2025-01-31 09:53:22.889 Df macos_sandbox[22535:1d268] [dev.shorebird:updater::cache::patch_manager] [shorebird] No public key provided, skipping signature verification
+    final prefixRegex = RegExp(
+      r'^[\d-]+\W+[\d:\.]+\W+\w+\W+\w+\[[\da-f]+:[\da-f]+\]',
+    );
     String removeLogPrefix(String line) {
       return line.trim().replaceFirst(prefixRegex, '').trim();
     }

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -1,3 +1,4 @@
+// cspell:words libinfo networkd
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' hide Platform;

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -2146,6 +2146,46 @@ channel: ${DeploymentTrack.staging.channel}
           verify(() => logger.info('hello world')).called(1);
         });
       });
+
+      group('log output', () {
+        final rawLogOutput = '''
+2025-01-31 10:15:29.807 Df macos_sandbox[33557:2cc3d] [com.apple.network:] networkd_settings_read_from_file initialized networkd settings by reading plist directly
+
+2025-01-31 10:15:29.807 Df macos_sandbox[33557:2cc3d] [com.apple.network:path] nw_path_libinfo_path_check [5E11C960-BB0A-456A-8024-620DAB6CCF17 Hostname#941210b4:0 tcp, legacy-socket, attribution: developer]
+        libinfo check path: satisfied (Path is satisfied), interface: en0, ipv4, dns
+
+2025-01-31 10:15:29.808 Df macos_sandbox[33557:2cc12] [dev.shorebird:updater::updater] [shorebird] Reporting successful launch.
+'''
+            .split('\n');
+
+        setUp(() {
+          setupMacosShorebirdYaml();
+          when(() => open.newApplication(path: any(named: 'path'))).thenAnswer(
+            (_) async => Stream.fromIterable(rawLogOutput.map(utf8.encode)),
+          );
+        });
+
+        test('removes noisy lines from log output', () async {
+          final result = await runWithOverrides(command.run);
+          expect(result, equals(ExitCode.success.code));
+
+          verify(
+            () => logger.info(
+              '''[dev.shorebird:updater::updater] [shorebird] Reporting successful launch.''',
+            ),
+          ).called(1);
+          verifyNever(
+            () => logger.info(
+              any(that: contains('networkd_settings_read_from_file')),
+            ),
+          );
+          verifyNever(
+            () => logger.info(
+              any(that: contains('nw_path_libinfo_path_check')),
+            ),
+          );
+        });
+      });
     });
 
     group('windows', () {


### PR DESCRIPTION
## Description

Removes a lot of noise from the macOS preview log output.

```
2025-01-31 10:15:29.822 A  macos_sandbox[33557:2cc12] (CoreFoundation) Loading Preferences From System CFPrefsD

2025-01-31 10:15:29.823 Df macos_sandbox[33557:2cc12] [com.apple.GenerativeModels:availability] registering darwin observer for name: com.apple.gms.availability.notification

2025-01-31 10:15:29.823 Df macos_sandbox[33557:2cc12] [com.apple.GenerativeModels:availability] registering darwin observer for name: com.apple.os-eligibility-domain.change.greymatter

2025-01-31 10:15:29.824 E  macos_sandbox[33557:2cc12] [com.apple.GenerativeModels:availability] Can't find or decode reasons
```

Becomes

```
[dev.shorebird:updater::updater] [shorebird] Reporting successful launch.
[dev.shorebird:updater::cache::patch_manager] [shorebird] Deleting patch artifacts older than 1
[dev.shorebird:updater::updater] [shorebird] Patch check response: PatchCheckResponse { patch_available: true, patch: Some(Patch { number: 1, hash: "67fa75e495302a5f4727b0b210c3cb87b4455edd599c9873bed1b8b540193fe1", download_url: "https://cdn.shorebird.cloud/api/v1/patches/b98ac807-cd22-40e5-87fc-bd22e5cb113c/macos/aarch64/151140/dlc.vmcode", hash_signature: None }), rolled_back_patch_numbers: Some([]) }
[dev.shorebird:updater::cache::patch_manager] [shorebird] No public key provided, skipping signature verification
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
