### PR TITLE
fix: make _maybeSetChannelInShorebirdYaml static

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -1027,7 +1027,7 @@ This is only applicable when previewing Android releases.''',
 
   /// Sets the channel property in the shorebird.yaml file if none is set or
   /// different from the provided channel.
-  Future<bool> _maybeSetChannelInShorebirdYaml({
+  static Future<bool> _maybeSetChannelInShorebirdYaml({
     required String channel,
     required File shorebirdYamlFile,
   }) async {


### PR DESCRIPTION
This fixes an issue where `shorebird preview` would fail for android apps with the following message:

```
bryanoltman@bryanoltman-XPS-8960 ~/Documents/Sandbox/android_preview 
⑆ shorebird preview
⠹ Fetching releases... (0.2s)
✓ Fetching releases (0.3s)
✓ Fetching releases (0.3s)
Which release would you like to preview? 1.0.0+1
✓ Fetching aab artifact (0.2s)
✓ Downloading release (2.0s)
../../flutter/third_party/dart/runtime/vm/object.h: 7195: error: unreachable code
[1]    104801 IOT instruction (core dumped)  shorebird preview
```

Note that this does not get to the point of running any application code - the failure comes from attempting to update the shorebird.yaml file.