### PR TITLE
fix: use temp dir for ios-framework release artifacts

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -4,9 +4,7 @@
 // cspell:words xcarchive codesigned xcframework
 
 import 'dart:io';
-import 'dart:isolate';
 
-import 'package:archive/archive_io.dart';
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
 import 'package:equatable/equatable.dart';
@@ -814,11 +812,7 @@ aar artifact already exists, continuing...''',
   }) async {
     final createArtifactProgress = logger.progress('Uploading artifacts');
     final appFrameworkDirectory = Directory(appFrameworkPath);
-    await Isolate.run(
-      () => ZipFileEncoder().zipDirectory(appFrameworkDirectory),
-    );
-    final zippedAppFrameworkFile = File('$appFrameworkPath.zip');
-
+    final zippedAppFrameworkFile = await appFrameworkDirectory.zipToTempFile();
     try {
       await codePushClient.createReleaseArtifact(
         appId: appId,

--- a/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
@@ -35,7 +35,10 @@ class IosFrameworkReleaser extends Releaser {
 
   /// The directory where the release artifacts are stored.
   Directory get releaseDirectory => Directory(
-        p.join(shorebirdEnv.getShorebirdProjectRoot()!.path, 'release'),
+        p.join(
+          shorebirdEnv.getShorebirdProjectRoot()!.path,
+          'release',
+        ),
       );
 
   @override


### PR DESCRIPTION
## Description

Create release artifacts for `ios-framework` releases in a temp dir

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
