### PR TITLE
feat: add isTrial to plan object

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/src/models/plan.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/plan.dart
@@ -21,6 +21,7 @@ class Plan {
     required this.currentPeriodEnd,
     required this.cancelAtPeriodEnd,
     required this.isTiered,
+    required this.isTrial,
     this.pricePerOverageInstall,
     this.maxTeamSize,
   });
@@ -65,6 +66,10 @@ class Plan {
 
   /// Whether the plan is tier (i.e., whether the user can change their plan).
   final bool isTiered;
+
+  /// Whether the user is on a trial plan. Trial plans are not billed and cancel
+  /// automatically at the end of the trial period.
+  final bool isTrial;
 
   /// The maximum number of collaborators allowed per account. This will be null
   /// for accounts with unlimited collaborators.

--- a/packages/shorebird_code_push_protocol/lib/src/models/plan.g.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/plan.g.dart
@@ -25,6 +25,7 @@ Plan _$PlanFromJson(Map<String, dynamic> json) => $checkedCreate(
           cancelAtPeriodEnd:
               $checkedConvert('cancel_at_period_end', (v) => v as bool),
           isTiered: $checkedConvert('is_tiered', (v) => v as bool),
+          isTrial: $checkedConvert('is_trial', (v) => v as bool),
           pricePerOverageInstall: $checkedConvert('price_per_overage_install',
               (v) => v == null ? null : Decimal.fromJson(v as String)),
           maxTeamSize:
@@ -39,6 +40,7 @@ Plan _$PlanFromJson(Map<String, dynamic> json) => $checkedCreate(
         'currentPeriodEnd': 'current_period_end',
         'cancelAtPeriodEnd': 'cancel_at_period_end',
         'isTiered': 'is_tiered',
+        'isTrial': 'is_trial',
         'pricePerOverageInstall': 'price_per_overage_install',
         'maxTeamSize': 'max_team_size'
       },
@@ -54,5 +56,6 @@ Map<String, dynamic> _$PlanToJson(Plan instance) => <String, dynamic>{
       'current_period_end': instance.currentPeriodEnd.toIso8601String(),
       'cancel_at_period_end': instance.cancelAtPeriodEnd,
       'is_tiered': instance.isTiered,
+      'is_trial': instance.isTrial,
       'max_team_size': instance.maxTeamSize,
     };

--- a/packages/shorebird_code_push_protocol/test/src/models/plan_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/models/plan_test.dart
@@ -16,6 +16,7 @@ void main() {
         isTiered: true,
         maxTeamSize: 42,
         pricePerOverageInstall: Decimal.fromInt(10),
+        isTrial: true,
       );
 
       expect(


### PR DESCRIPTION
## Description

This will allow our plan endpoint to communicate whether a plan is a trial plan.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
