### PR TITLE
fix: improve handling of CI tokens

### DIFF
--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -315,7 +315,19 @@ class Auth {
   void _loadCredentials() {
     final envToken = platform.environment[shorebirdTokenEnvVar];
     if (envToken != null) {
-      _token = CiToken.fromBase64(envToken);
+      try {
+        _token = CiToken.fromBase64(envToken.trim());
+      } on FormatException catch (e) {
+        logger
+          ..err(
+            '''
+Failed to parse CI token from environment. This likely means that your CI token is incorrectly formatted.
+
+Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar environment variable, and try again.''',
+          )
+          ..detail(e.toString());
+        rethrow;
+      }
       return;
     }
 

--- a/packages/shorebird_cli/test/src/auth/auth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_test.dart
@@ -538,8 +538,37 @@ void main() {
           );
         });
 
-        test('throws error when token string is not valid base64', () async {
+        test('logs and throws error when token string is not valid base64',
+            () async {
           expect(buildAuth, throwsA(isFormatException));
+          verify(
+            () => logger.err(
+              '''
+Failed to parse CI token from environment. This likely means that your CI token is incorrectly formatted.
+
+Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar environment variable, and try again.''',
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when token has leading or trailing spaces and newlines', () {
+        setUp(() {
+          when(() => platform.environment).thenReturn(
+            <String, String>{
+              shorebirdTokenEnvVar: '''
+    ${ciToken.toBase64()}  
+              
+''',
+            },
+          );
+        });
+
+        test('trims string', () {
+          auth = buildAuth();
+          final client = auth.client;
+          expect(client, isA<http.Client>());
+          expect(client, isA<AuthenticatedClient>());
         });
       });
 


### PR DESCRIPTION
## Description

Adds a more friendly error message when `SHOREBIRD_TOKEN` is malformed, and more gracefully handles trailing and leading whitespace.

Fixes https://github.com/shorebirdtech/shorebird/issues/2846

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
