### PR TITLE
chore: add new flutter revision to macOS patch allowlist

### DIFF
--- a/packages/shorebird_cli/lib/src/platform/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple.dart
@@ -121,6 +121,7 @@ final minimumSupportedMacosFlutterVersion = Version(3, 27, 3);
 const patchableMacosFlutterRevisions = {
   '5c1dcc19ebcee3565c65262dd95970186e4d81cc',
   '3d75b30b181d1d4ce66c426c64aca2498529f2e0',
+  // Contains engine updates to fix package:shorebird_code_push on windows.
   '009d947deb3a58d8801dbc995667e87523c7f08c',
 };
 

--- a/packages/shorebird_cli/lib/src/platform/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple.dart
@@ -121,6 +121,7 @@ final minimumSupportedMacosFlutterVersion = Version(3, 27, 3);
 const patchableMacosFlutterRevisions = {
   '5c1dcc19ebcee3565c65262dd95970186e4d81cc',
   '3d75b30b181d1d4ce66c426c64aca2498529f2e0',
+  '009d947deb3a58d8801dbc995667e87523c7f08c',
 };
 
 /// A reference to a [Apple] instance.


### PR DESCRIPTION
## Description

Add the new Flutter rev to the list of revisions that can patch macOS apps.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
