### PR TITLE
chore: update minimum supported macos and linux versions to 3.24.7

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/macos_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/macos_patcher.dart
@@ -146,11 +146,8 @@ This may indicate that the patch contains native changes, which cannot be applie
         shorebirdFlutter.getVersion(),
       ).wait;
 
-      // TODO(bryanoltman): revert this to checking the flutter version once
-      // the minimum supported version is updated.
-      if (!patchableMacosFlutterRevisions.contains(
-        shorebirdEnv.flutterRevision,
-      )) {
+      if ((flutterVersion ?? minimumSupportedMacosFlutterVersion) <
+          minimumSupportedMacosFlutterVersion) {
         logger.err(
           '''
 macOS patches are not supported with Flutter versions older than $minimumSupportedMacosFlutterVersion.

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -138,7 +138,8 @@ Bypass all confirmation messages. It's generally not advised to use this unless 
 ''',
   );
 
-  /// An argument that allows the user to specify a minimum link percentage threshold.
+  /// An argument that allows the user to specify a minimum link percentage
+  /// threshold.
   static const minLinkPercentage = ArgumentDescriber(
     name: 'min-link-percentage',
     defaultValue: '0',

--- a/packages/shorebird_cli/lib/src/platform/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple.dart
@@ -110,21 +110,7 @@ Please report issues at https://github.com/shorebirdtech/shorebird/issues/new
 final minimumSupportedIosFlutterVersion = Version(3, 22, 2);
 
 /// The minimum allowed Flutter version for creating macOS releases.
-// TODO(bryanoltman): bump this when 3.27.4 is released.
-final minimumSupportedMacosFlutterVersion = Version(3, 27, 3);
-
-/// Flutter revisions that support macOS patching.
-/// This is a temporary workaround. Some revisions of 3.27.3 (those included
-/// here) support our current (unlinked) method of patching macOS releases,
-/// while the rest do not.
-// TODO(bryanoltman): remove this when we can bump the minimum macOS version to
-// 3.27.4 or higher.
-const patchableMacosFlutterRevisions = {
-  '5c1dcc19ebcee3565c65262dd95970186e4d81cc',
-  '3d75b30b181d1d4ce66c426c64aca2498529f2e0',
-  // Contains engine updates to fix package:shorebird_code_push on windows.
-  '009d947deb3a58d8801dbc995667e87523c7f08c',
-};
+final minimumSupportedMacosFlutterVersion = Version(3, 27, 4);
 
 /// A reference to a [Apple] instance.
 final appleRef = create(Apple.new);

--- a/packages/shorebird_cli/lib/src/platform/linux.dart
+++ b/packages/shorebird_cli/lib/src/platform/linux.dart
@@ -15,8 +15,7 @@ import 'package:scoped_deps/scoped_deps.dart';
 const primaryLinuxReleaseArtifactArch = 'bundle';
 
 /// The minimum allowed Flutter version for creating Linux releases.
-// TODO(bryanoltman): bump this when 3.27.4 is released.
-final minimumSupportedLinuxFlutterVersion = Version(3, 27, 3);
+final minimumSupportedLinuxFlutterVersion = Version(3, 27, 4);
 
 /// A warning message printed at the start of `shorebird release linux` and
 /// `shorebird patch linux` commands.

--- a/packages/shorebird_cli/test/src/commands/patch/macos_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/macos_patcher_test.dart
@@ -511,7 +511,7 @@ This may indicate that the patch contains native changes, which cannot be applie
           ).thenAnswer((_) async => flutterVersionAndRevision);
           when(
             () => shorebirdFlutter.getVersion(),
-          ).thenAnswer((_) async => Version(3, 27, 3));
+          ).thenAnswer((_) async => Version(3, 27, 4));
         });
 
         group(
@@ -554,49 +554,6 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
           },
           skip:
               '''Skipping while we use the flutter revision when checking for patchability''',
-        );
-
-        // TODO(bryanoltman): this test can be removed (and the above test
-        // can be unskipped) when we can increase the
-        // minimumSupportedMacosVersion to 3.27.4 or higher.
-        group(
-          'when release flutter version is not in the allowlist',
-          () {
-            setUp(() {
-              when(
-                () => shorebirdValidator.validatePreconditions(
-                  checkUserIsAuthenticated: any(
-                    named: 'checkUserIsAuthenticated',
-                  ),
-                  checkShorebirdInitialized: any(
-                    named: 'checkShorebirdInitialized',
-                  ),
-                  validators: any(named: 'validators'),
-                  supportedOperatingSystems: any(
-                    named: 'supportedOperatingSystems',
-                  ),
-                ),
-              ).thenAnswer((_) async {});
-              when(
-                () => shorebirdEnv.flutterRevision,
-              ).thenReturn('not-a-supported-revision');
-            });
-
-            test('logs error and exits with code 70', () async {
-              await expectLater(
-                () => runWithOverrides(patcher.buildPatchArtifact),
-                exitsWithCode(ExitCode.software),
-              );
-
-              verify(
-                () => logger.err(
-                  '''
-macOS patches are not supported with Flutter versions older than $minimumSupportedMacosFlutterVersion.
-For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
-                ),
-              ).called(1);
-            });
-          },
         );
 
         group('when build fails with ProcessException', () {

--- a/packages/shorebird_cli/test/src/platform/linux_test.dart
+++ b/packages/shorebird_cli/test/src/platform/linux_test.dart
@@ -7,10 +7,10 @@ import 'package:test/test.dart';
 void main() {
   group('linux', () {
     group('minimumSupportedLinuxFlutterVersion', () {
-      test('is 3.27.3', () {
+      test('is 3.27.4', () {
         expect(
           minimumSupportedLinuxFlutterVersion,
-          equals(Version(3, 27, 3)),
+          equals(Version(3, 27, 4)),
         );
       });
     });


### PR DESCRIPTION
## Description

Now that Flutter 3.27.4 is out, we can gate these platforms on Flutter version instead of a list of known supported hashes.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
