### PR TITLE
refactor: move logging from individual releasers to release command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
@@ -13,7 +13,6 @@ import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_android_artifacts.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
-import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -45,6 +44,9 @@ class AarReleaser extends Releaser {
   ReleaseType get releaseType => ReleaseType.aar;
 
   @override
+  String get artifactDisplayName => 'Android archive';
+
+  @override
   bool get requiresReleaseVersionArg => true;
 
   @override
@@ -73,24 +75,13 @@ class AarReleaser extends Releaser {
   }
 
   @override
-  Future<FileSystemEntity> buildReleaseArtifacts() async {
-    final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
-    final buildAppBundleProgress =
-        logger.progress('Building aar with Flutter $flutterVersionString');
-
-    try {
-      await artifactBuilder.buildAar(
-        buildNumber: buildNumber,
-        targetPlatforms: architectures,
-        args: argResults.forwardedArgs,
-      );
-    } on Exception catch (e) {
-      logger.err('Failed to build aar: $e');
-      throw ProcessExit(ExitCode.software.code);
-    }
-
-    buildAppBundleProgress.complete(
-      'Built aar with Flutter $flutterVersionString',
+  Future<FileSystemEntity> buildReleaseArtifacts({
+    DetailProgress? progress,
+  }) async {
+    await artifactBuilder.buildAar(
+      buildNumber: buildNumber,
+      targetPlatforms: architectures,
+      args: argResults.forwardedArgs,
     );
 
     // Copy release AAR to a new directory to avoid overwriting with

--- a/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
@@ -45,6 +45,9 @@ class IosFrameworkReleaser extends Releaser {
   bool get requiresReleaseVersionArg => true;
 
   @override
+  String get artifactDisplayName => 'iOS framework';
+
+  @override
   ReleaseType get releaseType => ReleaseType.iosFramework;
 
   @override
@@ -84,9 +87,9 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
   }
 
   @override
-  Future<FileSystemEntity> buildReleaseArtifacts() async {
-    final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
-
+  Future<FileSystemEntity> buildReleaseArtifacts({
+    Progress? progress,
+  }) async {
     // Delete the Shorebird supplement directory if it exists.
     // This is to ensure that we don't accidentally upload stale artifacts
     // when building with older versions of Flutter.
@@ -96,18 +99,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
       shorebirdSupplementDir!.deleteSync(recursive: true);
     }
 
-    final buildProgress = logger.progress(
-      'Building iOS framework with Flutter $flutterVersionString',
-    );
-
-    try {
-      await artifactBuilder.buildIosFramework(args: argResults.forwardedArgs);
-    } on Exception catch (error) {
-      buildProgress.fail('Failed to build iOS framework: $error');
-      throw ProcessExit(ExitCode.software.code);
-    }
-
-    buildProgress.complete();
+    await artifactBuilder.buildIosFramework(args: argResults.forwardedArgs);
 
     // Copy release xcframework to a new directory to avoid overwriting with
     // subsequent patch builds.

--- a/packages/shorebird_cli/lib/src/commands/release/linux_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/linux_releaser.dart
@@ -29,6 +29,12 @@ class LinuxReleaser extends Releaser {
   });
 
   @override
+  ReleaseType get releaseType => ReleaseType.linux;
+
+  @override
+  String get artifactDisplayName => 'Linux app';
+
+  @override
   Future<void> assertArgsAreValid() async {
     if (argResults.wasParsed('release-version')) {
       logger.err(
@@ -69,25 +75,11 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
   }
 
   @override
-  Future<FileSystemEntity> buildReleaseArtifacts() async {
-    final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
-    final buildAppBundleProgress = logger.progress(
-      'Building Linux application with Flutter $flutterVersionString',
-    );
-
-    final base64PublicKey = argResults.encodedPublicKey;
-    try {
-      await artifactBuilder.buildLinuxApp(
-        base64PublicKey: base64PublicKey,
-      );
-    } on Exception catch (e) {
-      logger.err('Failed to build Linux application: $e');
-      buildAppBundleProgress.fail('$e');
-      throw ProcessExit(ExitCode.software.code);
-    }
-
-    buildAppBundleProgress.complete(
-      'Built Linux application with Flutter $flutterVersionString',
+  Future<FileSystemEntity> buildReleaseArtifacts({
+    DetailProgress? progress,
+  }) async {
+    await artifactBuilder.buildLinuxApp(
+      base64PublicKey: argResults.encodedPublicKey,
     );
 
     return artifactManager.linuxBundleDirectory;
@@ -106,9 +98,6 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
 
 Linux release created at ${artifactManager.linuxBundleDirectory.path}.
 ''';
-
-  @override
-  ReleaseType get releaseType => ReleaseType.linux;
 
   @override
   Future<void> uploadReleaseArtifacts({

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:shorebird_cli/src/logging/detail_progress.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -39,6 +40,10 @@ abstract class Releaser {
   /// The root directory of the current project.
   Directory get projectRoot => shorebirdEnv.getShorebirdProjectRoot()!;
 
+  /// The human-readable description of the release artifact being built (e.g.,
+  /// "Android app", "iOS app").
+  String get artifactDisplayName;
+
   /// Asserts that the command can be run.
   Future<void> assertPreconditions();
 
@@ -47,7 +52,11 @@ abstract class Releaser {
 
   /// Builds the release artifacts for the given platform. Returns the "primary"
   /// artifact for the platform (e.g. the AAB for Android, the IPA for iOS).
-  Future<FileSystemEntity> buildReleaseArtifacts();
+  ///
+  /// [progress], if provided, will be updated with the progress of the build.
+  /// It will not be completed or failed—that is the responsibility of the
+  /// caller.
+  Future<FileSystemEntity> buildReleaseArtifacts({DetailProgress? progress});
 
   /// Uploads the release artifacts to the CodePush server.
   Future<void> uploadReleaseArtifacts({

--- a/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
@@ -36,6 +36,9 @@ class WindowsReleaser extends Releaser {
   ReleaseType get releaseType => ReleaseType.windows;
 
   @override
+  String get artifactDisplayName => 'Windows app';
+
+  @override
   Future<void> assertArgsAreValid() async {
     if (argResults.wasParsed('release-version')) {
       logger.err(
@@ -81,30 +84,16 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
   }
 
   @override
-  Future<FileSystemEntity> buildReleaseArtifacts() async {
-    final flutterVersionString = await shorebirdFlutter.getVersionAndRevision();
-
-    final buildAppBundleProgress = logger.detailProgress(
-      'Building Windows app with Flutter $flutterVersionString',
+  Future<FileSystemEntity> buildReleaseArtifacts({
+    DetailProgress? progress,
+  }) {
+    return artifactBuilder.buildWindowsApp(
+      flavor: flavor,
+      target: target,
+      args: argResults.forwardedArgs,
+      base64PublicKey: argResults.encodedPublicKey,
+      buildProgress: progress,
     );
-
-    final base64PublicKey = argResults.encodedPublicKey;
-    final Directory releaseDir;
-    try {
-      releaseDir = await artifactBuilder.buildWindowsApp(
-        flavor: flavor,
-        target: target,
-        args: argResults.forwardedArgs,
-        base64PublicKey: base64PublicKey,
-        buildProgress: buildAppBundleProgress,
-      );
-      buildAppBundleProgress.complete();
-    } on Exception catch (e) {
-      buildAppBundleProgress.fail(e.toString());
-      throw ProcessExit(ExitCode.software.code);
-    }
-
-    return releaseDir;
   }
 
   @override

--- a/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
@@ -16,7 +16,6 @@ import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_android_artifacts.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
-import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -39,7 +38,6 @@ void main() {
     late Progress progress;
     late ShorebirdProcess shorebirdProcess;
     late ShorebirdEnv shorebirdEnv;
-    late ShorebirdFlutter shorebirdFlutter;
     late ShorebirdValidator shorebirdValidator;
     late ShorebirdAndroidArtifacts shorebirdAndroidArtifacts;
     late AarReleaser aarReleaser;
@@ -55,7 +53,6 @@ void main() {
           osInterfaceRef.overrideWith(() => operatingSystemInterface),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
-          shorebirdFlutterRef.overrideWith(() => shorebirdFlutter),
           shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
           shorebirdAndroidArtifactsRef
               .overrideWith(() => shorebirdAndroidArtifacts),
@@ -78,7 +75,6 @@ void main() {
       logger = MockShorebirdLogger();
       shorebirdProcess = MockShorebirdProcess();
       shorebirdEnv = MockShorebirdEnv();
-      shorebirdFlutter = MockShorebirdFlutter();
       shorebirdValidator = MockShorebirdValidator();
       shorebirdAndroidArtifacts = MockShorebirdAndroidArtifacts();
 
@@ -220,8 +216,6 @@ void main() {
     });
 
     group('buildReleaseArtifacts', () {
-      const flutterVersionAndRevision = '3.10.6 (83305b5088)';
-
       void setUpProjectRootArtifacts() {
         final aarDir = p.join(
           projectRoot.path,
@@ -260,9 +254,6 @@ void main() {
         ).thenAnswer(
           (_) async => File(''),
         );
-        when(
-          () => shorebirdFlutter.getVersionAndRevision(),
-        ).thenAnswer((_) async => flutterVersionAndRevision);
 
         setUpProjectRootArtifacts();
       });
@@ -301,28 +292,6 @@ void main() {
               targetPlatforms: Arch.values.toSet(),
               args: [],
             ),
-          ).called(1);
-        });
-      });
-
-      group('when build fails', () {
-        setUp(() {
-          when(
-            () => artifactBuilder.buildAar(
-              buildNumber: any(named: 'buildNumber'),
-              targetPlatforms: any(named: 'targetPlatforms'),
-              args: any(named: 'args'),
-            ),
-          ).thenThrow(Exception('build failed'));
-        });
-
-        test('logs error and exits with code 70', () async {
-          await expectLater(
-            () => runWithOverrides(() => aarReleaser.buildReleaseArtifacts()),
-            exitsWithCode(ExitCode.software),
-          );
-          verify(
-            () => logger.err('Failed to build aar: Exception: build failed'),
           ).called(1);
         });
       });

--- a/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
@@ -104,6 +104,12 @@ void main() {
       });
     });
 
+    group('artifactDisplayName', () {
+      test('has expected value', () {
+        expect(aarReleaser.artifactDisplayName, 'Android archive');
+      });
+    });
+
     group('requiresReleaseVersionArg', () {
       test('is true', () {
         expect(aarReleaser.requiresReleaseVersionArg, isTrue);

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -20,7 +20,6 @@ import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_android_artifacts.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
-import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/validators/validators.dart';
@@ -45,7 +44,6 @@ void main() {
     late Progress progress;
     late ShorebirdProcess shorebirdProcess;
     late ShorebirdEnv shorebirdEnv;
-    late ShorebirdFlutter shorebirdFlutter;
     late ShorebirdValidator shorebirdValidator;
     late ShorebirdAndroidArtifacts shorebirdAndroidArtifacts;
     late AndroidReleaser androidReleaser;
@@ -63,7 +61,6 @@ void main() {
           osInterfaceRef.overrideWith(() => operatingSystemInterface),
           processRef.overrideWith(() => shorebirdProcess),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
-          shorebirdFlutterRef.overrideWith(() => shorebirdFlutter),
           shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
           shorebirdAndroidArtifactsRef
               .overrideWith(() => shorebirdAndroidArtifacts),
@@ -90,7 +87,6 @@ void main() {
       logger = MockShorebirdLogger();
       shorebirdProcess = MockShorebirdProcess();
       shorebirdEnv = MockShorebirdEnv();
-      shorebirdFlutter = MockShorebirdFlutter();
       shorebirdValidator = MockShorebirdValidator();
       shorebirdAndroidArtifacts = MockShorebirdAndroidArtifacts();
 
@@ -238,7 +234,6 @@ To change the version of this release, change your app's version in your pubspec
     });
 
     group('buildReleaseArtifacts', () {
-      const flutterVersionAndRevision = '3.10.6 (83305b5088)';
       late File aabFile;
 
       setUp(() {
@@ -264,9 +259,6 @@ To change the version of this release, change your app's version in your pubspec
           (_) async => File(''),
         );
         when(
-          () => shorebirdFlutter.getVersionAndRevision(),
-        ).thenAnswer((_) async => flutterVersionAndRevision);
-        when(
           () => shorebirdAndroidArtifacts.findAab(
             project: any(named: 'project'),
             flavor: any(named: 'flavor'),
@@ -274,74 +266,9 @@ To change the version of this release, change your app's version in your pubspec
         ).thenReturn(aabFile);
       });
 
-      group('when aab build fails', () {
+      group('when platform was specified via arg results rest', () {
         setUp(() {
-          when(
-            () => artifactBuilder.buildAppBundle(
-              flavor: any(named: 'flavor'),
-              target: any(named: 'target'),
-              targetPlatforms: any(named: 'targetPlatforms'),
-              args: any(named: 'args'),
-              buildProgress: any(named: 'buildProgress'),
-            ),
-          ).thenThrow(ArtifactBuildException('Uh oh'));
-        });
-
-        test('logs error and exits with code 70', () async {
-          await expectLater(
-            () => runWithOverrides(androidReleaser.buildReleaseArtifacts),
-            exitsWithCode(ExitCode.software),
-          );
-          verify(() => progress.fail('Uh oh')).called(1);
-        });
-      });
-
-      group('when building apk', () {
-        setUp(() {
-          when(() => argResults['artifact']).thenReturn('apk');
-        });
-
-        group('when apk build fails', () {
-          setUp(() {
-            when(
-              () => artifactBuilder.buildApk(
-                flavor: any(named: 'flavor'),
-                target: any(named: 'target'),
-                targetPlatforms: any(named: 'targetPlatforms'),
-                args: any(named: 'args'),
-              ),
-            ).thenThrow(ArtifactBuildException('Uh oh'));
-          });
-
-          test('logs error and exits with code 70', () async {
-            await expectLater(
-              () => runWithOverrides(androidReleaser.buildReleaseArtifacts),
-              exitsWithCode(ExitCode.software),
-            );
-            verify(() => progress.fail('Uh oh')).called(1);
-          });
-        });
-      });
-
-      group('when the build succeeds', () {
-        group('when platform was specified via arg results rest', () {
-          setUp(() {
-            when(() => argResults.rest).thenReturn(['android', '--verbose']);
-          });
-
-          test('returns the path to the aab', () async {
-            final result = await runWithOverrides(
-              () => androidReleaser.buildReleaseArtifacts(),
-            );
-            expect(result, aabFile);
-            verify(
-              () => artifactBuilder.buildAppBundle(
-                targetPlatforms: Arch.values,
-                args: ['--verbose'],
-                buildProgress: any(named: 'buildProgress'),
-              ),
-            ).called(1);
-          });
+          when(() => argResults.rest).thenReturn(['android', '--verbose']);
         });
 
         test('returns the path to the aab', () async {
@@ -352,25 +279,39 @@ To change the version of this release, change your app's version in your pubspec
           verify(
             () => artifactBuilder.buildAppBundle(
               targetPlatforms: Arch.values,
-              args: [],
+              args: ['--verbose'],
               buildProgress: any(named: 'buildProgress'),
             ),
           ).called(1);
         });
+      });
 
-        test('does not built apk by default', () async {
-          await runWithOverrides(
-            () => androidReleaser.buildReleaseArtifacts(),
-          );
-          verifyNever(
-            () => artifactBuilder.buildApk(
-              flavor: any(named: 'flavor'),
-              target: any(named: 'target'),
-              targetPlatforms: any(named: 'targetPlatforms'),
-              args: any(named: 'args'),
-            ),
-          );
-        });
+      test('returns the path to the aab', () async {
+        final result = await runWithOverrides(
+          () => androidReleaser.buildReleaseArtifacts(),
+        );
+        expect(result, aabFile);
+        verify(
+          () => artifactBuilder.buildAppBundle(
+            targetPlatforms: Arch.values,
+            args: [],
+            buildProgress: any(named: 'buildProgress'),
+          ),
+        ).called(1);
+      });
+
+      test('does not built apk by default', () async {
+        await runWithOverrides(
+          () => androidReleaser.buildReleaseArtifacts(),
+        );
+        verifyNever(
+          () => artifactBuilder.buildApk(
+            flavor: any(named: 'flavor'),
+            target: any(named: 'target'),
+            targetPlatforms: any(named: 'targetPlatforms'),
+            args: any(named: 'args'),
+          ),
+        );
       });
 
       group('with flavor and target', () {

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:http/http.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;

--- a/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
@@ -122,6 +122,12 @@ void main() {
         });
       });
 
+      group('artifactDisplayName', () {
+        test('has expected value', () {
+          expect(iosFrameworkReleaser.artifactDisplayName, 'iOS framework');
+        });
+      });
+
       group('assertArgsAreValid', () {
         group('when split-per-abi is true', () {
           setUp(() {

--- a/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
@@ -261,8 +261,6 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
       });
 
       group('buildReleaseArtifacts', () {
-        const flutterVersionAndRevision = '3.10.6 (83305b5088)';
-
         void setUpProjectRootArtifacts() {
           // Create an xcframework in the release directory to simulate running
           // this command a subsequent time.
@@ -299,50 +297,34 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
               ),
             ),
           );
-          when(
-            () => shorebirdFlutter.getVersionAndRevision(),
-          ).thenAnswer((_) async => flutterVersionAndRevision);
 
           setUpProjectRootArtifacts();
         });
 
-        group('when build succeeds', () {
-          group('when stale build/ios/shorebird directory exists', () {
-            late Directory shorebirdSupplementDir;
+        group('when stale build/ios/shorebird directory exists', () {
+          late Directory shorebirdSupplementDir;
 
-            setUp(() {
-              shorebirdSupplementDir = Directory(
-                p.join(projectRoot.path, 'build', 'ios', 'shorebird'),
-              )..createSync(recursive: true);
-              when(
-                () => artifactManager.getIosReleaseSupplementDirectory(),
-              ).thenReturn(shorebirdSupplementDir);
-            });
-
-            test('deletes the directory', () async {
-              expect(shorebirdSupplementDir.existsSync(), isTrue);
-              await runWithOverrides(
-                iosFrameworkReleaser.buildReleaseArtifacts,
-              );
-              expect(shorebirdSupplementDir.existsSync(), isFalse);
-            });
+          setUp(() {
+            shorebirdSupplementDir = Directory(
+              p.join(projectRoot.path, 'build', 'ios', 'shorebird'),
+            )..createSync(recursive: true);
+            when(
+              () => artifactManager.getIosReleaseSupplementDirectory(),
+            ).thenReturn(shorebirdSupplementDir);
           });
 
-          group('when platform was specified via arg results rest', () {
-            setUp(() {
-              when(() => argResults.rest).thenReturn(['ios', '--verbose']);
-            });
+          test('deletes the directory', () async {
+            expect(shorebirdSupplementDir.existsSync(), isTrue);
+            await runWithOverrides(
+              iosFrameworkReleaser.buildReleaseArtifacts,
+            );
+            expect(shorebirdSupplementDir.existsSync(), isFalse);
+          });
+        });
 
-            test('produces xcframework in release directory', () async {
-              final xcframework = await runWithOverrides(
-                iosFrameworkReleaser.buildReleaseArtifacts,
-              );
-
-              expect(xcframework.path, p.join(projectRoot.path, 'release'));
-              verify(
-                () => artifactBuilder.buildIosFramework(args: ['--verbose']),
-              ).called(1);
-            });
+        group('when platform was specified via arg results rest', () {
+          setUp(() {
+            when(() => argResults.rest).thenReturn(['ios', '--verbose']);
           });
 
           test('produces xcframework in release directory', () async {
@@ -352,31 +334,20 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
 
             expect(xcframework.path, p.join(projectRoot.path, 'release'));
             verify(
-              () => artifactBuilder.buildIosFramework(args: []),
+              () => artifactBuilder.buildIosFramework(args: ['--verbose']),
             ).called(1);
           });
         });
 
-        group('when build fails', () {
-          setUp(() {
-            when(
-              () => artifactBuilder.buildIosFramework(args: any(named: 'args')),
-            ).thenThrow(Exception('build failed'));
-          });
+        test('produces xcframework in release directory', () async {
+          final xcframework = await runWithOverrides(
+            iosFrameworkReleaser.buildReleaseArtifacts,
+          );
 
-          test('logs error and exits with code 70', () async {
-            await expectLater(
-              () => runWithOverrides(
-                iosFrameworkReleaser.buildReleaseArtifacts,
-              ),
-              exitsWithCode(ExitCode.software),
-            );
-            verify(
-              () => progress.fail(
-                'Failed to build iOS framework: Exception: build failed',
-              ),
-            ).called(1);
-          });
+          expect(xcframework.path, p.join(projectRoot.path, 'release'));
+          verify(
+            () => artifactBuilder.buildIosFramework(args: []),
+          ).called(1);
         });
       });
 

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -123,6 +123,12 @@ void main() {
         });
       });
 
+      group('artifactDisplayName', () {
+        test('has expected value', () {
+          expect(iosReleaser.artifactDisplayName, 'iOS app');
+        });
+      });
+
       group('assertPreconditions', () {
         final flutterVersion = Version(3, 0, 0);
 

--- a/packages/shorebird_cli/test/src/commands/release/linux_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/linux_releaser_test.dart
@@ -128,6 +128,12 @@ void main() {
       });
     });
 
+    group('artifactDisplayName', () {
+      test('has expected value', () {
+        expect(releaser.artifactDisplayName, 'Linux app');
+      });
+    });
+
     group('assertArgsAreValid', () {
       group('when release-version is passed', () {
         setUp(() {

--- a/packages/shorebird_cli/test/src/commands/release/linux_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/linux_releaser_test.dart
@@ -228,9 +228,6 @@ To change the version of this release, change your app's version in your pubspec
               .thenReturn('3.27.1');
           when(() => shorebirdFlutter.resolveFlutterVersion('3.27.1'))
               .thenAnswer((_) async => Version(3, 27, 1));
-          when(
-            () => shorebirdFlutter.getRevisionForVersion(any()),
-          ).thenAnswer((_) async => 'deadbeef');
         });
 
         test('logs error and exits with usage err', () async {
@@ -253,80 +250,52 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
     group('buildReleaseArtifacts', () {
       setUp(() {
         when(
-          () => shorebirdFlutter.getVersionAndRevision(),
-        ).thenAnswer((_) async => '3.27.3');
+          () => artifactBuilder.buildLinuxApp(
+            target: any(named: 'target'),
+            args: any(named: 'args'),
+            buildProgress: any(named: 'buildProgress'),
+          ),
+        ).thenAnswer((_) async => projectRoot);
       });
 
-      group('when builder throws exception', () {
-        setUp(() {
-          when(
-            () => artifactBuilder.buildLinuxApp(
-              target: any(named: 'target'),
-              args: any(named: 'args'),
-              buildProgress: any(named: 'buildProgress'),
-            ),
-          ).thenThrow(Exception('oh no'));
-        });
+      test('returns path to release directory', () async {
+        final releaseDir =
+            await runWithOverrides(releaser.buildReleaseArtifacts);
+        expect(releaseDir, releaseDirectory);
+      });
+    });
 
-        test('fails progress, exits', () async {
-          await expectLater(
-            () => runWithOverrides(releaser.buildReleaseArtifacts),
-            exitsWithCode(ExitCode.software),
-          );
-          verify(() => progress.fail('Exception: oh no')).called(1);
-        });
+    group('when public key is passed as an arg', () {
+      setUp(() {
+        when(
+          () => artifactBuilder.buildLinuxApp(
+            target: any(named: 'target'),
+            args: any(named: 'args'),
+            buildProgress: any(named: 'buildProgress'),
+            base64PublicKey: any(named: 'base64PublicKey'),
+          ),
+        ).thenAnswer((_) async => projectRoot);
+        when(
+          () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
+        ).thenReturn(true);
+        when(
+          () => argResults[CommonArguments.publicKeyArg.name],
+        ).thenReturn('public_key');
+        when(
+          () => codeSigner.base64PublicKey(any()),
+        ).thenReturn('encoded_public_key');
       });
 
-      group('when build succeeds', () {
-        setUp(() {
-          when(
-            () => artifactBuilder.buildLinuxApp(
-              target: any(named: 'target'),
-              args: any(named: 'args'),
-              buildProgress: any(named: 'buildProgress'),
-            ),
-          ).thenAnswer((_) async => projectRoot);
-        });
-
-        test('returns path to release directory', () async {
-          final releaseDir =
-              await runWithOverrides(releaser.buildReleaseArtifacts);
-          expect(releaseDir, releaseDirectory);
-        });
-      });
-
-      group('when public key is passed as an arg', () {
-        setUp(() {
-          when(
-            () => artifactBuilder.buildLinuxApp(
-              target: any(named: 'target'),
-              args: any(named: 'args'),
-              buildProgress: any(named: 'buildProgress'),
-              base64PublicKey: any(named: 'base64PublicKey'),
-            ),
-          ).thenAnswer((_) async => projectRoot);
-          when(
-            () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
-          ).thenReturn(true);
-          when(
-            () => argResults[CommonArguments.publicKeyArg.name],
-          ).thenReturn('public_key');
-          when(
-            () => codeSigner.base64PublicKey(any()),
-          ).thenReturn('encoded_public_key');
-        });
-
-        test('passes public key to buildWindowsApp', () async {
-          await runWithOverrides(releaser.buildReleaseArtifacts);
-          verify(
-            () => artifactBuilder.buildLinuxApp(
-              base64PublicKey: 'encoded_public_key',
-              target: any(named: 'target'),
-              args: any(named: 'args'),
-              buildProgress: any(named: 'buildProgress'),
-            ),
-          ).called(1);
-        });
+      test('passes public key to buildLinuxApp', () async {
+        await runWithOverrides(releaser.buildReleaseArtifacts);
+        verify(
+          () => artifactBuilder.buildLinuxApp(
+            base64PublicKey: 'encoded_public_key',
+            target: any(named: 'target'),
+            args: any(named: 'args'),
+            buildProgress: any(named: 'buildProgress'),
+          ),
+        ).called(1);
       });
     });
 

--- a/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
@@ -102,6 +102,12 @@ void main() {
         });
       });
 
+      group('artifactDisplayName', () {
+        test('has expected value', () {
+          expect(releaser.artifactDisplayName, 'macOS app');
+        });
+      });
+
       group('assertPreconditions', () {
         final flutterVersion = Version(3, 0, 0);
 

--- a/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
@@ -347,62 +347,34 @@ To change the version of this release, change your app's version in your pubspec
           });
         });
 
-        group('when build fails', () {
+        group('when platform was specified via arg results rest', () {
           setUp(() {
-            when(
-              () => artifactBuilder.buildMacos(
-                codesign: any(named: 'codesign'),
-                flavor: any(named: 'flavor'),
-                target: any(named: 'target'),
-                args: any(named: 'args'),
-                buildProgress: any(named: 'buildProgress'),
-              ),
-            ).thenThrow(ArtifactBuildException('Failed to build'));
+            when(() => argResults.rest).thenReturn(['macos', '--verbose']);
           });
 
-          test('logs error and exits with code 70', () async {
-            await expectLater(
-              () => runWithOverrides(releaser.buildReleaseArtifacts),
-              exitsWithCode(ExitCode.software),
-            );
-
-            verify(
-              () => progress.fail('Failed to build'),
-            ).called(1);
-          });
-        });
-
-        group('when build succeeds', () {
-          group('when platform was specified via arg results rest', () {
-            setUp(() {
-              when(() => argResults.rest).thenReturn(['macos', '--verbose']);
-            });
-
-            test('verifies artifacts exist and returns xcarchive path',
-                () async {
-              expect(
-                await runWithOverrides(releaser.buildReleaseArtifacts),
-                equals(appDirectory),
-              );
-
-              verify(() => artifactManager.getMacOSAppDirectory()).called(1);
-              verify(
-                () => artifactBuilder.buildMacos(
-                  args: ['--verbose'],
-                  buildProgress: any(named: 'buildProgress'),
-                ),
-              ).called(1);
-            });
-          });
-
-          test('verifies artifacts exist and returns app path', () async {
+          test('verifies artifacts exist and returns xcarchive path', () async {
             expect(
               await runWithOverrides(releaser.buildReleaseArtifacts),
               equals(appDirectory),
             );
 
             verify(() => artifactManager.getMacOSAppDirectory()).called(1);
+            verify(
+              () => artifactBuilder.buildMacos(
+                args: ['--verbose'],
+                buildProgress: any(named: 'buildProgress'),
+              ),
+            ).called(1);
           });
+        });
+
+        test('verifies artifacts exist and returns app path', () async {
+          expect(
+            await runWithOverrides(releaser.buildReleaseArtifacts),
+            equals(appDirectory),
+          );
+
+          verify(() => artifactManager.getMacOSAppDirectory()).called(1);
         });
 
         group('when app not found after build', () {

--- a/packages/shorebird_cli/test/src/commands/release/releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/releaser_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:shorebird_cli/src/commands/release/releaser.dart';
+import 'package:shorebird_cli/src/logging/detail_progress.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_code_push_protocol/src/models/release.dart';
@@ -31,7 +32,12 @@ class FakeReleaser extends Releaser {
   });
 
   @override
-  Future<FileSystemEntity> buildReleaseArtifacts() {
+  String get artifactDisplayName => 'Fake artifact';
+
+  @override
+  Future<FileSystemEntity> buildReleaseArtifacts({
+    DetailProgress? progress,
+  }) {
     throw UnimplementedError();
   }
 

--- a/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
@@ -129,6 +129,12 @@ void main() {
       });
     });
 
+    group('artifactDisplayName', () {
+      test('has expected value', () {
+        expect(releaser.artifactDisplayName, 'Windows app');
+      });
+    });
+
     group('assertArgsAreValid', () {
       group('when release-version is passed', () {
         setUp(() {

--- a/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
@@ -272,48 +272,19 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''',
     group('buildReleaseArtifacts', () {
       setUp(() {
         when(
-          () => shorebirdFlutter.getVersionAndRevision(),
-        ).thenAnswer((_) async => '3.27.1');
+          () => artifactBuilder.buildWindowsApp(
+            flavor: any(named: 'flavor'),
+            target: any(named: 'target'),
+            args: any(named: 'args'),
+            buildProgress: any(named: 'buildProgress'),
+          ),
+        ).thenAnswer((_) async => projectRoot);
       });
 
-      group('when builder throws exception', () {
-        setUp(() {
-          when(
-            () => artifactBuilder.buildWindowsApp(
-              flavor: any(named: 'flavor'),
-              target: any(named: 'target'),
-              args: any(named: 'args'),
-              buildProgress: any(named: 'buildProgress'),
-            ),
-          ).thenThrow(Exception('oh no'));
-        });
-
-        test('fails progress, exits', () async {
-          await expectLater(
-            () => runWithOverrides(releaser.buildReleaseArtifacts),
-            exitsWithCode(ExitCode.software),
-          );
-          verify(() => progress.fail('Exception: oh no')).called(1);
-        });
-      });
-
-      group('when build succeeds', () {
-        setUp(() {
-          when(
-            () => artifactBuilder.buildWindowsApp(
-              flavor: any(named: 'flavor'),
-              target: any(named: 'target'),
-              args: any(named: 'args'),
-              buildProgress: any(named: 'buildProgress'),
-            ),
-          ).thenAnswer((_) async => projectRoot);
-        });
-
-        test('returns path to release directory', () async {
-          final releaseDir =
-              await runWithOverrides(releaser.buildReleaseArtifacts);
-          expect(releaseDir, projectRoot);
-        });
+      test('returns path to release directory', () async {
+        final releaseDir =
+            await runWithOverrides(releaser.buildReleaseArtifacts);
+        expect(releaseDir, projectRoot);
       });
 
       group('when public key is passed as an arg', () {


### PR DESCRIPTION
## Description

Moves duplicated logging code out of releasers into the release command.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
