### PR TITLE
feat: better handle archiving failures

### DIFF
--- a/packages/shorebird_cli/test/src/artifact_builder/artifact_build_exception_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/artifact_build_exception_test.dart
@@ -34,83 +34,119 @@ void main() {
       });
     });
 
-    group('when an error is recognized but no fix recommendation is found', () {
-      test('has a Flutter error and no fix recommendation', () {
-        final exception = ArtifactBuildException(
-          'message',
-          stderr: [
-            'some stderr output',
-            'FAILURE: Build failed with an exception.',
-            '* Exception is:',
-            'some stack trace',
-            '* Try:',
-            'some recommendation',
-          ],
-          stdout: ['some stdout output'],
-        );
-        expect(
-          exception.flutterError,
-          equals('FAILURE: Build failed with an exception.'),
-        );
-        expect(exception.fixRecommendation, isNull);
+    group('gradle', () {
+      group('when an error is recognized but no fix recommendation is found',
+          () {
+        test('has a Flutter error and no fix recommendation', () {
+          final exception = ArtifactBuildException(
+            'message',
+            stderr: [
+              'some stderr output',
+              'FAILURE: Build failed with an exception.',
+              '* Exception is:',
+              'some stack trace',
+              '* Try:',
+              'some recommendation',
+            ],
+            stdout: ['some stdout output'],
+          );
+          expect(
+            exception.flutterError,
+            equals('FAILURE: Build failed with an exception.'),
+          );
+          expect(exception.fixRecommendation, isNull);
+        });
       });
-    });
 
-    group('when a known error is recognized and a fix recommendation is found',
-        () {
-      test('has a Flutter error and a fix recommendation', () {
-        final exception = ArtifactBuildException(
-          'message',
-          stderr: [
-            'some stderr output',
-            'FAILURE: Build failed with an exception.',
-            '* What went wrong:',
-            "Execution failed for task ':app:signReleaseBundle'.",
-            r'''> A failure occurred while executing com.android.build.gradle.internal.tasks.FinalizeBundleTask$BundleToolRunnable''',
-            '> java.lang.NullPointerException (no error message)',
-            '* Exception is:',
-            'some stack trace',
-            '* Try:',
-            'some recommendation',
-          ],
-          stdout: ['some stdout output'],
-        );
-        expect(
-          exception.flutterError,
-          equals(r'''
+      group(
+          'when a known error is recognized and a fix recommendation is found',
+          () {
+        test('has a Flutter error and a fix recommendation', () {
+          final exception = ArtifactBuildException(
+            'message',
+            stderr: [
+              'some stderr output',
+              'FAILURE: Build failed with an exception.',
+              '* What went wrong:',
+              "Execution failed for task ':app:signReleaseBundle'.",
+              r'''> A failure occurred while executing com.android.build.gradle.internal.tasks.FinalizeBundleTask$BundleToolRunnable''',
+              '> java.lang.NullPointerException (no error message)',
+              '* Exception is:',
+              'some stack trace',
+              '* Try:',
+              'some recommendation',
+            ],
+            stdout: ['some stdout output'],
+          );
+          expect(
+            exception.flutterError,
+            equals(r'''
 FAILURE: Build failed with an exception.
 * What went wrong:
 Execution failed for task ':app:signReleaseBundle'.
 > A failure occurred while executing com.android.build.gradle.internal.tasks.FinalizeBundleTask$BundleToolRunnable
 > java.lang.NullPointerException (no error message)'''),
-        );
-        expect(
-          exception.fixRecommendation,
-          contains('This error is likely due to a missing keystore file'),
-        );
+          );
+          expect(
+            exception.fixRecommendation,
+            contains('This error is likely due to a missing keystore file'),
+          );
+        });
+      });
+
+      group('when a fix recommendation is provided', () {
+        test('does not read output to find fix recommendation', () {
+          final exception = ArtifactBuildException(
+            'message',
+            fixRecommendation: 'some recommendation',
+            stderr: [
+              'some stderr output',
+              'FAILURE: Build failed with an exception.',
+              '* Exception is:',
+              'some stack trace',
+              '* Try:',
+              'some recommendation',
+            ],
+            stdout: ['some stdout output'],
+          );
+          expect(
+            exception.flutterError,
+            'FAILURE: Build failed with an exception.',
+          );
+          expect(exception.fixRecommendation, equals('some recommendation'));
+        });
       });
     });
 
-    group('when a fix recommendation is provided', () {
-      test('does not read output to find fix recommendation', () {
-        final exception = ArtifactBuildException(
-          'message',
-          fixRecommendation: 'some recommendation',
-          stderr: [
-            'some stderr output',
-            'FAILURE: Build failed with an exception.',
-            '* Exception is:',
-            'some stack trace',
-            '* Try:',
-            'some recommendation',
-          ],
-          stdout: ['some stdout output'],
-        );
-        expect(
-          exception.flutterError,
-          'FAILURE: Build failed with an exception.',
-        );
-        expect(exception.fixRecommendation, equals('some recommendation'));
+    group('xcode archiving', () {
+      group(
+          'when a known error is recognized and a fix recommendation is found',
+          () {
+        test('has a Flutter error and a fix recommendation', () {
+          final exception = ArtifactBuildException(
+            'message',
+            stderr: [
+              'some stderr output',
+              'Error (Xcode):',
+              'some error message',
+              'some stack trace',
+              'some recommendation',
+              'Encountered error while archiving for device',
+              'not part of the reported error',
+            ],
+            stdout: ['some stdout output'],
+          );
+          expect(
+            exception.flutterError,
+            equals(
+              '''
+Error (Xcode):
+some error message
+some stack trace
+some recommendation''',
+            ),
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
## Description

Turns this:
![Screenshot 2025-02-11 at 11 30 02 AM](https://github.com/user-attachments/assets/fbffa785-6642-440d-86b8-c76939af8bd0)

Into this:
![Screenshot 2025-02-11 at 11 29 51 AM](https://github.com/user-attachments/assets/90183c80-813c-458f-96a2-78e06386d54a)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
