### PR TITLE
fix: gen_snapshot local engine path for ios arm64

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_artifacts.dart
@@ -237,7 +237,7 @@ class ShorebirdLocalEngineArtifacts implements ShorebirdArtifacts {
         'out',
         engineConfig.localEngine,
         'clang_x64',
-        'gen_snapshot_arm64',
+        'gen_snapshot',
       ),
     );
   }

--- a/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_artifacts_test.dart
@@ -272,7 +272,7 @@ void main() {
               'out',
               localEngine,
               'clang_x64',
-              'gen_snapshot_arm64',
+              'gen_snapshot',
             ),
           ),
         );


### PR DESCRIPTION
At least this is the path when built on an arm64 mac.