### PR TITLE
refactor(shorebird_cli): remove `runInShell` from process wrappers

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -111,7 +111,6 @@ class ArtifactBuilder {
       final buildProcess = await process.start(
         executable,
         arguments,
-        runInShell: true,
         environment: base64PublicKey?.toPublicKeyEnv(),
       );
 
@@ -205,7 +204,6 @@ class ArtifactBuilder {
       final result = await process.run(
         executable,
         arguments,
-        runInShell: true,
         environment: base64PublicKey?.toPublicKeyEnv(),
       );
 
@@ -256,7 +254,7 @@ class ArtifactBuilder {
         ...args,
       ];
 
-      final result = await process.run(executable, arguments, runInShell: true);
+      final result = await process.run(executable, arguments);
 
       if (result.exitCode != ExitCode.success.code) {
         throw ArtifactBuildException.fromProcessResult(
@@ -351,7 +349,6 @@ class ArtifactBuilder {
       final buildProcess = await process.start(
         executable,
         arguments,
-        runInShell: true,
         environment: base64PublicKey?.toPublicKeyEnv(),
       );
 
@@ -427,7 +424,6 @@ class ArtifactBuilder {
       final buildProcess = await process.start(
         executable,
         arguments,
-        runInShell: true,
         environment: base64PublicKey?.toPublicKeyEnv(),
       );
 
@@ -508,7 +504,7 @@ class ArtifactBuilder {
         ...args,
       ];
 
-      final result = await process.run(executable, arguments, runInShell: true);
+      final result = await process.run(executable, arguments);
 
       if (result.exitCode != ExitCode.success.code) {
         throw ArtifactBuildException('Failed to build: ${result.stderr}');
@@ -558,7 +554,6 @@ class ArtifactBuilder {
     final result = await process.run(
       executable,
       arguments,
-      runInShell: true,
       useVendedFlutter: false,
     );
 
@@ -617,7 +612,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
       final buildProcess = await process.start(
         executable,
         arguments,
-        runInShell: true,
         environment: base64PublicKey?.toPublicKeyEnv(),
       );
 

--- a/packages/shorebird_cli/lib/src/commands/run_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/run_command.dart
@@ -79,7 +79,7 @@ Please use "shorebird preview" instead.''');
       if (target != null) '--target=$target',
       if (dartDefines != null) ...dartDefines.map((e) => '--dart-define=$e'),
       ...results.rest,
-    ], runInShell: true);
+    ]);
 
     flutter.stdout.listen((event) {
       logger.info(utf8.decode(event));

--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -19,12 +19,10 @@ class Git {
   Future<ShorebirdProcessResult> git(
     List<String> arguments, {
     String? workingDirectory,
-    bool runInShell = false,
   }) async {
     final result = await process.run(
       executable,
       arguments,
-      runInShell: runInShell,
       workingDirectory: workingDirectory,
     );
     if (result.exitCode != 0) {
@@ -45,7 +43,7 @@ class Git {
     required String outputDirectory,
     List<String>? args,
   }) async {
-    await git(['clone', url, ...?args, outputDirectory], runInShell: true);
+    await git(['clone', url, ...?args, outputDirectory]);
   }
 
   /// Checks out the git repository located at [directory] to the [revision].
@@ -60,7 +58,7 @@ class Git {
       'advice.detachedHead=false',
       'checkout',
       revision,
-    ], runInShell: true);
+    ]);
   }
 
   /// Fetch branches/tags from the repository at [directory].

--- a/packages/shorebird_cli/lib/src/executables/gradlew.dart
+++ b/packages/shorebird_cli/lib/src/executables/gradlew.dart
@@ -105,7 +105,6 @@ class Gradlew {
     final result = await process.run(
       executablePath,
       args,
-      runInShell: true,
       workingDirectory: p.dirname(executablePath),
       environment: {if (!javaHome.isNullOrEmpty) 'JAVA_HOME': javaHome!},
     );

--- a/packages/shorebird_cli/lib/src/executables/powershell.dart
+++ b/packages/shorebird_cli/lib/src/executables/powershell.dart
@@ -20,7 +20,7 @@ class Powershell {
     List<String> arguments, {
     String? workingDirectory,
   }) async {
-    final result = await process.run(executable, arguments, runInShell: true);
+    final result = await process.run(executable, arguments);
     if (result.exitCode != ExitCode.success.code) {
       throw ProcessException(
         executable,

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -75,12 +75,10 @@ class ShorebirdFlutter {
     );
 
     try {
-      await process.run(
-        executable,
-        ['precache', ...precacheArgs],
-        workingDirectory: targetDirectory.path,
-        runInShell: true,
-      );
+      await process.run(executable, [
+        'precache',
+        ...precacheArgs,
+      ], workingDirectory: targetDirectory.path);
       precacheProgress.complete();
     } on Exception {
       precacheProgress.fail('Failed to precache Flutter $version');
@@ -105,12 +103,7 @@ class ShorebirdFlutter {
   /// parsed.
   Future<String?> getSystemVersion() async {
     const args = ['--version'];
-    final result = await process.run(
-      executable,
-      args,
-      runInShell: true,
-      useVendedFlutter: false,
-    );
+    final result = await process.run(executable, args, useVendedFlutter: false);
 
     if (result.exitCode != 0) {
       throw ProcessException(

--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:meta/meta.dart';
@@ -29,7 +30,6 @@ class ShorebirdProcess {
   Future<ShorebirdProcessResult> run(
     String executable,
     List<String> arguments, {
-    bool runInShell = false,
     Map<String, String>? environment,
     String? workingDirectory,
     bool useVendedFlutter = true,
@@ -55,7 +55,6 @@ class ShorebirdProcess {
     final result = await processWrapper.run(
       resolvedExecutable,
       resolvedArguments,
-      runInShell: runInShell,
       workingDirectory: workingDirectory,
       environment: resolvedEnvironment,
     );
@@ -69,7 +68,6 @@ class ShorebirdProcess {
   ShorebirdProcessResult runSync(
     String executable,
     List<String> arguments, {
-    bool runInShell = false,
     Map<String, String>? environment,
     String? workingDirectory,
     bool useVendedFlutter = true,
@@ -95,7 +93,6 @@ class ShorebirdProcess {
     final result = processWrapper.runSync(
       resolvedExecutable,
       resolvedArguments,
-      runInShell: runInShell,
       workingDirectory: workingDirectory,
       environment: resolvedEnvironment,
     );
@@ -110,7 +107,6 @@ class ShorebirdProcess {
     String executable,
     List<String> arguments, {
     Map<String, String>? environment,
-    bool runInShell = false,
     bool useVendedFlutter = true,
     String? workingDirectory,
   }) {
@@ -135,7 +131,6 @@ class ShorebirdProcess {
     return processWrapper.start(
       resolvedExecutable,
       resolvedArguments,
-      runInShell: runInShell,
       environment: resolvedEnvironment,
       workingDirectory: workingDirectory,
     );
@@ -250,7 +245,6 @@ class ProcessWrapper {
   Future<ShorebirdProcessResult> run(
     String executable,
     List<String> arguments, {
-    bool runInShell = false,
     Map<String, String>? environment,
     String? workingDirectory,
   }) async {
@@ -258,7 +252,7 @@ class ProcessWrapper {
       executable,
       arguments,
       environment: environment,
-      runInShell: runInShell,
+      runInShell: Platform.isWindows,
       workingDirectory: workingDirectory,
     );
     return ShorebirdProcessResult(
@@ -272,7 +266,6 @@ class ProcessWrapper {
   ShorebirdProcessResult runSync(
     String executable,
     List<String> arguments, {
-    bool runInShell = false,
     Map<String, String>? environment,
     String? workingDirectory,
   }) {
@@ -280,7 +273,7 @@ class ProcessWrapper {
       executable,
       arguments,
       environment: environment,
-      runInShell: runInShell,
+      runInShell: Platform.isWindows,
       workingDirectory: workingDirectory,
     );
     return ShorebirdProcessResult(
@@ -294,14 +287,13 @@ class ProcessWrapper {
   Future<Process> start(
     String executable,
     List<String> arguments, {
-    bool runInShell = false,
     Map<String, String>? environment,
     String? workingDirectory,
   }) {
     return Process.start(
       executable,
       arguments,
-      runInShell: runInShell,
+      runInShell: Platform.isWindows,
       environment: environment,
       workingDirectory: workingDirectory,
     );

--- a/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
@@ -73,22 +73,18 @@ void main() {
       buildProcess = MockProcess();
 
       when(
-        () => shorebirdProcess.run(
-          'flutter',
-          ['--no-version-check', 'pub', 'get', '--offline'],
-          runInShell: any(named: 'runInShell'),
-          useVendedFlutter: false,
-        ),
+        () => shorebirdProcess.run('flutter', [
+          '--no-version-check',
+          'pub',
+          'get',
+          '--offline',
+        ], useVendedFlutter: false),
       ).thenAnswer((_) async => pubGetProcessResult);
       when(
         () => pubGetProcessResult.exitCode,
       ).thenReturn(ExitCode.success.code);
       when(
-        () => shorebirdProcess.run(
-          any(),
-          any(),
-          runInShell: any(named: 'runInShell'),
-        ),
+        () => shorebirdProcess.run(any(), any()),
       ).thenAnswer((_) async => buildProcessResult);
       when(() => buildProcessResult.exitCode).thenReturn(ExitCode.success.code);
       when(() => buildProcessResult.stdout).thenReturn('some stdout');
@@ -96,7 +92,6 @@ void main() {
         () => shorebirdProcess.start(
           any(),
           any(),
-          runInShell: any(named: 'runInShell'),
           environment: any(named: 'environment'),
         ),
       ).thenAnswer((_) async => buildProcess);
@@ -132,12 +127,12 @@ void main() {
           await testCall();
 
           verify(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['--no-version-check', 'pub', 'get', '--offline'],
-              runInShell: any(named: 'runInShell'),
-              useVendedFlutter: false,
-            ),
+            () => shorebirdProcess.run('flutter', [
+              '--no-version-check',
+              'pub',
+              'get',
+              '--offline',
+            ], useVendedFlutter: false),
           ).called(1);
         });
 
@@ -167,12 +162,12 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
           await testCall();
 
           verifyNever(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['--no-version-check', 'pub', 'get', '--offline'],
-              runInShell: any(named: 'runInShell'),
-              useVendedFlutter: false,
-            ),
+            () => shorebirdProcess.run('flutter', [
+              '--no-version-check',
+              'pub',
+              'get',
+              '--offline',
+            ], useVendedFlutter: false),
           );
         });
       });
@@ -192,12 +187,11 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
         await runWithOverrides(() => builder.buildAppBundle());
 
         verify(
-          () => shorebirdProcess.start(
-            'flutter',
-            ['build', 'appbundle', '--release'],
-            runInShell: any(named: 'runInShell'),
-            environment: any(named: 'environment'),
-          ),
+          () => shorebirdProcess.start('flutter', [
+            'build',
+            'appbundle',
+            '--release',
+          ], environment: any(named: 'environment')),
         ).called(1);
       });
 
@@ -221,7 +215,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
             '--target-platform=android-arm64',
             '--foo',
             'bar',
-          ], runInShell: any(named: 'runInShell')),
+          ]),
         ).called(1);
       });
 
@@ -240,7 +234,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
                 '--target=target',
                 '--target-platform=android-arm64',
               ],
-              runInShell: any(named: 'runInShell'),
               environment: {'SHOREBIRD_PUBLIC_KEY': base64PublicKey},
             ),
           ).thenAnswer((_) async => buildProcess);
@@ -267,7 +260,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
                 '--target=target',
                 '--target-platform=android-arm64',
               ],
-              runInShell: any(named: 'runInShell'),
               environment: {'SHOREBIRD_PUBLIC_KEY': base64PublicKey},
             ),
           ).called(1);
@@ -422,12 +414,11 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
         await runWithOverrides(() => builder.buildApk());
 
         verify(
-          () => shorebirdProcess.run(
-            'flutter',
-            ['build', 'apk', '--release'],
-            runInShell: any(named: 'runInShell'),
-            environment: any(named: 'environment'),
-          ),
+          () => shorebirdProcess.run('flutter', [
+            'build',
+            'apk',
+            '--release',
+          ], environment: any(named: 'environment')),
         ).called(1);
       });
 
@@ -451,7 +442,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
             '--target-platform=android-arm64',
             '--foo',
             'bar',
-          ], runInShell: any(named: 'runInShell')),
+          ]),
         ).called(1);
       });
 
@@ -470,7 +461,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
                 '--target=target',
                 '--target-platform=android-arm64',
               ],
-              runInShell: any(named: 'runInShell'),
               environment: {'SHOREBIRD_PUBLIC_KEY': base64PublicKey},
             ),
           ).thenAnswer((_) async => buildProcessResult);
@@ -497,7 +487,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
                 '--target=target',
                 '--target-platform=android-arm64',
               ],
-              runInShell: any(named: 'runInShell'),
               environment: {'SHOREBIRD_PUBLIC_KEY': base64PublicKey},
             ),
           ).called(1);
@@ -601,18 +590,13 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
         );
 
         verify(
-          () => shorebirdProcess.run(
-            'flutter',
-            [
-              'build',
-              'aar',
-              '--no-debug',
-              '--no-profile',
-              '--build-number=1.0',
-            ],
-            runInShell: any(named: 'runInShell'),
-            environment: any(named: 'environment'),
-          ),
+          () => shorebirdProcess.run('flutter', [
+            'build',
+            'aar',
+            '--no-debug',
+            '--no-profile',
+            '--build-number=1.0',
+          ], environment: any(named: 'environment')),
         ).called(1);
       });
 
@@ -635,7 +619,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
             '--target-platform=android-arm64',
             '--foo',
             'bar',
-          ], runInShell: any(named: 'runInShell')),
+          ]),
         ).called(1);
       });
 
@@ -695,7 +679,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
             'build',
             'linux',
             '--release',
-          ], runInShell: any(named: 'runInShell')),
+          ]),
         ).thenAnswer((_) async => buildProcess);
       });
 
@@ -735,7 +719,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
               'linux',
               '--release',
               '--target=target.dart',
-            ], runInShell: any(named: 'runInShell')),
+            ]),
           ).called(1);
         });
       });
@@ -773,7 +757,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
             () => shorebirdProcess.start(
               'flutter',
               ['build', 'linux', '--release'],
-              runInShell: any(named: 'runInShell'),
               environment: {'SHOREBIRD_PUBLIC_KEY': publicKey},
             ),
           ).called(1);
@@ -823,12 +806,11 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
           final result = await runWithOverrides(builder.buildMacos);
 
           verify(
-            () => shorebirdProcess.start(
-              'flutter',
-              ['build', 'macos', '--release'],
-              runInShell: true,
-              environment: any(named: 'environment'),
-            ),
+            () => shorebirdProcess.start('flutter', [
+              'build',
+              'macos',
+              '--release',
+            ], environment: any(named: 'environment')),
           ).called(1);
           expect(result.kernelFile.path, equals('/path/to/app.dill'));
         });
@@ -842,7 +824,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
             () => shorebirdProcess.start(
               'flutter',
               ['build', 'macos', '--release'],
-              runInShell: any(named: 'runInShell'),
               environment: {'SHOREBIRD_PUBLIC_KEY': base64PublicKey},
             ),
           ).thenAnswer((_) async => buildProcess);
@@ -857,7 +838,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
             () => shorebirdProcess.start(
               'flutter',
               ['build', 'macos', '--release'],
-              runInShell: any(named: 'runInShell'),
               environment: {'SHOREBIRD_PUBLIC_KEY': base64PublicKey},
             ),
           ).called(1);
@@ -884,7 +864,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
             '--no-codesign',
             '--foo',
             'bar',
-          ], runInShell: any(named: 'runInShell')),
+          ]),
         ).called(1);
       });
 
@@ -984,12 +964,11 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
           final result = await runWithOverrides(builder.buildIpa);
 
           verify(
-            () => shorebirdProcess.start(
-              'flutter',
-              ['build', 'ipa', '--release'],
-              runInShell: true,
-              environment: any(named: 'environment'),
-            ),
+            () => shorebirdProcess.start('flutter', [
+              'build',
+              'ipa',
+              '--release',
+            ], environment: any(named: 'environment')),
           ).called(1);
           expect(result.kernelFile.path, equals('/path/to/app.dill'));
         });
@@ -1003,7 +982,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
             () => shorebirdProcess.start(
               'flutter',
               ['build', 'ipa', '--release'],
-              runInShell: any(named: 'runInShell'),
               environment: {'SHOREBIRD_PUBLIC_KEY': base64PublicKey},
             ),
           ).thenAnswer((_) async => buildProcess);
@@ -1018,7 +996,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
             () => shorebirdProcess.start(
               'flutter',
               ['build', 'ipa', '--release'],
-              runInShell: any(named: 'runInShell'),
               environment: {'SHOREBIRD_PUBLIC_KEY': base64PublicKey},
             ),
           ).called(1);
@@ -1045,7 +1022,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
             '--no-codesign',
             '--foo',
             'bar',
-          ], runInShell: any(named: 'runInShell')),
+          ]),
         ).called(1);
       });
 
@@ -1305,12 +1282,12 @@ error: exportArchive No signing certificate "iOS Distribution" found'''),
         final result = await runWithOverrides(builder.buildIosFramework);
 
         verify(
-          () => shorebirdProcess.run(
-            'flutter',
-            ['build', 'ios-framework', '--no-debug', '--no-profile'],
-            runInShell: true,
-            environment: any(named: 'environment'),
-          ),
+          () => shorebirdProcess.run('flutter', [
+            'build',
+            'ios-framework',
+            '--no-debug',
+            '--no-profile',
+          ], environment: any(named: 'environment')),
         ).called(1);
         expect(result.kernelFile.path, equals('/path/to/app.dill'));
       });
@@ -1328,7 +1305,7 @@ error: exportArchive No signing certificate "iOS Distribution" found'''),
             '--no-profile',
             '--foo',
             'bar',
-          ], runInShell: true),
+          ]),
         ).called(1);
       });
 
@@ -1476,7 +1453,7 @@ error: exportArchive No signing certificate "iOS Distribution" found'''),
             'build',
             'windows',
             '--release',
-          ], runInShell: any(named: 'runInShell')),
+          ]),
         ).thenAnswer((_) async => buildProcess);
       });
 
@@ -1541,7 +1518,6 @@ error: exportArchive No signing certificate "iOS Distribution" found'''),
             () => shorebirdProcess.start(
               'flutter',
               ['build', 'windows', '--release'],
-              runInShell: any(named: 'runInShell'),
               environment: {'SHOREBIRD_PUBLIC_KEY': publicKey},
             ),
           ).called(1);

--- a/packages/shorebird_cli/test/src/commands/run_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/run_command_test.dart
@@ -55,11 +55,7 @@ void main() {
       validator = MockValidator();
 
       when(
-        () => shorebirdProcess.start(
-          any(),
-          any(),
-          runInShell: any(named: 'runInShell'),
-        ),
+        () => shorebirdProcess.start(any(), any()),
       ).thenAnswer((_) async => process);
       when(() => argResults.rest).thenReturn([]);
       when(() => doctor.generalValidators).thenReturn([validator]);
@@ -177,11 +173,7 @@ Please use "shorebird preview" instead.'''),
 
       final args =
           verify(
-                () => shorebirdProcess.start(
-                  any(),
-                  captureAny(),
-                  runInShell: any(named: 'runInShell'),
-                ),
+                () => shorebirdProcess.start(any(), captureAny()),
               ).captured.first
               as List<String>;
       expect(

--- a/packages/shorebird_cli/test/src/executables/git_test.dart
+++ b/packages/shorebird_cli/test/src/executables/git_test.dart
@@ -31,7 +31,6 @@ void main() {
         () => process.run(
           any(),
           any(),
-          runInShell: any(named: 'runInShell'),
           workingDirectory: any(named: 'workingDirectory'),
         ),
       ).thenAnswer((_) async => processResult);
@@ -47,11 +46,7 @@ void main() {
           () => git.clone(url: url, outputDirectory: outputDirectory),
         );
         verify(
-          () => process.run('git', [
-            'clone',
-            url,
-            outputDirectory,
-          ], runInShell: true),
+          () => process.run('git', ['clone', url, outputDirectory]),
         ).called(1);
       });
 
@@ -65,12 +60,7 @@ void main() {
           ),
         );
         verify(
-          () => process.run('git', [
-            'clone',
-            url,
-            ...args,
-            outputDirectory,
-          ], runInShell: true),
+          () => process.run('git', ['clone', url, ...args, outputDirectory]),
         ).called(1);
       });
 
@@ -105,7 +95,7 @@ void main() {
             'advice.detachedHead=false',
             'checkout',
             revision,
-          ], runInShell: true),
+          ]),
         ).called(1);
       });
 

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -41,7 +41,6 @@ void main() {
         () => process.run(
           any(),
           any(),
-          runInShell: any(named: 'runInShell'),
           workingDirectory: any(named: 'workingDirectory'),
           environment: any(named: 'environment'),
         ),
@@ -84,7 +83,6 @@ Make sure you have run "flutter build apk" at least once.''');
           () => process.run(
             p.join(tempDir.path, 'android', 'gradlew'),
             ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
             workingDirectory: p.join(tempDir.path, 'android'),
             environment: {'JAVA_HOME': javaHome},
           ),
@@ -102,7 +100,6 @@ Make sure you have run "flutter build apk" at least once.''');
           () => process.run(
             p.join(tempDir.path, 'android', 'gradlew'),
             ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
             workingDirectory: p.join(tempDir.path, 'android'),
             environment: {'JAVA_HOME': javaHome},
           ),
@@ -122,7 +119,6 @@ Make sure you have run "flutter build apk" at least once.''');
           () => process.run(
             p.join(tempDir.path, 'android', 'gradlew'),
             ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
             workingDirectory: p.join(tempDir.path, 'android'),
             environment: {'JAVA_HOME': javaHome},
           ),
@@ -151,7 +147,6 @@ Make sure you have run "flutter build apk" at least once.''');
           () => process.run(
             p.join(tempDir.path, 'android', 'gradlew'),
             ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
             workingDirectory: p.join(tempDir.path, 'android'),
             environment: {'JAVA_HOME': javaHome},
           ),
@@ -239,7 +234,6 @@ BUILD FAILED in 3s
           () => process.run(
             p.join(tempDir.path, 'android', 'gradlew'),
             ['app:tasks', '--all', '--console=auto'],
-            runInShell: true,
             workingDirectory: p.join(tempDir.path, 'android'),
             environment: {'JAVA_HOME': javaHome},
           ),

--- a/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
+++ b/packages/shorebird_cli/test/src/executables/patch_executable_test.dart
@@ -40,11 +40,7 @@ void main() {
       platform = MockPlatform();
 
       when(
-        () => shorebirdProcess.run(
-          any(that: endsWith('patch')),
-          any(),
-          runInShell: any(named: 'runInShell'),
-        ),
+        () => shorebirdProcess.run(any(that: endsWith('patch')), any()),
       ).thenAnswer((invocation) async {
         final args = invocation.positionalArguments[1] as List<String>;
         final diffPath = args[2];
@@ -101,11 +97,7 @@ void main() {
       when(() => patchProcessResult.stdout).thenReturn(stdout);
 
       when(
-        () => shorebirdProcess.run(
-          any(that: endsWith('patch')),
-          any(),
-          runInShell: any(named: 'runInShell'),
-        ),
+        () => shorebirdProcess.run(any(that: endsWith('patch')), any()),
       ).thenAnswer((_) async => patchProcessResult);
 
       await expectLater(
@@ -137,11 +129,7 @@ void main() {
         when(() => patchProcessResult.stdout).thenReturn(stdout);
 
         when(
-          () => shorebirdProcess.run(
-            any(that: endsWith('patch')),
-            any(),
-            runInShell: any(named: 'runInShell'),
-          ),
+          () => shorebirdProcess.run(any(that: endsWith('patch')), any()),
         ).thenAnswer((_) async => patchProcessResult);
       });
 

--- a/packages/shorebird_cli/test/src/executables/powershell_test.dart
+++ b/packages/shorebird_cli/test/src/executables/powershell_test.dart
@@ -29,7 +29,6 @@ void main() {
         () => process.run(
           any(),
           any(),
-          runInShell: any(named: 'runInShell'),
           workingDirectory: any(named: 'workingDirectory'),
         ),
       ).thenAnswer((_) async => processResult);
@@ -82,7 +81,7 @@ void main() {
               () => process.run('powershell.exe', [
                 '-Command',
                 "(Get-Item -Path '${file.path}').VersionInfo.ProductVersion",
-              ], runInShell: true),
+              ]),
             ).called(1);
           });
         });

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -96,19 +96,13 @@ void main() {
       when(() => shorebirdEnv.flutterDirectory).thenReturn(flutterDirectory);
       when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
       when(
-        () => process.run(
-          'flutter',
-          ['--version'],
-          runInShell: true,
-          useVendedFlutter: false,
-        ),
+        () => process.run('flutter', ['--version'], useVendedFlutter: false),
       ).thenAnswer((_) async => versionProcessResult);
       when(() => versionProcessResult.exitCode).thenReturn(0);
       when(
         () => process.run(
           'flutter',
           any(that: contains('precache')),
-          runInShell: true,
           workingDirectory: any(named: 'workingDirectory'),
         ),
       ).thenAnswer((_) async => precacheProcessResult);
@@ -157,12 +151,8 @@ void main() {
             throwsA(isA<ProcessException>()),
           );
           verify(
-            () => process.run(
-              'flutter',
-              ['--version'],
-              runInShell: true,
-              useVendedFlutter: false,
-            ),
+            () =>
+                process.run('flutter', ['--version'], useVendedFlutter: false),
           ).called(1);
         },
       );
@@ -174,12 +164,7 @@ void main() {
           completion(isNull),
         );
         verify(
-          () => process.run(
-            'flutter',
-            ['--version'],
-            runInShell: true,
-            useVendedFlutter: false,
-          ),
+          () => process.run('flutter', ['--version'], useVendedFlutter: false),
         ).called(1);
       });
 
@@ -194,12 +179,7 @@ Tools • Dart 3.0.6 • DevTools 2.23.1''');
           completion(equals('3.10.6')),
         );
         verify(
-          () => process.run(
-            'flutter',
-            ['--version'],
-            runInShell: true,
-            useVendedFlutter: false,
-          ),
+          () => process.run('flutter', ['--version'], useVendedFlutter: false),
         ).called(1);
       });
     });
@@ -731,11 +711,7 @@ origin/flutter_release/3.10.6''';
           ),
         );
         verifyNever(
-          () => process.run(
-            'flutter',
-            any(that: contains('precache')),
-            runInShell: any(named: 'runInShell'),
-          ),
+          () => process.run('flutter', any(that: contains('precache'))),
         );
       });
 
@@ -764,11 +740,7 @@ origin/flutter_release/3.10.6''';
           ),
         ).called(1);
         verifyNever(
-          () => process.run(
-            'flutter',
-            any(that: contains('precache')),
-            runInShell: any(named: 'runInShell'),
-          ),
+          () => process.run('flutter', any(that: contains('precache'))),
         );
       });
 
@@ -815,7 +787,6 @@ origin/flutter_release/3.10.6''';
               'flutter',
               any(that: contains('precache')),
               workingDirectory: any(named: 'workingDirectory'),
-              runInShell: any(named: 'runInShell'),
             ),
           ).thenThrow(Exception('oh no!'));
         });
@@ -835,7 +806,6 @@ origin/flutter_release/3.10.6''';
                 ...runWithOverrides(() => shorebirdFlutter.precacheArgs),
               ],
               workingDirectory: p.join(flutterDirectory.parent.path, revision),
-              runInShell: true,
             ),
           ).called(1);
 
@@ -866,7 +836,6 @@ origin/flutter_release/3.10.6''';
                 ...runWithOverrides(() => shorebirdFlutter.precacheArgs),
               ],
               workingDirectory: p.join(flutterDirectory.parent.path, revision),
-              runInShell: true,
             ),
           ).called(1);
           verify(

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -73,7 +73,6 @@ void main() {
           () => processWrapper.run(
             any(),
             any(),
-            runInShell: any(named: 'runInShell'),
             environment: any(named: 'environment'),
             workingDirectory: any(named: 'workingDirectory'),
           ),
@@ -82,19 +81,13 @@ void main() {
 
       test('forwards non-flutter executables to Process.run', () async {
         await runWithOverrides(
-          () => shorebirdProcess.run(
-            'git',
-            ['pull'],
-            runInShell: true,
-            workingDirectory: '~',
-          ),
+          () => shorebirdProcess.run('git', ['pull'], workingDirectory: '~'),
         );
 
         verify(
           () => processWrapper.run(
             'git',
             ['pull'],
-            runInShell: true,
             environment: {},
             workingDirectory: '~',
           ),
@@ -103,12 +96,9 @@ void main() {
 
       test('replaces "flutter" with our local flutter', () async {
         await runWithOverrides(
-          () => shorebirdProcess.run(
-            'flutter',
-            ['--version'],
-            runInShell: true,
-            workingDirectory: '~',
-          ),
+          () => shorebirdProcess.run('flutter', [
+            '--version',
+          ], workingDirectory: '~'),
         );
 
         verify(
@@ -119,7 +109,6 @@ void main() {
               ),
             ),
             ['--version', '--verbose'],
-            runInShell: true,
             environment: flutterStorageBaseUrlEnv,
             workingDirectory: '~',
           ),
@@ -132,7 +121,6 @@ void main() {
           () => shorebirdProcess.run(
             'flutter',
             ['--version'],
-            runInShell: true,
             workingDirectory: '~',
             useVendedFlutter: false,
           ),
@@ -142,7 +130,6 @@ void main() {
           () => processWrapper.run(
             'flutter',
             ['--version', '--verbose'],
-            runInShell: true,
             environment: {},
             workingDirectory: '~',
           ),
@@ -154,7 +141,6 @@ void main() {
           () => shorebirdProcess.run(
             'flutter',
             ['--version'],
-            runInShell: true,
             workingDirectory: '~',
             useVendedFlutter: false,
             environment: {'ENV_VAR': 'asdfasdf'},
@@ -165,7 +151,6 @@ void main() {
           () => processWrapper.run(
             'flutter',
             ['--version', '--verbose'],
-            runInShell: true,
             workingDirectory: '~',
             environment: {'ENV_VAR': 'asdfasdf'},
           ),
@@ -179,7 +164,6 @@ void main() {
             () => shorebirdProcess.run(
               'flutter',
               ['--version'],
-              runInShell: true,
               workingDirectory: '~',
               useVendedFlutter: false,
               environment: {'ENV_VAR': 'asdfasdf'},
@@ -190,7 +174,6 @@ void main() {
             () => processWrapper.run(
               'flutter',
               ['--version', '--verbose'],
-              runInShell: true,
               workingDirectory: '~',
               environment: {'ENV_VAR': 'asdfasdf'},
             ),
@@ -218,7 +201,6 @@ void main() {
               '--local-engine-host=host_release',
               '--verbose',
             ],
-            runInShell: any(named: 'runInShell'),
             environment: any(named: 'environment'),
             workingDirectory: any(named: 'workingDirectory'),
           ),
@@ -239,7 +221,6 @@ void main() {
           () => processWrapper.runSync(
             any(),
             any(),
-            runInShell: any(named: 'runInShell'),
             environment: any(named: 'environment'),
             workingDirectory: any(named: 'workingDirectory'),
           ),
@@ -248,19 +229,14 @@ void main() {
 
       test('forwards non-flutter executables to Process.runSync', () async {
         runWithOverrides(
-          () => shorebirdProcess.runSync(
-            'git',
-            ['pull'],
-            runInShell: true,
-            workingDirectory: '~',
-          ),
+          () =>
+              shorebirdProcess.runSync('git', ['pull'], workingDirectory: '~'),
         );
 
         verify(
           () => processWrapper.runSync(
             'git',
             ['pull'],
-            runInShell: true,
             environment: {},
             workingDirectory: '~',
           ),
@@ -269,12 +245,9 @@ void main() {
 
       test('replaces "flutter" with our local flutter', () {
         runWithOverrides(
-          () => shorebirdProcess.runSync(
-            'flutter',
-            ['--version'],
-            runInShell: true,
-            workingDirectory: '~',
-          ),
+          () => shorebirdProcess.runSync('flutter', [
+            '--version',
+          ], workingDirectory: '~'),
         );
 
         verify(
@@ -285,7 +258,6 @@ void main() {
               ),
             ),
             ['--version', '--verbose'],
-            runInShell: true,
             environment: flutterStorageBaseUrlEnv,
             workingDirectory: '~',
           ),
@@ -299,7 +271,6 @@ void main() {
             () => shorebirdProcess.runSync(
               'flutter',
               ['--version'],
-              runInShell: true,
               workingDirectory: '~',
               useVendedFlutter: false,
             ),
@@ -309,7 +280,6 @@ void main() {
             () => processWrapper.runSync(
               'flutter',
               ['--version', '--verbose'],
-              runInShell: true,
               environment: {},
               workingDirectory: '~',
             ),
@@ -322,7 +292,6 @@ void main() {
           () => shorebirdProcess.runSync(
             'flutter',
             ['--version'],
-            runInShell: true,
             workingDirectory: '~',
             useVendedFlutter: false,
             environment: {'ENV_VAR': 'asdfasdf'},
@@ -333,7 +302,6 @@ void main() {
           () => processWrapper.runSync(
             'flutter',
             ['--version', '--verbose'],
-            runInShell: true,
             workingDirectory: '~',
             environment: {'ENV_VAR': 'asdfasdf'},
           ),
@@ -345,7 +313,6 @@ void main() {
           () => shorebirdProcess.runSync(
             'flutter',
             ['--version'],
-            runInShell: true,
             workingDirectory: '~',
             useVendedFlutter: false,
             environment: {'ENV_VAR': 'asdfasdf'},
@@ -356,7 +323,6 @@ void main() {
           () => processWrapper.runSync(
             'flutter',
             ['--version', '--verbose'],
-            runInShell: true,
             workingDirectory: '~',
             environment: {'ENV_VAR': 'asdfasdf'},
           ),
@@ -375,7 +341,6 @@ void main() {
             () => processWrapper.runSync(
               any(),
               ['--verbose'],
-              runInShell: any(named: 'runInShell'),
               environment: any(named: 'environment'),
               workingDirectory: any(named: 'workingDirectory'),
             ),
@@ -410,29 +375,21 @@ void main() {
             any(),
             any(),
             environment: any(named: 'environment'),
-            runInShell: any(named: 'runInShell'),
           ),
         ).thenAnswer((_) async => startProcess);
       });
 
       test('forwards non-flutter executables to Process.run', () async {
-        await runWithOverrides(
-          () => shorebirdProcess.start('git', ['pull'], runInShell: true),
-        );
+        await runWithOverrides(() => shorebirdProcess.start('git', ['pull']));
 
         verify(
-          () => processWrapper.start(
-            'git',
-            ['pull'],
-            runInShell: true,
-            environment: {},
-          ),
+          () => processWrapper.start('git', ['pull'], environment: {}),
         ).called(1);
       });
 
       test('replaces "flutter" with our local flutter', () async {
         await runWithOverrides(
-          () => shorebirdProcess.start('flutter', ['run'], runInShell: true),
+          () => shorebirdProcess.start('flutter', ['run']),
         );
 
         verify(
@@ -443,7 +400,6 @@ void main() {
               ),
             ),
             ['run', '--verbose'],
-            runInShell: true,
             environment: flutterStorageBaseUrlEnv,
           ),
         ).called(1);
@@ -452,21 +408,16 @@ void main() {
       test('does not replace flutter with our local flutter if'
           ' useVendedFlutter is false', () async {
         await runWithOverrides(
-          () => shorebirdProcess.start(
-            'flutter',
-            ['--version'],
-            runInShell: true,
-            useVendedFlutter: false,
-          ),
+          () => shorebirdProcess.start('flutter', [
+            '--version',
+          ], useVendedFlutter: false),
         );
 
         verify(
-          () => processWrapper.start(
-            'flutter',
-            ['--version', '--verbose'],
-            runInShell: true,
-            environment: {},
-          ),
+          () => processWrapper.start('flutter', [
+            '--version',
+            '--verbose',
+          ], environment: {}),
         ).called(1);
       });
       test('Updates environment if useVendedFlutter is true', () async {
@@ -474,7 +425,6 @@ void main() {
           () => shorebirdProcess.start(
             'flutter',
             ['--version'],
-            runInShell: true,
             environment: {'ENV_VAR': 'asdfasdf'},
           ),
         );
@@ -487,7 +437,6 @@ void main() {
               ),
             ),
             ['--version', '--verbose'],
-            runInShell: true,
             environment: {'ENV_VAR': 'asdfasdf', ...flutterStorageBaseUrlEnv},
           ),
         ).called(1);
@@ -500,7 +449,6 @@ void main() {
             () => shorebirdProcess.start(
               'flutter',
               ['--version'],
-              runInShell: true,
               useVendedFlutter: false,
               environment: {'hello': 'world'},
             ),
@@ -510,7 +458,6 @@ void main() {
             () => processWrapper.start(
               'flutter',
               ['--version', '--verbose'],
-              runInShell: true,
               environment: {'hello': 'world'},
             ),
           ).called(1);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- refactor(shorebird_cli): remove `runInShell` from process wrappers
  - We only use `runInShell` on Windows for various compatibility reasons (e.g. accessing parts of the PATH)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
