### PR TITLE
fix(shorebird_cli): `shorebird release windows` should support `--flutter-version=<hash>`

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
@@ -69,12 +69,7 @@ To change the version of this release, change your app's version in your pubspec
       final version = await shorebirdFlutter.resolveFlutterVersion(
         flutterVersionArg,
       );
-      final gitHash = await shorebirdFlutter.getRevisionForVersion(
-        flutterVersionArg,
-      );
-      if (version != null &&
-          version < minimumSupportedWindowsFlutterVersion &&
-          !windowsFlutterGitHashesBelowMinVersion.contains(gitHash)) {
+      if (version != null && version < minimumSupportedWindowsFlutterVersion) {
         logger.err('''
 Windows releases are not supported with Flutter versions older than $minimumSupportedWindowsFlutterVersion.
 For more information see: ${supportedFlutterVersionsUrl.toLink()}''');

--- a/packages/shorebird_cli/lib/src/platform/windows.dart
+++ b/packages/shorebird_cli/lib/src/platform/windows.dart
@@ -11,8 +11,3 @@ const primaryWindowsReleaseArtifactArch = 'win_archive';
 
 /// The minimum allowed Flutter version for creating Windows releases.
 final minimumSupportedWindowsFlutterVersion = Version(3, 27, 2);
-
-/// Revisions of Flutter 3.27.1 that support windows.
-const windowsFlutterGitHashesBelowMinVersion = {
-  '56228c343d6c7fd3e1e548dbb290f9713bb22aa9',
-};

--- a/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
@@ -246,9 +246,6 @@ To change the version of this release, change your app's version in your pubspec
           when(
             () => shorebirdFlutter.resolveFlutterVersion('3.27.1'),
           ).thenAnswer((_) async => Version(3, 27, 1));
-          when(
-            () => shorebirdFlutter.getRevisionForVersion(any()),
-          ).thenAnswer((_) async => 'deadbeef');
         });
 
         test('logs error and exits with usage err', () async {
@@ -262,23 +259,6 @@ To change the version of this release, change your app's version in your pubspec
 Windows releases are not supported with Flutter versions older than $minimumSupportedWindowsFlutterVersion.
 For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
           ).called(1);
-        });
-
-        group('when flutter version is 3.27.1 but hash is supported', () {
-          setUp(() {
-            when(
-              () => shorebirdFlutter.getRevisionForVersion(any()),
-            ).thenAnswer(
-              (_) async => windowsFlutterGitHashesBelowMinVersion.first,
-            );
-          });
-
-          test('completes normally', () async {
-            await expectLater(
-              runWithOverrides(releaser.assertPreconditions),
-              completes,
-            );
-          });
         });
       });
     });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- fix(shorebird_cli): `shorebird release windows` should support `--flutter-version=<hash>` (closes #2979)
  - removes support for the one specific revision of Flutter 3.27.1 and instead just requires Flutter 3.27.2 and above

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
