### PR TITLE
fix(shorebird_cli): adjust flutter and dart binary paths for windows

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_env.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_env.dart
@@ -73,12 +73,14 @@ class ShorebirdEnv {
 
   /// The Shorebird-vended Flutter binary.
   File get flutterBinaryFile {
-    return File(p.join(flutterDirectory.path, 'bin', 'flutter'));
+    final flutter = platform.isWindows ? 'flutter.bat' : 'flutter';
+    return File(p.join(flutterDirectory.path, 'bin', flutter));
   }
 
   /// The Shorebird-vended Dart binary.
   File get dartBinaryFile {
-    return File(p.join(flutterDirectory.path, 'bin', 'dart'));
+    final dart = platform.isWindows ? 'dart.bat' : 'dart';
+    return File(p.join(flutterDirectory.path, 'bin', dart));
   }
 
   /// The Cocoapods lockfile for this project's iOS app.

--- a/packages/shorebird_cli/test/src/shorebird_env_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_env_test.dart
@@ -179,6 +179,7 @@ void main() {
 
     group('dartBinaryFile', () {
       test('returns correct path', () {
+        when(() => platform.isWindows).thenReturn(false);
         expect(
           runWithOverrides(() => shorebirdEnv.dartBinaryFile.path),
           equals(
@@ -190,6 +191,21 @@ void main() {
               flutterRevision,
               'bin',
               'dart',
+            ),
+          ),
+        );
+        when(() => platform.isWindows).thenReturn(true);
+        expect(
+          runWithOverrides(() => shorebirdEnv.dartBinaryFile.path),
+          equals(
+            p.join(
+              shorebirdRoot.path,
+              'bin',
+              'cache',
+              'flutter',
+              flutterRevision,
+              'bin',
+              'dart.bat',
             ),
           ),
         );
@@ -241,6 +257,7 @@ void main() {
 
     group('flutterBinaryFile', () {
       test('returns correct path', () {
+        when(() => platform.isWindows).thenReturn(false);
         expect(
           runWithOverrides(() => shorebirdEnv.flutterBinaryFile.path),
           equals(
@@ -252,6 +269,21 @@ void main() {
               flutterRevision,
               'bin',
               'flutter',
+            ),
+          ),
+        );
+        when(() => platform.isWindows).thenReturn(true);
+        expect(
+          runWithOverrides(() => shorebirdEnv.flutterBinaryFile.path),
+          equals(
+            p.join(
+              shorebirdRoot.path,
+              'bin',
+              'cache',
+              'flutter',
+              flutterRevision,
+              'bin',
+              'flutter.bat',
             ),
           ),
         );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- fix(shorebird_cli): adjust flutter and dart binary paths for windows
  - previously these were working because they were always run with `runInShell: true`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
