### PR TITLE
feat: collect linker metadata if available

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -362,6 +362,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
     CreatePatchMetadata metadata,
   ) async => metadata.copyWith(
     linkPercentage: lastBuildLinkPercentage,
+    linkMetadata: lastBuildLinkMetadata,
     environment: metadata.environment.copyWith(
       xcodeVersion: await xcodeBuild.version(),
     ),

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -234,6 +234,7 @@ class AotTools {
   }
 
   /// Dump json metadata from a link debug result.
+  // Added in Flutter 3.29.3
   Future<Map<String, dynamic>> getLinkMetadata({
     required String debugDir,
     String? workingDirectory,

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -233,6 +233,18 @@ class AotTools {
     return result.stdout.toString().contains('dump-debug-info');
   }
 
+  /// Dump json metadata from a link debug result.
+  Future<Map<String, dynamic>> getLinkMetadata({
+    required String debugDir,
+    String? workingDirectory,
+  }) async {
+    final result = await _exec([
+      'link_metadata',
+      debugDir,
+    ], workingDirectory: workingDirectory);
+    return jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
+  }
+
   /// Generate a link vmcode file from two AOT snapshots.
   Future<double?> link({
     required String base,

--- a/packages/shorebird_cli/lib/src/metadata/create_patch_metadata.dart
+++ b/packages/shorebird_cli/lib/src/metadata/create_patch_metadata.dart
@@ -27,6 +27,7 @@ class CreatePatchMetadata extends Equatable {
     required this.inferredReleaseVersion,
     required this.environment,
     this.linkPercentage,
+    this.linkMetadata,
   });
 
   // coverage:ignore-start
@@ -40,6 +41,7 @@ class CreatePatchMetadata extends Equatable {
     bool hasNativeChanges = false,
     bool inferredReleaseVersion = false,
     double? linkPercentage,
+    Json? linkMetadata,
     BuildEnvironmentMetadata? environment,
   }) => CreatePatchMetadata(
     releasePlatform: releasePlatform,
@@ -49,6 +51,7 @@ class CreatePatchMetadata extends Equatable {
     hasNativeChanges: hasNativeChanges,
     inferredReleaseVersion: inferredReleaseVersion,
     linkPercentage: linkPercentage,
+    linkMetadata: linkMetadata,
     environment: environment ?? BuildEnvironmentMetadata.forTest(),
   );
   // coverage:ignore-end
@@ -70,6 +73,7 @@ class CreatePatchMetadata extends Equatable {
     bool? hasNativeChanges,
     bool? inferredReleaseVersion,
     double? linkPercentage,
+    Json? linkMetadata,
     BuildEnvironmentMetadata? environment,
   }) => CreatePatchMetadata(
     releasePlatform: releasePlatform ?? this.releasePlatform,
@@ -82,6 +86,7 @@ class CreatePatchMetadata extends Equatable {
     inferredReleaseVersion:
         inferredReleaseVersion ?? this.inferredReleaseVersion,
     linkPercentage: linkPercentage ?? this.linkPercentage,
+    linkMetadata: linkMetadata ?? this.linkMetadata,
     environment: environment ?? this.environment,
   );
 
@@ -124,6 +129,9 @@ class CreatePatchMetadata extends Equatable {
   /// Note: link percentage is currently only available for iOS patches.
   final double? linkPercentage;
 
+  /// Metadata from the linker, if available.
+  final Json? linkMetadata;
+
   /// Properties about the environment in which the patch was created.
   ///
   /// Reason: see [BuildEnvironmentMetadata].
@@ -137,6 +145,7 @@ class CreatePatchMetadata extends Equatable {
     usedIgnoreNativeChangesFlag,
     hasNativeChanges,
     linkPercentage,
+    linkMetadata,
     inferredReleaseVersion,
     environment,
   ];

--- a/packages/shorebird_cli/lib/src/metadata/create_patch_metadata.g.dart
+++ b/packages/shorebird_cli/lib/src/metadata/create_patch_metadata.g.dart
@@ -41,6 +41,10 @@ CreatePatchMetadata _$CreatePatchMetadataFromJson(
         'link_percentage',
         (v) => (v as num?)?.toDouble(),
       ),
+      linkMetadata: $checkedConvert(
+        'link_metadata',
+        (v) => v as Map<String, dynamic>?,
+      ),
     );
     return val;
   },
@@ -52,6 +56,7 @@ CreatePatchMetadata _$CreatePatchMetadataFromJson(
     'hasNativeChanges': 'has_native_changes',
     'inferredReleaseVersion': 'inferred_release_version',
     'linkPercentage': 'link_percentage',
+    'linkMetadata': 'link_metadata',
   },
 );
 
@@ -65,6 +70,7 @@ Map<String, dynamic> _$CreatePatchMetadataToJson(
   'has_native_changes': instance.hasNativeChanges,
   'inferred_release_version': instance.inferredReleaseVersion,
   'link_percentage': instance.linkPercentage,
+  'link_metadata': instance.linkMetadata,
   'environment': instance.environment.toJson(),
 };
 

--- a/packages/shorebird_cli/lib/src/platform/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple.dart
@@ -327,7 +327,6 @@ $error''');
       }
     } on Exception catch (error) {
       logger.detail('[aot_tools] Failed to get link metadata: $error');
-      linkMetadata = null;
     }
 
     linkProgress.complete();

--- a/packages/shorebird_cli/lib/src/platform/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple.dart
@@ -328,7 +328,7 @@ $error''');
         );
       }
     } on Exception catch (error) {
-      logger.detail('Failed to get link metadata: $error');
+      logger.detail('[aot_tools] Failed to get link metadata: $error');
       linkMetadata = null;
     }
 

--- a/packages/shorebird_cli/lib/src/platform/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple.dart
@@ -319,9 +319,7 @@ $error''');
     }
     Map<String, dynamic>? linkMetadata;
     try {
-      if (dumpDebugInfoDir == null) {
-        linkMetadata = null;
-      } else {
+      if (dumpDebugInfoDir != null) {
         linkMetadata = await aotTools.getLinkMetadata(
           debugDir: dumpDebugInfoDir.path,
           workingDirectory: buildDirectory.path,

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -661,7 +661,8 @@ void main() {
               vmCodeFile: any(named: 'vmCodeFile'),
             ),
           ).thenAnswer(
-            (_) async => LinkResult.success(linkPercentage: linkPercentage),
+            (_) async =>
+                const LinkResult.success(linkPercentage: linkPercentage),
           );
           when(
             aotTools.isGeneratePatchDiffBaseSupported,
@@ -856,6 +857,19 @@ void main() {
               });
             });
 
+            test('sets link percentage', () async {
+              expect(patcher.linkPercentage, isNull);
+              await runWithOverrides(
+                () => patcher.createPatchArtifacts(
+                  appId: appId,
+                  releaseId: releaseId,
+                  releaseArtifact: releaseArtifactFile,
+                  supplementArtifact: supplementArtifactFile,
+                ),
+              );
+              expect(patcher.linkPercentage, isNotNull);
+            });
+
             group('when code signing the patch', () {
               setUp(() {
                 final privateKey = File(
@@ -1040,9 +1054,12 @@ void main() {
 
       group('when linker is enabled', () {
         const linkPercentage = 100.0;
+        const linkMetadata = {'link': 'metadata'};
 
         setUp(() {
-          patcher.lastBuildLinkPercentage = linkPercentage;
+          patcher
+            ..lastBuildLinkPercentage = linkPercentage
+            ..lastBuildLinkMetadata = linkMetadata;
         });
 
         test('returns correct metadata', () async {
@@ -1075,6 +1092,7 @@ void main() {
                 hasNativeChanges: false,
                 inferredReleaseVersion: false,
                 linkPercentage: linkPercentage,
+                linkMetadata: linkMetadata,
                 environment: BuildEnvironmentMetadata(
                   flutterRevision: flutterRevision,
                   operatingSystem: operatingSystem,

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -661,10 +661,7 @@ void main() {
               vmCodeFile: any(named: 'vmCodeFile'),
             ),
           ).thenAnswer(
-            (_) async => (
-              exitCode: ExitCode.success.code,
-              linkPercentage: linkPercentage,
-            ),
+            (_) async => LinkResult.success(linkPercentage: linkPercentage),
           );
           when(
             aotTools.isGeneratePatchDiffBaseSupported,

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -968,10 +968,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
               vmCodeFile: any(named: 'vmCodeFile'),
             ),
           ).thenAnswer(
-            (_) async => (
-              exitCode: ExitCode.success.code,
-              linkPercentage: linkPercentage,
-            ),
+            (_) async => LinkResult.success(linkPercentage: linkPercentage),
           );
           when(
             aotTools.isGeneratePatchDiffBaseSupported,

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -968,7 +968,8 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
               vmCodeFile: any(named: 'vmCodeFile'),
             ),
           ).thenAnswer(
-            (_) async => LinkResult.success(linkPercentage: linkPercentage),
+            (_) async =>
+                const LinkResult.success(linkPercentage: linkPercentage),
           );
           when(
             aotTools.isGeneratePatchDiffBaseSupported,
@@ -1164,6 +1165,19 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
                     endsWith(diffPath),
                   ),
                 );
+              });
+
+              test('sets link percentage', () async {
+                expect(patcher.linkPercentage, isNull);
+                await runWithOverrides(
+                  () => patcher.createPatchArtifacts(
+                    appId: appId,
+                    releaseId: releaseId,
+                    releaseArtifact: releaseArtifactFile,
+                    supplementArtifact: supplementArtifactFile,
+                  ),
+                );
+                expect(patcher.linkPercentage, isNotNull);
               });
             });
 
@@ -1496,9 +1510,12 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
 
       group('when linker is enabled', () {
         const linkPercentage = 100.0;
+        const linkMetadata = {'link': 'metadata'};
 
         setUp(() {
-          patcher.lastBuildLinkPercentage = linkPercentage;
+          patcher
+            ..lastBuildLinkPercentage = linkPercentage
+            ..lastBuildLinkMetadata = linkMetadata;
         });
 
         test('returns correct metadata', () async {
@@ -1531,6 +1548,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
                 hasNativeChanges: false,
                 inferredReleaseVersion: false,
                 linkPercentage: linkPercentage,
+                linkMetadata: linkMetadata,
                 environment: BuildEnvironmentMetadata(
                   flutterRevision: flutterRevision,
                   operatingSystem: operatingSystem,

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -950,6 +950,69 @@ Run "aot_tools help <command>" for more information about a command.
           expect(result.existsSync(), isTrue);
         });
       });
+
+      group('getLinkMetadata', () {
+        late int exitCode;
+        late String stdout;
+        late String stderr;
+        setUp(() {
+          stdout = '';
+          stderr = '';
+          exitCode = 0;
+          when(
+            () => process.start(
+              any(),
+              any(),
+              workingDirectory: any(named: 'workingDirectory'),
+            ),
+          ).thenAnswer((_) async {
+            final mockProcess = MockProcess();
+            when(() => mockProcess.exitCode).thenAnswer((_) async => exitCode);
+            when(
+              () => mockProcess.stdout,
+            ).thenAnswer((_) => Stream.value(utf8.encode(stdout)));
+            when(
+              () => mockProcess.stderr,
+            ).thenAnswer((_) => Stream.value(utf8.encode(stderr)));
+            return mockProcess;
+          });
+          when(
+            () => process.start(
+              any(),
+              any(),
+              workingDirectory: any(named: 'workingDirectory'),
+            ),
+          ).thenAnswer((invocation) async {
+            final mockProcess = MockProcess();
+            when(() => mockProcess.exitCode).thenAnswer((_) async => exitCode);
+            when(
+              () => mockProcess.stdout,
+            ).thenAnswer((_) => Stream.value(utf8.encode(stdout)));
+            when(
+              () => mockProcess.stderr,
+            ).thenAnswer((_) => Stream.value(utf8.encode(stderr)));
+            return mockProcess;
+          });
+        });
+
+        test('returns link metadata', () async {
+          stdout = '{}';
+          final result = await runWithOverrides(
+            () => aotTools.getLinkMetadata(debugDir: '/debug'),
+          );
+          expect(result, isA<Map<String, dynamic>>());
+        });
+
+        test('returns invalid json', () async {
+          stdout = 'invalid';
+          await expectLater(
+            () => runWithOverrides(
+              () => aotTools.getLinkMetadata(debugDir: '/debug'),
+            ),
+            throwsFormatException,
+          );
+        });
+      });
     });
   });
 }

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -996,23 +996,29 @@ Run "aot_tools help <command>" for more information about a command.
           });
         });
 
-        test('returns link metadata when aot_tools executes successfully', () async {
-          stdout = '{}';
-          final result = await runWithOverrides(
-            () => aotTools.getLinkMetadata(debugDir: '/debug'),
-          );
-          expect(result, isA<Map<String, dynamic>>());
-        });
-
-        test('throws FormatException when aot_tools outputs invalid json', () async {
-          stdout = 'invalid';
-          await expectLater(
-            () => runWithOverrides(
+        test(
+          'returns link metadata when aot_tools executes successfully',
+          () async {
+            stdout = '{}';
+            final result = await runWithOverrides(
               () => aotTools.getLinkMetadata(debugDir: '/debug'),
-            ),
-            throwsFormatException,
-          );
-        });
+            );
+            expect(result, isA<Map<String, dynamic>>());
+          },
+        );
+
+        test(
+          'throws FormatException when aot_tools outputs invalid json',
+          () async {
+            stdout = 'invalid';
+            await expectLater(
+              () => runWithOverrides(
+                () => aotTools.getLinkMetadata(debugDir: '/debug'),
+              ),
+              throwsFormatException,
+            );
+          },
+        );
       });
     });
   });

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -955,6 +955,7 @@ Run "aot_tools help <command>" for more information about a command.
         late int exitCode;
         late String stdout;
         late String stderr;
+
         setUp(() {
           stdout = '';
           stderr = '';

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -982,7 +982,7 @@ Run "aot_tools help <command>" for more information about a command.
               any(),
               workingDirectory: any(named: 'workingDirectory'),
             ),
-          ).thenAnswer((invocation) async {
+          ).thenAnswer((_) async {
             final mockProcess = MockProcess();
             when(() => mockProcess.exitCode).thenAnswer((_) async => exitCode);
             when(

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -996,7 +996,7 @@ Run "aot_tools help <command>" for more information about a command.
           });
         });
 
-        test('returns link metadata', () async {
+        test('returns link metadata when aot_tools executes successfully', () async {
           stdout = '{}';
           final result = await runWithOverrides(
             () => aotTools.getLinkMetadata(debugDir: '/debug'),

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -1004,7 +1004,7 @@ Run "aot_tools help <command>" for more information about a command.
           expect(result, isA<Map<String, dynamic>>());
         });
 
-        test('returns invalid json', () async {
+        test('throws FormatException when aot_tools outputs invalid json', () async {
           stdout = 'invalid';
           await expectLater(
             () => runWithOverrides(

--- a/packages/shorebird_cli/test/src/platform/apple_test.dart
+++ b/packages/shorebird_cli/test/src/platform/apple_test.dart
@@ -639,6 +639,37 @@ To add macOS, run "flutter create . --platforms macos"''');
           expect(result.linkPercentage, equals(linkPercentage));
         });
       });
+
+      group('when call to aotTools.getLinkMetadata fails', () {
+        setUp(() {
+          when(
+            () => aotTools.isLinkDebugInfoSupported(),
+          ).thenAnswer((_) async => true);
+          when(
+            () => aotTools.getLinkMetadata(
+              debugDir: any(named: 'debugDir'),
+              workingDirectory: any(named: 'workingDirectory'),
+            ),
+          ).thenThrow(Exception('oops'));
+        });
+
+        test('logs error and exits with code 70', () async {
+          await runWithOverrides(
+            () => apple.runLinker(
+              aotOutputFile: aotOutputFile,
+              kernelFile: File('missing'),
+              releaseArtifact: File('missing'),
+              vmCodeFile: File('missing'),
+              splitDebugInfoArgs: [],
+            ),
+          );
+
+          verify(
+            () => logger.detail('Failed to get link metadata: Exception: oops'),
+          ).called(1);
+          verify(() => progress.complete()).called(1);
+        });
+      });
     });
   });
 }

--- a/packages/shorebird_cli/test/src/platform/apple_test.dart
+++ b/packages/shorebird_cli/test/src/platform/apple_test.dart
@@ -665,7 +665,9 @@ To add macOS, run "flutter create . --platforms macos"''');
           );
 
           verify(
-            () => logger.detail('Failed to get link metadata: Exception: oops'),
+            () => logger.detail(
+              '[aot_tools] Failed to get link metadata: Exception: oops',
+            ),
           ).called(1);
           verify(() => progress.complete()).called(1);
         });

--- a/packages/shorebird_cli/test/src/platform/apple_test.dart
+++ b/packages/shorebird_cli/test/src/platform/apple_test.dart
@@ -56,6 +56,13 @@ void main() {
 
       when(() => logger.progress(any())).thenReturn(progress);
       when(() => platform.environment).thenReturn({});
+
+      when(
+        () => aotTools.getLinkMetadata(
+          debugDir: any(named: 'debugDir'),
+          workingDirectory: any(named: 'workingDirectory'),
+        ),
+      ).thenAnswer((_) async => {'key': 'value'});
     });
 
     group(MissingXcodeProjectException, () {


### PR DESCRIPTION
Runs `aot_tools link_metadata` if available.  Does not block the build if it is not.