### PR TITLE
chore: centralize flutter_version validation

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
@@ -15,9 +15,7 @@ import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/platform/apple.dart';
 import 'package:shorebird_cli/src/release_type.dart';
-import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
-import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -53,6 +51,9 @@ class IosFrameworkReleaser extends Releaser {
   }
 
   @override
+  Version? get minimumFlutterVersion => minimumSupportedIosFlutterVersion;
+
+  @override
   Future<void> assertPreconditions() async {
     try {
       await shorebirdValidator.validatePreconditions(
@@ -63,19 +64,6 @@ class IosFrameworkReleaser extends Releaser {
       );
     } on PreconditionFailedException catch (e) {
       throw ProcessExit(e.exitCode.code);
-    }
-
-    final flutterVersionArg = argResults['flutter-version'] as String;
-    if (flutterVersionArg != 'latest') {
-      final version = await shorebirdFlutter.resolveFlutterVersion(
-        flutterVersionArg,
-      );
-      if (version != null && version < minimumSupportedIosFlutterVersion) {
-        logger.err('''
-iOS releases are not supported with Flutter versions older than $minimumSupportedIosFlutterVersion.
-For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
-        throw ProcessExit(ExitCode.usage.code);
-      }
     }
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -16,9 +16,7 @@ import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/platform/apple.dart';
 import 'package:shorebird_cli/src/release_type.dart';
-import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
-import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -68,6 +66,9 @@ To change the version of this release, change your app's version in your pubspec
   }
 
   @override
+  Version? get minimumFlutterVersion => minimumSupportedIosFlutterVersion;
+
+  @override
   Future<void> assertPreconditions() async {
     try {
       await shorebirdValidator.validatePreconditions(
@@ -78,19 +79,6 @@ To change the version of this release, change your app's version in your pubspec
       );
     } on PreconditionFailedException catch (e) {
       throw ProcessExit(e.exitCode.code);
-    }
-
-    final flutterVersionArg = argResults['flutter-version'] as String;
-    if (flutterVersionArg != 'latest') {
-      final version = await shorebirdFlutter.resolveFlutterVersion(
-        flutterVersionArg,
-      );
-      if (version != null && version < minimumSupportedIosFlutterVersion) {
-        logger.err('''
-iOS releases are not supported with Flutter versions older than $minimumSupportedIosFlutterVersion.
-For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
-        throw ProcessExit(ExitCode.usage.code);
-      }
     }
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/linux_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/linux_releaser.dart
@@ -11,8 +11,6 @@ import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
-import 'package:shorebird_cli/src/shorebird_documentation.dart';
-import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -48,6 +46,9 @@ To change the version of this release, change your app's version in your pubspec
   }
 
   @override
+  Version? get minimumFlutterVersion => minimumSupportedLinuxFlutterVersion;
+
+  @override
   Future<void> assertPreconditions() async {
     try {
       await shorebirdValidator.validatePreconditions(
@@ -58,18 +59,6 @@ To change the version of this release, change your app's version in your pubspec
       );
     } on PreconditionFailedException catch (e) {
       throw ProcessExit(e.exitCode.code);
-    }
-    final flutterVersionArg = argResults['flutter-version'] as String;
-    if (flutterVersionArg != 'latest') {
-      final version = await shorebirdFlutter.resolveFlutterVersion(
-        flutterVersionArg,
-      );
-      if (version != null && version < minimumSupportedLinuxFlutterVersion) {
-        logger.err('''
-Linux releases are not supported with Flutter versions older than $minimumSupportedLinuxFlutterVersion.
-For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
-        throw ProcessExit(ExitCode.usage.code);
-      }
     }
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/macos_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/macos_releaser.dart
@@ -16,9 +16,7 @@ import 'package:shorebird_cli/src/logging/shorebird_logger.dart';
 import 'package:shorebird_cli/src/metadata/update_release_metadata.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
-import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
-import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -68,6 +66,9 @@ To change the version of this release, change your app's version in your pubspec
   }
 
   @override
+  Version? get minimumFlutterVersion => minimumSupportedMacosFlutterVersion;
+
+  @override
   Future<void> assertPreconditions() async {
     try {
       await shorebirdValidator.validatePreconditions(
@@ -78,19 +79,6 @@ To change the version of this release, change your app's version in your pubspec
       );
     } on PreconditionFailedException catch (e) {
       throw ProcessExit(e.exitCode.code);
-    }
-
-    final flutterVersionArg = argResults['flutter-version'] as String;
-    if (flutterVersionArg != 'latest') {
-      final version = await shorebirdFlutter.resolveFlutterVersion(
-        flutterVersionArg,
-      );
-      if (version != null && version < minimumSupportedMacosFlutterVersion) {
-        logger.err('''
-macOS releases are not supported with Flutter versions older than $minimumSupportedMacosFlutterVersion.
-For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
-        throw ProcessExit(ExitCode.usage.code);
-      }
     }
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/release.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release.dart
@@ -1,3 +1,5 @@
+export 'package:pub_semver/pub_semver.dart' show Version;
+
 export 'aar_releaser.dart';
 export 'android_releaser.dart';
 export 'ios_framework_releaser.dart';

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -351,7 +351,7 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
         version != null &&
         version < minimumFlutterVersion) {
       logger.err('''
-${releaser.releaseType.name} releases are not supported with Flutter versions older than $minimumFlutterVersion.
+At least Flutter $minimumFlutterVersion is required to release with `${releaser.releaseType.name}`.
 For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
       throw ProcessExit(ExitCode.usage.code);
     }

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -18,6 +18,7 @@ import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
+import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
@@ -246,8 +247,7 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
   @visibleForTesting
   Future<void> createRelease(Releaser releaser) async {
     await releaser.assertPreconditions();
-    await assertArgsAreValid();
-    await releaser.assertArgsAreValid();
+    await assertArgsAreValid(releaser);
 
     await shorebirdValidator.validateFlavors(flavorArg: flavor);
 
@@ -340,8 +340,24 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
   }
 
   /// Validates arguments that are common to all release types.
-  Future<void> assertArgsAreValid() async {
+  Future<void> assertArgsAreValid(Releaser releaser) async {
     results.assertAbsentOrValidPublicKey();
+
+    final version = await shorebirdFlutter.resolveFlutterVersion(
+      flutterVersionArg,
+    );
+    final minimumFlutterVersion = releaser.minimumFlutterVersion;
+    if (minimumFlutterVersion != null &&
+        version != null &&
+        version < minimumFlutterVersion) {
+      logger.err('''
+${releaser.releaseType.name} releases are not supported with Flutter versions older than $minimumFlutterVersion.
+For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
+      throw ProcessExit(ExitCode.usage.code);
+    }
+
+    // Ask the releaser to assert its own args are valid.
+    await releaser.assertArgsAreValid();
   }
 
   /// Determines which Flutter version to use for the release. This will be
@@ -517,7 +533,7 @@ ${summary.join('\n')}
   }) async {
     final baseMetadata = UpdateReleaseMetadata(
       releasePlatform: releaser.releaseType.releasePlatform,
-      flutterVersionOverride: results['flutter-version'] as String,
+      flutterVersionOverride: flutterVersionArg,
       environment: BuildEnvironmentMetadata(
         flutterRevision: shorebirdEnv.flutterRevision,
         operatingSystem: platform.operatingSystem,

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -1,11 +1,14 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+
+export 'package:pub_semver/pub_semver.dart';
 
 /// {@template releaser}
 /// Executes platform-specific functionality to create a release.
@@ -28,6 +31,9 @@ abstract class Releaser {
   /// The target script to run, if any. This is the --target argument passed to
   /// the release command.
   final String? target;
+
+  /// The minimum Flutter version required to create a release of this type.
+  Version? get minimumFlutterVersion => null;
 
   /// The type of artifact we are creating a release for.
   ReleaseType get releaseType;

--- a/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
@@ -14,9 +14,7 @@ import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
-import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
-import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
@@ -52,6 +50,9 @@ To change the version of this release, change your app's version in your pubspec
   }
 
   @override
+  Version? get minimumFlutterVersion => minimumSupportedWindowsFlutterVersion;
+
+  @override
   Future<void> assertPreconditions() async {
     try {
       await shorebirdValidator.validatePreconditions(
@@ -62,19 +63,6 @@ To change the version of this release, change your app's version in your pubspec
       );
     } on PreconditionFailedException catch (e) {
       throw ProcessExit(e.exitCode.code);
-    }
-
-    final flutterVersionArg = argResults['flutter-version'] as String;
-    if (flutterVersionArg != 'latest') {
-      final version = await shorebirdFlutter.resolveFlutterVersion(
-        flutterVersionArg,
-      );
-      if (version != null && version < minimumSupportedWindowsFlutterVersion) {
-        logger.err('''
-Windows releases are not supported with Flutter versions older than $minimumSupportedWindowsFlutterVersion.
-For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
-        throw ProcessExit(ExitCode.usage.code);
-      }
     }
   }
 

--- a/packages/shorebird_cli/test/src/commands/patch/linux_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/linux_patcher_test.dart
@@ -5,7 +5,6 @@ import 'package:crypto/crypto.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
-import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/archive_analysis/linux_bundle_differ.dart';
 import 'package:shorebird_cli/src/artifact_builder/artifact_builder.dart';

--- a/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
@@ -6,7 +6,6 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/archive_analysis/archive_analysis.dart';
 import 'package:shorebird_cli/src/artifact_builder/artifact_builder.dart';

--- a/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
@@ -112,6 +112,14 @@ void main() {
       });
     });
 
+    group('minimumFlutterVersion', () {
+      test('is null', () {
+        // Shorebird has always had aar support, so we don't need to
+        // specify a minimum Flutter version.
+        expect(aarReleaser.minimumFlutterVersion, isNull);
+      });
+    });
+
     group('artifactDisplayName', () {
       test('has expected value', () {
         expect(aarReleaser.artifactDisplayName, 'Android archive');

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -116,6 +116,14 @@ void main() {
       });
     });
 
+    group('minimumFlutterVersion', () {
+      test('is null', () {
+        // Shorebird has always had Android support, so we don't need to
+        // specify a minimum Flutter version.
+        expect(androidReleaser.minimumFlutterVersion, isNull);
+      });
+    });
+
     group('artifactDisplayName', () {
       test('has expected value', () {
         expect(androidReleaser.artifactDisplayName, 'Android app bundle');

--- a/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
@@ -19,9 +19,7 @@ import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
-import 'package:shorebird_cli/src/platform/apple.dart';
 import 'package:shorebird_cli/src/release_type.dart';
-import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
@@ -239,19 +237,6 @@ void main() {
             ),
           ).thenAnswer((_) async {});
           when(() => argResults['flutter-version']).thenReturn('3.0.0');
-        });
-
-        test('logs error and exits with code 64', () async {
-          await expectLater(
-            () => runWithOverrides(iosFrameworkReleaser.assertPreconditions),
-            exitsWithCode(ExitCode.usage),
-          );
-
-          verify(
-            () => logger.err('''
-iOS releases are not supported with Flutter versions older than $minimumSupportedIosFlutterVersion.
-For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
-          ).called(1);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
@@ -119,6 +119,12 @@ void main() {
       });
     });
 
+    group('minimumFlutterVersion', () {
+      test('is 3.22.2', () {
+        expect(iosFrameworkReleaser.minimumFlutterVersion, Version(3, 22, 2));
+      });
+    });
+
     group('artifactDisplayName', () {
       test('has expected value', () {
         expect(iosFrameworkReleaser.artifactDisplayName, 'iOS framework');

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -23,7 +23,6 @@ import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/os/operating_system_interface.dart';
 import 'package:shorebird_cli/src/platform/apple.dart';
 import 'package:shorebird_cli/src/release_type.dart';
-import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
@@ -212,19 +211,6 @@ void main() {
             ),
           ).thenAnswer((_) async {});
           when(() => argResults['flutter-version']).thenReturn('3.0.0');
-        });
-
-        test('logs error and exits with code 64', () async {
-          await expectLater(
-            () => runWithOverrides(iosReleaser.assertPreconditions),
-            exitsWithCode(ExitCode.usage),
-          );
-
-          verify(
-            () => logger.err('''
-iOS releases are not supported with Flutter versions older than $minimumSupportedIosFlutterVersion.
-For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
-          ).called(1);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -121,6 +121,12 @@ void main() {
       });
     });
 
+    group('minimumFlutterVersion', () {
+      test('is 3.22.2', () {
+        expect(iosReleaser.minimumFlutterVersion, Version(3, 22, 2));
+      });
+    });
+
     group('artifactDisplayName', () {
       test('has expected value', () {
         expect(iosReleaser.artifactDisplayName, 'iOS app');

--- a/packages/shorebird_cli/test/src/commands/release/linux_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/linux_releaser_test.dart
@@ -120,6 +120,12 @@ void main() {
       });
     });
 
+    group('minimumFlutterVersion', () {
+      test('is 3.27.4', () {
+        expect(releaser.minimumFlutterVersion, Version(3, 27, 4));
+      });
+    });
+
     group('artifactDisplayName', () {
       test('has expected value', () {
         expect(releaser.artifactDisplayName, 'Linux app');

--- a/packages/shorebird_cli/test/src/commands/release/linux_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/linux_releaser_test.dart
@@ -5,7 +5,6 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/artifact_builder/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
@@ -17,7 +16,6 @@ import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
-import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
@@ -236,19 +234,6 @@ To change the version of this release, change your app's version in your pubspec
           when(
             () => shorebirdFlutter.resolveFlutterVersion('3.27.1'),
           ).thenAnswer((_) async => Version(3, 27, 1));
-        });
-
-        test('logs error and exits with usage err', () async {
-          await expectLater(
-            () => runWithOverrides(releaser.assertPreconditions),
-            exitsWithCode(ExitCode.usage),
-          );
-
-          verify(
-            () => logger.err('''
-Linux releases are not supported with Flutter versions older than $minimumSupportedLinuxFlutterVersion.
-For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
-          ).called(1);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
@@ -98,6 +98,12 @@ void main() {
       });
     });
 
+    group('minimumFlutterVersion', () {
+      test('is 3.27.4', () {
+        expect(releaser.minimumFlutterVersion, Version(3, 27, 4));
+      });
+    });
+
     group('artifactDisplayName', () {
       test('has expected value', () {
         expect(releaser.artifactDisplayName, 'macOS app');

--- a/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
@@ -7,7 +7,6 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/artifact_builder/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
@@ -18,9 +17,7 @@ import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/xcodebuild.dart';
 import 'package:shorebird_cli/src/logging/shorebird_logger.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
-import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
-import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
@@ -191,19 +188,6 @@ void main() {
             ),
           ).thenAnswer((_) async {});
           when(() => argResults['flutter-version']).thenReturn('3.0.0');
-        });
-
-        test('logs error and exits with code 64', () async {
-          await expectLater(
-            () => runWithOverrides(releaser.assertPreconditions),
-            exitsWithCode(ExitCode.usage),
-          );
-
-          verify(
-            () => logger.err('''
-macOS releases are not supported with Flutter versions older than $minimumSupportedMacosFlutterVersion.
-For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
-          ).called(1);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -28,7 +28,8 @@ void main() {
     const appId = 'test-app-id';
     const appDisplayName = 'Test App';
     const flutterRevision = '83305b5088e6fe327fb3334a73ff190828d85713';
-    const flutterVersion = '3.22.0';
+    const flutterVersionString = '3.22.0';
+    final flutterVersion = Version(3, 22, 0);
     const releaseVersion = '1.2.3+1';
     const postReleaseInstructions = 'Make a patch!';
     const artifactDisplayName = 'Amiga app';
@@ -44,7 +45,7 @@ void main() {
       appId: appId,
       version: releaseVersion,
       flutterRevision: flutterRevision,
-      flutterVersion: flutterVersion,
+      flutterVersion: flutterVersionString,
       displayName: '1.2.3+1',
       platformStatuses: {},
       createdAt: DateTime(2023),
@@ -187,6 +188,9 @@ void main() {
         () =>
             shorebirdFlutter.installRevision(revision: any(named: 'revision')),
       ).thenAnswer((_) async => {});
+      when(
+        () => shorebirdFlutter.resolveFlutterVersion(any()),
+      ).thenAnswer((_) async => flutterVersion);
 
       when(
         () => shorebirdValidator.validateFlavors(
@@ -417,12 +421,12 @@ void main() {
             () => shorebirdFlutter.getVersionForRevision(
               flutterRevision: flutterRevision,
             ),
-          ).thenAnswer((_) async => flutterVersion);
+          ).thenAnswer((_) async => flutterVersionString);
 
           when(
             () => shorebirdFlutter.formatVersion(
               revision: flutterRevision,
-              version: flutterVersion,
+              version: flutterVersionString,
             ),
           ).thenReturn('3.12.1');
           when(

--- a/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
@@ -127,6 +127,12 @@ void main() {
       });
     });
 
+    group('minimumFlutterVersion', () {
+      test('is 3.27.2', () {
+        expect(releaser.minimumFlutterVersion, Version(3, 27, 2));
+      });
+    });
+
     group('artifactDisplayName', () {
       test('has expected value', () {
         expect(releaser.artifactDisplayName, 'Windows app');

--- a/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
@@ -5,7 +5,6 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/artifact_builder/artifact_builder.dart';
 import 'package:shorebird_cli/src/artifact_manager.dart';
@@ -16,9 +15,7 @@ import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
-import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
-import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:shorebird_cli/src/shorebird_process.dart';
@@ -246,19 +243,6 @@ To change the version of this release, change your app's version in your pubspec
           when(
             () => shorebirdFlutter.resolveFlutterVersion('3.27.1'),
           ).thenAnswer((_) async => Version(3, 27, 1));
-        });
-
-        test('logs error and exits with usage err', () async {
-          await expectLater(
-            () => runWithOverrides(releaser.assertPreconditions),
-            exitsWithCode(ExitCode.usage),
-          );
-
-          verify(
-            () => logger.err('''
-Windows releases are not supported with Flutter versions older than $minimumSupportedWindowsFlutterVersion.
-For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
-          ).called(1);
         });
       });
     });


### PR DESCRIPTION
Deletes a bunch of redundant code.