### PR TITLE
feat: add support for extracting jwt from http headers

### DIFF
--- a/packages/jwt/lib/src/jwt.dart
+++ b/packages/jwt/lib/src/jwt.dart
@@ -77,10 +77,10 @@ class JwtExtractionFailure implements Exception {
 /// [JwtExtractionFailure] if the header is missing or the token is malformed.
 /// Does NOT verify the JWT.
 Jwt extractFromRequestHeaders(Map<String, String> headers) {
-  final caseInsensitveHeaders = headers.map(
+  final caseInsensitiveHeaders = headers.map(
     (key, value) => MapEntry(key.toLowerCase(), value),
   );
-  final authorization = caseInsensitveHeaders[HttpHeaders.authorizationHeader];
+  final authorization = caseInsensitiveHeaders[HttpHeaders.authorizationHeader];
   if (authorization == null) {
     throw const JwtExtractionFailure('Missing authorization header');
   }

--- a/packages/jwt/test/src/jwt_test.dart
+++ b/packages/jwt/test/src/jwt_test.dart
@@ -43,6 +43,70 @@ void main() {
     };
   });
 
+  group('extractFromRequestHeaders', () {
+    group('when no authorization header is provided', () {
+      test('throws JwtExtractionFailure', () {
+        expect(
+          () => extractFromRequestHeaders({}),
+          throwsA(
+            isA<JwtExtractionFailure>().having(
+              (e) => e.reason,
+              'reason',
+              'Missing authorization header',
+            ),
+          ),
+        );
+      });
+    });
+
+    group('when authorization header is malformed', () {
+      test('throws JwtExtractionFailure', () {
+        expect(
+          () => extractFromRequestHeaders({
+            HttpHeaders.authorizationHeader: 'not-a-jwt',
+          }),
+          throwsA(
+            isA<JwtExtractionFailure>().having(
+              (e) => e.reason,
+              'reason',
+              'Malformed authorization header',
+            ),
+          ),
+        );
+      });
+    });
+
+    group('when authorization header cannot be parsed into jwt', () {
+      test('throws JwtExtractionFailure', () {
+        expect(
+          () => extractFromRequestHeaders({
+            HttpHeaders.authorizationHeader: 'Bearer not-a-jwt',
+          }),
+          throwsA(
+            isA<JwtExtractionFailure>().having(
+              (e) => e.reason,
+              'reason',
+              'Malformed JWT',
+            ),
+          ),
+        );
+      });
+    });
+
+    group('when authorization header contains a valid jwt', () {
+      test('returns a Jwt', () {
+        final jwt = extractFromRequestHeaders({
+          HttpHeaders.authorizationHeader: 'Bearer $token',
+        });
+        expect(jwt.payload.aud, equals('my-app'));
+        expect(
+          jwt.payload.iss,
+          equals('https://securetoken.google.com/my-app'),
+        );
+      });
+    });
+  });
+
   group('verify', () {
     group('when key store is key-value', () {
       const issuer = 'https://securetoken.google.com/my-app';

--- a/packages/jwt/test/src/jwt_test.dart
+++ b/packages/jwt/test/src/jwt_test.dart
@@ -21,12 +21,12 @@ void main() {
       'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
   const jwkPublicKeysUrl =
       'https://login.microsoftonline.com/common/discovery/v2.0/keys';
-  final jwkKeyStoreJsonString =
-      File(p.join('test', 'fixtures', 'jwk_key_store.json')).readAsStringSync();
-  final keyValueKeyStoreString =
-      File(
-        p.join('test', 'fixtures', 'key_value_key_store.json'),
-      ).readAsStringSync();
+  final jwkKeyStoreJsonString = File(
+    p.join('test', 'fixtures', 'jwk_key_store.json'),
+  ).readAsStringSync();
+  final keyValueKeyStoreString = File(
+    p.join('test', 'fixtures', 'key_value_key_store.json'),
+  ).readAsStringSync();
   final expiresAt = DateTime.fromMillisecondsSinceEpoch(1643687866 * 1000);
   final validTime = expiresAt.subtract(const Duration(minutes: 15));
 

--- a/packages/jwt/test/src/jwt_test.dart
+++ b/packages/jwt/test/src/jwt_test.dart
@@ -23,9 +23,10 @@ void main() {
       'https://login.microsoftonline.com/common/discovery/v2.0/keys';
   final jwkKeyStoreJsonString =
       File(p.join('test', 'fixtures', 'jwk_key_store.json')).readAsStringSync();
-  final keyValueKeyStoreString = File(
-    p.join('test', 'fixtures', 'key_value_key_store.json'),
-  ).readAsStringSync();
+  final keyValueKeyStoreString =
+      File(
+        p.join('test', 'fixtures', 'key_value_key_store.json'),
+      ).readAsStringSync();
   final expiresAt = DateTime.fromMillisecondsSinceEpoch(1643687866 * 1000);
   final validTime = expiresAt.subtract(const Duration(minutes: 15));
 
@@ -225,8 +226,7 @@ void main() {
         });
       });
 
-      test(
-          'throws exception if invalid keys are provided '
+      test('throws exception if invalid keys are provided '
           'by the publicKeysUrl (KeyValueKeyStore)', () async {
         getOverride = (Uri uri) async {
           return Response(
@@ -255,8 +255,7 @@ void main() {
         });
       });
 
-      test(
-          'throws exception if invalid keys are provided '
+      test('throws exception if invalid keys are provided '
           'by the publicKeysUrl (JwkKeyStore)', () async {
         getOverride = (Uri uri) async {
           return Response(

--- a/packages/jwt/test/src/jwt_test.dart
+++ b/packages/jwt/test/src/jwt_test.dart
@@ -21,12 +21,12 @@ void main() {
       'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
   const jwkPublicKeysUrl =
       'https://login.microsoftonline.com/common/discovery/v2.0/keys';
-  final jwkKeyStoreJsonString = File(
-    p.join('test', 'fixtures', 'jwk_key_store.json'),
-  ).readAsStringSync();
-  final keyValueKeyStoreString = File(
-    p.join('test', 'fixtures', 'key_value_key_store.json'),
-  ).readAsStringSync();
+  final jwkKeyStoreJsonString =
+      File(p.join('test', 'fixtures', 'jwk_key_store.json')).readAsStringSync();
+  final keyValueKeyStoreString =
+      File(
+        p.join('test', 'fixtures', 'key_value_key_store.json'),
+      ).readAsStringSync();
   final expiresAt = DateTime.fromMillisecondsSinceEpoch(1643687866 * 1000);
   final validTime = expiresAt.subtract(const Duration(minutes: 15));
 
@@ -41,6 +41,16 @@ void main() {
         headers: {'cache-control': 'max-age=3600'},
       );
     };
+  });
+
+  group(JwtExtractionFailure, () {
+    group('toString', () {
+      test('returns the reason', () {
+        const reason = 'reason';
+        const failure = JwtExtractionFailure(reason);
+        expect(failure.toString(), equals('JwtExtractionFailure: $reason'));
+      });
+    });
   });
 
   group('extractFromRequestHeaders', () {

--- a/packages/jwt/test/src/jwt_test.dart
+++ b/packages/jwt/test/src/jwt_test.dart
@@ -23,10 +23,9 @@ void main() {
       'https://login.microsoftonline.com/common/discovery/v2.0/keys';
   final jwkKeyStoreJsonString =
       File(p.join('test', 'fixtures', 'jwk_key_store.json')).readAsStringSync();
-  final keyValueKeyStoreString =
-      File(
-        p.join('test', 'fixtures', 'key_value_key_store.json'),
-      ).readAsStringSync();
+  final keyValueKeyStoreString = File(
+    p.join('test', 'fixtures', 'key_value_key_store.json'),
+  ).readAsStringSync();
   final expiresAt = DateTime.fromMillisecondsSinceEpoch(1643687866 * 1000);
   final validTime = expiresAt.subtract(const Duration(minutes: 15));
 
@@ -226,7 +225,8 @@ void main() {
         });
       });
 
-      test('throws exception if invalid keys are provided '
+      test(
+          'throws exception if invalid keys are provided '
           'by the publicKeysUrl (KeyValueKeyStore)', () async {
         getOverride = (Uri uri) async {
           return Response(
@@ -255,7 +255,8 @@ void main() {
         });
       });
 
-      test('throws exception if invalid keys are provided '
+      test(
+          'throws exception if invalid keys are provided '
           'by the publicKeysUrl (JwkKeyStore)', () async {
         getOverride = (Uri uri) async {
           return Response(

--- a/packages/jwt/test/src/jwt_test.dart
+++ b/packages/jwt/test/src/jwt_test.dart
@@ -104,7 +104,7 @@ void main() {
     });
 
     group('when authorization header contains a valid jwt', () {
-      test('returns a Jwt', () {
+      test('returns a jwt', () {
         final jwt = extractFromRequestHeaders({
           HttpHeaders.authorizationHeader: 'Bearer $token',
         });


### PR DESCRIPTION
## Description

This logic current exists in our _shorebird repository, but seeing as this is a common operation for any consumer of a JWT, it makes more sense for it to live in `package:jwt`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
