### PR TITLE
feat: add shorebird flutter versions use command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_command.dart
@@ -9,6 +9,7 @@ class FlutterVersionsCommand extends ShorebirdCommand {
   /// {@macro flutter_versions_command}
   FlutterVersionsCommand() {
     addSubcommand(FlutterVersionsListCommand());
+    addSubcommand(FlutterVersionsUseCommand());
   }
 
   @override

--- a/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_use_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/flutter/versions/flutter_versions_use_command.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/logging/logging.dart';
+import 'package:shorebird_cli/src/shorebird_command.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_flutter.dart';
+
+/// {@template flutter_versions_use_command}
+/// `shorebird flutter versions use`
+/// Set the global Flutter version used by Shorebird.
+/// {@endtemplate}
+class FlutterVersionsUseCommand extends ShorebirdCommand {
+  /// {@macro flutter_versions_use_command}
+  FlutterVersionsUseCommand();
+
+  @override
+  String get description => 'Set the global Flutter version used by Shorebird.';
+
+  @override
+  String get name => 'use';
+
+  @override
+  String get invocation => 'shorebird flutter versions use <version>';
+
+  @override
+  Future<int> run() async {
+    final args = results.rest;
+    if (args.isEmpty) {
+      logger
+        ..err('Please specify a Flutter version.')
+        ..info('Usage: $invocation')
+        ..info('')
+        ..info('Available versions can be listed with:')
+        ..info('  shorebird flutter versions list');
+      return ExitCode.usage.code;
+    }
+
+    final requestedVersion = args.first;
+
+    // Проверяем, является ли это версией или git revision
+    final progress = logger.progress('Resolving Flutter version');
+
+    final String? revision;
+    try {
+      revision = await shorebirdFlutter.resolveFlutterRevision(
+        requestedVersion,
+      );
+    } on Exception catch (e) {
+      progress.fail('Failed to resolve Flutter version');
+      logger.err('$e');
+      return ExitCode.software.code;
+    }
+
+    if (revision == null) {
+      progress.fail('Version $requestedVersion not found');
+      logger
+        ..info('')
+        ..info('Available versions can be listed with:')
+        ..info('  shorebird flutter versions list');
+      return ExitCode.software.code;
+    }
+
+    progress.complete();
+
+    // Получаем человекочитаемую версию для отображения
+    final version = await shorebirdFlutter.getVersionForRevision(
+      flutterRevision: revision,
+    );
+    final displayVersion = version ?? requestedVersion;
+
+    // Проверяем текущую версию
+    String? currentVersion;
+    try {
+      currentVersion = await shorebirdFlutter.getVersionString();
+    } on Exception {
+      // Игнорируем ошибки при получении текущей версии
+    }
+
+    if (currentVersion == version && version != null) {
+      logger.info('Flutter $displayVersion is already the active version.');
+      return ExitCode.success.code;
+    }
+
+    // Устанавливаем Flutter если его еще нет
+    final installProgress = logger.progress(
+      'Setting Flutter version to $displayVersion',
+    );
+
+    try {
+      // Устанавливаем версию если ее еще нет
+      await shorebirdFlutter.installRevision(revision: revision);
+
+      // Обновляем файл flutter.version
+      final versionFile = File(
+        p.join(
+          shorebirdEnv.shorebirdRoot.path,
+          'bin',
+          'internal',
+          'flutter.version',
+        ),
+      );
+
+      if (!versionFile.existsSync()) {
+        versionFile.createSync(recursive: true);
+      }
+
+      versionFile.writeAsStringSync(revision);
+
+      installProgress.complete();
+
+      logger
+        ..info('')
+        ..success('Flutter version set to $displayVersion')
+        ..info('')
+        ..info('To verify the change, run:')
+        ..info('  ${lightCyan.wrap('shorebird flutter --version')}');
+
+      return ExitCode.success.code;
+    } on Exception catch (error) {
+      installProgress.fail('Failed to set Flutter version');
+      logger.err('$error');
+      return ExitCode.software.code;
+    }
+  }
+}

--- a/packages/shorebird_cli/lib/src/commands/flutter/versions/versions.dart
+++ b/packages/shorebird_cli/lib/src/commands/flutter/versions/versions.dart
@@ -1,2 +1,3 @@
 export 'flutter_versions_command.dart';
 export 'flutter_versions_list_command.dart';
+export 'flutter_versions_use_command.dart';

--- a/packages/shorebird_cli/test/src/commands/flutter/versions/flutter_versions_use_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/flutter/versions/flutter_versions_use_command_test.dart
@@ -1,0 +1,256 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as p;
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_cli/src/commands/commands.dart';
+import 'package:shorebird_cli/src/logging/logging.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_flutter.dart';
+import 'package:test/test.dart';
+
+import '../../../mocks.dart';
+
+void main() {
+  group(FlutterVersionsUseCommand, () {
+    late ArgResults argResults;
+    late Progress progress;
+    late ShorebirdLogger logger;
+    late ShorebirdFlutter shorebirdFlutter;
+    late ShorebirdEnv shorebirdEnv;
+    late FlutterVersionsUseCommand command;
+    late Directory testDirectory;
+    late File versionFile;
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        body,
+        values: {
+          loggerRef.overrideWith(() => logger),
+          shorebirdFlutterRef.overrideWith(() => shorebirdFlutter),
+          shorebirdEnvRef.overrideWith(() => shorebirdEnv),
+        },
+      );
+    }
+
+    setUp(() {
+      argResults = MockArgResults();
+      progress = MockProgress();
+      logger = MockShorebirdLogger();
+      shorebirdFlutter = MockShorebirdFlutter();
+      shorebirdEnv = MockShorebirdEnv();
+      testDirectory = Directory.systemTemp.createTempSync();
+      versionFile = File(
+        p.join(testDirectory.path, 'bin', 'internal', 'flutter.version'),
+      );
+
+      when(() => shorebirdEnv.shorebirdRoot).thenReturn(testDirectory);
+      when(() => logger.progress(any())).thenReturn(progress);
+      when(() => argResults.rest).thenReturn([]);
+
+      command = runWithOverrides(FlutterVersionsUseCommand.new)
+        ..testArgResults = argResults;
+    });
+
+    tearDown(() {
+      testDirectory.deleteSync(recursive: true);
+    });
+
+    test('has correct name, description and invocation', () {
+      expect(command.name, equals('use'));
+      expect(
+        command.description,
+        equals('Set the global Flutter version used by Shorebird.'),
+      );
+      expect(
+        command.invocation,
+        equals('shorebird flutter versions use <version>'),
+      );
+    });
+
+    test('exits with usage code when no version specified', () async {
+      when(() => argResults.rest).thenReturn([]);
+
+      await expectLater(
+        runWithOverrides(command.run),
+        completion(equals(ExitCode.usage.code)),
+      );
+      verifyInOrder([
+        () => logger.err('Please specify a Flutter version.'),
+        () => logger.info('Usage: shorebird flutter versions use <version>'),
+        () => logger.info(''),
+        () => logger.info('Available versions can be listed with:'),
+        () => logger.info('  shorebird flutter versions list'),
+      ]);
+    });
+
+    test('exits with software code when version cannot be resolved', () async {
+      when(() => argResults.rest).thenReturn(['1.0.0']);
+      when(
+        () => shorebirdFlutter.resolveFlutterRevision(any()),
+      ).thenAnswer((_) async => null);
+
+      await expectLater(
+        runWithOverrides(command.run),
+        completion(equals(ExitCode.software.code)),
+      );
+
+      verifyInOrder([
+        () => logger.progress('Resolving Flutter version'),
+        () => shorebirdFlutter.resolveFlutterRevision('1.0.0'),
+        () => progress.fail('Version 1.0.0 not found'),
+        () => logger.info(''),
+        () => logger.info('Available versions can be listed with:'),
+        () => logger.info('  shorebird flutter versions list'),
+      ]);
+    });
+
+    test('exits with success when version is already active', () async {
+      const version = '3.16.0';
+      const revision = 'abc123';
+
+      when(() => argResults.rest).thenReturn([version]);
+      when(
+        () => shorebirdFlutter.resolveFlutterRevision(any()),
+      ).thenAnswer((_) async => revision);
+      when(
+        () => shorebirdFlutter.getVersionForRevision(flutterRevision: revision),
+      ).thenAnswer((_) async => version);
+      when(
+        () => shorebirdFlutter.getVersionString(),
+      ).thenAnswer((_) async => version);
+
+      await expectLater(
+        runWithOverrides(command.run),
+        completion(equals(ExitCode.success.code)),
+      );
+
+      verify(
+        () => logger.info('Flutter $version is already the active version.'),
+      ).called(1);
+    });
+
+    test('successfully sets new Flutter version', () async {
+      const requestedVersion = '3.16.0';
+      const revision = 'abc123';
+      const currentVersion = '3.15.0';
+
+      when(() => argResults.rest).thenReturn([requestedVersion]);
+      when(
+        () => shorebirdFlutter.resolveFlutterRevision(any()),
+      ).thenAnswer((_) async => revision);
+      when(
+        () => shorebirdFlutter.getVersionForRevision(flutterRevision: revision),
+      ).thenAnswer((_) async => requestedVersion);
+      when(
+        () => shorebirdFlutter.getVersionString(),
+      ).thenAnswer((_) async => currentVersion);
+      when(
+        () => shorebirdFlutter.installRevision(revision: revision),
+      ).thenAnswer((_) async {});
+
+      await expectLater(
+        runWithOverrides(command.run),
+        completion(equals(ExitCode.success.code)),
+      );
+
+      expect(versionFile.existsSync(), isTrue);
+      expect(versionFile.readAsStringSync(), equals(revision));
+
+      verifyInOrder([
+        () => logger.progress('Resolving Flutter version'),
+        () => progress.complete(),
+        () => logger.progress('Setting Flutter version to $requestedVersion'),
+        () => shorebirdFlutter.installRevision(revision: revision),
+        () => progress.complete(),
+        () => logger.info(''),
+        () => logger.success('Flutter version set to $requestedVersion'),
+        () => logger.info(''),
+        () => logger.info('To verify the change, run:'),
+        () => logger.info('  ${lightCyan.wrap('shorebird flutter --version')}'),
+      ]);
+    });
+
+    test('exits with software code when installation fails', () async {
+      const requestedVersion = '3.16.0';
+      const revision = 'abc123';
+      const error = 'Installation failed';
+
+      when(() => argResults.rest).thenReturn([requestedVersion]);
+      when(
+        () => shorebirdFlutter.resolveFlutterRevision(any()),
+      ).thenAnswer((_) async => revision);
+      when(
+        () => shorebirdFlutter.getVersionForRevision(flutterRevision: revision),
+      ).thenAnswer((_) async => requestedVersion);
+      when(
+        () => shorebirdFlutter.getVersionString(),
+      ).thenAnswer((_) async => null);
+      when(
+        () => shorebirdFlutter.installRevision(revision: revision),
+      ).thenThrow(Exception(error));
+
+      await expectLater(
+        runWithOverrides(command.run),
+        completion(equals(ExitCode.software.code)),
+      );
+
+      verifyInOrder([
+        () => logger.progress('Setting Flutter version to $requestedVersion'),
+        () => shorebirdFlutter.installRevision(revision: revision),
+        () => progress.fail('Failed to set Flutter version'),
+        () => logger.err('Exception: $error'),
+      ]);
+    });
+
+    test('works with git revision instead of version number', () async {
+      const revision = 'abc123def456';
+      const version = '3.16.0';
+
+      when(() => argResults.rest).thenReturn([revision]);
+      when(
+        () => shorebirdFlutter.resolveFlutterRevision(any()),
+      ).thenAnswer((_) async => revision);
+      when(
+        () => shorebirdFlutter.getVersionForRevision(flutterRevision: revision),
+      ).thenAnswer((_) async => version);
+      when(
+        () => shorebirdFlutter.getVersionString(),
+      ).thenAnswer((_) async => null);
+      when(
+        () => shorebirdFlutter.installRevision(revision: revision),
+      ).thenAnswer((_) async {});
+
+      await expectLater(
+        runWithOverrides(command.run),
+        completion(equals(ExitCode.success.code)),
+      );
+
+      expect(versionFile.readAsStringSync(), equals(revision));
+      verify(() => logger.success('Flutter version set to $version')).called(1);
+    });
+
+    test('handles resolveFlutterRevision errors gracefully', () async {
+      const requestedVersion = '3.16.0';
+      const error = 'Network error';
+
+      when(() => argResults.rest).thenReturn([requestedVersion]);
+      when(
+        () => shorebirdFlutter.resolveFlutterRevision(any()),
+      ).thenThrow(Exception(error));
+
+      await expectLater(
+        runWithOverrides(command.run),
+        completion(equals(ExitCode.software.code)),
+      );
+
+      verifyInOrder([
+        () => logger.progress('Resolving Flutter version'),
+        () => progress.fail('Failed to resolve Flutter version'),
+        () => logger.err('Exception: $error'),
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
# Add `shorebird flutter versions use` command

## Problem

Currently, there is no way to set a global Flutter version for Shorebird. Users must specify `--flutter-version` with every command when they want to use a specific Flutter version, even if it's the latest one. This is inconvenient and error-prone.

For example:
- When Flutter 3.32.0 is released, `shorebird flutter --version` shows an older version
- To use the new version, users must run: `shorebird release ios --flutter-version=3.32.0`
- This version parameter must be repeated for every command

## Solution

This PR introduces a new command: `shorebird flutter versions use <version>`

This command allows users to set a global Flutter version that will be used by all Shorebird commands.

### Usage

```bash
# List available Flutter versions
shorebird flutter versions list

# Set a specific Flutter version as the global version
shorebird flutter versions use 3.32.0

# Verify the change
shorebird flutter --version

# You can also use a git revision
shorebird flutter versions use abc123def456
```

### How it works

1. The command accepts either a semver version (e.g., `3.32.0`) or a git revision hash
2. It validates that the version exists in Shorebird's Flutter fork
3. If the version is not already installed, it downloads and installs it
4. It updates the `bin/internal/flutter.version` file with the git revision
5. All subsequent Shorebird commands will use this version by default

### Features

- ✅ Validates version existence before setting
- ✅ Shows helpful error messages if version not found
- ✅ Detects if the requested version is already active
- ✅ Supports both version numbers and git revision hashes
- ✅ Provides clear success feedback with verification instructions
- ✅ Comprehensive test coverage

### Implementation details

The implementation follows existing patterns in the Shorebird codebase:
- Uses the existing `shorebirdFlutter.resolveFlutterRevision` to handle version/revision resolution
- Uses the existing `shorebirdFlutter.installRevision` to ensure the Flutter version is installed
- Updates the same `bin/internal/flutter.version` file that Shorebird already uses
- Follows the same command structure as other `shorebird flutter versions` subcommands

### Testing

The PR includes comprehensive unit tests covering:
- Missing version arguments
- Invalid versions
- Already active versions
- Successful version changes
- Installation failures
- Git revision support

## Related issues

This addresses the need for a more convenient way to manage Flutter versions in Shorebird, as discussed in various community channels.

## Checklist

- [x] I've added tests for my changes
- [x] I've updated the documentation (if applicable)
- [x] I've followed the existing code style and patterns
- [x] All tests pass locally 