### PR TITLE
feat(redis_client): add support for t-digest functions

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -89,6 +89,7 @@ words:
   - propertylistserialization
   - pubspec
   - pwsh
+  - quantiles
   - rdata
   - reactivecircus # From .github dir, doesn't show up in "**" check?
   - readlink
@@ -110,6 +111,7 @@ words:
   - subosito # From .github dir, doesn't show up in "**" check?
   - swiftshader # From .github dir, doesn't show up in "**" check?
   - sysroot
+  - tdigest
   - temurin # From .github dir, doesn't show up in "**" check?
   - udevadm # From .github/workflows/e2e.yaml
   - udid # Unique Device Identifier


### PR DESCRIPTION
## Description

Adds support for a subset of the t-digest functions (https://redis.io/docs/latest/develop/data-types/probabilistic/t-digest/)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
