### PR TITLE
fix(shorebird_cli): forward `target` and additional arguments when building windows artifacts

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -579,14 +579,19 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
 
   /// Builds a windows app and returns the x64 Release directory
   Future<Directory> buildWindowsApp({
-    String? flavor,
     String? target,
     List<String> args = const [],
     String? base64PublicKey,
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
-      final arguments = ['build', 'windows', '--release', ...args];
+      final arguments = [
+        'build',
+        'windows',
+        '--release',
+        if (target != null) '--target=$target',
+        ...args,
+      ];
 
       final exitCode = await process.stream(
         executable,

--- a/packages/shorebird_cli/lib/src/commands/patch/windows_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/windows_patcher.dart
@@ -73,6 +73,9 @@ class WindowsPatcher extends Patcher {
   @override
   Future<File> buildPatchArtifact({String? releaseVersion}) async {
     final releaseDir = await artifactBuilder.buildWindowsApp(
+      flavor: flavor,
+      target: target,
+      args: argResults.forwardedArgs,
       base64PublicKey: argResults.encodedPublicKey,
     );
     return releaseDir.zipToTempFile();

--- a/packages/shorebird_cli/lib/src/commands/patch/windows_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/windows_patcher.dart
@@ -73,7 +73,6 @@ class WindowsPatcher extends Patcher {
   @override
   Future<File> buildPatchArtifact({String? releaseVersion}) async {
     final releaseDir = await artifactBuilder.buildWindowsApp(
-      flavor: flavor,
       target: target,
       args: argResults.forwardedArgs,
       base64PublicKey: argResults.encodedPublicKey,

--- a/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/windows_releaser.dart
@@ -69,7 +69,6 @@ To change the version of this release, change your app's version in your pubspec
   @override
   Future<FileSystemEntity> buildReleaseArtifacts() {
     return artifactBuilder.buildWindowsApp(
-      flavor: flavor,
       target: target,
       args: argResults.forwardedArgs,
       base64PublicKey: argResults.encodedPublicKey,

--- a/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
@@ -1453,6 +1453,23 @@ Reason: Exited with code 70.'''),
         ).thenAnswer((_) async => ExitCode.success.code);
       });
 
+      group('when target is provided', () {
+        test('forwards target to flutter command', () async {
+          await runWithOverrides(
+            () => builder.buildWindowsApp(target: 'target.dart'),
+          );
+
+          verify(
+            () => shorebirdProcess.stream('flutter', [
+              'build',
+              'windows',
+              '--release',
+              '--target=target.dart',
+            ], runInShell: false),
+          ).called(1);
+        });
+      });
+
       group('when flutter build fails', () {
         setUp(() {
           when(

--- a/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
@@ -86,7 +86,6 @@ void main() {
       registerFallbackValue(ShorebirdArtifact.genSnapshotMacosArm64);
       registerFallbackValue(Uri.parse('https://example.com'));
       registerFallbackValue(const WindowsArchiveDiffer());
-      registerFallbackValue(<String>[]);
     });
 
     setUp(() {

--- a/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
@@ -289,7 +289,6 @@ void main() {
         setUp(() {
           when(
             () => artifactBuilder.buildWindowsApp(
-              flavor: any(named: 'flavor'),
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
@@ -319,7 +318,6 @@ void main() {
           )..createSync(recursive: true);
           when(
             () => artifactBuilder.buildWindowsApp(
-              flavor: any(named: 'flavor'),
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),

--- a/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
@@ -333,6 +333,22 @@ void main() {
             ),
           );
         });
+
+        test('forwards additional args', () async {
+          when(
+            () => argResults.rest,
+          ).thenReturn(['--build-name=1.2.3', '--build-number=4']);
+          await runWithOverrides(() => patcher.buildPatchArtifact());
+          verify(
+            () => artifactBuilder.buildWindowsApp(
+              target: any(named: 'target'),
+              args: any(
+                named: 'args',
+                that: containsAll(['--build-name=1.2.3', '--build-number=4']),
+              ),
+            ),
+          ).called(1);
+        });
       });
     });
 

--- a/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
@@ -86,6 +86,7 @@ void main() {
       registerFallbackValue(ShorebirdArtifact.genSnapshotMacosArm64);
       registerFallbackValue(Uri.parse('https://example.com'));
       registerFallbackValue(const WindowsArchiveDiffer());
+      registerFallbackValue(<String>[]);
     });
 
     setUp(() {
@@ -286,7 +287,14 @@ void main() {
       group('when build fails', () {
         final exception = Exception('Failed to build Windows app');
         setUp(() {
-          when(() => artifactBuilder.buildWindowsApp()).thenThrow(exception);
+          when(
+            () => artifactBuilder.buildWindowsApp(
+              flavor: any(named: 'flavor'),
+              target: any(named: 'target'),
+              args: any(named: 'args'),
+              base64PublicKey: any(named: 'base64PublicKey'),
+            ),
+          ).thenThrow(exception);
         });
 
         test('throws exception', () async {
@@ -310,7 +318,12 @@ void main() {
             ),
           )..createSync(recursive: true);
           when(
-            () => artifactBuilder.buildWindowsApp(),
+            () => artifactBuilder.buildWindowsApp(
+              flavor: any(named: 'flavor'),
+              target: any(named: 'target'),
+              args: any(named: 'args'),
+              base64PublicKey: any(named: 'base64PublicKey'),
+            ),
           ).thenAnswer((_) async => releaseDir);
         });
 

--- a/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
@@ -282,7 +282,7 @@ To change the version of this release, change your app's version in your pubspec
           );
         });
 
-        test('builds artifacts with flavor and target', () async {
+        test('builds correct artifacts', () async {
           await runWithOverrides(releaser.buildReleaseArtifacts);
           verify(
             () => artifactBuilder.buildWindowsApp(target: target, args: []),

--- a/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
@@ -257,7 +257,6 @@ To change the version of this release, change your app's version in your pubspec
       setUp(() {
         when(
           () => artifactBuilder.buildWindowsApp(
-            flavor: any(named: 'flavor'),
             target: any(named: 'target'),
             args: any(named: 'args'),
           ),
@@ -271,11 +270,30 @@ To change the version of this release, change your app's version in your pubspec
         expect(releaseDir, projectRoot);
       });
 
+      group('when target and flavor are specified', () {
+        const flavor = 'my-flavor';
+        const target = 'my-target';
+
+        setUp(() {
+          releaser = WindowsReleaser(
+            argResults: argResults,
+            flavor: flavor,
+            target: target,
+          );
+        });
+
+        test('builds artifacts with flavor and target', () async {
+          await runWithOverrides(releaser.buildReleaseArtifacts);
+          verify(
+            () => artifactBuilder.buildWindowsApp(target: target, args: []),
+          ).called(1);
+        });
+      });
+
       group('when public key is passed as an arg', () {
         setUp(() {
           when(
             () => artifactBuilder.buildWindowsApp(
-              flavor: any(named: 'flavor'),
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
@@ -297,7 +315,6 @@ To change the version of this release, change your app's version in your pubspec
           verify(
             () => artifactBuilder.buildWindowsApp(
               base64PublicKey: 'encoded_public_key',
-              flavor: any(named: 'flavor'),
               target: any(named: 'target'),
               args: any(named: 'args'),
             ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
* The ```shoerbird patch windows``` command would not pass the flutter arguments provided while building patch artifacts
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [X] 🧪 Tests
