### PR TITLE
refactor: add initial shorebird_process_tools package

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -87,6 +87,11 @@ jobs:
               - ./.github/workflows/main.yaml
               - ./.github/actions/dart_package/action.yaml
               - packages/shorebird_code_push_protocol/**
+            shorebird_process_tools:
+              - ./.github/codecov.yml
+              - ./.github/workflows/main.yaml
+              - ./.github/actions/dart_package/action.yaml
+              - packages/shorebird_process_tools/**
             jwt:
               - ./.github/codecov.yml
               - ./.github/workflows/main.yaml

--- a/packages/shorebird_process_tools/.gitignore
+++ b/packages/shorebird_process_tools/.gitignore
@@ -1,0 +1,8 @@
+# See https://www.dartlang.org/guides/libraries/private-files
+
+# Files and directories created by pub
+.dart_tool/
+.packages
+build/
+pubspec.lock
+coverage/

--- a/packages/shorebird_process_tools/analysis_options.yaml
+++ b/packages/shorebird_process_tools/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: ../../analysis_options.yaml
+analyzer:
+  exclude:
+    - build/**

--- a/packages/shorebird_process_tools/lib/shorebird_process_tools.dart
+++ b/packages/shorebird_process_tools/lib/shorebird_process_tools.dart
@@ -1,0 +1,2 @@
+export 'src/executables/executables.dart';
+export 'src/process.dart';

--- a/packages/shorebird_process_tools/lib/src/executables/executables.dart
+++ b/packages/shorebird_process_tools/lib/src/executables/executables.dart
@@ -1,0 +1,1 @@
+export 'git.dart';

--- a/packages/shorebird_process_tools/lib/src/executables/git.dart
+++ b/packages/shorebird_process_tools/lib/src/executables/git.dart
@@ -1,0 +1,170 @@
+// cspell:words unmatch
+import 'dart:io';
+
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_process_tools/src/process.dart';
+
+/// A reference to a [Git] instance.
+final gitRef = create(Git.new);
+
+/// The [Git] instance available in the current zone.
+Git get git => read(gitRef);
+
+/// A wrapper around all git related functionality.
+class Git {
+  /// Name of the git executable.
+  static const executable = 'git';
+
+  /// Execute a git command with the provided [arguments].
+  Future<ShorebirdProcessResult> git(
+    List<String> arguments, {
+    String? workingDirectory,
+  }) async {
+    final result = await process.run(
+      executable,
+      arguments,
+      workingDirectory: workingDirectory,
+    );
+    if (result.exitCode != 0) {
+      throw ProcessException(
+        executable,
+        arguments,
+        '${result.stderr}',
+        result.exitCode,
+      );
+    }
+    return result;
+  }
+
+  /// Clones the git repository located at [url] into the [outputDirectory].
+  /// `git clone <url> ...<args> <outputDirectory>`
+  Future<void> clone({
+    required String url,
+    required String outputDirectory,
+    List<String>? args,
+  }) async {
+    await git(['clone', url, ...?args, outputDirectory]);
+  }
+
+  /// Checks out the git repository located at [directory] to the [revision].
+  Future<void> checkout({
+    required String directory,
+    required String revision,
+  }) async {
+    await git([
+      '-C',
+      directory,
+      '-c',
+      'advice.detachedHead=false',
+      'checkout',
+      revision,
+    ]);
+  }
+
+  /// Fetch branches/tags from the repository at [directory].
+  Future<void> fetch({required String directory, List<String>? args}) async {
+    await git(['fetch', ...?args], workingDirectory: directory);
+  }
+
+  /// Run `git remote` at [directory].
+  Future<void> remote({required String directory, List<String>? args}) async {
+    await git(['remote', ...?args], workingDirectory: directory);
+  }
+
+  /// Iterate over all refs that match [pattern] and show them
+  /// according to the given [format].
+  Future<String> forEachRef({
+    required String directory,
+    required String format,
+    required String pattern,
+    String? contains,
+  }) async {
+    final result = await git([
+      'for-each-ref',
+      if (contains != null) ...['--contains', contains],
+      '--format',
+      format,
+      pattern,
+    ], workingDirectory: directory);
+    return '${result.stdout}'.trim();
+  }
+
+  /// Resets the git repository located at [directory] to the [revision].
+  Future<void> reset({
+    required String revision,
+    required String directory,
+    List<String>? args,
+  }) async {
+    await git(['reset', ...?args, revision], workingDirectory: directory);
+  }
+
+  /// Returns the revision of the git repository located at [directory].
+  Future<String> revParse({
+    required String revision,
+    required String directory,
+  }) async {
+    final result = await git([
+      'rev-parse',
+      '--verify',
+      revision,
+    ], workingDirectory: directory);
+    return '${result.stdout}'.trim();
+  }
+
+  /// Returns the status of the git repository located at [directory].
+  Future<String> status({required String directory, List<String>? args}) async {
+    final result = await git(['status', ...?args], workingDirectory: directory);
+    return '${result.stdout}'.trim();
+  }
+
+  /// The output of `git symbolic-ref [revision]` for the git repository located
+  /// in [directory]. If not provided, [revision] defaults to 'HEAD'.
+  Future<String> symbolicRef({
+    required Directory directory,
+    String revision = 'HEAD',
+  }) async {
+    final result = await git([
+      'symbolic-ref',
+      revision,
+    ], workingDirectory: directory.path);
+    return '${result.stdout}'.trim();
+  }
+
+  /// Returns the name of the branch the git repository located at [directory]
+  /// is currently on.
+  Future<String> currentBranch({required Directory directory}) async {
+    return (await symbolicRef(
+      directory: directory,
+    )).replaceAll('refs/heads/', '');
+  }
+
+  /// Whether [directory] is part of a git repository.
+  Future<bool> isGitRepo({required Directory directory}) async {
+    try {
+      // [git] throws if the command's exit code is nonzero, which is what we're
+      // checking for here.
+      await git(['status'], workingDirectory: directory.path);
+    } on Exception {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Whether [file] is tracked by its git repository.
+  Future<bool> isFileTracked({required File file}) async {
+    try {
+      // [git] throws if the command's exit code is nonzero, which is what we're
+      // checking for here.
+      await git([
+        'ls-files',
+        '--error-unmatch',
+        file.absolute.path,
+      ], workingDirectory: file.parent.path);
+    } on Exception {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/packages/shorebird_process_tools/lib/src/executables/git.dart
+++ b/packages/shorebird_process_tools/lib/src/executables/git.dart
@@ -4,13 +4,11 @@ import 'dart:io';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_process_tools/src/process.dart';
 
-// coverage:ignore-start
 /// A reference to a [Git] instance.
 final gitRef = create(Git.new);
 
 /// The [Git] instance available in the current zone.
 Git get git => read(gitRef);
-// coverage:ignore-end
 
 /// A wrapper around all git related functionality.
 class Git {

--- a/packages/shorebird_process_tools/lib/src/executables/git.dart
+++ b/packages/shorebird_process_tools/lib/src/executables/git.dart
@@ -4,11 +4,13 @@ import 'dart:io';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_process_tools/src/process.dart';
 
+// coverage:ignore-start
 /// A reference to a [Git] instance.
 final gitRef = create(Git.new);
 
 /// The [Git] instance available in the current zone.
 Git get git => read(gitRef);
+// coverage:ignore-end
 
 /// A wrapper around all git related functionality.
 class Git {

--- a/packages/shorebird_process_tools/lib/src/process.dart
+++ b/packages/shorebird_process_tools/lib/src/process.dart
@@ -116,3 +116,5 @@ class ProcessWrapper {
     return process.exitCode;
   }
 }
+
+// coverage:ignore-end

--- a/packages/shorebird_process_tools/lib/src/process.dart
+++ b/packages/shorebird_process_tools/lib/src/process.dart
@@ -1,0 +1,118 @@
+import 'dart:io';
+
+import 'package:scoped_deps/scoped_deps.dart';
+
+/// A reference to a [ProcessWrapper] instance.
+final processRef = create(ProcessWrapper.new);
+
+/// The [ProcessWrapper] instance available in the current zone.
+ProcessWrapper get process => read(processRef);
+
+/// {@template shorebird_process_result}
+/// Result from running a process.
+/// {@endtemplate}
+class ShorebirdProcessResult {
+  /// {@macro shorebird_process_result}
+  const ShorebirdProcessResult({
+    required this.exitCode,
+    required this.stdout,
+    required this.stderr,
+  });
+
+  /// The exit code of the process.
+  final int exitCode;
+
+  /// The standard output of the process.
+  final dynamic stdout;
+
+  /// The standard error of the process.
+  final dynamic stderr;
+}
+
+/// A wrapper around [Process] that can be mocked for testing.
+// coverage:ignore-start
+class ProcessWrapper {
+  /// Runs the process and returns the result.
+  Future<ShorebirdProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    Map<String, String>? environment,
+    String? workingDirectory,
+    bool? runInShell,
+  }) async {
+    final result = await Process.run(
+      executable,
+      arguments,
+      environment: environment,
+      // TODO(felangel): refactor to never runInShell
+      runInShell: runInShell ?? Platform.isWindows,
+      workingDirectory: workingDirectory,
+    );
+    return ShorebirdProcessResult(
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    );
+  }
+
+  /// Runs the process synchronously and returns the result.
+  ShorebirdProcessResult runSync(
+    String executable,
+    List<String> arguments, {
+    Map<String, String>? environment,
+    String? workingDirectory,
+  }) {
+    final result = Process.runSync(
+      executable,
+      arguments,
+      environment: environment,
+      runInShell: Platform.isWindows,
+      workingDirectory: workingDirectory,
+    );
+    return ShorebirdProcessResult(
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    );
+  }
+
+  /// Starts a new process running the executable with the specified arguments.
+  Future<Process> start(
+    String executable,
+    List<String> arguments, {
+    Map<String, String>? environment,
+    bool? runInShell,
+    String? workingDirectory,
+    ProcessStartMode mode = ProcessStartMode.normal,
+  }) {
+    return Process.start(
+      executable,
+      arguments,
+      // TODO(felangel): refactor to never runInShell
+      runInShell: runInShell ?? Platform.isWindows,
+      environment: environment,
+      workingDirectory: workingDirectory,
+      mode: mode,
+    );
+  }
+
+  /// Starts a process, streams the output in real-time, and returns the exit
+  /// code.
+  Future<int> stream(
+    String executable,
+    List<String> arguments, {
+    Map<String, String>? environment,
+    bool? runInShell,
+    String? workingDirectory,
+  }) async {
+    final process = await start(
+      executable,
+      arguments,
+      environment: environment,
+      runInShell: runInShell,
+      workingDirectory: workingDirectory,
+      mode: ProcessStartMode.inheritStdio,
+    );
+    return process.exitCode;
+  }
+}

--- a/packages/shorebird_process_tools/pubspec.yaml
+++ b/packages/shorebird_process_tools/pubspec.yaml
@@ -11,14 +11,6 @@ environment:
 
 dependencies:
   scoped_deps: ^0.1.0
-  mason_logger: ^0.3.3
-  platform: ^3.1.6
-  path: ^1.9.1
-  collection: ^1.19.1
-  pub_semver: ^2.2.0
-  io: ^1.0.5
-  json_path: ^0.7.6
-  json_annotation: ^4.9.0
 
 dev_dependencies:
   mocktail: ^1.0.0

--- a/packages/shorebird_process_tools/pubspec.yaml
+++ b/packages/shorebird_process_tools/pubspec.yaml
@@ -1,0 +1,25 @@
+name: shorebird_process_tools
+description: Helpers for interacting with system utilities (e.g., git)
+version: 0.1.0
+repository: https://github.com/shorebirdtech/shorebird
+resolution: workspace
+
+publish_to: none
+
+environment:
+  sdk: ">=3.8.0 <4.0.0"
+
+dependencies:
+  scoped_deps: ^0.1.0
+  mason_logger: ^0.3.3
+  platform: ^3.1.6
+  path: ^1.9.1
+  collection: ^1.19.1
+  pub_semver: ^2.2.0
+  io: ^1.0.5
+  json_path: ^0.7.6
+  json_annotation: ^4.9.0
+
+dev_dependencies:
+  mocktail: ^1.0.0
+  test: ^1.19.2

--- a/packages/shorebird_process_tools/pubspec.yaml
+++ b/packages/shorebird_process_tools/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 
 dependencies:
   scoped_deps: ^0.1.0
+  mason_logger: ^0.3.3
 
 dev_dependencies:
   mocktail: ^1.0.0

--- a/packages/shorebird_process_tools/test/src/executables/git_test.dart
+++ b/packages/shorebird_process_tools/test/src/executables/git_test.dart
@@ -36,6 +36,15 @@ void main() {
       when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
     });
 
+    group('scoped', () {
+      test('has access to git reference', () {
+        expect(
+          runScoped(() => git, values: {gitRef}),
+          isA<Git>(),
+        );
+      });
+    });
+
     group('clone', () {
       const url = 'https://github.com/shorebirdtech/shorebird';
       const outputDirectory = './output';

--- a/packages/shorebird_process_tools/test/src/executables/git_test.dart
+++ b/packages/shorebird_process_tools/test/src/executables/git_test.dart
@@ -1,0 +1,520 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_process_tools/shorebird_process_tools.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group(Git, () {
+    late ShorebirdProcessResult processResult;
+    late ProcessWrapper process;
+    late Git git;
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        () => body(),
+        values: {processRef.overrideWith(() => process)},
+      );
+    }
+
+    setUp(() {
+      processResult = MockShorebirdProcessResult();
+      process = MockProcessWrapper();
+      git = runWithOverrides(Git.new);
+
+      when(
+        () => process.run(
+          any(),
+          any(),
+          workingDirectory: any(named: 'workingDirectory'),
+        ),
+      ).thenAnswer((_) async => processResult);
+      when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+    });
+
+    group('clone', () {
+      const url = 'https://github.com/shorebirdtech/shorebird';
+      const outputDirectory = './output';
+
+      test('executes correct command (no args)', () async {
+        await runWithOverrides(
+          () => git.clone(url: url, outputDirectory: outputDirectory),
+        );
+        verify(
+          () => process.run('git', ['clone', url, outputDirectory]),
+        ).called(1);
+      });
+
+      test('executes correct command (with args)', () async {
+        const args = <String>['--filter-tree:0', '--no-checkout'];
+        await runWithOverrides(
+          () => git.clone(
+            url: url,
+            args: ['--filter-tree:0', '--no-checkout'],
+            outputDirectory: outputDirectory,
+          ),
+        );
+        verify(
+          () => process.run('git', ['clone', url, ...args, outputDirectory]),
+        ).called(1);
+      });
+
+      test('throws ProcessException if process exits with error', () async {
+        const error = 'oops';
+        when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        when(() => processResult.stderr).thenReturn(error);
+        expect(
+          () => runWithOverrides(
+            () => git.clone(url: url, outputDirectory: outputDirectory),
+          ),
+          throwsA(
+            isA<ProcessException>().having((e) => e.message, 'message', error),
+          ),
+        );
+      });
+    });
+
+    group('checkout', () {
+      const directory = './output';
+      const revision = 'revision';
+
+      test('executes correct command', () async {
+        await runWithOverrides(
+          () => git.checkout(directory: directory, revision: revision),
+        );
+        verify(
+          () => process.run('git', [
+            '-C',
+            directory,
+            '-c',
+            'advice.detachedHead=false',
+            'checkout',
+            revision,
+          ]),
+        ).called(1);
+      });
+
+      test('throws ProcessException if process exits with error', () async {
+        const error = 'oops';
+        when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        when(() => processResult.stderr).thenReturn(error);
+        expect(
+          () => runWithOverrides(
+            () => git.checkout(directory: directory, revision: revision),
+          ),
+          throwsA(
+            isA<ProcessException>().having((e) => e.message, 'message', error),
+          ),
+        );
+      });
+    });
+
+    group('fetch', () {
+      const directory = 'repository';
+      test('executes correct command', () async {
+        await expectLater(
+          runWithOverrides(() => git.fetch(directory: directory)),
+          completes,
+        );
+        verify(
+          () => process.run('git', ['fetch'], workingDirectory: directory),
+        ).called(1);
+      });
+
+      test('executes correct command w/args', () async {
+        final args = ['--tags'];
+        await expectLater(
+          runWithOverrides(() => git.fetch(directory: directory, args: args)),
+          completes,
+        );
+        verify(
+          () => process.run('git', [
+            'fetch',
+            ...args,
+          ], workingDirectory: directory),
+        ).called(1);
+      });
+
+      test('throws ProcessException if process exits with error', () async {
+        const error = 'oops';
+        when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        when(() => processResult.stderr).thenReturn(error);
+        expect(
+          () => runWithOverrides(() => git.fetch(directory: directory)),
+          throwsA(
+            isA<ProcessException>().having((e) => e.message, 'message', error),
+          ),
+        );
+      });
+    });
+
+    group('forEachRef', () {
+      const directory = 'repository';
+      const format = '%(refname:short)';
+      const pattern = 'refs/remotes/origin/flutter_release/*';
+      const output = '''
+
+origin/flutter_release/3.10.0
+origin/flutter_release/3.10.1
+origin/flutter_release/3.10.2
+origin/flutter_release/3.10.3
+origin/flutter_release/3.10.4
+origin/flutter_release/3.10.5
+origin/flutter_release/3.10.6''';
+      test('executes correct command', () async {
+        when(() => processResult.stdout).thenReturn(output);
+        await expectLater(
+          runWithOverrides(
+            () => git.forEachRef(
+              pattern: pattern,
+              format: format,
+              directory: directory,
+            ),
+          ),
+          completion(equals(output.trim())),
+        );
+        verify(
+          () => process.run('git', [
+            'for-each-ref',
+            '--format',
+            format,
+            pattern,
+          ], workingDirectory: directory),
+        ).called(1);
+      });
+
+      test('executes correct command w/contains', () async {
+        const contains = 'revision';
+        when(() => processResult.stdout).thenReturn(output);
+        await expectLater(
+          runWithOverrides(
+            () => git.forEachRef(
+              contains: contains,
+              pattern: pattern,
+              format: format,
+              directory: directory,
+            ),
+          ),
+          completion(equals(output.trim())),
+        );
+        verify(
+          () => process.run('git', [
+            'for-each-ref',
+            '--contains',
+            contains,
+            '--format',
+            format,
+            pattern,
+          ], workingDirectory: directory),
+        ).called(1);
+      });
+
+      test('throws ProcessException if process exits with error', () async {
+        const error = 'oops';
+        when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        when(() => processResult.stderr).thenReturn(error);
+        expect(
+          () => runWithOverrides(
+            () => git.forEachRef(
+              pattern: pattern,
+              format: format,
+              directory: directory,
+            ),
+          ),
+          throwsA(
+            isA<ProcessException>().having((e) => e.message, 'message', error),
+          ),
+        );
+      });
+    });
+
+    group('reset', () {
+      const directory = './output';
+      const revision = 'revision';
+
+      test('executes correct command', () async {
+        await expectLater(
+          runWithOverrides(
+            () => git.reset(directory: directory, revision: revision),
+          ),
+          completes,
+        );
+        verify(
+          () => process.run('git', [
+            'reset',
+            revision,
+          ], workingDirectory: directory),
+        ).called(1);
+      });
+
+      test('executes correct command w/args', () async {
+        const args = ['--hard'];
+        await expectLater(
+          runWithOverrides(
+            () =>
+                git.reset(directory: directory, revision: revision, args: args),
+          ),
+          completes,
+        );
+        verify(
+          () => process.run('git', [
+            'reset',
+            ...args,
+            revision,
+          ], workingDirectory: directory),
+        ).called(1);
+      });
+
+      test('throws ProcessException if process exits with error', () async {
+        const error = 'oops';
+        when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        when(() => processResult.stderr).thenReturn(error);
+        expect(
+          () => runWithOverrides(
+            () => git.reset(directory: directory, revision: revision),
+          ),
+          throwsA(
+            isA<ProcessException>().having((e) => e.message, 'message', error),
+          ),
+        );
+      });
+    });
+
+    group('remote', () {
+      const directory = './output';
+
+      test('executes correct command', () async {
+        await expectLater(
+          runWithOverrides(() => git.remote(directory: directory)),
+          completes,
+        );
+        verify(
+          () => process.run('git', ['remote'], workingDirectory: directory),
+        ).called(1);
+      });
+
+      test('executes correct command w/args', () async {
+        const args = ['prune', 'origin'];
+        await expectLater(
+          runWithOverrides(() => git.remote(directory: directory, args: args)),
+          completes,
+        );
+        verify(
+          () => process.run('git', [
+            'remote',
+            ...args,
+          ], workingDirectory: directory),
+        ).called(1);
+      });
+
+      test('throws ProcessException if process exits with error', () async {
+        const error = 'oops';
+        when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        when(() => processResult.stderr).thenReturn(error);
+        expect(
+          () => runWithOverrides(() => git.remote(directory: directory)),
+          throwsA(
+            isA<ProcessException>().having((e) => e.message, 'message', error),
+          ),
+        );
+      });
+    });
+
+    group('revParse', () {
+      const directory = './output';
+      const revision = 'revision';
+
+      test('executes correct command', () async {
+        const output = 'revision';
+        when(() => processResult.stdout).thenReturn(output);
+        await expectLater(
+          runWithOverrides(
+            () => git.revParse(directory: directory, revision: revision),
+          ),
+          completion(equals(output)),
+        );
+        verify(
+          () => process.run('git', [
+            'rev-parse',
+            '--verify',
+            revision,
+          ], workingDirectory: directory),
+        ).called(1);
+      });
+
+      test('throws ProcessException if process exits with error', () async {
+        const error = 'oops';
+        when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        when(() => processResult.stderr).thenReturn(error);
+        expect(
+          () => runWithOverrides(
+            () => git.revParse(directory: directory, revision: revision),
+          ),
+          throwsA(
+            isA<ProcessException>().having((e) => e.message, 'message', error),
+          ),
+        );
+      });
+    });
+
+    group('status', () {
+      const directory = './output';
+
+      test('executes correct command', () async {
+        const output = 'status';
+        when(() => processResult.stdout).thenReturn(output);
+        await expectLater(
+          runWithOverrides(() => git.status(directory: directory)),
+          completion(equals(output)),
+        );
+        verify(
+          () => process.run('git', ['status'], workingDirectory: directory),
+        ).called(1);
+      });
+
+      test('executes correct command w/args', () async {
+        const output = 'status';
+        const args = ['--porcelain'];
+        when(() => processResult.stdout).thenReturn(output);
+        await expectLater(
+          runWithOverrides(() => git.status(directory: directory, args: args)),
+          completion(equals(output)),
+        );
+        verify(
+          () => process.run('git', [
+            'status',
+            ...args,
+          ], workingDirectory: directory),
+        ).called(1);
+      });
+
+      test('throws ProcessException if process exits with error', () async {
+        const error = 'oops';
+        when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        when(() => processResult.stderr).thenReturn(error);
+        expect(
+          () => runWithOverrides(() => git.status(directory: directory)),
+          throwsA(
+            isA<ProcessException>().having((e) => e.message, 'message', error),
+          ),
+        );
+      });
+    });
+
+    group('symbolicRef', () {
+      setUp(() {
+        when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+        when(() => processResult.stdout).thenReturn('refs/heads/main');
+      });
+
+      test('executes correct command', () async {
+        final directory = Directory.current;
+        await expectLater(
+          runWithOverrides(
+            () => git.symbolicRef(directory: directory, revision: '1234'),
+          ),
+          completion(equals('refs/heads/main')),
+        );
+        verify(
+          () => process.run('git', [
+            'symbolic-ref',
+            '1234',
+          ], workingDirectory: directory.path),
+        ).called(1);
+      });
+
+      test('defaults to HEAD if no revision is provided', () async {
+        final directory = Directory.current;
+        await expectLater(
+          runWithOverrides(() => git.symbolicRef(directory: directory)),
+          completion(equals('refs/heads/main')),
+        );
+        verify(
+          () => process.run('git', [
+            'symbolic-ref',
+            'HEAD',
+          ], workingDirectory: directory.path),
+        ).called(1);
+      });
+    });
+
+    group('currentBranch', () {
+      setUp(() {
+        when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+        when(() => processResult.stdout).thenReturn('''
+refs/heads/main
+''');
+      });
+
+      test('removes refs/heads from branch name', () async {
+        final directory = Directory.current;
+        await expectLater(
+          runWithOverrides(() => git.currentBranch(directory: directory)),
+          completion(equals('main')),
+        );
+      });
+    });
+
+    group('isGitRepo', () {
+      group('when git exits with code 0', () {
+        setUp(() {
+          when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+        });
+
+        test('returns true', () async {
+          final directory = Directory.current;
+          final result = await runWithOverrides(
+            () => git.isGitRepo(directory: directory),
+          );
+          expect(result, isTrue);
+        });
+      });
+
+      group('when git exits with nonzero code', () {
+        setUp(() {
+          when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        });
+
+        test('returns true', () async {
+          final directory = Directory.current;
+          final result = await runWithOverrides(
+            () => git.isGitRepo(directory: directory),
+          );
+          expect(result, isFalse);
+        });
+      });
+    });
+
+    group('isFileTracked', () {
+      group('when git exits with code 0', () {
+        setUp(() {
+          when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
+        });
+
+        test('returns true', () async {
+          final result = await runWithOverrides(
+            () => git.isFileTracked(file: File('file')),
+          );
+          expect(result, isTrue);
+        });
+      });
+
+      group('when git exits with nonzero code', () {
+        setUp(() {
+          when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        });
+
+        test('returns true', () async {
+          final result = await runWithOverrides(
+            () => git.isFileTracked(file: File('file')),
+          );
+          expect(result, isFalse);
+        });
+      });
+    });
+  });
+}

--- a/packages/shorebird_process_tools/test/src/executables/git_test.dart
+++ b/packages/shorebird_process_tools/test/src/executables/git_test.dart
@@ -9,6 +9,15 @@ import 'package:test/test.dart';
 import '../mocks.dart';
 
 void main() {
+  group('scoped', () {
+    test('has access to git reference', () {
+      expect(
+        runScoped(() => git, values: {gitRef}),
+        isA<Git>(),
+      );
+    });
+  });
+
   group(Git, () {
     late ShorebirdProcessResult processResult;
     late ProcessWrapper process;
@@ -34,15 +43,6 @@ void main() {
         ),
       ).thenAnswer((_) async => processResult);
       when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
-    });
-
-    group('scoped', () {
-      test('has access to git reference', () {
-        expect(
-          runScoped(() => git, values: {gitRef}),
-          isA<Git>(),
-        );
-      });
     });
 
     group('clone', () {

--- a/packages/shorebird_process_tools/test/src/mocks.dart
+++ b/packages/shorebird_process_tools/test/src/mocks.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shorebird_process_tools/shorebird_process_tools.dart';
+
+class MockDirectory extends Mock implements Directory {}
+
+class MockFile extends Mock implements File {}
+
+class MockGit extends Mock implements Git {}
+
+class MockIOSink extends Mock implements IOSink {}
+
+class MockShorebirdProcessResult extends Mock
+    implements ShorebirdProcessResult {}
+
+class MockProcessSignal extends Mock implements ProcessSignal {}
+
+class MockProcessWrapper extends Mock implements ProcessWrapper {}
+
+class MockProcess extends Mock implements Process {}
+
+class MockProgress extends Mock implements Progress {}
+
+class MockStdin extends Mock implements Stdin {}
+
+class MockStdout extends Mock implements Stdout {}

--- a/packages/shorebird_process_tools/test/src/process_test.dart
+++ b/packages/shorebird_process_tools/test/src/process_test.dart
@@ -1,0 +1,17 @@
+import 'package:shorebird_process_tools/src/process.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(ShorebirdProcessResult, () {
+    test('can be instantiated', () {
+      const result = ShorebirdProcessResult(
+        exitCode: 0,
+        stdout: 'stdout',
+        stderr: 'stderr',
+      );
+      expect(result.exitCode, equals(0));
+      expect(result.stdout, equals('stdout'));
+      expect(result.stderr, equals('stderr'));
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ workspace:
   - packages/shorebird_cli
   - packages/shorebird_code_push_client
   - packages/shorebird_code_push_protocol
+  - packages/shorebird_process_tools
 
 dev_dependencies:
   very_good_analysis: ^9.0.0


### PR DESCRIPTION
## Description

Pulls git logic and deps out of shorebird_cli for use in other packages.

This is still a bit proof-of-concepty and will leave the cli in an odd state where some classes (other executables) that live in the cli's executables folder.

If we like this approach, we can move those other executable support classes over to this package.

Also, very much not married to the package name.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
