### PR TITLE
feat(shorebird_process_tools): add Dart executable

### DIFF
--- a/packages/shorebird_process_tools/lib/src/executables/dart.dart
+++ b/packages/shorebird_process_tools/lib/src/executables/dart.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_process_tools/shorebird_process_tools.dart';
+
+/// A reference to a [Dart] instance.
+final dartRef = create(Dart.new);
+
+/// The [Dart] instance available in the current zone.
+Dart get dart => read(dartRef);
+
+/// {@template dart_format_result}
+/// The result of running `dart format`.
+/// {@endtemplate}
+class DartFormatResult {
+  /// {@macro dart_format_result}
+  DartFormatResult({
+    required this.isFormattedCorrectly,
+    required this.output,
+  });
+
+  /// Whether `dart format` changed any files.
+  final bool isFormattedCorrectly;
+
+  /// The stdout of the `dart format` command.
+  final String output;
+}
+
+/// A wrapper around Dart-related functionality.
+class Dart {
+  /// Name of the dart executable.
+  static const executable = 'dart';
+
+  /// Runs `dart format` on the given [path].
+  Future<DartFormatResult> format({
+    required String path,
+    bool setExitIfChanged = false,
+  }) async {
+    final formatResult = await process.run(
+      executable,
+      ['format', if (setExitIfChanged) '--set-exit-if-changed', path],
+    );
+
+    return DartFormatResult(
+      isFormattedCorrectly: formatResult.exitCode == 0,
+      output: formatResult.stdout as String,
+    );
+  }
+
+  /// Runs `dart pub get` on the given [path].
+  Future<void> pubGet({required String path}) async {
+    final result = await process.run(executable, [
+      'pub',
+      'get',
+    ], workingDirectory: path);
+
+    if (result.exitCode != 0) {
+      throw ProcessException(executable, [
+        'pub',
+        'get',
+      ], result.stderr as String);
+    }
+  }
+}

--- a/packages/shorebird_process_tools/lib/src/executables/dart.dart
+++ b/packages/shorebird_process_tools/lib/src/executables/dart.dart
@@ -14,7 +14,7 @@ Dart get dart => read(dartRef);
 /// {@endtemplate}
 class DartFormatResult {
   /// {@macro dart_format_result}
-  DartFormatResult({
+  const DartFormatResult({
     required this.isFormattedCorrectly,
     required this.output,
   });

--- a/packages/shorebird_process_tools/lib/src/executables/executables.dart
+++ b/packages/shorebird_process_tools/lib/src/executables/executables.dart
@@ -1,1 +1,2 @@
+export 'dart.dart';
 export 'git.dart';

--- a/packages/shorebird_process_tools/test/src/executables/dart_test.dart
+++ b/packages/shorebird_process_tools/test/src/executables/dart_test.dart
@@ -8,6 +8,15 @@ import 'package:test/test.dart';
 import '../mocks.dart';
 
 void main() {
+  group('scoped', () {
+    test('has access to dart reference', () {
+      expect(
+        runScoped(() => dart, values: {dartRef}),
+        isA<Dart>(),
+      );
+    });
+  });
+
   group(Dart, () {
     late ProcessWrapper processWrapper;
     late ShorebirdProcessResult processResult;
@@ -38,13 +47,6 @@ void main() {
           workingDirectory: any(named: 'workingDirectory'),
         ),
       ).thenAnswer((_) async => processResult);
-    });
-
-    test('has access to dart reference', () {
-      expect(
-        runScoped(() => dart, values: {dartRef}),
-        isA<Dart>(),
-      );
     });
 
     test('has correct executable name', () {

--- a/packages/shorebird_process_tools/test/src/executables/dart_test.dart
+++ b/packages/shorebird_process_tools/test/src/executables/dart_test.dart
@@ -1,0 +1,193 @@
+import 'dart:io';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_process_tools/shorebird_process_tools.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group(Dart, () {
+    late ProcessWrapper processWrapper;
+    late ShorebirdProcessResult processResult;
+    late Dart dart;
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        () => body(),
+        values: {
+          processRef.overrideWith(() => processWrapper),
+        },
+      );
+    }
+
+    setUp(() {
+      processWrapper = MockProcessWrapper();
+      processResult = MockShorebirdProcessResult();
+      dart = Dart();
+
+      when(() => processResult.exitCode).thenReturn(0);
+      when(() => processResult.stdout).thenReturn('');
+      when(() => processResult.stderr).thenReturn('');
+
+      when(
+        () => processWrapper.run(
+          any(),
+          any(),
+          workingDirectory: any(named: 'workingDirectory'),
+        ),
+      ).thenAnswer((_) async => processResult);
+    });
+
+    test('has access to dart reference', () {
+      expect(
+        runScoped(() => dart, values: {dartRef}),
+        isA<Dart>(),
+      );
+    });
+
+    test('has correct executable name', () {
+      expect(Dart.executable, equals('dart'));
+    });
+
+    group('format', () {
+      setUp(() {
+        when(() => processResult.exitCode).thenReturn(0);
+        when(() => processResult.stdout).thenReturn('');
+      });
+
+      test('runs dart format with correct arguments', () async {
+        await runWithOverrides(
+          () => dart.format(path: '/test/path'),
+        );
+
+        verify(
+          () => processWrapper.run(
+            'dart',
+            ['format', '/test/path'],
+          ),
+        ).called(1);
+      });
+
+      test('includes --set-exit-if-changed when specified', () async {
+        await runWithOverrides(
+          () => dart.format(
+            path: '/test/path',
+            setExitIfChanged: true,
+          ),
+        );
+
+        verify(
+          () => processWrapper.run(
+            'dart',
+            ['format', '--set-exit-if-changed', '/test/path'],
+          ),
+        ).called(1);
+      });
+
+      group('when format succeeds', () {
+        setUp(() {
+          when(() => processResult.exitCode).thenReturn(0);
+          when(() => processResult.stdout).thenReturn('Formatted 2 files');
+        });
+
+        test('returns correct result', () async {
+          final result = await runWithOverrides(
+            () => dart.format(path: '/test/path'),
+          );
+
+          expect(result.isFormattedCorrectly, isTrue);
+          expect(result.output, equals('Formatted 2 files'));
+        });
+      });
+
+      group('when format fails', () {
+        setUp(() {
+          when(() => processResult.exitCode).thenReturn(1);
+          when(() => processResult.stdout).thenReturn('Format failed');
+        });
+
+        test('returns correct result', () async {
+          final result = await runWithOverrides(
+            () => dart.format(path: '/test/path'),
+          );
+
+          expect(result.isFormattedCorrectly, isFalse);
+          expect(result.output, equals('Format failed'));
+        });
+      });
+    });
+
+    group('pubGet', () {
+      setUp(() {
+        when(() => processResult.exitCode).thenReturn(0);
+        when(
+          () => processResult.stdout,
+        ).thenReturn('Resolving dependencies...');
+      });
+
+      test('runs dart pub get with correct arguments', () async {
+        await runWithOverrides(
+          () => dart.pubGet(path: '/test/path'),
+        );
+
+        verify(
+          () => processWrapper.run(
+            'dart',
+            ['pub', 'get'],
+            workingDirectory: '/test/path',
+          ),
+        ).called(1);
+      });
+
+      group('when pub get succeeds', () {
+        setUp(() {
+          when(() => processResult.exitCode).thenReturn(0);
+        });
+
+        test('completes normally', () async {
+          await expectLater(
+            runWithOverrides(
+              () => dart.pubGet(path: '/test/path'),
+            ),
+            completes,
+          );
+        });
+      });
+
+      group('when pub get fails', () {
+        setUp(() {
+          when(() => processResult.exitCode).thenReturn(1);
+          when(() => processResult.stderr).thenReturn('Package not found');
+        });
+
+        test('throws ProcessException with correct error message', () async {
+          await expectLater(
+            runWithOverrides(
+              () => dart.pubGet(path: '/test/path'),
+            ),
+            throwsA(
+              isA<ProcessException>()
+                  .having(
+                    (e) => e.executable,
+                    'executable',
+                    'dart',
+                  )
+                  .having(
+                    (e) => e.arguments,
+                    'arguments',
+                    ['pub', 'get'],
+                  )
+                  .having(
+                    (e) => e.message,
+                    'message',
+                    'Package not found',
+                  ),
+            ),
+          );
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds a basic Dart executable that supports `format` and `pub get`

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
