### PR TITLE
chore(shorebird_cli): update bundletool from 1.17.1 to 1.18.1

### DIFF
--- a/packages/shorebird_cli/lib/src/cache.dart
+++ b/packages/shorebird_cli/lib/src/cache.dart
@@ -372,7 +372,7 @@ class BundleToolArtifact extends CachedArtifact {
 
   @override
   String get storageUrl {
-    return 'https://github.com/google/bundletool/releases/download/1.17.1/bundletool-all-1.17.1.jar';
+    return 'https://github.com/google/bundletool/releases/download/1.18.1/bundletool-all-1.18.1.jar';
   }
 
   @override
@@ -383,5 +383,5 @@ class BundleToolArtifact extends CachedArtifact {
       // ```shell
       // shasum --algorithm 256 /path/to/file
       // ```
-      '''45881ead13388872d82c4255b195488b7fc33f2cac5a9a977b0afc5e92367592''';
+      '''675786493983787ffa11550bdb7c0715679a44e1643f3ff980a529e9c822595c''';
 }

--- a/packages/shorebird_cli/test/src/cache_test.dart
+++ b/packages/shorebird_cli/test/src/cache_test.dart
@@ -355,7 +355,7 @@ void main() {
 
           final expected = [
             perEngine('patch-darwin-x64.zip'),
-            'https://github.com/google/bundletool/releases/download/1.17.1/bundletool-all-1.17.1.jar',
+            'https://github.com/google/bundletool/releases/download/1.18.1/bundletool-all-1.18.1.jar',
             perEngine('aot-tools.dill'),
           ].map(Uri.parse).toList();
 
@@ -379,7 +379,7 @@ void main() {
 
           final expected = [
             perEngine('patch-windows-x64.zip'),
-            'https://github.com/google/bundletool/releases/download/1.17.1/bundletool-all-1.17.1.jar',
+            'https://github.com/google/bundletool/releases/download/1.18.1/bundletool-all-1.18.1.jar',
             perEngine('aot-tools.dill'),
           ].map(Uri.parse).toList();
 
@@ -403,7 +403,7 @@ void main() {
 
           final expected = [
             perEngine('patch-linux-x64.zip'),
-            'https://github.com/google/bundletool/releases/download/1.17.1/bundletool-all-1.17.1.jar',
+            'https://github.com/google/bundletool/releases/download/1.18.1/bundletool-all-1.18.1.jar',
             perEngine('aot-tools.dill'),
           ].map(Uri.parse).toList();
 


### PR DESCRIPTION
Fixes https://github.com/shorebirdtech/shorebird/issues/3194