### PR TITLE
chore: clarify that app id comes from shorebird.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,7 +5,7 @@ title: "fix: "
 labels: bug
 ---
 
-App ID: (insert your app ID here)
+App ID: (insert the app ID from your shorebird.yaml here)
 
 **Description**
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,7 +5,7 @@ title: "fix: "
 labels: bug
 ---
 
-App ID: (insert the app ID from your shorebird.yaml here)
+App ID: (insert the app_id from your shorebird.yaml here)
 
 **Description**
 


### PR DESCRIPTION
## Description

It's very common for people filing bugs to provide their bundle ID instead of their shorebird app ID. This PR adds clarification to reduce the confusion.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
