### PR TITLE
fix: set the low-link-percentage warning threshold to 90 rather than 75

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -30,7 +30,7 @@ abstract class Patcher {
   });
 
   /// Link percentage below which a warning is issued.
-  static const double linkPercentageWarningThreshold = 75;
+  static const double linkPercentageWarningThreshold = 90;
 
   /// The standard link percentage warning.
   static String lowLinkPercentageWarning(double linkPercentage) {


### PR DESCRIPTION
I was under the impression that this threshold also would cause a build to fail if below this, however the code does not seem to fail, just warn.

I think we should consider changing the code to fail when below this percentage, possibly unifying this logic with --min-link-percentage