### PR TITLE
feat: support --flutter-version=fvm and --flutter-version=system

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -10,6 +10,7 @@ import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
+import 'package:shorebird_cli/src/executables/flutter_version.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/extensions/string.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
@@ -21,6 +22,7 @@ import 'package:shorebird_cli/src/shorebird_command.dart';
 import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_cli/src/version.dart';
@@ -95,7 +97,12 @@ class ReleaseCommand extends ShorebirdCommand {
         help: '''
 The Flutter version to use when building the app (e.g: 3.16.3).
 This option also accepts Flutter commit hashes (e.g. 611a4066f1).
-Defaults to "latest" which builds using the latest stable Flutter version.''',
+Note that the commit hash is for Shorebird's fork of Flutter, not upstream.
+Also accepts special values:
+  * "system" calls `flutter --version` to get the version.
+  * "fvm" calls `fvm flutter --version` to get the version.
+  * "latest" builds using the latest stable Flutter version.
+''',
       )
       ..addOption(
         'artifact',
@@ -369,6 +376,12 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
   /// specified by the user is not found/supported.
   Future<String> resolveTargetFlutterRevision() async {
     if (flutterVersionArg == 'latest') return shorebirdEnv.flutterRevision;
+    if (flutterVersionArg == 'system') {
+      return flutterVersionFromSystemFlutter(process);
+    }
+    if (flutterVersionArg == 'fvm') {
+      return flutterVersionFromFVMFlutter(process);
+    }
 
     final String? revision;
     try {

--- a/packages/shorebird_cli/lib/src/executables/flutter_version.dart
+++ b/packages/shorebird_cli/lib/src/executables/flutter_version.dart
@@ -1,0 +1,41 @@
+import 'package:shorebird_cli/src/shorebird_process.dart';
+
+/// Parses the output of `flutter --version` to get the version number.
+///
+/// The output of `flutter --version` is of the form:
+///
+/// ```text
+/// Flutter 3.32.4 • channel stable • https://github.com/flutter/flutter.git
+/// Framework • revision 6fba2447e9 (5 weeks ago) • 2025-06-12 19:03:56 -0700
+/// Engine • revision 8cd19e509d (5 weeks ago) • 2025-06-12 16:30:12 -0700
+/// Tools • Dart 3.8.1 • DevTools 2.45.1
+/// ```
+String parseFlutterVersionFromOutput(String output) {
+  final lines = output.split('\n');
+  for (final line in lines) {
+    if (line.contains('Flutter')) {
+      return line.split(' ')[1].trim();
+    }
+  }
+  throw Exception('Failed to parse Flutter version from output: $output');
+}
+
+/// Returns the Flutter version from a system-installed Flutter if available.
+String flutterVersionFromSystemFlutter(ShorebirdProcess process) {
+  try {
+    final output = process.runSync('flutter', ['--version']);
+    return parseFlutterVersionFromOutput(output.stdout as String);
+  } on Exception catch (e) {
+    throw Exception('Failed to get Flutter version from `flutter` on path: $e');
+  }
+}
+
+/// Returns the Flutter version from a FVM-installed Flutter if available.
+String flutterVersionFromFVMFlutter(ShorebirdProcess process) {
+  try {
+    final output = process.runSync('fvm', ['flutter', '--version']);
+    return parseFlutterVersionFromOutput(output.stdout as String);
+  } on Exception catch (e) {
+    throw Exception('Failed to get Flutter version from `fvm flutter`: $e');
+  }
+}

--- a/packages/shorebird_cli/lib/src/executables/flutter_version.dart
+++ b/packages/shorebird_cli/lib/src/executables/flutter_version.dart
@@ -10,14 +10,21 @@ import 'package:shorebird_cli/src/shorebird_process.dart';
 /// Engine • revision 8cd19e509d (5 weeks ago) • 2025-06-12 16:30:12 -0700
 /// Tools • Dart 3.8.1 • DevTools 2.45.1
 /// ```
+String? maybeParseFlutterVersionFromOutput(String output) {
+  final flutterVersionRegex = RegExp(r'Flutter (\d+.\d+.\d+)');
+  final match = flutterVersionRegex.firstMatch(output);
+  return match?.group(1);
+}
+
+/// Parses the output of `flutter --version` to get the version number.
+/// Unlike [maybeParseFlutterVersionFromOutput], this method throws an exception
+/// if the version cannot be parsed.
 String parseFlutterVersionFromOutput(String output) {
-  final lines = output.split('\n');
-  for (final line in lines) {
-    if (line.contains('Flutter')) {
-      return line.split(' ')[1].trim();
-    }
+  final version = maybeParseFlutterVersionFromOutput(output);
+  if (version == null) {
+    throw Exception('Failed to parse Flutter version from output: $output');
   }
-  throw Exception('Failed to parse Flutter version from output: $output');
+  return version;
 }
 
 /// Returns the Flutter version from a system-installed Flutter if available.

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
+import 'package:shorebird_cli/src/executables/flutter_version.dart';
 import 'package:shorebird_cli/src/extensions/version.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/platform.dart';
@@ -115,10 +116,7 @@ class ShorebirdFlutter {
     }
 
     final output = result.stdout.toString();
-    final flutterVersionRegex = RegExp(r'Flutter (\d+.\d+.\d+)');
-    final match = flutterVersionRegex.firstMatch(output);
-
-    return match?.group(1);
+    return maybeParseFlutterVersionFromOutput(output);
   }
 
   /// Executes `flutter config --list` and returns the output as a map.

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -17,6 +17,7 @@ import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_flutter.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:test/test.dart';
@@ -64,6 +65,7 @@ void main() {
     late ShorebirdEnv shorebirdEnv;
     late ShorebirdFlutter shorebirdFlutter;
     late ShorebirdValidator shorebirdValidator;
+    late ShorebirdProcess process; // Only used by resolveTargetFlutterRevision.
 
     late ReleaseCommand command;
 
@@ -77,6 +79,7 @@ void main() {
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
           shorebirdFlutterRef.overrideWith(() => shorebirdFlutter),
           shorebirdValidatorRef.overrideWith(() => shorebirdValidator),
+          processRef.overrideWith(() => process),
         },
       );
     }
@@ -101,6 +104,7 @@ void main() {
       shorebirdEnv = MockShorebirdEnv();
       shorebirdFlutter = MockShorebirdFlutter();
       shorebirdValidator = MockShorebirdValidator();
+      process = MockShorebirdProcess();
 
       when(() => argResults['dry-run']).thenReturn(false);
       when(() => argResults['platforms']).thenReturn(['android']);
@@ -632,6 +636,74 @@ $exception'''),
 At least Flutter $laterFlutterVersion is required to release with `${releaseType.name}`.
 For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
         ).called(1);
+      });
+    });
+
+    group('resolveTargetFlutterRevision', () {
+      test('flutter-version=latest', () async {
+        const flutterRevision = '1.2.3';
+        when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
+        const flutterVersionArg = 'latest';
+        final resolvedFlutterRevision = await runWithOverrides(
+          () => resolveTargetFlutterRevision(flutterVersionArg),
+        );
+        verify(
+          () => shorebirdEnv.flutterRevision,
+        ).called(1);
+        expect(resolvedFlutterRevision, equals(flutterRevision));
+      });
+
+      test('flutter-version=system', () async {
+        const flutterRevision = '3.32.4';
+        const flutterVersionArg = 'system';
+        when(() => process.runSync('flutter', ['--version'])).thenReturn(
+          const ShorebirdProcessResult(
+            exitCode: 0,
+            stdout: '''
+Flutter 3.32.4 • channel stable • https://github.com/flutter/flutter.git
+Framework • revision 6fba2447e9 (5 weeks ago) • 2025-06-12 19:03:56 -0700
+Engine • revision 8cd19e509d (5 weeks ago) • 2025-06-12 16:30:12 -0700
+Tools • Dart 3.8.1 • DevTools 2.45.1
+''',
+            stderr: '',
+          ),
+        );
+        final resolvedFlutterRevision = await runWithOverrides(
+          () => resolveTargetFlutterRevision(flutterVersionArg),
+        );
+        expect(resolvedFlutterRevision, equals(flutterRevision));
+      });
+
+      test('flutter-version=fvm', () async {
+        const flutterRevision = '3.32.4';
+        const flutterVersionArg = 'fvm';
+        when(() => process.runSync('fvm', ['flutter', '--version'])).thenReturn(
+          const ShorebirdProcessResult(
+            exitCode: 0,
+            stdout: '''
+Flutter 3.32.4 • channel stable • https://github.com/flutter/flutter.git
+Framework • revision 6fba2447e9 (5 weeks ago) • 2025-06-12 19:03:56 -0700
+Engine • revision 8cd19e509d (5 weeks ago) • 2025-06-12 16:30:12 -0700
+Tools • Dart 3.8.1 • DevTools 2.45.1
+''',
+            stderr: '',
+          ),
+        );
+        final resolvedFlutterRevision = await runWithOverrides(
+          () => resolveTargetFlutterRevision(flutterVersionArg),
+        );
+        expect(resolvedFlutterRevision, equals(flutterRevision));
+      });
+
+      test('flutter-version=3.16.3', () async {
+        const flutterVersionArg = '3.16.3';
+        when(
+          () => shorebirdFlutter.resolveFlutterRevision(any()),
+        ).thenAnswer((_) async => flutterVersionArg);
+        final resolvedFlutterRevision = await runWithOverrides(
+          () => resolveTargetFlutterRevision(flutterVersionArg),
+        );
+        expect(resolvedFlutterRevision, equals(flutterVersionArg));
       });
     });
   });

--- a/packages/shorebird_cli/test/src/executables/flutter_version_test.dart
+++ b/packages/shorebird_cli/test/src/executables/flutter_version_test.dart
@@ -1,0 +1,114 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:shorebird_cli/src/executables/flutter_version.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group('flutterVersionFromSystemFlutter', () {
+    test('returns the Flutter version from the output', () {
+      final process = MockShorebirdProcess();
+      const output = '''
+Flutter 3.32.4 • channel stable • https://github.com/flutter/flutter.git
+Framework • revision 6fba2447e9 (5 weeks ago) • 2025-06-12 19:03:56 -0700
+Engine • revision 8cd19e509d (5 weeks ago) • 2025-06-12 16:30:12 -0700
+Tools • Dart 3.8.1 • DevTools 2.45.1
+      ''';
+      when(() => process.runSync('flutter', ['--version'])).thenReturn(
+        const ShorebirdProcessResult(
+          exitCode: 0,
+          stdout: output,
+          stderr: '',
+        ),
+      );
+      expect(flutterVersionFromSystemFlutter(process), '3.32.4');
+    });
+
+    test(
+      'throws an exception if the output does not contain a Flutter version',
+      () {
+        final process = MockShorebirdProcess();
+        const output = '''
+Framework • revision 6fba2447e9 (5 weeks ago) • 2025-06-12 19:03:56 -0700
+Engine • revision 8cd19e509d (5 weeks ago) • 2025-06-12 16:30:12 -0700
+Tools • Dart 3.8.1 • DevTools 2.45.1
+      ''';
+        when(() => process.runSync('flutter', ['--version'])).thenReturn(
+          const ShorebirdProcessResult(
+            exitCode: 0,
+            stdout: output,
+            stderr: '',
+          ),
+        );
+        expect(
+          () => flutterVersionFromSystemFlutter(process),
+          throwsA(isA<Exception>()),
+        );
+      },
+    );
+    test('throws an exception if the process fails', () {
+      final process = MockShorebirdProcess();
+      when(() => process.runSync('flutter', ['--version'])).thenThrow(
+        Exception('Failed to run flutter'),
+      );
+      expect(
+        () => flutterVersionFromSystemFlutter(process),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('flutterVersionFromFVMFlutter', () {
+    test('returns the Flutter version from the output', () {
+      final process = MockShorebirdProcess();
+      const output = '''
+Flutter 3.32.4 • channel stable • https://github.com/flutter/flutter.git
+Framework • revision 6fba2447e9 (5 weeks ago) • 2025-06-12 19:03:56 -0700
+Engine • revision 8cd19e509d (5 weeks ago) • 2025-06-12 16:30:12 -0700
+Tools • Dart 3.8.1 • DevTools 2.45.1
+      ''';
+      when(() => process.runSync('fvm', ['flutter', '--version'])).thenReturn(
+        const ShorebirdProcessResult(
+          exitCode: 0,
+          stdout: output,
+          stderr: '',
+        ),
+      );
+      expect(flutterVersionFromFVMFlutter(process), '3.32.4');
+    });
+
+    test(
+      'throws an exception if the output does not contain a Flutter version',
+      () {
+        final process = MockShorebirdProcess();
+        const output = '''
+Framework • revision 6fba2447e9 (5 weeks ago) • 2025-06-12 19:03:56 -0700
+Engine • revision 8cd19e509d (5 weeks ago) • 2025-06-12 16:30:12 -0700
+Tools • Dart 3.8.1 • DevTools 2.45.1
+      ''';
+        when(() => process.runSync('fvm', ['flutter', '--version'])).thenReturn(
+          const ShorebirdProcessResult(
+            exitCode: 0,
+            stdout: output,
+            stderr: '',
+          ),
+        );
+        expect(
+          () => flutterVersionFromFVMFlutter(process),
+          throwsA(isA<Exception>()),
+        );
+      },
+    );
+    test('throws an exception if the process fails', () {
+      final process = MockShorebirdProcess();
+      when(() => process.runSync('fvm', ['flutter', '--version'])).thenThrow(
+        Exception('Failed to run fvm flutter'),
+      );
+      expect(
+        () => flutterVersionFromFVMFlutter(process),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
I chose this approach so we didn't have to write any code to read .fvmrc files, and all we do is just know to run `fvm flutter` rather than `flutter` when determining the version from the system-available flutter.

Fixes https://github.com/shorebirdtech/shorebird/issues/1385

And is part of potentially fixing https://github.com/shorebirdtech/shorebird/issues/2529.