### PR TITLE
feat: Add support for signing macOS PKG installers and implement productbuild functionality

### DIFF
--- a/packages/shorebird_cli/bin/shorebird.dart
+++ b/packages/shorebird_cli/bin/shorebird.dart
@@ -79,6 +79,7 @@ Command: shorebird ${args.join(' ')}
           patchDiffCheckerRef,
           platformRef,
           powershellRef,
+          productBuildRef,
           processRef,
           pubspecEditorRef,
           shorebirdAndroidArtifactsRef,

--- a/packages/shorebird_cli/lib/src/commands/release/macos_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/macos_releaser.dart
@@ -10,7 +10,7 @@ import 'package:shorebird_cli/src/artifact_manager.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/doctor.dart';
-import 'package:shorebird_cli/src/executables/xcodebuild.dart';
+import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logging/shorebird_logger.dart';
 import 'package:shorebird_cli/src/metadata/update_release_metadata.dart';
@@ -34,6 +34,9 @@ class MacosReleaser extends Releaser {
 
   /// Whether to codesign the release.
   bool get codesign => argResults['codesign'] == true;
+
+  /// The Developer ID Installer identity to sign the PKG with, if provided.
+  String? get pkgSign => argResults['pkg-sign'] as String?;
 
   @override
   ReleaseType get releaseType => ReleaseType.macos;
@@ -108,7 +111,52 @@ To change the version of this release, change your app's version in your pubspec
       throw ProcessExit(ExitCode.software.code);
     }
 
+    // If PKG signing is requested, create a PKG installer as an additional
+    // artifact
+    if (pkgSign != null) {
+      await _createPkgInstaller(appDirectory);
+    }
+
+    // Always return the app directory for other processes to continue with
     return appDirectory;
+  }
+
+  /// Creates a signed PKG installer from the built app.
+  Future<File> _createPkgInstaller(Directory appDirectory) async {
+    final buildDir = Directory(
+      p.join(
+        shorebirdEnv.getShorebirdProjectRoot()!.path,
+        'build',
+        'macos',
+        'pkg',
+      ),
+    );
+
+    if (!buildDir.existsSync()) {
+      buildDir.createSync(recursive: true);
+    }
+
+    final appName = p.basenameWithoutExtension(appDirectory.path);
+    final pkgPath = p.join(buildDir.path, '$appName.pkg');
+
+    // Create signed PKG installer directly with productbuild
+    final buildProgress = logger.progress('Creating signed PKG installer');
+    final productBuildResult = await productBuild.buildFromComponent(
+      componentPath: appDirectory.path,
+      installLocation: '/Applications',
+      outputPath: pkgPath,
+      sign: pkgSign,
+    );
+
+    if (productBuildResult.exitCode != 0) {
+      buildProgress.fail('Failed to create signed PKG installer');
+      logger.err('productbuild error: ${productBuildResult.stderr}');
+      throw ProcessExit(ExitCode.software.code);
+    }
+    buildProgress.complete();
+
+    logger.info('Created signed PKG installer at $pkgPath');
+    return File(pkgPath);
   }
 
   @override
@@ -172,9 +220,27 @@ To change the version of this release, change your app's version in your pubspec
   );
 
   @override
-  String get postReleaseInstructions =>
-      '''
+  String get postReleaseInstructions {
+    final appPath = artifactManager.getMacOSAppDirectory(flavor: flavor)!.path;
 
-macOS app created at ${artifactManager.getMacOSAppDirectory(flavor: flavor)!.path}.
+    if (pkgSign != null) {
+      final buildDir = p.join(
+        shorebirdEnv.getShorebirdProjectRoot()!.path,
+        'build',
+        'macos',
+        'pkg',
+      );
+      return '''
+
+macOS app created at $appPath.
+macOS PKG installer created at $buildDir.
+The PKG file is signed and ready for distribution.
 ''';
+    }
+
+    return '''
+
+macOS app created at $appPath.
+''';
+  }
 }

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -148,6 +148,13 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
       ..addOption(
         CommonArguments.splitDebugInfoArg.name,
         help: CommonArguments.splitDebugInfoArg.description,
+      )
+      ..addOption(
+        'pkg-sign',
+        help:
+            'The Developer ID Installer identity to sign the macOS PKG '
+            'installer with (macOS only). For example: '
+            '"3rd Party Mac Developer Installer: <Team Name> (<Team ID>)"',
       );
   }
 

--- a/packages/shorebird_cli/lib/src/executables/executables.dart
+++ b/packages/shorebird_cli/lib/src/executables/executables.dart
@@ -1,4 +1,5 @@
-// cspell:words bundletool devicectl gradlew idevicesyslog xcodebuild
+// cspell:words bundletool devicectl gradlew idevicesyslog productbuild
+// cspell:words xcodebuild
 
 export 'adb.dart';
 export 'aot_tools.dart';
@@ -13,5 +14,6 @@ export 'java.dart';
 export 'open.dart';
 export 'patch_executable.dart';
 export 'powershell.dart';
+export 'productbuild.dart';
 export 'shorebird_tools.dart';
 export 'xcodebuild.dart';

--- a/packages/shorebird_cli/lib/src/executables/productbuild.dart
+++ b/packages/shorebird_cli/lib/src/executables/productbuild.dart
@@ -1,0 +1,69 @@
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
+
+/// A reference to a [ProductBuild] instance.
+final productBuildRef = create(ProductBuild.new);
+
+/// The [ProductBuild] instance available in the current zone.
+ProductBuild get productBuild => read(productBuildRef);
+
+/// {@template productbuild}
+/// A wrapper around the `productbuild` command.
+/// {@endtemplate}
+class ProductBuild {
+  /// {@macro productbuild}
+  const ProductBuild();
+
+  /// The path to the `productbuild` executable.
+  static const executable = 'productbuild';
+
+  /// Creates a signed macOS installer package from component packages.
+  Future<ShorebirdProcessResult> build({
+    required String packagePath,
+    required String outputPath,
+    String? sign,
+  }) async {
+    final args = <String>[
+      '--package',
+      packagePath,
+    ];
+
+    if (sign != null) {
+      args.addAll(['--sign', sign]);
+    }
+
+    args.add(outputPath);
+
+    return process.run(
+      executable,
+      args,
+      runInShell: true,
+    );
+  }
+
+  /// Creates a signed macOS installer package from a component.
+  Future<ShorebirdProcessResult> buildFromComponent({
+    required String componentPath,
+    required String installLocation,
+    required String outputPath,
+    String? sign,
+  }) async {
+    final args = <String>[
+      '--component',
+      componentPath,
+      installLocation,
+    ];
+
+    if (sign != null) {
+      args.addAll(['--sign', sign]);
+    }
+
+    args.add(outputPath);
+
+    return process.run(
+      executable,
+      args,
+      runInShell: true,
+    );
+  }
+}

--- a/packages/shorebird_cli/test/src/executables/productbuild_test.dart
+++ b/packages/shorebird_cli/test/src/executables/productbuild_test.dart
@@ -1,0 +1,189 @@
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_cli/src/executables/executables.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group(ProductBuild, () {
+    late ShorebirdProcess process;
+    late ProductBuild productBuildExecutable;
+
+    setUp(() {
+      process = MockShorebirdProcess();
+      productBuildExecutable = const ProductBuild();
+    });
+
+    group('build', () {
+      test(
+        'builds package from existing package with required arguments',
+        () async {
+          when(
+            () => process.run(
+              any(),
+              any(),
+              runInShell: any(named: 'runInShell'),
+            ),
+          ).thenAnswer(
+            (_) async => ShorebirdProcessResult(
+              exitCode: ExitCode.success.code,
+              stdout: '',
+              stderr: '',
+            ),
+          );
+
+          await runScoped(
+            () => productBuildExecutable.build(
+              packagePath: '/path/to/input.pkg',
+              outputPath: '/path/to/output.pkg',
+            ),
+            values: {
+              processRef.overrideWith(() => process),
+            },
+          );
+
+          verify(
+            () => process.run(
+              'productbuild',
+              [
+                '--package',
+                '/path/to/input.pkg',
+                '/path/to/output.pkg',
+              ],
+              runInShell: true,
+            ),
+          ).called(1);
+        },
+      );
+
+      test('builds package with signing identity', () async {
+        when(
+          () => process.run(
+            any(),
+            any(),
+            runInShell: any(named: 'runInShell'),
+          ),
+        ).thenAnswer(
+          (_) async => ShorebirdProcessResult(
+            exitCode: ExitCode.success.code,
+            stdout: '',
+            stderr: '',
+          ),
+        );
+
+        await runScoped(
+          () => productBuildExecutable.build(
+            packagePath: '/path/to/input.pkg',
+            outputPath: '/path/to/output.pkg',
+            sign: 'Developer ID Installer: Test Company (XXXXXXXXX)',
+          ),
+          values: {
+            processRef.overrideWith(() => process),
+          },
+        );
+
+        verify(
+          () => process.run(
+            'productbuild',
+            [
+              '--package',
+              '/path/to/input.pkg',
+              '--sign',
+              'Developer ID Installer: Test Company (XXXXXXXXX)',
+              '/path/to/output.pkg',
+            ],
+            runInShell: true,
+          ),
+        ).called(1);
+      });
+    });
+
+    group('buildFromComponent', () {
+      test('builds package from component with required arguments', () async {
+        when(
+          () => process.run(
+            any(),
+            any(),
+            runInShell: any(named: 'runInShell'),
+          ),
+        ).thenAnswer(
+          (_) async => ShorebirdProcessResult(
+            exitCode: ExitCode.success.code,
+            stdout: '',
+            stderr: '',
+          ),
+        );
+
+        await runScoped(
+          () => productBuildExecutable.buildFromComponent(
+            componentPath: '/path/to/app.app',
+            installLocation: '/Applications',
+            outputPath: '/path/to/output.pkg',
+          ),
+          values: {
+            processRef.overrideWith(() => process),
+          },
+        );
+
+        verify(
+          () => process.run(
+            'productbuild',
+            [
+              '--component',
+              '/path/to/app.app',
+              '/Applications',
+              '/path/to/output.pkg',
+            ],
+            runInShell: true,
+          ),
+        ).called(1);
+      });
+
+      test('builds package from component with signing identity', () async {
+        when(
+          () => process.run(
+            any(),
+            any(),
+            runInShell: any(named: 'runInShell'),
+          ),
+        ).thenAnswer(
+          (_) async => ShorebirdProcessResult(
+            exitCode: ExitCode.success.code,
+            stdout: '',
+            stderr: '',
+          ),
+        );
+
+        await runScoped(
+          () => productBuildExecutable.buildFromComponent(
+            componentPath: '/path/to/app.app',
+            installLocation: '/Applications',
+            outputPath: '/path/to/output.pkg',
+            sign: 'Developer ID Installer: Test Company (XXXXXXXXX)',
+          ),
+          values: {
+            processRef.overrideWith(() => process),
+          },
+        );
+
+        verify(
+          () => process.run(
+            'productbuild',
+            [
+              '--component',
+              '/path/to/app.app',
+              '/Applications',
+              '--sign',
+              'Developer ID Installer: Test Company (XXXXXXXXX)',
+              '/path/to/output.pkg',
+            ],
+            runInShell: true,
+          ),
+        ).called(1);
+      });
+    });
+  });
+}


### PR DESCRIPTION
# PR: Add support for signing macOS PKG installers and implement productbuild functionality

## Description

This PR introduces support for signing macOS PKG installers and implements the necessary productbuild functionality. The changes include:
- Added a wrapper for the `productbuild` command to create signed PKG installers.
- Updated the macOS release flow to optionally generate a signed PKG installer if a signing identity is provided.
- Extended CLI options to allow specifying a Developer ID Installer identity for PKG signing.
- Added tests for the new productbuild functionality.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Files Changed
- `packages/shorebird_cli/bin/shorebird.dart`
- `packages/shorebird_cli/lib/src/commands/release/macos_releaser.dart`
- `packages/shorebird_cli/lib/src/commands/release/release_command.dart`
- `packages/shorebird_cli/lib/src/executables/executables.dart`
- `packages/shorebird_cli/lib/src/executables/productbuild.dart` (new)
- `packages/shorebird_cli/test/src/executables/productbuild_test.dart` (new)

## Summary
- Implements signed PKG installer creation for macOS releases.
- Adds CLI option for specifying PKG signing identity.
- Adds productbuild wrapper and related tests.

---

Please review and let me know if further changes are needed.
