### PR TITLE
refactor(flutter_version_resolver): replace scoped dep logger with log fn

### DIFF
--- a/packages/flutter_version_resolver/bin/flutter_version_resolver.dart
+++ b/packages/flutter_version_resolver/bin/flutter_version_resolver.dart
@@ -1,9 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_version_resolver/flutter_version_resolver.dart';
-import 'package:flutter_version_resolver/src/logger.dart';
 import 'package:mason_logger/mason_logger.dart';
-import 'package:scoped_deps/scoped_deps.dart';
 
 /// Resolves the Flutter version for a package and optionally writes it to a
 /// file.
@@ -13,34 +11,35 @@ import 'package:scoped_deps/scoped_deps.dart';
 /// dart run bin/flutter_version_resolver.dart <path-to-package> [<output-file>]
 /// ```
 Future<int> main(List<String> arguments) async {
-  return await runScoped(() async {
-    if (arguments.isEmpty || arguments.length > 2) {
-      logger.err(
-        'Usage: dart run bin/flutter_version_resolver.dart <path-to-package> [<output-file>]',
-      );
-      return ExitCode.usage.code;
-    }
+  final logger = Logger();
 
-    final packageDirectory = Directory(arguments[0]);
-    if (!packageDirectory.existsSync()) {
-      logger.err(
-        'Package directory does not exist: ${packageDirectory.path}',
-      );
-      return ExitCode.usage.code;
-    }
-
-    final flutterVersion = resolveFlutterVersion(
-      packagePath: packageDirectory.path,
+  if (arguments.isEmpty || arguments.length > 2) {
+    logger.err(
+      'Usage: dart run bin/flutter_version_resolver.dart <path-to-package> [<output-file>]',
     );
-    logger.info('Resolved Flutter version: $flutterVersion');
+    return ExitCode.usage.code;
+  }
 
-    if (arguments.length > 1) {
-      final outputFile = File(arguments[1])
-        ..createSync(recursive: true)
-        ..writeAsStringSync(flutterVersion);
-      logger.info('Wrote flutter version to ${outputFile.path}');
-    }
+  final packageDirectory = Directory(arguments[0]);
+  if (!packageDirectory.existsSync()) {
+    logger.err(
+      'Package directory does not exist: ${packageDirectory.path}',
+    );
+    return ExitCode.usage.code;
+  }
 
-    return ExitCode.success.code;
-  }, values: {loggerRef});
+  final flutterVersion = resolveFlutterVersion(
+    packagePath: packageDirectory.path,
+    log: logger.info,
+  );
+  logger.info('Resolved Flutter version: $flutterVersion');
+
+  if (arguments.length > 1) {
+    final outputFile = File(arguments[1])
+      ..createSync(recursive: true)
+      ..writeAsStringSync(flutterVersion);
+    logger.info('Wrote flutter version to ${outputFile.path}');
+  }
+
+  return ExitCode.success.code;
 }

--- a/packages/flutter_version_resolver/bin/flutter_version_resolver.dart
+++ b/packages/flutter_version_resolver/bin/flutter_version_resolver.dart
@@ -13,9 +13,9 @@ import 'package:mason_logger/mason_logger.dart';
 Future<int> main(List<String> arguments) async {
   final logger = Logger();
 
-  if (arguments.isEmpty || arguments.length > 2) {
+  if (arguments.isEmpty) {
     logger.err(
-      'Usage: dart run bin/flutter_version_resolver.dart <path-to-package> [<output-file>]',
+      'Usage: dart run bin/flutter_version_resolver.dart <path-to-package>',
     );
     return ExitCode.usage.code;
   }
@@ -33,13 +33,6 @@ Future<int> main(List<String> arguments) async {
     log: logger.info,
   );
   logger.info('Resolved Flutter version: $flutterVersion');
-
-  if (arguments.length > 1) {
-    final outputFile = File(arguments[1])
-      ..createSync(recursive: true)
-      ..writeAsStringSync(flutterVersion);
-    logger.info('Wrote flutter version to ${outputFile.path}');
-  }
 
   return ExitCode.success.code;
 }

--- a/packages/flutter_version_resolver/lib/flutter_version_resolver.dart
+++ b/packages/flutter_version_resolver/lib/flutter_version_resolver.dart
@@ -1,9 +1,11 @@
 import 'dart:io';
 
-import 'package:flutter_version_resolver/src/logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
+
+/// A function that handles log output (e.g. [print]).
+typedef LogFn = void Function(String message);
 
 /// {@template version_constraint_exception}
 /// Thrown when a version constraint is found unexpectedly.
@@ -27,32 +29,31 @@ class VersionConstraintException implements Exception {
 /// If no version is found, this returns the `stable` version.
 String resolveFlutterVersion({
   required String packagePath,
+  required LogFn log,
 }) {
-  logger
-    ..info('Resolving Flutter version for $packagePath')
-    ..info('Checking pubspec.yaml environment section for flutter version');
+  log('Resolving Flutter version for $packagePath');
+  log('Checking pubspec.yaml environment section for flutter version');
 
   try {
     final flutterVersion = flutterVersionFromPubspecEnvironment(
       packagePath: packagePath,
     );
     if (flutterVersion != null) {
-      logger.info('Found flutter version in pubspec.yaml: $flutterVersion');
+      log('Found flutter version in pubspec.yaml: $flutterVersion');
       return flutterVersion.toString();
     }
   } on VersionConstraintException catch (e) {
-    logger.err(
+    log(
       '''Found version constraint: ${e.versionConstraint}. Version constraints are not supported in pubspec.yaml. Please specify a specific version.''',
     );
     return 'stable';
   } on Exception catch (e) {
-    logger
-      ..err('Error resolving Flutter version: $e')
-      ..info('Falling back to "stable" branch');
+    log('Error resolving Flutter version: $e');
+    log('Falling back to "stable" branch');
     return 'stable';
   }
 
-  logger.info('No flutter version found in pubspec.yaml, using stable');
+  log('No flutter version found in pubspec.yaml, using stable');
   return 'stable';
 }
 

--- a/packages/flutter_version_resolver/lib/src/logger.dart
+++ b/packages/flutter_version_resolver/lib/src/logger.dart
@@ -1,8 +1,0 @@
-import 'package:mason_logger/mason_logger.dart';
-import 'package:scoped_deps/scoped_deps.dart';
-
-/// A reference to a [Logger] instance.
-final loggerRef = create(Logger.new);
-
-/// The [Logger] instance available in the current zone.
-Logger get logger => read(loggerRef);

--- a/packages/flutter_version_resolver/pubspec.yaml
+++ b/packages/flutter_version_resolver/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   mason_logger: ^0.3.3
   path: ^1.9.1
   pub_semver: ^2.2.0
-  scoped_deps: ^0.1.0+2
   yaml: ^3.1.3
 
 dev_dependencies:

--- a/packages/flutter_version_resolver/test/flutter_version_resolver_test.dart
+++ b/packages/flutter_version_resolver/test/flutter_version_resolver_test.dart
@@ -1,12 +1,10 @@
 import 'dart:io';
 
 import 'package:flutter_version_resolver/flutter_version_resolver.dart';
-import 'package:flutter_version_resolver/src/logger.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
-import 'package:scoped_deps/scoped_deps.dart';
 import 'package:test/test.dart';
 
 class _MockLogger extends Mock implements Logger {}
@@ -15,13 +13,6 @@ void main() {
   late Logger logger;
   late Directory packageDirectory;
   late File pubspecFile;
-
-  R runWithOverrides<R>(R Function() body) {
-    return runScoped(
-      body,
-      values: {loggerRef.overrideWith(() => logger)},
-    );
-  }
 
   setUp(() {
     logger = _MockLogger();
@@ -37,12 +28,13 @@ void main() {
   group('resolveFlutterVersion', () {
     group('when no flutter version is specified in the pubspec.yaml file', () {
       test('returns the stable version', () {
-        runWithOverrides(() {
-          expect(
-            resolveFlutterVersion(packagePath: packageDirectory.path),
-            equals('stable'),
-          );
-        });
+        expect(
+          resolveFlutterVersion(
+            packagePath: packageDirectory.path,
+            log: logger.info,
+          ),
+          equals('stable'),
+        );
       });
     });
 
@@ -56,12 +48,13 @@ environment:
       });
 
       test('returns the version', () {
-        runWithOverrides(() {
-          expect(
-            resolveFlutterVersion(packagePath: packageDirectory.path),
-            equals('3.20.0'),
-          );
-        });
+        expect(
+          resolveFlutterVersion(
+            packagePath: packageDirectory.path,
+            log: logger.info,
+          ),
+          equals('3.20.0'),
+        );
       });
     });
 
@@ -75,14 +68,15 @@ environment:
       });
 
       test('prints an error message and returns the stable version', () {
-        runWithOverrides(() {
-          expect(
-            resolveFlutterVersion(packagePath: packageDirectory.path),
-            equals('stable'),
-          );
-        });
+        expect(
+          resolveFlutterVersion(
+            packagePath: packageDirectory.path,
+            log: logger.info,
+          ),
+          equals('stable'),
+        );
         verify(
-          () => logger.err(
+          () => logger.info(
             '''Found version constraint: ^3.8.0. Version constraints are not supported in pubspec.yaml. Please specify a specific version.''',
           ),
         ).called(1);


### PR DESCRIPTION
## Description

1. Removes scoped deps, as they are a bit painful to use in dependencies (libraries with scoped deps need to export their refs and their dependencies need to wrap all calls with `runScoped`.
2. Replaces `logger.info` and `logger.err` with a `LogFn`, which gives calling code the ability to consume log output
3. Removes outputFile CLI parameter, as it is not being used.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
