### PR TITLE
feat: add support for proxying engine_stamp.json

### DIFF
--- a/packages/artifact_proxy/lib/config.dart
+++ b/packages/artifact_proxy/lib/config.dart
@@ -54,6 +54,7 @@ final engineArtifactPatterns = {
   r'flutter_infra_release\/flutter\/(.*)\/dart-sdk-linux-arm64\.zip',
   r'flutter_infra_release\/flutter\/(.*)\/dart-sdk-darwin-x64\.zip',
   r'flutter_infra_release\/flutter\/(.*)\/dart-sdk-darwin-arm64\.zip',
+  r'flutter_infra_release\/flutter\/(.*)\/engine_stamp\.json',
   r'flutter_infra_release\/flutter\/(.*)\/android-x86\/artifacts\.zip',
   r'flutter_infra_release\/flutter\/(.*)\/android-x86-jit-release\/artifacts\.zip',
   r'flutter_infra_release\/flutter\/(.*)\/android-x64\/artifacts\.zip',

--- a/packages/artifact_proxy/tool/generate_manifest.sh
+++ b/packages/artifact_proxy/tool/generate_manifest.sh
@@ -48,6 +48,9 @@ artifact_overrides:
   - flutter_infra_release/flutter/\$engine/android-x64-release/symbols.zip
   - flutter_infra_release/flutter/\$engine/android-x64-release/windows-x64.zip
 
+  # engine_stamp.json
+  - flutter_infra_release/flutter/\$engine/engine_stamp.json
+
   # Dart SDK
   - flutter_infra_release/flutter/\$engine/dart-sdk-darwin-arm64.zip
   - flutter_infra_release/flutter/\$engine/dart-sdk-darwin-x64.zip


### PR DESCRIPTION
The latest `flutter` tool requires this:

```
Failed to download https://download.shorebird.dev/flutter_infra_release/flutter/7ffd69b84d0a157acda23956d00d5a13c1bd8283/engine_stamp.json. Ensure you have network connectivity and then try again.
```