### PR TITLE
chore: forward libusbmuxd download to flutter

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -57,6 +57,7 @@ words:
   - libflutter
   - libimobiledevice
   - libplist
+  - libusbmuxd
   - lldb
   - LOCALAPPDATA
   - logcat

--- a/packages/artifact_proxy/lib/config.dart
+++ b/packages/artifact_proxy/lib/config.dart
@@ -121,6 +121,7 @@ final engineArtifactPatterns = {
 /// Patterns for Flutter artifacts which don't depend on an engine revision.
 final flutterArtifactPatterns = {
   r'flutter_infra_release\/ios-usb-dependencies\/usbmuxd\/(.*)\/usbmuxd\.zip',
+  r'flutter_infra_release\/ios-usb-dependencies\/libusbmuxd\/(.*)\/libusbmuxd\.zip',
   r'flutter_infra_release\/ios-usb-dependencies\/openssl\/(.*)\/openssl\.zip',
   r'flutter_infra_release\/ios-usb-dependencies\/libplist\/(.*)\/libplist\.zip',
   r'flutter_infra_release\/ios-usb-dependencies\/libimobiledevice\/(.*)\/libimobiledevice\.zip',


### PR DESCRIPTION
I'm not sure if usbmuxd has been renamed or if this is separate, but forwarding both for now.