### PR TITLE
fix(shorebird_cli): improve error message when xcodeproj is missing

### DIFF
--- a/packages/shorebird_cli/lib/src/platform/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple.dart
@@ -49,21 +49,28 @@ class LinkResult {
 }
 
 /// {@template missing_xcode_project_exception}
-/// Thrown when the Flutter project does not have iOS configured as a platform.
+/// Thrown when the Flutter project has an ios or macos folder that is missing
+/// an Xcode project.
 /// {@endtemplate}
 class MissingXcodeProjectException implements Exception {
   /// {@macro missing_xcode_project_exception}
-  const MissingXcodeProjectException(this.projectPath);
+  const MissingXcodeProjectException({
+    required this.platformFolderPath,
+    required this.platform,
+  });
 
-  /// Expected path of the XCode project.
-  final String projectPath;
+  /// Expected path of the Xcode project.
+  final String platformFolderPath;
+
+  /// The platform that is missing an Xcode project.
+  final ApplePlatform platform;
 
   @override
   String toString() {
     return '''
-Could not find an Xcode project in $projectPath.
-To add iOS, run "flutter create . --platforms ios"
-To add macOS, run "flutter create . --platforms macos"''';
+Could not find an Xcode project in $platformFolderPath.
+If your project does not support ${platform.name}, you can safely remove $platformFolderPath.
+Otherwise, to add ${platform.name}, run "flutter create . --platforms ${platform.name}"''';
   }
 }
 
@@ -214,7 +221,10 @@ class Apple {
         .whereType<Directory>()
         .firstWhereOrNull((d) => p.extension(d.path) == '.xcodeproj');
     if (xcodeProjDirectory == null) {
-      throw MissingXcodeProjectException(projectRoot.path);
+      throw MissingXcodeProjectException(
+        platformFolderPath: platformDir.path,
+        platform: platform,
+      );
     }
 
     final xcschemesDir = Directory(

--- a/packages/shorebird_cli/lib/src/platform/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple.dart
@@ -70,7 +70,7 @@ class MissingXcodeProjectException implements Exception {
     return '''
 Could not find an Xcode project in $platformFolderPath.
 If your project does not support ${platform.name}, you can safely remove $platformFolderPath.
-Otherwise, to add ${platform.name}, run "flutter create . --platforms ${platform.name}"''';
+Otherwise, to repair ${platform.name}, run "flutter create . --platforms ${platform.name}"''';
   }
 }
 

--- a/packages/shorebird_cli/test/src/commands/init_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/init_command_test.dart
@@ -493,7 +493,12 @@ Please make sure you are running "shorebird init" from within your Flutter proje
         setUp(() {
           when(
             () => apple.flavors(platform: any(named: 'platform')),
-          ).thenThrow(MissingXcodeProjectException(projectRoot.path));
+          ).thenThrow(
+            MissingXcodeProjectException(
+              platformFolderPath: projectRoot.path,
+              platform: ApplePlatform.ios,
+            ),
+          );
         });
 
         test('exits with software error code', () async {

--- a/packages/shorebird_cli/test/src/platform/apple_test.dart
+++ b/packages/shorebird_cli/test/src/platform/apple_test.dart
@@ -77,7 +77,7 @@ void main() {
             '''
 Could not find an Xcode project in test_project_path.
 If your project does not support ios, you can safely remove test_project_path.
-Otherwise, to add ios, run "flutter create . --platforms ios"''',
+Otherwise, to repair ios, run "flutter create . --platforms ios"''',
           );
         });
       });
@@ -93,7 +93,7 @@ Otherwise, to add ios, run "flutter create . --platforms ios"''',
             '''
 Could not find an Xcode project in test_project_path.
 If your project does not support macos, you can safely remove test_project_path.
-Otherwise, to add macos, run "flutter create . --platforms macos"''',
+Otherwise, to repair macos, run "flutter create . --platforms macos"''',
           );
         });
       });

--- a/packages/shorebird_cli/test/src/platform/apple_test.dart
+++ b/packages/shorebird_cli/test/src/platform/apple_test.dart
@@ -66,12 +66,36 @@ void main() {
     });
 
     group(MissingXcodeProjectException, () {
-      test('toString', () {
-        const exception = MissingXcodeProjectException('test_project_path');
-        expect(exception.toString(), '''
+      group('ios', () {
+        test('toString', () {
+          const exception = MissingXcodeProjectException(
+            platformFolderPath: 'test_project_path',
+            platform: ApplePlatform.ios,
+          );
+          expect(
+            exception.toString(),
+            '''
 Could not find an Xcode project in test_project_path.
-To add iOS, run "flutter create . --platforms ios"
-To add macOS, run "flutter create . --platforms macos"''');
+If your project does not support ios, you can safely remove test_project_path.
+Otherwise, to add ios, run "flutter create . --platforms ios"''',
+          );
+        });
+      });
+
+      group('macos', () {
+        test('toString', () {
+          const exception = MissingXcodeProjectException(
+            platformFolderPath: 'test_project_path',
+            platform: ApplePlatform.macos,
+          );
+          expect(
+            exception.toString(),
+            '''
+Could not find an Xcode project in test_project_path.
+If your project does not support macos, you can safely remove test_project_path.
+Otherwise, to add macos, run "flutter create . --platforms macos"''',
+          );
+        });
       });
     });
 


### PR DESCRIPTION
## Description

Motivated by https://discord.com/channels/1030243211995791380/1412350334390636644

When an Xcode project is missing during `shorebird init`, the error message does not currently indicate whether macos or ios is the problem platform. This change improves the error message to more clearly point to the offending platform and provides better instructions.

When removing the .xcodeproj folder from a Flutter project's `macos` directory, note that the "before" error message does not clearly indicate that the issue is with the `macos` project.

Before this change:
```
✗ Detecting product flavors (1.3s)
Unable to extract product flavors.
Could not find an Xcode project in /Users/bryanoltman/Documents/sandbox/bad_macos_test.
To add iOS, run "flutter create . --platforms ios"
To add macOS, run "flutter create . --platforms macos"
```

After this change:
```
✗ Detecting product flavors (0.9s)
Unable to extract product flavors.
Could not find an Xcode project in /Users/bryanoltman/Documents/sandbox/bad_macos_test/macos.
If your project does not support macos, you can safely remove /Users/bryanoltman/Documents/sandbox/bad_macos_test/macos.
Otherwise, to repair macos, run "flutter create . --platforms macos"
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
