### PR TITLE
fix(shorebird_cli): warn instead of error when no flavor provided to app that has flavors

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_validator.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_validator.dart
@@ -175,12 +175,23 @@ To fix, update your pubspec.yaml to include the following:
 
       throw ValidationFailedException();
     }
+
+    if (validationIssuesContainsWarning(issues)) {
+      for (final issue in issues) {
+        logger.warn(issue.message);
+      }
+    }
   }
 
   /// Whether any [ValidationIssue]s have a severity of
   /// [ValidationIssueSeverity.error].
   bool validationIssuesContainsError(List<ValidationIssue> issues) =>
       issues.any((issue) => issue.severity == ValidationIssueSeverity.error);
+
+  /// Whether any [ValidationIssue]s have a severity of
+  /// [ValidationIssueSeverity.warning].
+  bool validationIssuesContainsWarning(List<ValidationIssue> issues) =>
+      issues.any((issue) => issue.severity == ValidationIssueSeverity.warning);
 
   /// Logs a message indicating that validation failed. If any of the issues
   /// can be automatically fixed, this also prompts the user to run

--- a/packages/shorebird_cli/lib/src/validators/flavor_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/flavor_validator.dart
@@ -23,7 +23,8 @@ class FlavorValidator extends Validator {
 
   @override
   Future<List<ValidationIssue>> validate() async {
-    final projectFlavors = shorebirdEnv.getShorebirdYaml()!.flavors;
+    final shorebirdYaml = shorebirdEnv.getShorebirdYaml()!;
+    final projectFlavors = shorebirdYaml.flavors;
     if (projectFlavors == null && flavorArg != null) {
       return [
         ValidationIssue.error(
@@ -35,9 +36,11 @@ class FlavorValidator extends Validator {
 
     if (projectFlavors != null && flavorArg == null) {
       return [
-        ValidationIssue.error(
+        ValidationIssue.warning(
           message:
-              '''The project has flavors ${projectFlavors.keys}, but no --flavor argument was provided''',
+              '''
+The project has flavors ${projectFlavors.keys}, but no --flavor argument was provided.
+The default app id ${shorebirdYaml.appId} will be used.''',
         ),
       ];
     }

--- a/packages/shorebird_cli/test/src/shorebird_validator_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_validator_test.dart
@@ -283,7 +283,7 @@ To fix, update your pubspec.yaml to include the following:
 
         group('when platform supports flavors', () {
           group('when no flavor is specified', () {
-            test('fails validation', () async {
+            test('logs warning and fails validation', () async {
               await expectLater(
                 runWithOverrides(
                   () => shorebirdValidator.validateFlavors(
@@ -291,8 +291,15 @@ To fix, update your pubspec.yaml to include the following:
                     releasePlatform: ReleasePlatform.android,
                   ),
                 ),
-                throwsA(isA<ValidationFailedException>()),
+                completes,
               );
+              verify(
+                () => logger.warn(
+                  '''
+The project has flavors (flavorA), but no --flavor argument was provided.
+The default app id test will be used.''',
+                ),
+              ).called(1);
             });
           });
 

--- a/packages/shorebird_cli/test/src/validators/flavor_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/flavor_validator_test.dart
@@ -119,14 +119,15 @@ void main() {
             validator = FlavorValidator(flavorArg: null);
           });
 
-          test('returns validation error', () async {
+          test('returns validation warning', () async {
             final issues = await runWithOverrides(validator.validate);
             expect(
               issues,
               equals([
-                ValidationIssue.error(
-                  message:
-                      '''The project has flavors (flavorA, flavorB), but no --flavor argument was provided''',
+                ValidationIssue.warning(
+                  message: '''
+The project has flavors (flavorA, flavorB), but no --flavor argument was provided.
+The default app id $appId will be used.''',
                 ),
               ]),
             );


### PR DESCRIPTION
## Description

Some apps have flavors for one platform, but not others. This change updates the behavior of `shorebird release` and `shorebird patch` for apps with flavors when no `--flavor` argument is provided. Instead of an error (current behavior), this will instead print a warning, telling the user which app id will be targeted by the release or patch.

<img width="733" height="87" alt="Screenshot 2025-10-14 at 3 24 29 PM" src="https://github.com/user-attachments/assets/fdb40e3e-533f-4c0f-9347-fbbc49ca4023" />

Fixes https://github.com/shorebirdtech/shorebird/issues/3248

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
