### PR TITLE
chore(shorebird_cli): fix FAQ/troubleshooting links

### DIFF
--- a/packages/shorebird_cli/lib/src/patch_diff_checker.dart
+++ b/packages/shorebird_cli/lib/src/patch_diff_checker.dart
@@ -85,7 +85,7 @@ class PatchDiffChecker {
           yellow.wrap(
             '''
 
-If you don't know why you're seeing this error, visit our troubleshooting page at ${troubleshootingUrl.toLink()}''',
+If you don't know why you're seeing this error, visit our troubleshooting page at ${nativeChangesTroubleshootingUrl.toLink()}''',
           ),
         );
 
@@ -108,6 +108,13 @@ If you don't know why you're seeing this error, visit our troubleshooting page a
         ..info(
           yellow.wrap(
             archiveDiffer.assetsFileSetDiff(contentDiffs).prettyString,
+          ),
+        )
+        ..info(
+          yellow.wrap(
+            '''
+
+If you don't know why you're seeing this error, visit our troubleshooting page at ${assetChangesTroubleshootingUrl.toLink()}''',
           ),
         );
 

--- a/packages/shorebird_cli/lib/src/shorebird_documentation.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_documentation.dart
@@ -1,3 +1,4 @@
+// cspell:words swiftobjective ckotlinjava havent
 import 'package:mason_logger/mason_logger.dart';
 
 /// Link to the Shorebird documentation page.

--- a/packages/shorebird_cli/lib/src/shorebird_documentation.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_documentation.dart
@@ -12,7 +12,7 @@ const supportedFlutterVersionsUrl =
     '$flutterVersionUrl#supported-flutter-versions';
 
 /// Link to the troubleshooting page on the Shorebird documentation.
-const troubleshootingUrl = '$docsUrl/faq';
+const troubleshootingUrl = '$docsUrl/code-push/troubleshooting';
 
 /// Link to the troubleshooting section which covers the
 /// Unsupported class file major version
@@ -22,7 +22,17 @@ const unsupportedClassFileVersionUrl =
 /// Link to the troubleshooting section which covers the
 /// not being able to run the app in VS Code after installing Shorebird.
 const cannotRunInVSCodeUrl =
-    '''$troubleshootingUrl#i-installed-shorebird-and-now-i-cant-run-my-app-in-vs-code''';
+    '''$troubleshootingUrl#cant-run-my-app-in-vs-code''';
+
+/// Link to the troubleshooting section which provides more information about
+/// what causes the asset changes warning and what to do about it.
+const assetChangesTroubleshootingUrl =
+    '''$troubleshootingUrl#your-app-contains-asset-changes-warning-when-creating-a-patch''';
+
+/// Link to the troubleshooting section which provides more information about
+/// what causes the native code changes warning and what to do about it.
+const nativeChangesTroubleshootingUrl =
+    '''$troubleshootingUrl#your-app-contains-native-changes-warning-when-creating-a-patch-even-though-you-havent-changed-swiftobjective-ckotlinjava-code''';
 
 /// Extension to convert a string to a CLI link.
 extension ToLink on String {


### PR DESCRIPTION
## Description

FAQ and Troubleshooting now live under https://docs.shorebird.dev/code-push. Additionally, this adds a link to the asset changes section of our troubleshooting docs when asset changes are detected.

In response to https://github.com/shorebirdtech/shorebird/issues/3357#issuecomment-3452084509

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
