### PR TITLE
fix(artifact_proxy): version generate_manifest script

### DIFF
--- a/packages/artifact_proxy/tool/generate_manifest/README.md
+++ b/packages/artifact_proxy/tool/generate_manifest/README.md
@@ -1,0 +1,7 @@
+# generate_manifest
+
+This script is used by https://github.com/shorebirdtech/_build_engine to
+generate the artifacts_manifest.yaml used by the artifact proxy. It is versioned
+within this directory to ensure that changes to either the set of artifacts
+needed by Flutter or the set of artifacts we need to provide (vs those we proxy)
+will not prevent us from rebuilding older versions of Flutter if necessary.

--- a/packages/artifact_proxy/tool/generate_manifest/v1/README.md
+++ b/packages/artifact_proxy/tool/generate_manifest/v1/README.md
@@ -1,0 +1,1 @@
+The artifact proxy config required to support Flutter 3.27.4 and below.

--- a/packages/artifact_proxy/tool/generate_manifest/v1/generate_manifest.sh
+++ b/packages/artifact_proxy/tool/generate_manifest/v1/generate_manifest.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-# This script outputs an artifact_manifest.yaml mapping 
+# This script outputs an artifact_manifest.yaml mapping
 # a shorebird engine revision to a flutter engine revision.
 # Usage:
 #  ./generate_manifest.sh <flutter_engine_revision> > artifact_manifest.yaml
-
-# TODO(bryanoltman): This script is deprecated. Use the versioned scripts instead.
 
 set -e
 
@@ -50,9 +48,6 @@ artifact_overrides:
   - flutter_infra_release/flutter/\$engine/android-x64-release/symbols.zip
   - flutter_infra_release/flutter/\$engine/android-x64-release/windows-x64.zip
 
-  # engine_stamp.json
-  - flutter_infra_release/flutter/\$engine/engine_stamp.json
-
   # Dart SDK
   - flutter_infra_release/flutter/\$engine/dart-sdk-darwin-arm64.zip
   - flutter_infra_release/flutter/\$engine/dart-sdk-darwin-x64.zip
@@ -71,9 +66,6 @@ artifact_overrides:
   # x86_64 release
   - download.flutter.io/io/flutter/x86_64_release/1.0.0-\$engine/x86_64_release-1.0.0-\$engine.pom
   - download.flutter.io/io/flutter/x86_64_release/1.0.0-\$engine/x86_64_release-1.0.0-\$engine.jar
-
-  # Common release artifacts
-  - flutter_infra_release/flutter/\$engine/flutter_patched_sdk_product.zip
 
   # iOS release artifacts
   # Includes unified Flutter.framework for device and simulator (debug)

--- a/packages/artifact_proxy/tool/generate_manifest/v2/README.md
+++ b/packages/artifact_proxy/tool/generate_manifest/v2/README.md
@@ -1,0 +1,5 @@
+TODO(bryanoltman): I'm not sure if this is fully correct. There appear to have
+been several changes made after the engine was brought into the flutter/flutter
+repo, and I'm not sure which Flutter versions those map to.
+
+The artifact proxy config required to support Flutter 3.29.0 and above.

--- a/packages/artifact_proxy/tool/generate_manifest/v2/generate_manifest.sh
+++ b/packages/artifact_proxy/tool/generate_manifest/v2/generate_manifest.sh
@@ -5,8 +5,6 @@
 # Usage:
 #  ./generate_manifest.sh <flutter_engine_revision> > artifact_manifest.yaml
 
-# TODO(bryanoltman): This script is deprecated. Use the versioned scripts instead.
-
 set -e
 
 # NOTE: If you edit this file you also may need to edit the global list


### PR DESCRIPTION
In order to be able to re-release older versions of Flutter (due to cancelled certs, etc.), we need to be able to generate an artifact manifest that reflects the state of our artifact proxy at the time an engine build was made. Because every revision of build_engine points at the latest generate_manifest.sh, the artifact proxy might proxy (or not proxy) an incorrect set of artifacts.

This is not intended to be comprehensive. Also, there have been changes to this script since the engine was added to flutter/flutter, and it's not clear which versions of Flutter those affect, so I've simply split this into v1 and v2, where v1 is intended to represent everything before the engine+flutter merge and v2 is the current version as of this PR.