### PR TITLE
feat: bump version for 1.6.70

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,10 @@
 cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkishan appbundle proto tlsv kingdomseed Peetee
  -->
 
+## 1.6.70 (November 26, 2025)
+
+- 🩹 Fix Shorebird builds with Dart hooks and Dart 3.10.0 and 3.10.1.
+
 ## 1.6.69 (November 24, 2025)
 
 - 🐦 Support for Flutter 3.38.3

--- a/packages/shorebird_cli/lib/src/version.dart
+++ b/packages/shorebird_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.6.69';
+const packageVersion = '1.6.70';

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_cli
 description: Command-line tool to interact with Shorebird's services.
-version: 1.6.69
+version: 1.6.70
 repository: https://github.com/shorebirdtech/shorebird
 resolution: workspace
 


### PR DESCRIPTION
Release fix for https://github.com/shorebirdtech/shorebird/pull/3408.