### PR TITLE
fix(redis_client): throw exception instead of type error when redis response is not List<RespType>

### DIFF
--- a/packages/redis_client/lib/src/redis_client.dart
+++ b/packages/redis_client/lib/src/redis_client.dart
@@ -867,30 +867,33 @@ class RedisTimeSeries {
     RedisTimeSeriesAlign? align,
     RedisTimeSeriesAggregation? aggregation,
   }) async {
-    final results =
-        await _client.execute([
-              'TS.RANGE',
-              key,
-              from.value,
-              to.value,
-              if (filterByTimestamp != null) ...[
-                'FILTER_BY_TS',
-                ...filterByTimestamp.map((t) => t.value),
-              ],
-              if (filterByValue != null) ...[
-                'FILTER_BY_VALUE',
-                filterByValue.min,
-                filterByValue.max,
-              ],
-              if (count != null) ...['COUNT', count],
-              if (align != null) ...['ALIGN', align.value],
-              if (aggregation != null) ...[
-                'AGGREGATION',
-                aggregation.aggregator.toArgument(),
-                aggregation.bucketDuration.inMilliseconds,
-              ],
-            ])
-            as List<RespType>;
+    final results = await _client.execute([
+      'TS.RANGE',
+      key,
+      from.value,
+      to.value,
+      if (filterByTimestamp != null) ...[
+        'FILTER_BY_TS',
+        ...filterByTimestamp.map((t) => t.value),
+      ],
+      if (filterByValue != null) ...[
+        'FILTER_BY_VALUE',
+        filterByValue.min,
+        filterByValue.max,
+      ],
+      if (count != null) ...['COUNT', count],
+      if (align != null) ...['ALIGN', align.value],
+      if (aggregation != null) ...[
+        'AGGREGATION',
+        aggregation.aggregator.toArgument(),
+        aggregation.bucketDuration.inMilliseconds,
+      ],
+    ]);
+
+    if (results is! List<RespType>) {
+      throw RedisException(results.toString());
+    }
+
     return results.map((result) {
       final payload = result.payload as List<RespType>;
       final timestamp = payload[0] as RespInteger;


### PR DESCRIPTION
## Description

This seems to be the source of an issue in our usage client, although I'm not able to reproduce the issue locally. This is meant to be a temporary, diagnostic fix.

Internal logs error: https://console.cloud.google.com/logs/query;cursorTimestamp=2025-12-02T17:04:33.325087Z;duration=PT15M;query=resource.labels.service_name%3D%22code-push-server%22%0A%22redis%22%0Atimestamp%3D%222025-12-02T17:04:33.325087Z%22%0AinsertId%3D%22692f1c210004f5df3e4ba5c1%22?project=code-push-prod

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
