### PR TITLE
fix: handle unsupported flutter versions gracefully (#3405)

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -263,11 +263,15 @@ class ShorebirdFlutter {
   /// Returns the git revision for the provided [version].
   /// e.g. 3.16.3 -> b9b23902966504a9778f4c07e3a3487fa84dcb2a
   Future<String?> getRevisionForVersion(String version) async {
-    final result = await git.revParse(
-      revision: 'refs/remotes/origin/flutter_release/$version',
-      directory: _workingDirectory(),
-    );
-    return LineSplitter.split(result).toList().firstOrNull;
+    try {
+      final result = await git.revParse(
+        revision: 'refs/remotes/origin/flutter_release/$version',
+        directory: _workingDirectory(),
+      );
+      return LineSplitter.split(result).toList().firstOrNull;
+    } on ProcessException {
+      return null;
+    }
   }
 
   /// Get the list of Flutter versions for the given [revision].

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -465,12 +465,12 @@ Tools • Dart 3.0.6 • DevTools 2.23.1''');
           ).thenThrow(exception);
         });
 
-        test('throws exception', () async {
+        test('returns null', () async {
           await expectLater(
             runWithOverrides(
               () => shorebirdFlutter.getRevisionForVersion(version),
             ),
-            throwsA(exception),
+            completion(isNull),
           );
           verify(
             () => git.revParse(


### PR DESCRIPTION
## Description

Fixes #3405.

Previously, running `shorebird release` with an unsupported Flutter version (e.g., `3.35.0`) would crash with an unhandled `ProcessException` from `git rev-parse`.

This PR updates `getRevisionForVersion` to catch the `ProcessException` and return `null` when a version is not found. This allows the existing error handling logic to display a user-friendly message instead of a crash.

**Before:**
```
% shorebird release android --flutter-version 3.35.0
✓ Fetching apps (0.3s)
Unable to determine revision for Flutter version: 3.35.0.
ProcessException: fatal: Needed a single revision

  Command: git rev-parse --verify refs/remotes/origin/flutter_release/3.35.0

If you aren't sure why this command failed, re-run with the --verbose flag to see more information.

You can also file an issue if you think this is a bug. Please include the following log file in your report:
/Users/eseidel/Library/Application Support/shorebird/logs/1764102902874_shorebird.log
```

**After:**
```
> shorebird release android --flutter-version 3.35.0
✓ Fetching apps (4.8s)
Version 3.35.0 not found. Please open an issue to request a new version.
Use `shorebird flutter versions list` to list available versions.


If you aren't sure why this command failed, re-run with the --verbose flag to see more information.

You can also file an issue if you think this is a bug. Please include the following log file in your report:
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [x] 🧪 Tests