### PR TITLE
feat(shorebird_cli): show Assets.car diff if change is detected in iOS patch

### DIFF
--- a/packages/shorebird_cli/bin/shorebird.dart
+++ b/packages/shorebird_cli/bin/shorebird.dart
@@ -63,6 +63,7 @@ Command: shorebird ${args.join(' ')}
           codePushClientWrapperRef,
           codeSignerRef,
           devicectlRef,
+          diffRef,
           dittoRef,
           doctorRef,
           engineConfigRef,

--- a/packages/shorebird_cli/lib/src/archive_analysis/archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/archive_differ.dart
@@ -107,4 +107,13 @@ abstract class ArchiveDiffer {
       };
     });
   }
+
+  /// Prints the diffs of the changed files to the console.
+  Future<String> availableAssetDiffs({
+    required FileSetDiff fileSetDiff,
+    required String oldArchivePath,
+    required String newArchivePath,
+  }) async {
+    return '';
+  }
 }

--- a/packages/shorebird_cli/lib/src/executables/diff.dart
+++ b/packages/shorebird_cli/lib/src/executables/diff.dart
@@ -1,0 +1,41 @@
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
+
+/// The color mode for the `diff` command.
+enum DiffColorMode {
+  /// Never color the diff.
+  never,
+
+  /// Always color the diff.
+  always,
+
+  /// Color the diff automatically based on the output device.
+  auto,
+}
+
+/// A reference to a [Diff] instance.
+final diffRef = create(Diff.new);
+
+/// The [Diff] instance available in the current zone.
+Diff get diff => read(diffRef);
+
+/// A wrapper around the `diff` command.
+class Diff {
+  /// The name of the `diff` executable.
+  static const executable = 'diff';
+
+  /// Runs the `diff` command and returns the result.
+  Future<ShorebirdProcessResult> run(
+    String fileAPath,
+    String fileBPath, {
+    required bool unified,
+    required DiffColorMode colorMode,
+  }) async {
+    return process.run(executable, [
+      if (unified) '--unified',
+      '--color=${colorMode.name}',
+      fileAPath,
+      fileBPath,
+    ]);
+  }
+}

--- a/packages/shorebird_cli/lib/src/executables/executables.dart
+++ b/packages/shorebird_cli/lib/src/executables/executables.dart
@@ -4,6 +4,7 @@ export 'adb.dart';
 export 'aot_tools.dart';
 export 'bundletool.dart';
 export 'devicectl/devicectl.dart';
+export 'diff.dart';
 export 'ditto.dart';
 export 'git.dart';
 export 'gradlew.dart';

--- a/packages/shorebird_cli/lib/src/patch_diff_checker.dart
+++ b/packages/shorebird_cli/lib/src/patch_diff_checker.dart
@@ -109,14 +109,24 @@ If you don't know why you're seeing this error, visit our troubleshooting page a
           yellow.wrap(
             archiveDiffer.assetsFileSetDiff(contentDiffs).prettyString,
           ),
-        )
-        ..info(
-          yellow.wrap(
-            '''
+        );
+
+      final diffs = await archiveDiffer.availableAssetDiffs(
+        fileSetDiff: contentDiffs,
+        oldArchivePath: releaseArchive.path,
+        newArchivePath: localArchive.path,
+      );
+      if (diffs.isNotEmpty) {
+        logger.info(diffs);
+      }
+
+      logger.info(
+        yellow.wrap(
+          '''
 
 If you don't know why you're seeing this error, visit our troubleshooting page at ${assetChangesTroubleshootingUrl.toLink()}''',
-          ),
-        );
+        ),
+      );
 
       if (!allowAssetChanges) {
         if (!shorebirdEnv.canAcceptUserInput) {

--- a/packages/shorebird_cli/test/src/archive_analysis/archive_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/archive_differ_test.dart
@@ -78,4 +78,11 @@ class TestArchiveDiffer extends ArchiveDiffer {
 
   @override
   bool isNativeFilePath(String filePath) => true;
+
+  @override
+  Future<String> availableAssetDiffs({
+    required FileSetDiff fileSetDiff,
+    required String oldArchivePath,
+    required String newArchivePath,
+  }) async => '';
 }

--- a/packages/shorebird_cli/test/src/executables/diff_test.dart
+++ b/packages/shorebird_cli/test/src/executables/diff_test.dart
@@ -1,0 +1,54 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_cli/src/executables/diff.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group(Diff, () {
+    late ShorebirdProcess process;
+    late Diff diff;
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(body, values: {processRef.overrideWith(() => process)});
+    }
+
+    setUp(() {
+      process = MockShorebirdProcess();
+      diff = Diff();
+    });
+
+    group('run', () {
+      setUp(() {
+        when(() => process.run(any(), any())).thenAnswer(
+          (_) async => const ShorebirdProcessResult(
+            exitCode: 0,
+            stdout: 'stdout',
+            stderr: 'stderr',
+          ),
+        );
+      });
+
+      test('returns the result of the `diff` command', () async {
+        await runWithOverrides(
+          () => diff.run(
+            'fileA',
+            'fileB',
+            unified: true,
+            colorMode: DiffColorMode.always,
+          ),
+        );
+        verify(
+          () => process.run(Diff.executable, [
+            '--unified',
+            '--color=always',
+            'fileA',
+            'fileB',
+          ]),
+        ).called(1);
+      });
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/mocks.dart
+++ b/packages/shorebird_cli/test/src/mocks.dart
@@ -91,6 +91,8 @@ class MockCodeSigner extends Mock implements CodeSigner {}
 
 class MockDevicectl extends Mock implements Devicectl {}
 
+class MockDiff extends Mock implements Diff {}
+
 class MockDitto extends Mock implements Ditto {}
 
 class MockDirectory extends Mock implements Directory {}

--- a/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
+++ b/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
@@ -72,6 +72,13 @@ void main() {
       when(
         () => archiveDiffer.containsPotentiallyBreakingNativeDiffs(any()),
       ).thenReturn(false);
+      when(
+        () => archiveDiffer.availableAssetDiffs(
+          fileSetDiff: any(named: 'fileSetDiff'),
+          oldArchivePath: any(named: 'oldArchivePath'),
+          newArchivePath: any(named: 'newArchivePath'),
+        ),
+      ).thenAnswer((_) async => '');
 
       when(() => httpClient.send(any())).thenAnswer(
         (_) async => http.StreamedResponse(const Stream.empty(), HttpStatus.ok),
@@ -219,6 +226,13 @@ void main() {
           verify(
             () => logger.warn(
               '''Your app contains asset changes, which will not be included in the patch.''',
+            ),
+          ).called(1);
+          verify(
+            () => archiveDiffer.availableAssetDiffs(
+              fileSetDiff: any(named: 'fileSetDiff'),
+              oldArchivePath: any(named: 'oldArchivePath'),
+              newArchivePath: any(named: 'newArchivePath'),
             ),
           ).called(1);
           verify(


### PR DESCRIPTION
## Description

We may want to make this a verbose-logs-only feature (and I sort of question whether our users will be able to do anything useful with this info).

Fixes https://github.com/shorebirdtech/shorebird/issues/3442

<img width="1597" height="1174" alt="Screenshot 2025-12-30 at 5 25 02 PM" src="https://github.com/user-attachments/assets/807134af-86ea-4a71-b6de-28b181c671e6" />

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
