### PR TITLE
fix(shorebird_cli): remove `--no-confirm` flag from patch and release commands

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -103,6 +103,11 @@ To target the latest release (e.g. the release that was most recently updated) u
 [DEPRECATED] Whether to publish the patch to the staging environment. Use --track=staging instead.''',
         hide: true,
       )
+      ..addFlag(
+        CommonArguments.noConfirmArg.name,
+        help: CommonArguments.noConfirmArg.description,
+        negatable: false,
+      )
       ..addOption(
         CommonArguments.exportOptionsPlistArg.name,
         help: CommonArguments.exportOptionsPlistArg.description,

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -103,11 +103,6 @@ To target the latest release (e.g. the release that was most recently updated) u
 [DEPRECATED] Whether to publish the patch to the staging environment. Use --track=staging instead.''',
         hide: true,
       )
-      ..addFlag(
-        CommonArguments.noConfirmArg.name,
-        help: CommonArguments.noConfirmArg.description,
-        negatable: false,
-      )
       ..addOption(
         CommonArguments.exportOptionsPlistArg.name,
         help: CommonArguments.exportOptionsPlistArg.description,
@@ -185,9 +180,6 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
 
   /// Whether to allow changes in native code (--allow-native-diffs).
   bool get allowNativeDiffs => results['allow-native-diffs'] == true;
-
-  /// Whether --no-confirm was passed.
-  bool get noConfirm => results['no-confirm'] == true;
 
   /// Whether the patch is for the staging environment.
   bool get isStaging => track == DeploymentTrack.staging;
@@ -433,7 +425,7 @@ Building patch with Flutter $flutterVersionString
           throw ProcessExit(ExitCode.success.code);
         }
 
-        await confirmCreatePatch(
+        await logPatchSummary(
           app: app,
           releaseVersion: release.version,
           patcher: patcher,
@@ -548,8 +540,14 @@ Please re-run the release command for this version or create a new release.''');
     }
   }
 
-  /// Confirms the patch creation (including a summary).
-  Future<void> confirmCreatePatch({
+  /// Logs a summary of the patch to be created, including:
+  /// - The app name and ID
+  /// - The release version
+  /// - The platform
+  /// - The track
+  /// - The link percentage (if iOS)
+  /// - The debug info file (if iOS)
+  Future<void> logPatchSummary({
     required AppMetadata app,
     required String releaseVersion,
     required Patcher patcher,
@@ -596,15 +594,6 @@ ${styleBold.wrap(lightGreen.wrap('🚀 Ready to publish a new patch!'))}
 
 ${summary.join('\n')}
 ''');
-
-    if (shorebirdEnv.canAcceptUserInput && !noConfirm) {
-      final confirm = logger.confirm('Would you like to continue?');
-
-      if (!confirm) {
-        logger.info('Aborting.');
-        throw ProcessExit(ExitCode.success.code);
-      }
-    }
   }
 
   /// Downloads the given [releaseArtifact].

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -124,6 +124,11 @@ Defaults to "latest" which builds using the latest stable Flutter version.''',
         hide: true,
         negatable: false,
       )
+      ..addFlag(
+        CommonArguments.noConfirmArg.name,
+        help: CommonArguments.noConfirmArg.description,
+        negatable: false,
+      )
       ..addOption(
         'release-version',
         help: '''

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -124,11 +124,6 @@ Defaults to "latest" which builds using the latest stable Flutter version.''',
         hide: true,
         negatable: false,
       )
-      ..addFlag(
-        CommonArguments.noConfirmArg.name,
-        help: CommonArguments.noConfirmArg.description,
-        negatable: false,
-      )
       ..addOption(
         'release-version',
         help: '''
@@ -229,9 +224,6 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
 
   /// The target script, if provided.
   String? get target => results.findOption('target', argParser: argParser);
-
-  /// Whether --no-confirm was passed.
-  bool get noConfirm => results['no-confirm'] == true;
 
   /// The flutter version specified.
   String get flutterVersionArg => results['flutter-version'] as String;

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -130,6 +130,14 @@ symbolize" command with the right program symbol file is required to obtain a hu
 ''',
   );
 
+  /// An argument that allows the user to bypass interactive confirmations.
+  static const noConfirmArg = ArgumentDescriber(
+    name: 'no-confirm',
+    description: '''
+Bypass all confirmation messages. It's generally not advised to use this unless running from a script.
+''',
+  );
+
   /// An argument that allows the user to specify a minimum link percentage
   /// threshold.
   static const minLinkPercentage = ArgumentDescriber(

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -130,14 +130,6 @@ symbolize" command with the right program symbol file is required to obtain a hu
 ''',
   );
 
-  /// An argument that allows the user to bypass interactive confirmations.
-  static const noConfirmArg = ArgumentDescriber(
-    name: 'no-confirm',
-    description: '''
-Bypass all confirmation messages. It's generally not advised to use this unless running from a script.
-''',
-  );
-
   /// An argument that allows the user to specify a minimum link percentage
   /// threshold.
   static const minLinkPercentage = ArgumentDescriber(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -266,7 +266,6 @@ void main() {
           display: any(named: 'display'),
         ),
       ).thenReturn(release);
-      when(() => logger.confirm(any())).thenReturn(true);
       when(() => logger.progress(any())).thenReturn(progress);
 
       when(() => patcher.assertArgsAreValid()).thenAnswer((_) async {});
@@ -599,7 +598,7 @@ void main() {
           ];
           await expectLater(
             runWithOverrides(
-              () => command.confirmCreatePatch(
+              () => command.logPatchSummary(
                 app: appMetadata,
                 releaseVersion: releaseVersion,
                 patcher: patcher,
@@ -630,7 +629,7 @@ void main() {
           ];
           await expectLater(
             runWithOverrides(
-              () => command.confirmCreatePatch(
+              () => command.logPatchSummary(
                 app: appMetadata,
                 releaseVersion: releaseVersion,
                 patcher: patcher,
@@ -665,7 +664,7 @@ void main() {
           ];
           await expectLater(
             runWithOverrides(
-              () => command.confirmCreatePatch(
+              () => command.logPatchSummary(
                 app: appMetadata,
                 releaseVersion: releaseVersion,
                 patcher: patcher,
@@ -696,7 +695,7 @@ void main() {
           ];
           await expectLater(
             runWithOverrides(
-              () => command.confirmCreatePatch(
+              () => command.logPatchSummary(
                 app: appMetadata,
                 releaseVersion: releaseVersion,
                 patcher: patcher,
@@ -734,7 +733,7 @@ void main() {
           ];
           await expectLater(
             runWithOverrides(
-              () => command.confirmCreatePatch(
+              () => command.logPatchSummary(
                 app: appMetadata,
                 releaseVersion: releaseVersion,
                 patcher: patcher,
@@ -761,7 +760,7 @@ void main() {
             test('completes, does not print error message', () async {
               await expectLater(
                 runWithOverrides(
-                  () => command.confirmCreatePatch(
+                  () => command.logPatchSummary(
                     app: appMetadata,
                     releaseVersion: releaseVersion,
                     patcher: patcher,
@@ -791,7 +790,7 @@ void main() {
             test('prints error message and exits', () async {
               await expectLater(
                 runWithOverrides(
-                  () => command.confirmCreatePatch(
+                  () => command.logPatchSummary(
                     app: appMetadata,
                     releaseVersion: releaseVersion,
                     patcher: patcher,
@@ -870,7 +869,6 @@ void main() {
             releaseId: release.id,
             releaseArtifact: any(named: 'releaseArtifact'),
           ),
-          () => logger.confirm('Would you like to continue?'),
           () => patcher.updatedCreatePatchMetadata(
             any(
               that: isA<CreatePatchMetadata>().having(
@@ -1069,7 +1067,6 @@ void main() {
               releaseId: release.id,
               releaseArtifact: any(named: 'releaseArtifact'),
             ),
-            () => logger.confirm('Would you like to continue?'),
             () => patcher.uploadPatchArtifacts(
               appId: appId,
               releaseId: release.id,
@@ -1295,20 +1292,6 @@ void main() {
         expect(exitCode, equals(ExitCode.success.code));
 
         verifyNever(() => logger.confirm(any()));
-      });
-    });
-
-    group('when user declines to continue', () {
-      setUp(() {
-        when(() => logger.confirm(any())).thenReturn(false);
-      });
-
-      test('exits with message and success code', () async {
-        await expectLater(
-          () => runWithOverrides(command.run),
-          exitsWithCode(ExitCode.success),
-        );
-        verify(() => logger.info('Aborting.')).called(1);
       });
     });
 


### PR DESCRIPTION
## Description

Removes the `--no-confirm` option from the patch and release commands

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
