### PR TITLE
fix(shorebird_cli): use correct local-engine out dirs for Android on macOS

### DIFF
--- a/packages/shorebird_cli/lib/src/platform/android/android.dart
+++ b/packages/shorebird_cli/lib/src/platform/android/android.dart
@@ -1,7 +1,4 @@
-import 'dart:ffi';
-
 import 'package:collection/collection.dart';
-import 'package:shorebird_cli/src/abi.dart';
 import 'package:shorebird_cli/src/engine_config.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 
@@ -39,15 +36,7 @@ extension AndroidArch on Arch {
       Arch.arm64 => 'android_release_arm64',
       Arch.x86_64 => 'android_release_x64',
     };
-    // arm64 host architectures (i.e., Apple Silicon Macs) append _arm64 to the
-    // base arch.
-    // This check ignores linux and windows arm64 architectures, as this has
-    // only been verified on Apple Silicon Macs.
-    if (abi.current == Abi.macosArm64) {
-      return '${baseArch}_arm64';
-    } else {
-      return baseArch;
-    }
+    return baseArch;
   }
 
   /// Returns the available Android architectures.

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -130,6 +130,31 @@ void main() {
       });
     });
 
+    group('architectures', () {
+      test('returns all architectures by default', () {
+        final architectures = runWithOverrides(
+          () => androidReleaser.architectures,
+        );
+        expect(architectures, equals(Arch.values.toSet()));
+      });
+
+      test('throws exception when unknown platform is provided', () {
+        when(
+          () => argResults['target-platform'],
+        ).thenReturn(['android-arm', 'unknown-platform']);
+        expect(
+          () => runWithOverrides(() => androidReleaser.architectures),
+          throwsA(
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'toString',
+              contains('Unknown target platform: unknown-platform'),
+            ),
+          ),
+        );
+      });
+    });
+
     group('assertPreconditions', () {
       setUp(() {
         when(

--- a/packages/shorebird_cli/test/src/platform/android/android_test.dart
+++ b/packages/shorebird_cli/test/src/platform/android/android_test.dart
@@ -50,7 +50,7 @@ void main() {
         setUp(() {
           when(
             () => engineConfig.localEngine,
-          ).thenReturn('android_release_arm64_arm64');
+          ).thenReturn('android_release_arm64');
         });
 
         test('returns archs matching local engine arch', () async {
@@ -123,15 +123,15 @@ void main() {
         test('returns correct path', () {
           expect(
             runWithOverrides(() => Arch.arm32.androidEnginePath),
-            equals('android_release_arm64'),
+            equals('android_release'),
           );
           expect(
             runWithOverrides(() => Arch.arm64.androidEnginePath),
-            equals('android_release_arm64_arm64'),
+            equals('android_release_arm64'),
           );
           expect(
             runWithOverrides(() => Arch.x86_64.androidEnginePath),
-            equals('android_release_x64_arm64'),
+            equals('android_release_x64'),
           );
         });
       });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Removes some special sauce originally added in https://github.com/shorebirdtech/shorebird/pull/3363.

Flutter's GN script takes an `--android-cpu {arm,x64,x86,arm64,riscv64}` param which [determines the suffix](https://github.com/flutter/flutter/blob/9aea438bfcb9b8041106650c847d29d49ffbf120/engine/src/flutter/tools/gn#L38-L39) of the build output directory. However, if you look at the surrounding code, you'll notice it'll blindly append more stuff if you accidentally include multiple CPU parameters, which I assume is what caused the confusion here. :)

So if your GN args are `--android --android-cpu=arm64 --mac-cpu=arm64 --simulator-cpu=arm64 --linux-cpu=x86 --windows-cpu=x86 --runtime-mode=release`, then you'll get a pretty hilarious output directory: `android_release_arm64_arm64_arm64_x86_x86`
We should fix this in the engine. 🤣 

This patch also adds a clear error message when no matching build architectures are available.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
