### PR TITLE
chore: bump version for 1.6.77

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,11 @@
 cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkishan appbundle proto tlsv kingdomseed Peetee Aditya
  -->
 
+## 1.6.77 (January 16, 2026)
+
+- 🐦 Support for Flutter 3.38.7
+- ⏱️ Support patch_verification: install_only for faster boot of very large patches.
+
 ## 1.6.76 (January 11, 2026)
 
 - 🐦 Support for Flutter 3.38.6

--- a/packages/shorebird_cli/lib/src/version.dart
+++ b/packages/shorebird_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.6.76';
+const packageVersion = '1.6.77';

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_cli
 description: Command-line tool to interact with Shorebird's services.
-version: 1.6.76
+version: 1.6.77
 repository: https://github.com/shorebirdtech/shorebird
 resolution: workspace
 


### PR DESCRIPTION
Fixes https://github.com/shorebirdtech/updater/issues/301 as of Flutter 3.38.7 (included in this change).