### PR TITLE
chore: prepare fore 1.6.78 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,10 @@
 cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkishan appbundle proto tlsv kingdomseed Peetee Aditya
  -->
 
+## 1.6.78 (January 26, 2026)
+
+- ⚙️ Fix: using FlutterEngineGroup could cause patches to fail.
+
 ## 1.6.77 (January 16, 2026)
 
 - 🐦 Support for Flutter 3.38.7

--- a/packages/shorebird_cli/lib/src/version.dart
+++ b/packages/shorebird_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.6.77';
+const packageVersion = '1.6.78';

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_cli
 description: Command-line tool to interact with Shorebird's services.
-version: 1.6.77
+version: 1.6.78
 repository: https://github.com/shorebirdtech/shorebird
 resolution: workspace
 


### PR DESCRIPTION
This includes the fix for FlutterEngineGroup breaking patching.

Fix in https://github.com/shorebirdtech/shorebird/issues/3477.