### PR TITLE
feat: warn if patch_verification is in shorebird.yaml but public-key-path not set

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -369,6 +369,16 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
   Future<void> assertArgsAreValid(Releaser releaser) async {
     results.assertAbsentOrValidPublicKey();
 
+    final shorebirdYaml = shorebirdEnv.getShorebirdYaml();
+    if (shorebirdYaml?.patchVerification != null &&
+        !results.wasParsed(CommonArguments.publicKeyArg.name)) {
+      logger.warn(
+        'patch_verification is set in shorebird.yaml but '
+        '--${CommonArguments.publicKeyArg.name} was not provided.\n'
+        'patch_verification configuration will have no effect.',
+      );
+    }
+
     final version = await shorebirdFlutter.resolveFlutterVersion(
       flutterVersionArg,
     );

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -677,6 +677,36 @@ $exception'''),
         verify(releaser.assertArgsAreValid).called(1);
       });
 
+      group(
+        'when patch_verification is set but public-key-path is not provided',
+        () {
+          setUp(() {
+            when(() => shorebirdEnv.getShorebirdYaml()).thenReturn(
+              const ShorebirdYaml(
+                appId: appId,
+                patchVerification: PatchVerification.strict,
+              ),
+            );
+            when(
+              () => argResults.wasParsed(CommonArguments.publicKeyArg.name),
+            ).thenReturn(false);
+          });
+
+          test('logs a warning', () async {
+            final releaser = MockReleaser();
+            when(releaser.assertArgsAreValid).thenAnswer((_) async => {});
+            await runWithOverrides(() => command.assertArgsAreValid(releaser));
+            verify(
+              () => logger.warn(
+                'patch_verification is set in shorebird.yaml but '
+                '--${CommonArguments.publicKeyArg.name} was not provided.\n'
+                'patch_verification configuration will have no effect.',
+              ),
+            ).called(1);
+          });
+        },
+      );
+
       test('exits with code 64 if flutter version is not supported', () async {
         final releaser = MockReleaser();
         const releaseType = ReleaseType.android;


### PR DESCRIPTION
patch_verification configuration doesn't change anything if public-key-path isn't set.