### PR TITLE
feat: migrate CLI to auth.shorebird.dev

### DIFF
--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -338,49 +338,18 @@ class Auth {
     }
   }
 
-  /// Logs in the user.
-  Future<void> login(
-    AuthProvider authProvider, {
+  /// Logs in the user via auth.shorebird.dev.
+  ///
+  /// Opens a browser to the auth service where the user picks
+  /// Google or Microsoft, then receives Shorebird tokens via localhost
+  /// callback.
+  Future<void> login({
     required void Function(String) prompt,
   }) async {
     if (isAuthenticated) {
-      // Because isAuthenticated is checks for the presence of either an email
-      // or a CI token, and because this method is for logging in without a CI
-      // token, we can safely assume that _email is not null.
       throw UserAlreadyLoggedInException(email: _email!);
     }
 
-    if (authProvider == AuthProvider.shorebird) {
-      return _loginShorebird(prompt: prompt);
-    }
-
-    final client = http.Client();
-    try {
-      _credentials = await _obtainAccessCredentials(
-        authProvider.clientId,
-        authProvider.scopes,
-        client,
-        prompt,
-        authEndpoints: authProvider.authEndpoints,
-      );
-
-      final codePushClient = _buildCodePushClient(httpClient: this.client);
-
-      final user = await codePushClient.getCurrentUser();
-      if (user == null) {
-        throw UserNotFoundException(email: _credentials!.email!);
-      }
-
-      _email = user.email;
-      _flushOauthCredentials(_credentials!);
-    } finally {
-      client.close();
-    }
-  }
-
-  Future<void> _loginShorebird({
-    required void Function(String) prompt,
-  }) async {
     final result = await _performShorebirdLogin(
       prompt: prompt,
       authServiceUrl: _authServiceUrl,

--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -512,8 +512,9 @@ extension OauthValues on AuthProvider {
   oauth2.AuthEndpoints get authEndpoints => switch (this) {
     (AuthProvider.google) => const oauth2.GoogleAuthEndpoints(),
     (AuthProvider.microsoft) => MicrosoftAuthEndpoints(),
-    (AuthProvider.shorebird) =>
-      throw UnsupportedError('Shorebird uses auth.shorebird.dev, not OAuth'),
+    (AuthProvider.shorebird) => throw UnsupportedError(
+      'Shorebird uses auth.shorebird.dev, not OAuth',
+    ),
   };
 
   /// The OAuth 2.0 client ID for the provider.
@@ -560,7 +561,8 @@ extension OauthValues on AuthProvider {
       // Required to get refresh tokens.
       'offline_access',
     ],
-    (AuthProvider.shorebird) =>
-      throw UnsupportedError('Shorebird uses auth.shorebird.dev, not OAuth'),
+    (AuthProvider.shorebird) => throw UnsupportedError(
+      'Shorebird uses auth.shorebird.dev, not OAuth',
+    ),
   };
 }

--- a/packages/shorebird_cli/lib/src/auth/ci_token.g.dart
+++ b/packages/shorebird_cli/lib/src/auth/ci_token.g.dart
@@ -35,4 +35,5 @@ Map<String, dynamic> _$CiTokenToJson(CiToken instance) => <String, dynamic>{
 const _$AuthProviderEnumMap = {
   AuthProvider.google: 'google',
   AuthProvider.microsoft: 'microsoft',
+  AuthProvider.shorebird: 'shorebird',
 };

--- a/packages/shorebird_cli/lib/src/auth/shorebird_auth_login.dart
+++ b/packages/shorebird_cli/lib/src/auth/shorebird_auth_login.dart
@@ -31,8 +31,8 @@ Future<ShorebirdLoginResult> performShorebirdLogin({
 
   final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
   final port = server.port;
-  final returnTo = Uri.encodeFull('http://localhost:$port');
-  final loginUrl = '$authServiceUrl/login?return_to=$returnTo';
+  final redirectUri = Uri.encodeFull('http://localhost:$port');
+  final loginUrl = '$authServiceUrl/login?redirect_uri=$redirectUri';
 
   prompt(loginUrl);
 

--- a/packages/shorebird_cli/lib/src/auth/shorebird_auth_login.dart
+++ b/packages/shorebird_cli/lib/src/auth/shorebird_auth_login.dart
@@ -14,10 +14,11 @@ typedef ShorebirdLoginResult = ({String accessToken, String refreshToken});
 ///
 /// Starts a local HTTP server, opens auth.shorebird.dev/login in the browser,
 /// and waits for the callback with tokens.
-typedef PerformShorebirdLogin = Future<ShorebirdLoginResult> Function({
-  required void Function(String url) prompt,
-  String authServiceUrl,
-});
+typedef PerformShorebirdLogin =
+    Future<ShorebirdLoginResult> Function({
+      required void Function(String url) prompt,
+      String authServiceUrl,
+    });
 
 /// Performs the Shorebird login flow via auth.shorebird.dev.
 ///
@@ -60,8 +61,7 @@ Future<ShorebirdLoginResult> performShorebirdLogin({
           );
         }
 
-        final body =
-            jsonDecode(tokenResponse.body) as Map<String, dynamic>;
+        final body = jsonDecode(tokenResponse.body) as Map<String, dynamic>;
         final accessToken = body['access_token'] as String;
         final refreshToken = body['refresh_token'] as String;
 

--- a/packages/shorebird_cli/lib/src/auth/shorebird_auth_login.dart
+++ b/packages/shorebird_cli/lib/src/auth/shorebird_auth_login.dart
@@ -50,8 +50,10 @@ Future<ShorebirdLoginResult> performShorebirdLogin({
         // Exchange the authorization code for tokens.
         final tokenResponse = await client.post(
           Uri.parse('$authServiceUrl/token'),
-          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-          body: 'grant_type=authorization_code&code=$code',
+          body: {
+            'grant_type': 'authorization_code',
+            'code': code,
+          },
         );
 
         if (tokenResponse.statusCode != 200) {
@@ -94,7 +96,12 @@ Future<ShorebirdLoginResult> performShorebirdLogin({
   });
 
   try {
-    return await completer.future;
+    return await completer.future.timeout(
+      const Duration(minutes: 5),
+      onTimeout: () => throw TimeoutException(
+        'Login timed out waiting for browser callback after 5 minutes.',
+      ),
+    );
   } finally {
     await server.close();
   }

--- a/packages/shorebird_cli/lib/src/auth/shorebird_auth_login.dart
+++ b/packages/shorebird_cli/lib/src/auth/shorebird_auth_login.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:shorebird_cli/src/auth/shorebird_credentials.dart';
+
+/// {@template shorebird_login_result}
+/// The result of a Shorebird login flow.
+/// {@endtemplate}
+typedef ShorebirdLoginResult = ({String accessToken, String refreshToken});
+
+/// Callback for performing the Shorebird login flow.
+///
+/// Starts a local HTTP server, opens auth.shorebird.dev/login in the browser,
+/// and waits for the callback with tokens.
+typedef PerformShorebirdLogin = Future<ShorebirdLoginResult> Function({
+  required void Function(String url) prompt,
+  String authServiceUrl,
+});
+
+/// Performs the Shorebird login flow via auth.shorebird.dev.
+///
+/// 1. Starts a local HTTP server on a random port
+/// 2. Calls [prompt] with the auth URL for the user to visit
+/// 3. Waits for the auth service to redirect back with tokens
+/// 4. Returns the access token and refresh token
+Future<ShorebirdLoginResult> performShorebirdLogin({
+  required void Function(String url) prompt,
+  String authServiceUrl = defaultAuthServiceUrl,
+}) async {
+  final completer = Completer<ShorebirdLoginResult>();
+
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  final port = server.port;
+  final returnTo = Uri.encodeFull('http://localhost:$port');
+  final loginUrl = '$authServiceUrl/login?return_to=$returnTo';
+
+  prompt(loginUrl);
+
+  server.listen((request) async {
+    try {
+      final accessToken = request.uri.queryParameters['access_token'];
+      final refreshToken = request.uri.queryParameters['refresh_token'];
+
+      if (accessToken != null && refreshToken != null) {
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.html
+          ..write(
+            '<html><body><h2>Login successful!</h2>'
+            '<p>You can close this window and return to the CLI.</p>'
+            '</body></html>',
+          );
+        await request.response.close();
+
+        if (!completer.isCompleted) {
+          completer.complete(
+            (accessToken: accessToken, refreshToken: refreshToken),
+          );
+        }
+      } else {
+        request.response
+          ..statusCode = HttpStatus.badRequest
+          ..write('Missing tokens');
+        await request.response.close();
+      }
+    } on Exception catch (e) {
+      if (!completer.isCompleted) {
+        completer.completeError(e);
+      }
+    }
+  });
+
+  try {
+    return await completer.future;
+  } finally {
+    await server.close();
+  }
+}

--- a/packages/shorebird_cli/lib/src/auth/shorebird_credentials.dart
+++ b/packages/shorebird_cli/lib/src/auth/shorebird_credentials.dart
@@ -35,10 +35,10 @@ class ShorebirdCredentials {
 
   /// Converts to a JSON map for storage.
   Map<String, dynamic> toJson() => {
-        'type': 'shorebird',
-        'access_token': accessToken,
-        'refresh_token': refreshToken,
-      };
+    'type': 'shorebird',
+    'access_token': accessToken,
+    'refresh_token': refreshToken,
+  };
 
   /// The email from the JWT claims, or null if unavailable.
   String? get email {

--- a/packages/shorebird_cli/lib/src/auth/shorebird_credentials.dart
+++ b/packages/shorebird_cli/lib/src/auth/shorebird_credentials.dart
@@ -76,10 +76,15 @@ class ShorebirdCredentials {
     required http.Client httpClient,
     String authServiceUrl = defaultAuthServiceUrl,
   }) async {
+    if (isApiKey) {
+      throw StateError('Cannot refresh an API key credential.');
+    }
     final response = await httpClient.post(
       Uri.parse('$authServiceUrl/token'),
-      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-      body: 'grant_type=refresh_token&refresh_token=$refreshToken',
+      body: {
+        'grant_type': 'refresh_token',
+        'refresh_token': refreshToken,
+      },
     );
 
     if (response.statusCode != 200) {

--- a/packages/shorebird_cli/lib/src/auth/shorebird_credentials.dart
+++ b/packages/shorebird_cli/lib/src/auth/shorebird_credentials.dart
@@ -50,8 +50,16 @@ class ShorebirdCredentials {
     }
   }
 
+  /// Whether this is an API key (sb_api_...) rather than a JWT.
+  bool get isApiKey => accessToken.startsWith('sb_api_');
+
   /// Whether the access token has expired.
+  ///
+  /// API keys never expire (server validates them directly).
+  /// Empty access tokens are treated as expired to trigger a refresh.
   bool get isExpired {
+    if (isApiKey) return false;
+    if (accessToken.isEmpty) return true;
     try {
       final jwt = Jwt.parse(accessToken);
       final exp = DateTime.fromMillisecondsSinceEpoch(jwt.payload.exp * 1000);

--- a/packages/shorebird_cli/lib/src/auth/shorebird_credentials.dart
+++ b/packages/shorebird_cli/lib/src/auth/shorebird_credentials.dart
@@ -30,8 +30,8 @@ class ShorebirdCredentials {
   /// The Shorebird JWT (access token).
   String accessToken;
 
-  /// The refresh token (sb_rt_...).
-  final String refreshToken;
+  /// The refresh token (sb_rt_...). Updated on each refresh (token rotation).
+  String refreshToken;
 
   /// Converts to a JSON map for storage.
   Map<String, dynamic> toJson() => {
@@ -90,5 +90,9 @@ class ShorebirdCredentials {
 
     final body = jsonDecode(response.body) as Map<String, dynamic>;
     accessToken = body['access_token'] as String;
+    // The server rotates the refresh token on each use.
+    if (body['refresh_token'] != null) {
+      refreshToken = body['refresh_token'] as String;
+    }
   }
 }

--- a/packages/shorebird_cli/lib/src/auth/shorebird_credentials.dart
+++ b/packages/shorebird_cli/lib/src/auth/shorebird_credentials.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:jwt/jwt.dart';
+
+/// The default base URL for the Shorebird auth service.
+const defaultAuthServiceUrl = 'https://auth.shorebird.dev';
+
+/// Environment variable to override the auth service URL.
+const authServiceUrlEnvVar = 'SHOREBIRD_AUTH_URL';
+
+/// {@template shorebird_credentials}
+/// Credentials issued by auth.shorebird.dev.
+/// {@endtemplate}
+class ShorebirdCredentials {
+  /// {@macro shorebird_credentials}
+  ShorebirdCredentials({
+    required this.accessToken,
+    required this.refreshToken,
+  });
+
+  /// Creates [ShorebirdCredentials] from a JSON map.
+  factory ShorebirdCredentials.fromJson(Map<String, dynamic> json) {
+    return ShorebirdCredentials(
+      accessToken: json['access_token'] as String,
+      refreshToken: json['refresh_token'] as String,
+    );
+  }
+
+  /// The Shorebird JWT (access token).
+  String accessToken;
+
+  /// The refresh token (sb_rt_...).
+  final String refreshToken;
+
+  /// Converts to a JSON map for storage.
+  Map<String, dynamic> toJson() => {
+        'type': 'shorebird',
+        'access_token': accessToken,
+        'refresh_token': refreshToken,
+      };
+
+  /// The email from the JWT claims, or null if unavailable.
+  String? get email {
+    try {
+      final jwt = Jwt.parse(accessToken);
+      return jwt.claims['email'] as String?;
+    } on Exception {
+      return null;
+    }
+  }
+
+  /// Whether the access token has expired.
+  bool get isExpired {
+    try {
+      final jwt = Jwt.parse(accessToken);
+      final exp = DateTime.fromMillisecondsSinceEpoch(jwt.payload.exp * 1000);
+      return exp.isBefore(DateTime.now());
+    } on Exception {
+      return true;
+    }
+  }
+
+  /// Refreshes the access token by calling auth.shorebird.dev/token.
+  ///
+  /// Returns the new access token, or throws on failure.
+  Future<void> refresh({
+    required http.Client httpClient,
+    String authServiceUrl = defaultAuthServiceUrl,
+  }) async {
+    final response = await httpClient.post(
+      Uri.parse('$authServiceUrl/token'),
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: 'grant_type=refresh_token&refresh_token=$refreshToken',
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception(
+        'Failed to refresh token: ${response.statusCode} ${response.body}',
+      );
+    }
+
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    accessToken = body['access_token'] as String;
+  }
+}

--- a/packages/shorebird_cli/lib/src/commands/login_ci_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/login_ci_command.dart
@@ -2,31 +2,12 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
-import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart'
-    as api;
 
 /// {@template login_ci_command}
 /// `shorebird login:ci`
 /// Login as a CI user.
 /// {@endtemplate}
 class LoginCiCommand extends ShorebirdCommand {
-  /// {@macro login_ci_command}
-  LoginCiCommand() {
-    argParser.addOption(
-      'provider',
-      abbr: 'p',
-      allowed: _oauthProviders.map((e) => e.name),
-      defaultsTo: api.AuthProvider.google.name,
-      help: 'The authentication provider to use. Defaults to Google.',
-    );
-  }
-
-  /// Providers that support direct OAuth (used for CI token generation).
-  static const _oauthProviders = [
-    api.AuthProvider.google,
-    api.AuthProvider.microsoft,
-  ];
-
   @override
   String get description => 'Login as a CI user.';
 
@@ -35,20 +16,9 @@ class LoginCiCommand extends ShorebirdCommand {
 
   @override
   Future<int> run() async {
-    final api.AuthProvider provider;
-    if (results.wasParsed('provider')) {
-      provider = api.AuthProvider.values.byName(results['provider'] as String);
-    } else {
-      provider = logger.chooseOne(
-        'Choose an auth provider',
-        choices: _oauthProviders,
-        display: (p) => p.displayName,
-      );
-    }
-
     final CiToken ciToken;
     try {
-      ciToken = await auth.loginCI(provider, prompt: prompt);
+      ciToken = await auth.loginCI(prompt: prompt);
     } on UserNotFoundException catch (error) {
       logger
         ..err('''
@@ -69,7 +39,7 @@ We could not find a Shorebird account for ${error.email}.''')
 ${lightCyan.wrap(ciToken.toBase64())}
 
 Example:
-  
+
 ${lightCyan.wrap('export $shorebirdTokenEnvVar="\$SHOREBIRD_TOKEN" && shorebird patch android')}
 ''');
     return ExitCode.success.code;

--- a/packages/shorebird_cli/lib/src/commands/login_ci_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/login_ci_command.dart
@@ -15,11 +15,17 @@ class LoginCiCommand extends ShorebirdCommand {
     argParser.addOption(
       'provider',
       abbr: 'p',
-      allowed: api.AuthProvider.values.map((e) => e.name),
+      allowed: _oauthProviders.map((e) => e.name),
       defaultsTo: api.AuthProvider.google.name,
       help: 'The authentication provider to use. Defaults to Google.',
     );
   }
+
+  /// Providers that support direct OAuth (used for CI token generation).
+  static const _oauthProviders = [
+    api.AuthProvider.google,
+    api.AuthProvider.microsoft,
+  ];
 
   @override
   String get description => 'Login as a CI user.';
@@ -35,7 +41,7 @@ class LoginCiCommand extends ShorebirdCommand {
     } else {
       provider = logger.chooseOne(
         'Choose an auth provider',
-        choices: api.AuthProvider.values,
+        choices: _oauthProviders,
         display: (p) => p.displayName,
       );
     }

--- a/packages/shorebird_cli/lib/src/commands/login_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/login_command.dart
@@ -2,24 +2,12 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
-import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart'
-    as api;
 
 /// {@template login_command}
 /// `shorebird login`
 /// Login as a new Shorebird user.
 /// {@endtemplate}
 class LoginCommand extends ShorebirdCommand {
-  /// {@macro login_command}
-  LoginCommand() {
-    argParser.addOption(
-      'provider',
-      abbr: 'p',
-      allowed: api.AuthProvider.values.map((e) => e.name),
-      help: 'The authentication provider to use.',
-    );
-  }
-
   @override
   String get description => 'Login as a new Shorebird user.';
 
@@ -37,19 +25,8 @@ class LoginCommand extends ShorebirdCommand {
       return ExitCode.success.code;
     }
 
-    final api.AuthProvider provider;
-    if (results.wasParsed('provider')) {
-      provider = api.AuthProvider.values.byName(results['provider'] as String);
-    } else {
-      provider = logger.chooseOne(
-        'Choose an auth provider',
-        choices: api.AuthProvider.values,
-        display: (p) => p.displayName,
-      );
-    }
-
     try {
-      await auth.login(provider, prompt: prompt);
+      await auth.login(prompt: prompt);
     } on UserNotFoundException catch (error) {
       final consoleUri = Uri.https('console.shorebird.dev');
       logger

--- a/packages/shorebird_cli/test/src/auth/auth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_test.dart
@@ -142,6 +142,7 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(FakeBaseRequest());
+      registerFallbackValue(Uri.parse('https://example.com'));
     });
 
     R runWithOverrides<R>(R Function() body) {
@@ -173,6 +174,12 @@ void main() {
               }) async {
                 return accessCredentials;
               },
+          performShorebirdLogin: ({
+            required void Function(String url) prompt,
+            String authServiceUrl = 'https://auth.shorebird.dev',
+          }) async {
+            return (accessToken: idToken, refreshToken: refreshToken);
+          },
         ),
       );
     }
@@ -180,7 +187,11 @@ void main() {
     void writeCredentials() {
       File(
         p.join(credentialsDir, 'credentials.json'),
-      ).writeAsStringSync(jsonEncode(accessCredentials.toJson()));
+      ).writeAsStringSync(jsonEncode({
+        'type': 'shorebird',
+        'access_token': idToken,
+        'refresh_token': refreshToken,
+      }));
     }
 
     setUp(() {
@@ -505,14 +516,28 @@ void main() {
     group('client', () {
       test('returns an authenticated client '
           'when credentials are present.', () async {
+        // Stub the refresh POST (the test JWT is expired).
+        when(
+          () => httpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            encoding: any(named: 'encoding'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            '{"access_token": "$idToken", "token_type": "Bearer", "expires_in": 900}',
+            HttpStatus.ok,
+          ),
+        );
         when(() => httpClient.send(any())).thenAnswer(
           (_) async =>
               http.StreamedResponse(const Stream.empty(), HttpStatus.ok),
         );
-        await auth.login(AuthProvider.google, prompt: (_) {});
+        await auth.login(prompt: (_) {});
         final client = auth.client;
         expect(client, isA<http.Client>());
-        expect(client, isA<AuthenticatedClient>());
+        expect(client, isA<ShorebirdAuthenticatedClient>());
 
         await runWithOverrides(
           () => client.get(Uri.parse('https://example.com')),
@@ -607,26 +632,13 @@ Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar e
       test(
         'should set the email when claims are valid and current user exists',
         () async {
-          await auth.login(AuthProvider.google, prompt: (_) {});
+          await auth.login(prompt: (_) {});
           expect(auth.email, email);
           expect(auth.isAuthenticated, isTrue);
           expect(buildAuth().email, email);
           expect(buildAuth().isAuthenticated, isTrue);
         },
       );
-
-      group('with custom auth provider', () {
-        test(
-          '''should set the email when claims are valid and current user exists''',
-          () async {
-            await auth.login(AuthProvider.microsoft, prompt: (_) {});
-            expect(auth.email, email);
-            expect(auth.isAuthenticated, isTrue);
-            expect(buildAuth().email, email);
-            expect(buildAuth().isAuthenticated, isTrue);
-          },
-        );
-      });
 
       test(
         'throws UserAlreadyLoggedInException if user is authenticated',
@@ -635,7 +647,7 @@ Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar e
           auth = buildAuth();
 
           await expectLater(
-            auth.login(AuthProvider.google, prompt: (_) {}),
+            auth.login(prompt: (_) {}),
             throwsA(isA<UserAlreadyLoggedInException>()),
           );
 
@@ -646,19 +658,25 @@ Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar e
 
       group('when login credentials are corrupted', () {
         setUp(() {
-          accessCredentials = oauth2.AccessCredentials(
-            accessToken,
-            refreshToken,
-            scopes,
-            idToken: 'not a valid jwt',
-          );
-          writeCredentials();
+          // Write corrupted Shorebird credentials.
+          File(
+            p.join(credentialsDir, 'credentials.json'),
+          ).writeAsStringSync(jsonEncode({
+            'type': 'shorebird',
+            'access_token': 'not a valid jwt',
+            'refresh_token': 'sb_rt_test',
+          }));
           auth = buildAuth();
         });
 
         test('proceeds with login', () async {
+          // Email is null because the JWT is corrupted.
           expect(auth.email, isNull);
-          await auth.login(AuthProvider.google, prompt: (_) {});
+          // But isAuthenticated is true because we have shorebird credentials.
+          expect(auth.isAuthenticated, isTrue);
+          // Logout first so login doesn't throw UserAlreadyLoggedInException.
+          auth.logout();
+          await auth.login(prompt: (_) {});
           expect(auth.email, equals(email));
           expect(auth.isAuthenticated, isTrue);
         });
@@ -670,7 +688,7 @@ Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar e
         ).thenAnswer((_) async => null);
 
         await expectLater(
-          auth.login(AuthProvider.google, prompt: (_) {}),
+          auth.login(prompt: (_) {}),
           throwsA(isA<UserNotFoundException>()),
         );
 
@@ -742,7 +760,7 @@ Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar e
 
     group('logout', () {
       test('clears session and wipes state', () async {
-        await auth.login(AuthProvider.google, prompt: (_) {});
+        await auth.login(prompt: (_) {});
         expect(auth.email, email);
         expect(auth.isAuthenticated, isTrue);
 

--- a/packages/shorebird_cli/test/src/auth/auth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_test.dart
@@ -164,12 +164,13 @@ void main() {
           buildCodePushClient: ({Uri? hostedUri, http.Client? httpClient}) {
             return codePushClient;
           },
-          performShorebirdLogin: ({
-            required void Function(String url) prompt,
-            String authServiceUrl = 'https://auth.shorebird.dev',
-          }) async {
-            return (accessToken: idToken, refreshToken: refreshToken);
-          },
+          performShorebirdLogin:
+              ({
+                required void Function(String url) prompt,
+                String authServiceUrl = 'https://auth.shorebird.dev',
+              }) async {
+                return (accessToken: idToken, refreshToken: refreshToken);
+              },
         ),
       );
     }
@@ -177,11 +178,13 @@ void main() {
     void writeCredentials() {
       File(
         p.join(credentialsDir, 'credentials.json'),
-      ).writeAsStringSync(jsonEncode({
-        'type': 'shorebird',
-        'access_token': idToken,
-        'refresh_token': refreshToken,
-      }));
+      ).writeAsStringSync(
+        jsonEncode({
+          'type': 'shorebird',
+          'access_token': idToken,
+          'refresh_token': refreshToken,
+        }),
+      );
     }
 
     setUp(() {
@@ -651,11 +654,13 @@ Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar e
           // Write corrupted Shorebird credentials.
           File(
             p.join(credentialsDir, 'credentials.json'),
-          ).writeAsStringSync(jsonEncode({
-            'type': 'shorebird',
-            'access_token': 'not a valid jwt',
-            'refresh_token': 'sb_rt_test',
-          }));
+          ).writeAsStringSync(
+            jsonEncode({
+              'type': 'shorebird',
+              'access_token': 'not a valid jwt',
+              'refresh_token': 'sb_rt_test',
+            }),
+          );
           auth = buildAuth();
         });
 
@@ -696,12 +701,14 @@ Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar e
       });
 
       test('returns an API key', () async {
-        when(() => httpClient.post(
-              any(),
-              headers: any(named: 'headers'),
-              body: any(named: 'body'),
-              encoding: any(named: 'encoding'),
-            )).thenAnswer(
+        when(
+          () => httpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            encoding: any(named: 'encoding'),
+          ),
+        ).thenAnswer(
           (_) async => http.Response(
             '{"api_key": "$apiKey", "name": "CI"}',
             HttpStatus.created,
@@ -721,12 +728,14 @@ Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar e
       });
 
       test('throws when API key creation fails', () async {
-        when(() => httpClient.post(
-              any(),
-              headers: any(named: 'headers'),
-              body: any(named: 'body'),
-              encoding: any(named: 'encoding'),
-            )).thenAnswer(
+        when(
+          () => httpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            encoding: any(named: 'encoding'),
+          ),
+        ).thenAnswer(
           (_) async => http.Response(
             '{"error": "unauthorized"}',
             HttpStatus.unauthorized,

--- a/packages/shorebird_cli/test/src/commands/login_ci_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/login_ci_command_test.dart
@@ -1,4 +1,3 @@
-import 'package:args/args.dart';
 import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
@@ -15,7 +14,6 @@ void main() {
   group(LoginCiCommand, () {
     const email = 'test@email.com';
 
-    late ArgResults results;
     late Auth auth;
     late http.Client httpClient;
     late ShorebirdLogger logger;
@@ -31,138 +29,80 @@ void main() {
       );
     }
 
-    setUpAll(() {
-      registerFallbackValue(AuthProvider.google);
-    });
-
     setUp(() {
       auth = MockAuth();
       httpClient = MockHttpClient();
       logger = MockShorebirdLogger();
-      results = MockArgResults();
 
-      when(() => results.wasParsed('provider')).thenReturn(false);
-      when(() => results['provider']).thenReturn(null);
       when(() => auth.client).thenReturn(httpClient);
-      when(() => auth.loginCI(any(), prompt: any(named: 'prompt'))).thenAnswer(
-        (_) async => const CiToken(
-          // "shorebird-token" in base64
-          refreshToken: 'c2hvcmViaXJkLXRva2Vu', // cspell:disable-line
-          authProvider: AuthProvider.google,
-        ),
-      );
       when(
-        () => logger.chooseOne<AuthProvider>(
-          any(),
-          choices: any(named: 'choices'),
-          display: any(named: 'display'),
+        () => auth.loginCI(prompt: any(named: 'prompt')),
+      ).thenAnswer(
+        (_) async => const CiToken(
+          refreshToken: 'sb_rt_test_token',
+          authProvider: AuthProvider.shorebird,
         ),
-      ).thenReturn(AuthProvider.google);
-
-      command = runWithOverrides(
-        () => LoginCiCommand()..testArgResults = results,
       );
-    });
 
-    group('provider', () {
-      group('when provider is passed as an arg', () {
-        const provider = AuthProvider.google;
-
-        setUp(() {
-          when(() => results.wasParsed('provider')).thenReturn(true);
-          when(() => results['provider']).thenReturn(provider.name);
-        });
-
-        test('uses the passed provider', () async {
-          await runWithOverrides(() => command.run());
-
-          verify(
-            () => auth.loginCI(provider, prompt: any(named: 'prompt')),
-          ).called(1);
-        });
-      });
-
-      group('when provider is not passed as an arg', () {
-        const provider = AuthProvider.microsoft;
-
-        setUp(() {
-          when(() => results.wasParsed('provider')).thenReturn(false);
-          when(
-            () => logger.chooseOne<AuthProvider>(
-              any(),
-              choices: any(named: 'choices'),
-              display: captureAny(named: 'display'),
-            ),
-          ).thenReturn(provider);
-        });
-
-        test('uses the provider chosen by the user', () async {
-          await runWithOverrides(() => command.run());
-
-          verify(
-            () => auth.loginCI(provider, prompt: any(named: 'prompt')),
-          ).called(1);
-          final captured =
-              verify(
-                    () => logger.chooseOne<AuthProvider>(
-                      any(),
-                      choices: any(named: 'choices'),
-                      display: captureAny(named: 'display'),
-                    ),
-                  ).captured.single
-                  as String Function(AuthProvider);
-          expect(captured(AuthProvider.google), contains('Google'));
-        });
-      });
+      command = runWithOverrides(LoginCiCommand.new);
     });
 
     test('exits with code 70 if no user is found', () async {
       when(
-        () => auth.loginCI(any(), prompt: any(named: 'prompt')),
+        () => auth.loginCI(prompt: any(named: 'prompt')),
       ).thenThrow(UserNotFoundException(email: email));
 
       final result = await runWithOverrides(command.run);
       expect(result, equals(ExitCode.software.code));
 
       verify(
-        () => logger.err('We could not find a Shorebird account for $email.'),
+        () => logger.err(
+          'We could not find a Shorebird account for $email.',
+        ),
       ).called(1);
       verify(
-        () => logger.info(any(that: contains('https://console.shorebird.dev'))),
+        () => logger.info(
+          any(that: contains('https://console.shorebird.dev')),
+        ),
       ).called(1);
     });
 
     test('exits with code 70 when error occurs', () async {
       final error = Exception('oops something went wrong!');
       when(
-        () => auth.loginCI(any(), prompt: any(named: 'prompt')),
+        () => auth.loginCI(prompt: any(named: 'prompt')),
       ).thenThrow(error);
 
       final result = await runWithOverrides(command.run);
       expect(result, equals(ExitCode.software.code));
 
-      verify(() => auth.loginCI(any(), prompt: any(named: 'prompt'))).called(1);
+      verify(
+        () => auth.loginCI(prompt: any(named: 'prompt')),
+      ).called(1);
       verify(() => logger.err(error.toString())).called(1);
     });
 
     test('exits with code 0 when logged in successfully', () async {
       const token = CiToken(
-        // "shorebird-token" in base64
-        refreshToken: 'c2hvcmViaXJkLXRva2Vu', // cspell:disable-line
-        authProvider: AuthProvider.google,
+        refreshToken: 'sb_rt_test_token',
+        authProvider: AuthProvider.shorebird,
       );
       when(
-        () => auth.loginCI(any(), prompt: any(named: 'prompt')),
+        () => auth.loginCI(prompt: any(named: 'prompt')),
       ).thenAnswer((_) async => token);
       when(() => auth.email).thenReturn(email);
 
       final result = await runWithOverrides(command.run);
       expect(result, equals(ExitCode.success.code));
 
-      verify(() => auth.loginCI(any(), prompt: any(named: 'prompt'))).called(1);
+      verify(
+        () => auth.loginCI(prompt: any(named: 'prompt')),
+      ).called(1);
       verify(
         () => logger.info(
-          any(that: contains('${lightCyan.wrap(token.toBase64())}')),
+          any(
+            that: contains('${lightCyan.wrap(token.toBase64())}'),
+          ),
         ),
       ).called(1);
     });

--- a/packages/shorebird_cli/test/src/commands/login_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/login_command_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:args/args.dart';
 import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
@@ -9,7 +8,6 @@ import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/commands/login_command.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
-import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';
 
 import '../mocks.dart';
@@ -18,7 +16,6 @@ void main() {
   group(LoginCommand, () {
     const email = 'test@email.com';
 
-    late ArgResults results;
     late Auth auth;
     late http.Client httpClient;
     late Directory applicationConfigHome;
@@ -35,91 +32,22 @@ void main() {
       );
     }
 
-    setUpAll(() {
-      registerFallbackValue(AuthProvider.google);
-    });
-
     setUp(() {
       applicationConfigHome = Directory.systemTemp.createTempSync();
-      results = MockArgResults();
       auth = MockAuth();
       httpClient = MockHttpClient();
       logger = MockShorebirdLogger();
 
-      when(() => results.wasParsed('provider')).thenReturn(false);
-      when(() => results['provider']).thenReturn(null);
       when(() => auth.isAuthenticated).thenReturn(false);
       when(() => auth.client).thenReturn(httpClient);
       when(
         () => auth.credentialsFilePath,
       ).thenReturn(p.join(applicationConfigHome.path, 'credentials.json'));
       when(
-        () => auth.login(any(), prompt: any(named: 'prompt')),
+        () => auth.login(prompt: any(named: 'prompt')),
       ).thenAnswer((_) async {});
 
-      when(
-        () => logger.chooseOne<AuthProvider>(
-          any(),
-          choices: any(named: 'choices'),
-          display: any(named: 'display'),
-        ),
-      ).thenReturn(AuthProvider.google);
-
-      command = runWithOverrides(
-        () => LoginCommand()..testArgResults = results,
-      );
-    });
-
-    group('provider', () {
-      group('when provider is passed as an arg', () {
-        const provider = AuthProvider.google;
-
-        setUp(() {
-          when(() => results.wasParsed('provider')).thenReturn(true);
-          when(() => results['provider']).thenReturn(provider.name);
-        });
-
-        test('uses the passed provider', () async {
-          await runWithOverrides(() => command.run());
-
-          verify(
-            () => auth.login(provider, prompt: any(named: 'prompt')),
-          ).called(1);
-        });
-      });
-
-      group('when provider is not passed as an arg', () {
-        const provider = AuthProvider.microsoft;
-
-        setUp(() {
-          when(() => results.wasParsed('provider')).thenReturn(false);
-          when(
-            () => logger.chooseOne<AuthProvider>(
-              any(),
-              choices: any(named: 'choices'),
-              display: any(named: 'display'),
-            ),
-          ).thenReturn(provider);
-        });
-
-        test('uses the provider chosen by the user', () async {
-          await runWithOverrides(() => command.run());
-
-          verify(
-            () => auth.login(provider, prompt: any(named: 'prompt')),
-          ).called(1);
-          final captured =
-              verify(
-                    () => logger.chooseOne<AuthProvider>(
-                      any(),
-                      choices: any(named: 'choices'),
-                      display: captureAny(named: 'display'),
-                    ),
-                  ).captured.single
-                  as String Function(AuthProvider);
-          expect(captured(AuthProvider.google), contains('Google'));
-        });
-      });
+      command = runWithOverrides(LoginCommand.new);
     });
 
     group('when user is already logged in', () {
@@ -142,14 +70,14 @@ void main() {
               '''Run ${lightCyan.wrap('shorebird logout')} to log out and try again.''',
             ),
           ).called(1);
-          verifyNever(() => auth.login(any(), prompt: any(named: 'prompt')));
+          verifyNever(() => auth.login(prompt: any(named: 'prompt')));
         },
       );
     });
 
     test('exits with code 70 if no user is found', () async {
       when(
-        () => auth.login(any(), prompt: any(named: 'prompt')),
+        () => auth.login(prompt: any(named: 'prompt')),
       ).thenThrow(UserNotFoundException(email: email));
 
       final result = await runWithOverrides(command.run);
@@ -166,26 +94,26 @@ void main() {
     test('exits with code 70 when error occurs', () async {
       final error = Exception('oops something went wrong!');
       when(
-        () => auth.login(any(), prompt: any(named: 'prompt')),
+        () => auth.login(prompt: any(named: 'prompt')),
       ).thenThrow(error);
 
       final result = await runWithOverrides(command.run);
       expect(result, equals(ExitCode.software.code));
 
-      verify(() => auth.login(any(), prompt: any(named: 'prompt'))).called(1);
+      verify(() => auth.login(prompt: any(named: 'prompt'))).called(1);
       verify(() => logger.err(error.toString())).called(1);
     });
 
     test('exits with code 0 when logged in successfully', () async {
       when(
-        () => auth.login(any(), prompt: any(named: 'prompt')),
+        () => auth.login(prompt: any(named: 'prompt')),
       ).thenAnswer((_) async {});
       when(() => auth.email).thenReturn(email);
 
       final result = await runWithOverrides(command.run);
       expect(result, equals(ExitCode.success.code));
 
-      verify(() => auth.login(any(), prompt: any(named: 'prompt'))).called(1);
+      verify(() => auth.login(prompt: any(named: 'prompt'))).called(1);
       verify(
         () => logger.info(
           any(that: contains('You are now logged in as <$email>.')),

--- a/packages/shorebird_code_push_protocol/lib/src/models/auth_provider.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/auth_provider.dart
@@ -4,7 +4,10 @@ enum AuthProvider {
   google('Google'),
 
   /// The user authenticated with their Azure/Entra account.
-  microsoft('Microsoft');
+  microsoft('Microsoft'),
+
+  /// The user authenticated via Shorebird's own auth service.
+  shorebird('Shorebird');
 
   const AuthProvider(this.displayName);
 


### PR DESCRIPTION
Part of https://github.com/shorebirdtech/shorebird/issues/1722.

This removes the --provider option from `shorebird login` instead asking the user to pick at auth.shorebird.dev.  We *could* keep the --provider option and just pass through to auth.shorebird.dev but I'm choosing the simpler UX for now.