### PR TITLE
fix: stop unnecessary rebuild on every CLI invocation (#3435)

### DIFF
--- a/bin/shorebird.ps1
+++ b/bin/shorebird.ps1
@@ -141,6 +141,10 @@ function Update-Shorebird {
     Push-Location $shorebirdCliDir
     & $dart pub get
     Pop-Location
+    # pub get may not update pubspec.lock's mtime if dependencies are unchanged,
+    # which would cause the pubspec.yaml -gt pubspec.lock check to keep
+    # triggering a rebuild on every invocation.
+    (Get-Item "$shorebirdRootDir/pubspec.lock").LastWriteTime = Get-Date
 
     Write-Output "Compiling shorebird..."
 

--- a/third_party/flutter/bin/internal/shared.sh
+++ b/third_party/flutter/bin/internal/shared.sh
@@ -155,6 +155,10 @@ function upgrade_shorebird () (
 
     export PUB_ENVIRONMENT="$PUB_ENVIRONMENT:shorebird_install"
     pub_get_with_retry
+    # pub get may not update pubspec.lock's mtime if dependencies are unchanged,
+    # which would cause the pubspec.yaml -nt pubspec.lock check above to keep
+    # triggering a rebuild on every invocation.
+    touch "$SHOREBIRD_ROOT/pubspec.lock"
 
     # Move the old snapshot - we can't just overwrite it as the VM might currently have it
     # memory mapped (e.g. on shorebird upgrade). For downloading a new dart sdk the folder is moved,


### PR DESCRIPTION
`pub get` doesn't update pubspec.lock's mtime when dependencies are
unchanged, causing the pubspec.yaml -nt pubspec.lock cache check to
keep triggering a full Flutter update and snapshot recompile on every
invocation. Touch pubspec.lock after pub get to prevent this.

Fixes #3435.