### PR TITLE
fix: fix flaky network checker timeout tests

### DIFF
--- a/packages/shorebird_cli/test/src/network_checker_test.dart
+++ b/packages/shorebird_cli/test/src/network_checker_test.dart
@@ -255,8 +255,9 @@ void main() {
         setUp(() {
           // Use a Completer that never completes so the timeout always fires,
           // regardless of how slow the CI machine is.
-          when(() => httpClient.send(any()))
-              .thenAnswer((_) => Completer<http.StreamedResponse>().future);
+          when(
+            () => httpClient.send(any()),
+          ).thenAnswer((_) => Completer<http.StreamedResponse>().future);
         });
 
         test('throws a NetworkCheckerException', () async {

--- a/packages/shorebird_cli/test/src/network_checker_test.dart
+++ b/packages/shorebird_cli/test/src/network_checker_test.dart
@@ -121,19 +121,15 @@ void main() {
 
       group('when download times out', () {
         const downloadTimeout = Duration(milliseconds: 1);
-        // Make this a healthy multiple of the upload timeout to avoid flakiness
-        // on slow (read: Windows) CI machines.
-        final responseTime = downloadTimeout * 100;
         setUp(() {
+          // Use a Completer that never completes so the timeout always fires,
+          // regardless of how slow the CI machine is.
           when(
             () => artifactManager.downloadFile(
               any(),
               outputPath: any(named: 'outputPath'),
             ),
-          ).thenAnswer((_) async {
-            await Future<void>.delayed(responseTime);
-            return File('');
-          });
+          ).thenAnswer((_) => Completer<File>().future);
         });
 
         test('throws a NetworkCheckerException', () async {
@@ -256,17 +252,11 @@ void main() {
 
       group('when upload times out', () {
         const uploadTimeout = Duration(milliseconds: 1);
-        // Make this a healthy multiple of the upload timeout to avoid flakiness
-        // on slow (read: Windows) CI machines.
-        final responseTime = uploadTimeout * 5;
         setUp(() {
-          when(() => httpClient.send(any())).thenAnswer((_) async {
-            await Future<void>.delayed(responseTime);
-            return http.StreamedResponse(
-              const Stream.empty(),
-              HttpStatus.noContent,
-            );
-          });
+          // Use a Completer that never completes so the timeout always fires,
+          // regardless of how slow the CI machine is.
+          when(() => httpClient.send(any()))
+              .thenAnswer((_) => Completer<http.StreamedResponse>().future);
         });
 
         test('throws a NetworkCheckerException', () async {


### PR DESCRIPTION
## Summary
- Replace `Future.delayed` with a never-completing `Completer` in the upload and download timeout tests in `network_checker_test.dart`
- The previous approach used a small time multiplier over the timeout, but real file I/O before the timed call could consume enough wall-clock time for the mock to resolve before the timeout fired, causing flaky failures on slow CI machines

## Test plan
- [x] `dart test packages/shorebird_cli/test/src/network_checker_test.dart` passes