### PR TITLE
fix: deflake throttled progress update test

### DIFF
--- a/packages/shorebird_cli/test/src/artifact_manager_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_manager_test.dart
@@ -352,10 +352,10 @@ void main() {
                 ),
               ),
             );
-            // Download the first 3/5. The first addition will trigger the first
-            // progress update, the second addition will be throttled, and the
-            // third addition will trigger the second progress update after the
-            // delay.
+            // Download the first 3/5. The first addition will trigger the
+            // first progress update, the second addition will be throttled,
+            // and the third addition will trigger the second progress update
+            // after the delay.
             responseStreamController
               ..add([1])
               ..add([1])
@@ -364,9 +364,14 @@ void main() {
             // Download the last 2/5, bringing the total to 5/5
             responseStreamController.add([1, 1]);
             await Future<void>.delayed(const Duration(milliseconds: 70));
+            // The first update (20%) always fires immediately. The
+            // trailing throttled update may be 40% or 60% depending on
+            // timing. The final 100% always fires.
             verifyInOrder([
               () => progress.update('hello (20%)'),
-              () => progress.update('hello (60%)'),
+              () => progress.update(
+                    any(that: anyOf('hello (40%)', 'hello (60%)')),
+                  ),
               () => progress.update('hello (100%)'),
             ]);
             verifyNever(() => progress.update('hello (0%)'));

--- a/packages/shorebird_cli/test/src/artifact_manager_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_manager_test.dart
@@ -370,8 +370,8 @@ void main() {
             verifyInOrder([
               () => progress.update('hello (20%)'),
               () => progress.update(
-                    any(that: anyOf('hello (40%)', 'hello (60%)')),
-                  ),
+                any(that: anyOf('hello (40%)', 'hello (60%)')),
+              ),
               () => progress.update('hello (100%)'),
             ]);
             verifyNever(() => progress.update('hello (0%)'));


### PR DESCRIPTION
## Summary
- The `artifact_manager_test.dart` throttled progress test was flaky because it asserted the intermediate throttle update was exactly `hello (60%)`, but on slow CI bots the trailing throttle could fire at `hello (40%)` instead.
- Changed the `verifyInOrder` assertion to accept either `hello (40%)` or `hello (60%)` using `anyOf`.

## Test plan
- [x] `dart test test/src/artifact_manager_test.dart` passes