### PR TITLE
feat: allow adding flavors without resetting base app_id

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -161,12 +161,16 @@ Please make sure you are running "shorebird init" from within your Flutter proje
     if (existingFlavors != null) {
       final existingFlavorNames = existingFlavors.keys.toSet();
       newFlavors = productFlavors.difference(existingFlavorNames);
+    } else if (shorebirdYaml != null) {
+      // Existing shorebird.yaml without flavors — treat all detected flavors
+      // as new so they can be added without resetting the base app_id.
+      newFlavors = productFlavors;
     } else {
       newFlavors = {};
     }
 
-    // New flavors not being empty means that we have existing flavors, which
-    // means that there is already an existing app.
+    // New flavors not being empty means that there is already an existing app
+    // and we just need to add the new flavor entries.
     // If the --force flag is present, we will completely reinit the app and
     // don't care about which flavors are new.
     if (!force && newFlavors.isNotEmpty) {
@@ -188,7 +192,7 @@ Please make sure you are running "shorebird init" from within your Flutter proje
       final deflavoredAppName = existingApp.displayName
           .replaceAll(RegExp(r'\(.*\)'), '')
           .trim();
-      final flavorsToAppIds = shorebirdYaml.flavors!;
+      final flavorsToAppIds = shorebirdYaml.flavors ?? {};
       for (final flavor in newFlavors) {
         final app = await codePushClientWrapper.createApp(
           appName: '$deflavoredAppName ($flavor)',


### PR DESCRIPTION
## Summary
- When a project was initialized without flavors and later added them, `shorebird init` would show "already up-to-date" and require `--force`, which resets the base `app_id`
- Now detects new flavors even when the existing `shorebird.yaml` has no `flavors` entry, and adds them while preserving the existing `app_id`
- Added tests for the new path and for previously untested "no new flavors" scenarios

Fixes #3437

## Test plan
- [x] Existing tests pass (40/40)
- [x] New test: existing yaml without flavors + flavors detected → adds flavors, preserves app_id
- [x] New test: existing yaml without flavors + no flavors detected → shows up-to-date error
- [x] New test: existing yaml with flavors + no new flavors → shows up-to-date error