### PR TITLE
fix: use forward slashes in AAB ZIP entries on Windows

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -962,13 +962,10 @@ This is only applicable when previewing Android releases.''',
       final encoder = ZipFileEncoder()..create(tmpAabFile.path);
       for (final file in Directory(outputPath).listSync(recursive: true)) {
         if (file is File) {
-          // Use forward slashes for ZIP entry names per the ZIP spec.
-          // Without this, Windows backslashes cause bundletool to fail
-          // with "File 'base/manifest/AndroidManifest.xml' not found".
-          final entryName = file.path
-              .replaceFirst('$outputPath${p.separator}', '')
-              .replaceAll(r'\', '/');
-          await encoder.addFile(file, entryName);
+          await encoder.addFile(
+            file,
+            file.path.replaceFirst('$outputPath${p.separator}', ''),
+          );
         }
       }
       await encoder.close();

--- a/packages/shorebird_cli/lib/src/commands/preview_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/preview_command.dart
@@ -962,10 +962,13 @@ This is only applicable when previewing Android releases.''',
       final encoder = ZipFileEncoder()..create(tmpAabFile.path);
       for (final file in Directory(outputPath).listSync(recursive: true)) {
         if (file is File) {
-          await encoder.addFile(
-            file,
-            file.path.replaceFirst('$outputPath${p.separator}', ''),
-          );
+          // Use forward slashes for ZIP entry names per the ZIP spec.
+          // Without this, Windows backslashes cause bundletool to fail
+          // with "File 'base/manifest/AndroidManifest.xml' not found".
+          final entryName = file.path
+              .replaceFirst('$outputPath${p.separator}', '')
+              .replaceAll(r'\', '/');
+          await encoder.addFile(file, entryName);
         }
       }
       await encoder.close();

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.9.0 <4.0.0"
 
 dependencies:
-  archive: ^4.0.7
+  archive: ^4.0.8
   args: ^2.7.0
   checked_yaml: ^2.0.4
   cli_completion: ^0.5.0

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -815,8 +815,7 @@ channel: ${track.channel}
 ''');
           });
 
-          test('re-zipped AAB uses forward slashes in entry names',
-              () async {
+          test('re-zipped AAB uses forward slashes in entry names', () async {
             aabFile = await createAabFile(channel: 'dev');
             await runWithOverrides(
               () => command.setChannelOnAab(
@@ -834,8 +833,7 @@ channel: ${track.channel}
               expect(
                 file.name,
                 isNot(contains(r'\')),
-                reason:
-                    'ZIP entry "${file.name}" contains backslash',
+                reason: 'ZIP entry "${file.name}" contains backslash',
               );
             }
           });

--- a/packages/shorebird_cli/test/src/commands/preview_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/preview_command_test.dart
@@ -139,6 +139,18 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync(yamlContents);
 
+      // Include AndroidManifest.xml to match real AAB structure.
+      File(
+          p.join(
+            aabDirectory.path,
+            'base',
+            'manifest',
+            'AndroidManifest.xml',
+          ),
+        )
+        ..createSync(recursive: true)
+        ..writeAsStringSync('<manifest />');
+
       await ZipFileEncoder().zipDirectory(aabDirectory, filename: aabPath());
 
       return File(aabPath());
@@ -801,6 +813,31 @@ channel: ${track.channel}
 app_id: $appId
 channel: ${track.channel}
 ''');
+          });
+
+          test('re-zipped AAB uses forward slashes in entry names',
+              () async {
+            aabFile = await createAabFile(channel: 'dev');
+            await runWithOverrides(
+              () => command.setChannelOnAab(
+                aabFile: aabFile,
+                channel: track.channel,
+              ),
+            );
+
+            // Verify all ZIP entry names use forward slashes per the
+            // ZIP spec. On Windows, without normalization, entries would
+            // contain backslashes which breaks bundletool.
+            final bytes = aabFile.readAsBytesSync();
+            final archive = ZipDecoder().decodeBytes(bytes);
+            for (final file in archive.files) {
+              expect(
+                file.name,
+                isNot(contains(r'\')),
+                reason:
+                    'ZIP entry "${file.name}" contains backslash',
+              );
+            }
           });
         });
       });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "4.0.9"
   args:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixes https://github.com/shorebirdtech/shorebird/issues/3621

## Summary

`shorebird preview` on Windows fails with `File 'base/manifest/AndroidManifest.xml' not found` when using a non-default track (e.g., `--track staging`).

### Root cause

`setChannelOnAab` extracts the AAB, modifies `shorebird.yaml`, and re-zips it. But it **short-circuits** when no yaml change is needed — specifically when the track is `stable` (the default) and no channel is set in the yaml. Most users run `shorebird preview` without `--track`, so the AAB is never re-zipped and goes straight to bundletool untouched.

When a non-default track like `staging` is used, the yaml update triggers the re-zip. On Windows, the `archive` package (v4.0.7) stored ZIP entry names with backslash path separators (e.g., `base\manifest\AndroidManifest.xml`). The [ZIP spec (PKWARE AppNote 4.4.17)](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) requires forward slashes, and Java's bundletool can't find entries with backslashes.

### Fix

Bump `archive` from 4.0.7 to 4.0.8, which includes the upstream fix for this exact issue: [brendan-duncan/archive#404](https://github.com/brendan-duncan/archive/issues/404). The package now forces POSIX path separators in `ZipFileEncoder`.

### Test

- Adds a regression test that verifies all re-zipped AAB entries use forward slashes
- Adds `base/manifest/AndroidManifest.xml` to the test AAB to match real AAB structure

## Test plan
- [x] Existing `setChannelOnAab` tests pass
- [x] New test verifies no backslashes in re-zipped AAB entry names
- [ ] CI passes on all platforms (macOS, Windows, Ubuntu)