### PR TITLE
feat: support RSA JWK key stores for Shorebird auth

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -119,6 +119,7 @@ words:
   - udid # Unique Device Identifier
   - unawaited
   - unmockable
+  - unpadded
   - Unpatchable
   - unsets
   - unskipped

--- a/packages/jwt/example/main.dart
+++ b/packages/jwt/example/main.dart
@@ -6,6 +6,7 @@ Future<void> main() async {
     issuer: '<ISSUER>',
     audience: {'<AUDIENCE>'},
     publicKeysUrl: '<PUBLIC_KEYS_URL>',
+    jwksFormat: jwt.JwksFormat.keyValue,
   );
   print(token);
 }

--- a/packages/jwt/lib/jwt.dart
+++ b/packages/jwt/lib/jwt.dart
@@ -1,2 +1,3 @@
+export 'src/jwks_format.dart';
 export 'src/jwt.dart';
 export 'src/models/models.dart';

--- a/packages/jwt/lib/src/jwks_format.dart
+++ b/packages/jwt/lib/src/jwks_format.dart
@@ -1,0 +1,19 @@
+/// {@template jwks_format}
+/// The JWKS response format used by an auth provider's public key endpoint.
+///
+/// Each value maps to a specific [PublicKeyStore] subclass that knows how to
+/// parse that format.
+/// {@endtemplate}
+enum JwksFormat {
+  /// Google's format: a flat JSON object mapping key IDs to PEM certificate
+  /// strings.
+  keyValue,
+
+  /// Microsoft Entra ID's format: a JWK Set containing X.509 certificate
+  /// chains (`x5c`/`x5t` fields).
+  jwkCertificate,
+
+  /// Shorebird auth's format: a JWK Set with bare RSA public key parameters
+  /// (`n`, `e`, `kid`, `kty`, `use`; no certificates).
+  rsaJwk,
+}

--- a/packages/jwt/lib/src/models/public_key_store/jwk_key_store.dart
+++ b/packages/jwt/lib/src/models/public_key_store/jwk_key_store.dart
@@ -26,15 +26,15 @@ class JwkKeyStore extends PublicKeyStore {
   Iterable<String> get keyIds => keys.map((key) => key.kid);
 
   @override
-  String? getPublicKey(String kid) {
+  KeyMaterial? getKeyMaterial(String kid) {
     final key = keys.firstWhereOrNull((key) => key.kid == kid)?.x5c.firstOrNull;
     if (key == null) {
       return null;
     }
 
-    return '''
+    return PemKeyMaterial('''
 -----BEGIN CERTIFICATE-----
 $key
------END CERTIFICATE-----''';
+-----END CERTIFICATE-----''');
   }
 }

--- a/packages/jwt/lib/src/models/public_key_store/key_value_key_store.dart
+++ b/packages/jwt/lib/src/models/public_key_store/key_value_key_store.dart
@@ -26,5 +26,9 @@ class KeyValueKeyStore extends PublicKeyStore {
   Iterable<String> get keyIds => keys.keys;
 
   @override
-  String? getPublicKey(String kid) => keys[kid];
+  KeyMaterial? getKeyMaterial(String kid) {
+    final pem = keys[kid];
+    if (pem == null) return null;
+    return PemKeyMaterial(pem);
+  }
 }

--- a/packages/jwt/lib/src/models/public_key_store/public_key_store.dart
+++ b/packages/jwt/lib/src/models/public_key_store/public_key_store.dart
@@ -1,5 +1,35 @@
+import 'package:jwt/src/jwks_format.dart';
 import 'package:jwt/src/models/public_key_store/jwk_key_store.dart';
 import 'package:jwt/src/models/public_key_store/key_value_key_store.dart';
+import 'package:jwt/src/models/public_key_store/rsa_jwk_key_store.dart';
+import 'package:pointycastle/pointycastle.dart' as pointycastle;
+
+/// {@template key_material}
+/// The material needed to verify a JWT signature.
+/// {@endtemplate}
+sealed class KeyMaterial {}
+
+/// {@template pem_key_material}
+/// Key material represented as a PEM-encoded string.
+/// {@endtemplate}
+class PemKeyMaterial extends KeyMaterial {
+  /// {@macro pem_key_material}
+  PemKeyMaterial(this.pem);
+
+  /// The PEM-encoded key string.
+  final String pem;
+}
+
+/// {@template rsa_key_material}
+/// Key material represented as a raw RSA public key.
+/// {@endtemplate}
+class RsaKeyMaterial extends KeyMaterial {
+  /// {@macro rsa_key_material}
+  RsaKeyMaterial(this.publicKey);
+
+  /// The RSA public key.
+  final pointycastle.RSAPublicKey publicKey;
+}
 
 /// {@template public_key_store}
 /// A store for the public keys.
@@ -8,30 +38,27 @@ abstract class PublicKeyStore {
   /// {@macro public_key_store}
   const PublicKeyStore();
 
-  /// Attempts to deserialize a [PublicKeyStore] from a JSON object. This will
-  /// return the appropriate subclass of [PublicKeyStore] if the JSON object
-  /// contains the necessary fields.
-  static PublicKeyStore? tryDeserialize(Map<String, dynamic> json) {
-    if (json.containsKey('keys')) {
-      try {
-        return JwkKeyStore.fromJson(json);
-      } on Exception {
-        // Swallow deserialization exceptions and return null.
-      }
-    } else {
-      try {
-        return KeyValueKeyStore.fromJson(json);
-      } on Exception {
-        // Swallow deserialization exceptions and return null.
-      }
+  /// Attempts to deserialize a [PublicKeyStore] from a JSON object for the
+  /// given [format].
+  static PublicKeyStore? tryDeserialize(
+    Map<String, dynamic> json, {
+    required JwksFormat format,
+  }) {
+    try {
+      return switch (format) {
+        JwksFormat.keyValue => KeyValueKeyStore.fromJson(json),
+        JwksFormat.jwkCertificate => JwkKeyStore.fromJson(json),
+        JwksFormat.rsaJwk => RsaJwkKeyStore.fromJson(json),
+      };
+    } on Exception {
+      // Swallow deserialization exceptions and return null.
+      return null;
     }
-
-    return null;
   }
 
   /// The key IDs contained in this store.
   Iterable<String> get keyIds;
 
-  /// Returns a public key for the given key ID, if one exists.
-  String? getPublicKey(String kid);
+  /// Returns the key material for the given key ID, if one exists.
+  KeyMaterial? getKeyMaterial(String kid);
 }

--- a/packages/jwt/lib/src/models/public_key_store/rsa_jwk_key_store.dart
+++ b/packages/jwt/lib/src/models/public_key_store/rsa_jwk_key_store.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:jwt/src/models/public_key_store/public_key_store.dart';
+import 'package:jwt/src/models/rsa_jwk.dart';
+import 'package:pointycastle/pointycastle.dart' as pointycastle;
+
+part 'rsa_jwk_key_store.g.dart';
+
+/// {@template rsa_jwk_key_store}
+/// A collection of bare RSA JSON Web Keys, as produced by Shorebird's auth
+/// service.
+///
+/// Unlike [JwkKeyStore], which wraps X.509 certificates, this key store
+/// converts base64url-encoded JWK parameters (`n`, `e`) directly into a
+/// PointyCastle [pointycastle.RSAPublicKey].
+/// {@endtemplate}
+@JsonSerializable(createToJson: false)
+class RsaJwkKeyStore extends PublicKeyStore {
+  /// {@macro rsa_jwk_key_store}
+  RsaJwkKeyStore({required this.keys});
+
+  /// The collection of RSA JWKs.
+  final List<RsaJwk> keys;
+
+  /// Decodes a JSON object into an [RsaJwkKeyStore].
+  static RsaJwkKeyStore fromJson(Map<String, dynamic> json) =>
+      _$RsaJwkKeyStoreFromJson(json);
+
+  @override
+  Iterable<String> get keyIds => keys.map((key) => key.kid);
+
+  @override
+  KeyMaterial? getKeyMaterial(String kid) {
+    final key = keys.firstWhereOrNull((key) => key.kid == kid);
+    if (key == null) return null;
+
+    // Validate key type.
+    if (key.kty != 'RSA') return null;
+
+    // Only accept keys intended for signature verification.
+    if (key.use != 'sig') return null;
+
+    // Validate algorithm: accept RS256 or absent (verifier defaults to RS256).
+    // Reject any other algorithm to prevent algorithm confusion attacks.
+    if (key.alg != null && key.alg != 'RS256') return null;
+
+    final modulus = _decodeBigInt(key.n);
+    final exponent = _decodeBigInt(key.e);
+
+    return RsaKeyMaterial(pointycastle.RSAPublicKey(modulus, exponent));
+  }
+}
+
+/// Decodes a base64url-encoded unsigned big-endian integer (as used in JWK
+/// `n` and `e` fields) into a [BigInt].
+BigInt _decodeBigInt(String base64UrlValue) {
+  final padded = base64UrlValue.padRight(
+    base64UrlValue.length + (4 - base64UrlValue.length % 4) % 4,
+    '=',
+  );
+  final bytes = base64Url.decode(padded);
+
+  var result = BigInt.zero;
+  for (final byte in bytes) {
+    result = (result << 8) | BigInt.from(byte);
+  }
+  return result;
+}

--- a/packages/jwt/lib/src/models/public_key_store/rsa_jwk_key_store.g.dart
+++ b/packages/jwt/lib/src/models/public_key_store/rsa_jwk_key_store.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, require_trailing_commas, cast_nullable_to_non_nullable, lines_longer_than_80_chars, document_ignores
+
+part of 'rsa_jwk_key_store.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+RsaJwkKeyStore _$RsaJwkKeyStoreFromJson(Map<String, dynamic> json) =>
+    $checkedCreate('RsaJwkKeyStore', json, ($checkedConvert) {
+      final val = RsaJwkKeyStore(
+        keys: $checkedConvert(
+          'keys',
+          (v) => (v as List<dynamic>)
+              .map((e) => RsaJwk.fromJson(e as Map<String, dynamic>))
+              .toList(),
+        ),
+      );
+      return val;
+    });

--- a/packages/jwt/lib/src/models/rsa_jwk.dart
+++ b/packages/jwt/lib/src/models/rsa_jwk.dart
@@ -1,0 +1,44 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'rsa_jwk.g.dart';
+
+/// {@template rsa_jwk}
+/// An RSA JSON Web Key (JWK) as produced by Shorebird's auth service.
+///
+/// Contains only the bare RSA public key fields exported by `jose.exportJWK()`
+/// (`kty`, `n`, `e`, `kid`, `use`, and optionally `alg`) — without the X.509
+/// certificate fields (`x5c`, `x5t`) present in [Jwk].
+/// {@endtemplate}
+@JsonSerializable(createToJson: false)
+class RsaJwk {
+  /// {@macro rsa_jwk}
+  const RsaJwk({
+    required this.kty,
+    required this.use,
+    required this.kid,
+    required this.n,
+    required this.e,
+    this.alg,
+  });
+
+  /// Decodes a JSON object into an [RsaJwk].
+  factory RsaJwk.fromJson(Map<String, dynamic> json) => _$RsaJwkFromJson(json);
+
+  /// Key type (must be `"RSA"`).
+  final String kty;
+
+  /// Key use (e.g., `"sig"`).
+  final String use;
+
+  /// Key ID.
+  final String kid;
+
+  /// RSA modulus (base64url-encoded, unpadded).
+  final String n;
+
+  /// RSA public exponent (base64url-encoded, unpadded).
+  final String e;
+
+  /// Algorithm — optional per RFC 7517 §4.4.
+  final String? alg;
+}

--- a/packages/jwt/lib/src/models/rsa_jwk.g.dart
+++ b/packages/jwt/lib/src/models/rsa_jwk.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, require_trailing_commas, cast_nullable_to_non_nullable, lines_longer_than_80_chars, document_ignores
+
+part of 'rsa_jwk.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+RsaJwk _$RsaJwkFromJson(Map<String, dynamic> json) =>
+    $checkedCreate('RsaJwk', json, ($checkedConvert) {
+      final val = RsaJwk(
+        kty: $checkedConvert('kty', (v) => v as String),
+        use: $checkedConvert('use', (v) => v as String),
+        kid: $checkedConvert('kid', (v) => v as String),
+        n: $checkedConvert('n', (v) => v as String),
+        e: $checkedConvert('e', (v) => v as String),
+        alg: $checkedConvert('alg', (v) => v as String?),
+      );
+      return val;
+    });


### PR DESCRIPTION
Shorebird's auth service exposes public keys via a standard JWKS endpoint, but uses bare RSA parameters (`n`, `e`, `kid`, `kty`, `use`) rather than X.509 certificate chains (`x5c`/`x5t`). The existing `JwkKeyStore` only supports certificate-based JWKs, and the `KeyValueKeyStore` only supports Google's flat PEM format. This PR adds the third format so the `jwt` package can verify tokens from our own auth service.

## Description

- Adds a new `RsaJwkKeyStore` that can parse bare RSA JWK sets as produced by Shorebird's Auth service
- Introduces a `JwksFormat` enum so callers explicitly declare the expected JWKS format, replacing the previous heuristic-based format detection in `PublicKeyStore.tryDeseriealize`
- Refactors key material handling from raw `String` to a `KeyMaterial` class (`PemKeyMaterial`/`RsaKeyMaterial`) for signature verification

## Changes

| Area | What changed |
|------|-------------|
| **New: `JwksFormat`** | Enum with variants `keyValue`, `jwkCertificate`, `rsaJwk` — passed into `verify()` and `PublicKeyStore.tryDeserialize` |
| **New: `KeyMaterial`** | Sealed class replacing `String? getPublicKey(kid)` with `KeyMaterial? getKeyMaterial(kid)` — subtypes `PemKeyMaterial` and `RsaKeyMaterial` |
| **New: `RsaJwk`** | `@JsonSerializable` model for a single RSA JWK entry (`kty`, `use`, `kid`, `n`, `e`, optional `alg`) |
| **New: `RsaJwkKeyStore`** | Decodes base64url `n`/`e` into `RSAPublicKey`; validates `kty=RSA`, `use=sig`, and `alg` (RS256 or absent) |
| **Modified: `PublicKeyStore`** | `tryDeserialize` now takes a `JwksFormat` and uses a `switch` expression instead of try-catch guessing |
| **Modified: `_verifySignature`** | Pattern matches on `KeyMaterial` to handle both PEM parsing and direct RSA key paths |
| **Modified: `JwkKeyStore` / `KeyValueKeyStore`** | Updated to return `KeyMaterial` instead of `String` |
| **Tests** | Unit tests for `RsaJwkKeyStore` (deserialization, key ID lookup, `alg`/`kty`/`use` validation); end-to-end tests that generate an RSA key pair, sign a JWT, and verify it through the full `verify()` flow |


## Security considerations

- `RsaJwkKeyStore.getKeyMaterial` validates `kty`, `use`, and `alg` before returning key material to guard against algorithm confusion attacks
- Only `RS256` (or absent `alg`, which defaults to RS256 at the verifier) is accepted; all other algorithms are rejected
- Existing PEM-based verification paths are unchanged

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
