### PR TITLE
feat: add --confirm flag to release and patch commands

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -108,6 +108,11 @@ To target the latest release (e.g. the release that was most recently updated) u
         help: CommonArguments.noConfirmArg.description,
         negatable: false,
       )
+      ..addFlag(
+        'confirm',
+        negatable: false,
+        hide: true,
+      )
       ..addOption(
         CommonArguments.exportOptionsPlistArg.name,
         help: CommonArguments.exportOptionsPlistArg.description,
@@ -187,6 +192,9 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
 
   /// The target script, if provided.
   late String? target = results.findOption('target', argParser: argParser);
+
+  /// Whether to prompt for confirmation before creating the patch.
+  bool get confirm => results['confirm'] == true;
 
   /// Whether to allow changes in assets (--allow-asset-diffs).
   bool get allowAssetDiffs => results['allow-asset-diffs'] == true;
@@ -608,6 +616,13 @@ ${styleBold.wrap(lightGreen.wrap('🚀 Ready to publish a new patch!'))}
 
 ${summary.join('\n')}
 ''');
+
+    if (confirm && shorebirdEnv.canAcceptUserInput) {
+      if (!logger.confirm('Would you like to continue?', defaultValue: true)) {
+        logger.info('Aborting.');
+        throw ProcessExit(ExitCode.success.code);
+      }
+    }
   }
 
   /// Downloads the given [releaseArtifact].

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -108,6 +108,8 @@ To target the latest release (e.g. the release that was most recently updated) u
         help: CommonArguments.noConfirmArg.description,
         negatable: false,
       )
+      // Added for https://github.com/shorebirdtech/shorebird/issues/3223.
+      // Can be removed fall 2026 or later.
       ..addFlag(
         'confirm',
         negatable: false,

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -129,6 +129,11 @@ Defaults to "latest" which builds using the latest stable Flutter version.''',
         help: CommonArguments.noConfirmArg.description,
         negatable: false,
       )
+      ..addFlag(
+        'confirm',
+        negatable: false,
+        hide: true,
+      )
       ..addOption(
         'release-version',
         help: '''
@@ -224,6 +229,9 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
         );
     }
   }
+
+  /// Whether to prompt for confirmation before creating the release.
+  bool get confirm => results['confirm'] == true;
 
   /// The shorebird app ID for the current project.
   String get appId => shorebirdEnv.getShorebirdYaml()!.getAppId(flavor: flavor);
@@ -524,6 +532,13 @@ ${styleBold.wrap(lightGreen.wrap('🚀 Ready to create a new release!'))}
 
 ${summary.join('\n')}
 ''');
+
+    if (confirm && shorebirdEnv.canAcceptUserInput) {
+      if (!logger.confirm('Would you like to continue?', defaultValue: true)) {
+        logger.info('Aborting.');
+        throw ProcessExit(ExitCode.success.code);
+      }
+    }
   }
 
   /// Fetches the release with version [version] from the server or creates a

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -129,6 +129,8 @@ Defaults to "latest" which builds using the latest stable Flutter version.''',
         help: CommonArguments.noConfirmArg.description,
         negatable: false,
       )
+      // Added for https://github.com/shorebirdtech/shorebird/issues/3223.
+      // Can be removed fall 2026 or later.
       ..addFlag(
         'confirm',
         negatable: false,

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -825,7 +825,10 @@ void main() {
         group('when user confirms', () {
           setUp(() {
             when(
-              () => logger.confirm(any(), defaultValue: any(named: 'defaultValue')),
+              () => logger.confirm(
+                any(),
+                defaultValue: any(named: 'defaultValue'),
+              ),
             ).thenReturn(true);
           });
 
@@ -853,7 +856,10 @@ void main() {
         group('when user declines', () {
           setUp(() {
             when(
-              () => logger.confirm(any(), defaultValue: any(named: 'defaultValue')),
+              () => logger.confirm(
+                any(),
+                defaultValue: any(named: 'defaultValue'),
+              ),
             ).thenReturn(false);
           });
 
@@ -892,7 +898,8 @@ void main() {
             completes,
           );
           verifyNever(
-            () => logger.confirm(any(), defaultValue: any(named: 'defaultValue')),
+            () =>
+                logger.confirm(any(), defaultValue: any(named: 'defaultValue')),
           );
         });
       });

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -815,6 +815,87 @@ void main() {
           });
         });
       });
+
+      group('when --confirm is passed', () {
+        setUp(() {
+          when(() => argResults['confirm']).thenReturn(true);
+          when(() => shorebirdEnv.canAcceptUserInput).thenReturn(true);
+        });
+
+        group('when user confirms', () {
+          setUp(() {
+            when(
+              () => logger.confirm(any(), defaultValue: any(named: 'defaultValue')),
+            ).thenReturn(true);
+          });
+
+          test('continues', () async {
+            await expectLater(
+              runWithOverrides(
+                () => command.logPatchSummary(
+                  app: appMetadata,
+                  releaseVersion: releaseVersion,
+                  patcher: patcher,
+                  patchArtifactBundles: patchArtifactBundles,
+                ),
+              ),
+              completes,
+            );
+            verify(
+              () => logger.confirm(
+                'Would you like to continue?',
+                defaultValue: true,
+              ),
+            ).called(1);
+          });
+        });
+
+        group('when user declines', () {
+          setUp(() {
+            when(
+              () => logger.confirm(any(), defaultValue: any(named: 'defaultValue')),
+            ).thenReturn(false);
+          });
+
+          test('exits with success and prints Aborting.', () async {
+            await expectLater(
+              runWithOverrides(
+                () => command.logPatchSummary(
+                  app: appMetadata,
+                  releaseVersion: releaseVersion,
+                  patcher: patcher,
+                  patchArtifactBundles: patchArtifactBundles,
+                ),
+              ),
+              exitsWithCode(ExitCode.success),
+            );
+            verify(() => logger.info('Aborting.')).called(1);
+          });
+        });
+      });
+
+      group('when --confirm is not passed', () {
+        setUp(() {
+          when(() => argResults['confirm']).thenReturn(false);
+        });
+
+        test('does not prompt for confirmation', () async {
+          await expectLater(
+            runWithOverrides(
+              () => command.logPatchSummary(
+                app: appMetadata,
+                releaseVersion: releaseVersion,
+                patcher: patcher,
+                patchArtifactBundles: patchArtifactBundles,
+              ),
+            ),
+            completes,
+          );
+          verifyNever(
+            () => logger.confirm(any(), defaultValue: any(named: 'defaultValue')),
+          );
+        });
+      });
     });
 
     group('when flutter install fails', () {

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -414,6 +414,69 @@ void main() {
       });
     });
 
+    group('when --confirm is passed', () {
+      setUp(() {
+        when(() => argResults['confirm']).thenReturn(true);
+        when(() => shorebirdEnv.canAcceptUserInput).thenReturn(true);
+      });
+
+      group('when user confirms', () {
+        setUp(() {
+          when(
+            () => logger.confirm(
+              any(),
+              defaultValue: any(named: 'defaultValue'),
+            ),
+          ).thenReturn(true);
+        });
+
+        test('continues', () async {
+          await runWithOverrides(command.run);
+          verify(
+            () => logger.confirm(
+              'Would you like to continue?',
+              defaultValue: true,
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when user declines', () {
+        setUp(() {
+          when(
+            () => logger.confirm(
+              any(),
+              defaultValue: any(named: 'defaultValue'),
+            ),
+          ).thenReturn(false);
+        });
+
+        test('exits with success and prints Aborting.', () async {
+          await expectLater(
+            runWithOverrides(command.run),
+            exitsWithCode(ExitCode.success),
+          );
+          verify(() => logger.info('Aborting.')).called(1);
+        });
+      });
+    });
+
+    group('when --confirm is not passed', () {
+      setUp(() {
+        when(() => argResults['confirm']).thenReturn(false);
+      });
+
+      test('does not prompt for confirmation', () async {
+        await runWithOverrides(command.run);
+        verifyNever(
+          () => logger.confirm(
+            any(),
+            defaultValue: any(named: 'defaultValue'),
+          ),
+        );
+      });
+    });
+
     group('when flavor and target are provided', () {
       const flavor = 'test-flavor';
       const target = 'test-target';


### PR DESCRIPTION
## Summary
- Adds a hidden `--confirm` flag to `shorebird release` and `shorebird patch` that restores the interactive confirmation prompt when explicitly passed
- Default behavior (no confirmation) is unchanged; `--no-confirm` preserved for backwards compatibility
- When `--confirm` is passed and the terminal supports input, prompts "Would you like to continue?" before proceeding

## Test plan
- [x] `dart test packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart` — all 48 tests pass
- [x] `dart test packages/shorebird_cli/test/src/commands/release/release_command_test.dart` — all 27 tests pass
- [x] Tests cover: `--confirm` + user confirms (continues), `--confirm` + user declines (aborts), no `--confirm` (no prompt)