### PR TITLE
refactor: use single negatable --confirm flag instead of separate flags

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -103,16 +103,10 @@ To target the latest release (e.g. the release that was most recently updated) u
 [DEPRECATED] Whether to publish the patch to the staging environment. Use --track=staging instead.''',
         hide: true,
       )
-      ..addFlag(
-        CommonArguments.noConfirmArg.name,
-        help: CommonArguments.noConfirmArg.description,
-        negatable: false,
-      )
       // Added for https://github.com/shorebirdtech/shorebird/issues/3223.
       // Can be removed fall 2026 or later.
       ..addFlag(
         'confirm',
-        negatable: false,
         hide: true,
       )
       ..addOption(

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -124,16 +124,10 @@ Defaults to "latest" which builds using the latest stable Flutter version.''',
         hide: true,
         negatable: false,
       )
-      ..addFlag(
-        CommonArguments.noConfirmArg.name,
-        help: CommonArguments.noConfirmArg.description,
-        negatable: false,
-      )
       // Added for https://github.com/shorebirdtech/shorebird/issues/3223.
       // Can be removed fall 2026 or later.
       ..addFlag(
         'confirm',
-        negatable: false,
         hide: true,
       )
       ..addOption(

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -1386,7 +1386,7 @@ void main() {
 
     group('when --no-confirm is specified', () {
       setUp(() {
-        when(() => argResults['no-confirm']).thenReturn(true);
+        when(() => argResults['confirm']).thenReturn(false);
       });
 
       test('does not prompt for confirmation', () async {

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -405,7 +405,7 @@ void main() {
     // but we do accept a --no-confirm argument for backwards compatibility.
     group('when --no-confirm is specified', () {
       setUp(() {
-        when(() => argResults['no-confirm']).thenReturn(true);
+        when(() => argResults['confirm']).thenReturn(false);
       });
 
       test('does not prompt for confirmation', () async {


### PR DESCRIPTION
## Summary
- Replaces the separate `--no-confirm` (non-negatable) and `--confirm` (non-negatable) flags with a single negatable `--confirm` flag
- `--no-confirm` continues to work as the negated form of `--confirm`, preserving backwards compatibility
- Follows up on #3628

## Test plan
- [x] `dart test packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart` — all 48 tests pass
- [x] `dart test packages/shorebird_cli/test/src/commands/release/release_command_test.dart` — all 27 tests pass