### PR TITLE
feat: Add release notes and version bump for v1.6.87

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,10 @@
 cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkishan appbundle proto tlsv kingdomseed Peetee Aditya
  -->
 
+## 1.6.87 (March 5, 2026)
+
+- 🔐 `shorebird login` now uses the new Shorebird auth service (direct Google and Microsoft login deprecated)
+
 ## 1.6.86 (March 4, 2026)
 
 - 🐦 Support for Flutter 3.41.4
@@ -1288,7 +1292,6 @@ Please let us know if we can help!
 ## 0.17.4 (November 10, 2023)
 
 - 💿 Includes our new custom Dart Virtual Machine "mixed-mode" (not yet enabled)
-
   - We rewrote how Dart code is executed on iOS in this release. We haven't yet enabled the new faster "mixed-mode" execution so there should be no observable change, but the faster VM is now included and in partial use. Because this was such a large (multi-month!) change, there could be unanticipated changes on iOS devices. If you see anything surprising, please let us know!
 
 📚 Release notes can be found at https://github.com/shorebirdtech/shorebird/releases/tag/v0.17.4

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@ cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkisha
 
 ## 1.6.87 (March 5, 2026)
 
-- 🔐 `shorebird login` now uses the new Shorebird auth service (direct Google and Microsoft login deprecated)
+- 🔐 `shorebird login` now uses the new Shorebird auth service.
 
 ## 1.6.86 (March 4, 2026)
 

--- a/packages/shorebird_cli/lib/src/version.dart
+++ b/packages/shorebird_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.6.86';
+const packageVersion = '1.6.87';

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_cli
 description: Command-line tool to interact with Shorebird's services.
-version: 1.6.86
+version: 1.6.87
 repository: https://github.com/shorebirdtech/shorebird
 resolution: workspace
 


### PR DESCRIPTION
## Description

- Adds release note for version 1.6.87
- Updates version number in `packages/shorebird_cli/pubspec.yaml`
- Updates generated version number in `packages/shorebird_cli/lib/src/version.dart`

This release migrates Shorebird CLI to use new Auth service for the `login` command.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
