### PR TITLE
feat: use git worktrees for Flutter version management

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -138,6 +138,7 @@ words:
   - unmockable
   - unobfuscated
   - unpadded
+  - unparseable
   - Unpatchable
   - unsets
   - unskipped
@@ -147,6 +148,7 @@ words:
   - VCRUNTIME
   - Verdana
   - vmcode
+  - worktree
   - writeln
   - WRONGPASS
   - xcarchive

--- a/packages/shorebird_cli/lib/src/commands/cache/clean_cache_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/cache/clean_cache_command.dart
@@ -6,6 +6,7 @@ import 'package:shorebird_cli/src/cache.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
+import 'package:shorebird_cli/src/shorebird_flutter.dart';
 
 /// {@template clean_cache_command}
 /// `shorebird cache clean`
@@ -13,7 +14,13 @@ import 'package:shorebird_cli/src/shorebird_command.dart';
 /// {@endtemplate}
 class CleanCacheCommand extends ShorebirdCommand {
   /// {@macro clean_cache_command}
-  CleanCacheCommand();
+  CleanCacheCommand() {
+    argParser.addFlag(
+      'prune',
+      help: 'Only remove old, unused Flutter revisions instead of the '
+          'entire cache.',
+    );
+  }
 
   @override
   String get description => 'Clears the Shorebird cache directory.';
@@ -26,6 +33,10 @@ class CleanCacheCommand extends ShorebirdCommand {
 
   @override
   Future<int> run() async {
+    if (results['prune'] == true) {
+      return _pruneOldRevisions();
+    }
+
     final progress = logger.progress('Clearing cache');
     try {
       await cache.clear();
@@ -52,5 +63,21 @@ This could be because a program is using a file in the cache directory. To find 
 
     progress.complete('Cleared cache');
     return ExitCode.success.code;
+  }
+
+  Future<int> _pruneOldRevisions() async {
+    final progress = logger.progress('Pruning old Flutter revisions');
+    try {
+      final pruned = await shorebirdFlutter.pruneOldRevisions();
+      if (pruned == 0) {
+        progress.complete('No old Flutter revisions to prune');
+      } else {
+        progress.complete('Pruned $pruned old Flutter revision(s)');
+      }
+      return ExitCode.success.code;
+    } on Exception catch (error) {
+      progress.fail('Failed to prune old Flutter revisions: $error');
+      return ExitCode.software.code;
+    }
   }
 }

--- a/packages/shorebird_cli/lib/src/commands/cache/clean_cache_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/cache/clean_cache_command.dart
@@ -17,7 +17,8 @@ class CleanCacheCommand extends ShorebirdCommand {
   CleanCacheCommand() {
     argParser.addFlag(
       'prune',
-      help: 'Only remove old, unused Flutter revisions instead of the '
+      help:
+          'Only remove old, unused Flutter revisions instead of the '
           'entire cache.',
     );
   }

--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -198,6 +198,44 @@ class Git {
     return true;
   }
 
+  /// Clone a bare repository.
+  /// `git clone --bare <url> ...<args> <outputDirectory>`
+  Future<void> cloneBare({
+    required String url,
+    required String outputDirectory,
+    List<String>? args,
+  }) async {
+    await git(['clone', '--bare', url, ...?args, outputDirectory]);
+  }
+
+  /// Add a git worktree at [directory] checked out to [revision].
+  Future<void> worktreeAdd({
+    required String directory,
+    required String revision,
+    required String repoDirectory,
+  }) async {
+    await git([
+      'worktree',
+      'add',
+      '--detach',
+      directory,
+      revision,
+    ], workingDirectory: repoDirectory);
+  }
+
+  /// Remove a git worktree at [directory].
+  Future<void> worktreeRemove({
+    required String directory,
+    required String repoDirectory,
+  }) async {
+    await git([
+      'worktree',
+      'remove',
+      '--force',
+      directory,
+    ], workingDirectory: repoDirectory);
+  }
+
   /// Whether [file] is tracked by its git repository.
   Future<bool> isFileTracked({required File file}) async {
     try {

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -32,18 +32,68 @@ class ShorebirdFlutter {
   static const String flutterGitUrl =
       'https://github.com/shorebirdtech/flutter.git';
 
+  /// Default max age for pruning old Flutter revisions.
+  static const defaultPruneMaxAge = Duration(days: 30);
+
   /// Arguments to pass to `flutter precache`.
   List<String> get precacheArgs => ['--android', if (platform.isMacOS) '--ios'];
+
+  /// The path to the shared bare repo for Flutter revisions.
+  String get _repoDirectory => p.join(
+    shorebirdEnv.flutterDirectory.parent.path,
+    '.repo',
+  );
+
+  /// The path to the last-used timestamp directory.
+  String get _lastUsedDirectory => p.join(
+    shorebirdEnv.flutterDirectory.parent.path,
+    '.last_used',
+  );
 
   String _workingDirectory({String? revision}) {
     revision ??= shorebirdEnv.flutterRevision;
     return p.join(shorebirdEnv.flutterDirectory.parent.path, revision);
   }
 
+  /// Returns a directory suitable for running git queries (forEachRef,
+  /// revParse, etc.). Prefers the shared bare repo when available, falling
+  /// back to the current revision's checkout.
+  String _gitQueryDirectory() {
+    final repoDir = _repoDirectory;
+    if (Directory(repoDir).existsSync()) return repoDir;
+    return _workingDirectory();
+  }
+
+  /// Ensures the shared bare repo exists and is up-to-date.
+  Future<void> _ensureBareRepo() async {
+    final repoDir = Directory(_repoDirectory);
+    if (repoDir.existsSync()) {
+      await git.fetch(directory: repoDir.path, args: ['--all']);
+      return;
+    }
+    await git.cloneBare(
+      url: flutterGitUrl,
+      outputDirectory: repoDir.path,
+      args: ['--filter=tree:0'],
+    );
+  }
+
+  /// Records that [revision] was used at the current time.
+  void _touchLastUsed(String revision) {
+    final file = File(p.join(_lastUsedDirectory, revision));
+    file.createSync(recursive: true);
+    file.writeAsStringSync(DateTime.now().toIso8601String());
+  }
+
   /// Install the provided Flutter [revision].
   Future<void> installRevision({required String revision}) async {
     final targetDirectory = Directory(_workingDirectory(revision: revision));
-    if (targetDirectory.existsSync()) return;
+    if (targetDirectory.existsSync()) {
+      _touchLastUsed(revision);
+      return;
+    }
+
+    await _ensureBareRepo();
 
     final version = await getVersionForRevision(flutterRevision: revision);
 
@@ -52,15 +102,11 @@ class ShorebirdFlutter {
     );
 
     try {
-      // Clone the Shorebird Flutter repo into the target directory.
-      await git.clone(
-        url: flutterGitUrl,
-        outputDirectory: targetDirectory.path,
-        args: ['--filter=tree:0', '--no-checkout'],
+      await git.worktreeAdd(
+        directory: targetDirectory.path,
+        revision: revision,
+        repoDirectory: _repoDirectory,
       );
-
-      // Checkout the correct revision.
-      await git.checkout(directory: targetDirectory.path, revision: revision);
       installProgress.complete();
     } catch (error) {
       installProgress.fail(
@@ -86,6 +132,8 @@ class ShorebirdFlutter {
         '''This is not a critical error, but your next build make take longer than usual.''',
       );
     }
+
+    _touchLastUsed(revision);
   }
 
   /// Whether the current revision is unmodified.
@@ -205,7 +253,7 @@ class ShorebirdFlutter {
       contains: flutterRevision,
       format: '%(refname:short)',
       pattern: 'refs/remotes/origin/flutter_release/*',
-      directory: _workingDirectory(),
+      directory: _gitQueryDirectory(),
     );
 
     return LineSplitter.split(result)
@@ -239,7 +287,7 @@ class ShorebirdFlutter {
     try {
       final fullHash = await git.revParse(
         revision: versionOrHash,
-        directory: _workingDirectory(),
+        directory: _gitQueryDirectory(),
       );
       return fullHash;
     } on ProcessException {
@@ -287,7 +335,7 @@ class ShorebirdFlutter {
     try {
       final result = await git.revParse(
         revision: 'refs/remotes/origin/flutter_release/$version',
-        directory: _workingDirectory(),
+        directory: _gitQueryDirectory(),
       );
       return LineSplitter.split(result).toList().firstOrNull;
     } on ProcessException {
@@ -300,10 +348,57 @@ class ShorebirdFlutter {
     final result = await git.forEachRef(
       format: '%(refname:short)',
       pattern: 'refs/remotes/origin/flutter_release/*',
-      directory: _workingDirectory(revision: revision),
+      directory: _gitQueryDirectory(),
     );
     return LineSplitter.split(
       result,
     ).map((e) => e.replaceFirst('origin/flutter_release/', '')).toList();
+  }
+
+  /// Remove Flutter revisions not used in [maxAge] (default 30 days).
+  /// Skips the currently active revision.
+  /// Returns the number of revisions pruned.
+  Future<int> pruneOldRevisions({
+    Duration maxAge = defaultPruneMaxAge,
+    DateTime? now,
+  }) async {
+    final lastUsedDir = Directory(_lastUsedDirectory);
+    if (!lastUsedDir.existsSync()) return 0;
+
+    final currentRevision = shorebirdEnv.flutterRevision;
+    final currentTime = now ?? DateTime.now();
+    var pruned = 0;
+
+    for (final file in lastUsedDir.listSync().whereType<File>()) {
+      final revision = p.basename(file.path);
+      if (revision == currentRevision) continue;
+
+      final content = file.readAsStringSync();
+      final lastUsed = DateTime.tryParse(content);
+      if (lastUsed == null) continue;
+      if (currentTime.difference(lastUsed) < maxAge) continue;
+
+      final revisionDir = Directory(_workingDirectory(revision: revision));
+      if (revisionDir.existsSync()) {
+        // Try worktree remove first, fall back to directory delete for
+        // legacy standalone clones.
+        final repoDir = Directory(_repoDirectory);
+        if (repoDir.existsSync()) {
+          try {
+            await git.worktreeRemove(
+              directory: revisionDir.path,
+              repoDirectory: _repoDirectory,
+            );
+          } catch (_) {
+            await revisionDir.delete(recursive: true);
+          }
+        } else {
+          await revisionDir.delete(recursive: true);
+        }
+      }
+      file.deleteSync();
+      pruned++;
+    }
+    return pruned;
   }
 }

--- a/packages/shorebird_cli/test/src/commands/cache/clean_cache_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/cache/clean_cache_command_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:platform/platform.dart';
@@ -9,6 +10,7 @@ import 'package:shorebird_cli/src/commands/commands.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_flutter.dart';
 import 'package:test/test.dart';
 
 import '../../mocks.dart';
@@ -20,6 +22,7 @@ void main() {
     late Platform platform;
     late Progress progress;
     late ShorebirdEnv shorebirdEnv;
+    late ShorebirdFlutter shorebirdFlutter;
     late CleanCacheCommand command;
 
     R runWithOverrides<R>(R Function() body) {
@@ -30,6 +33,7 @@ void main() {
           loggerRef.overrideWith(() => logger),
           platformRef.overrideWith(() => platform),
           shorebirdEnvRef.overrideWith(() => shorebirdEnv),
+          shorebirdFlutterRef.overrideWith(() => shorebirdFlutter),
         },
       );
     }
@@ -40,7 +44,13 @@ void main() {
       platform = MockPlatform();
       progress = MockProgress();
       shorebirdEnv = MockShorebirdEnv();
+      shorebirdFlutter = MockShorebirdFlutter();
       command = runWithOverrides(CleanCacheCommand.new);
+
+      // Set up default arg results (no --prune flag).
+      final defaultArgResults = MockArgResults();
+      when(() => defaultArgResults['prune']).thenReturn(false);
+      command.testArgResults = defaultArgResults;
 
       when(() => logger.progress(any())).thenReturn(progress);
       when(
@@ -107,6 +117,54 @@ void main() {
           verify(() => progress.fail(any())).called(1);
           verifyNever(() => logger.info(any()));
         });
+      });
+    });
+
+    group('with --prune flag', () {
+      late ArgResults argResults;
+
+      setUp(() {
+        argResults = MockArgResults();
+        when(() => argResults['prune']).thenReturn(true);
+        command.testArgResults = argResults;
+      });
+
+      test('prunes old revisions successfully', () async {
+        when(
+          () => shorebirdFlutter.pruneOldRevisions(),
+        ).thenAnswer((_) async => 3);
+
+        final result = await runWithOverrides(command.run);
+
+        expect(result, equals(ExitCode.success.code));
+        verify(
+          () => progress.complete('Pruned 3 old Flutter revision(s)'),
+        ).called(1);
+        verifyNever(cache.clear);
+      });
+
+      test('reports no revisions to prune', () async {
+        when(
+          () => shorebirdFlutter.pruneOldRevisions(),
+        ).thenAnswer((_) async => 0);
+
+        final result = await runWithOverrides(command.run);
+
+        expect(result, equals(ExitCode.success.code));
+        verify(
+          () => progress.complete('No old Flutter revisions to prune'),
+        ).called(1);
+      });
+
+      test('handles prune failure', () async {
+        when(
+          () => shorebirdFlutter.pruneOldRevisions(),
+        ).thenThrow(Exception('prune failed'));
+
+        final result = await runWithOverrides(command.run);
+
+        expect(result, equals(ExitCode.software.code));
+        verify(() => progress.fail(any())).called(1);
       });
     });
   });

--- a/packages/shorebird_cli/test/src/executables/git_test.dart
+++ b/packages/shorebird_cli/test/src/executables/git_test.dart
@@ -537,6 +537,136 @@ refs/heads/main
       });
     });
 
+    group('cloneBare', () {
+      const url = 'https://github.com/shorebirdtech/shorebird';
+      const outputDirectory = './output';
+
+      test('executes correct command (no args)', () async {
+        await runWithOverrides(
+          () => git.cloneBare(url: url, outputDirectory: outputDirectory),
+        );
+        verify(
+          () => process.run(
+            'git',
+            ['clone', '--bare', url, outputDirectory],
+          ),
+        ).called(1);
+      });
+
+      test('executes correct command (with args)', () async {
+        const args = <String>['--filter=tree:0'];
+        await runWithOverrides(
+          () => git.cloneBare(
+            url: url,
+            args: args,
+            outputDirectory: outputDirectory,
+          ),
+        );
+        verify(
+          () => process.run(
+            'git',
+            ['clone', '--bare', url, ...args, outputDirectory],
+          ),
+        ).called(1);
+      });
+
+      test('throws ProcessException if process exits with error', () async {
+        const error = 'oops';
+        when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        when(() => processResult.stderr).thenReturn(error);
+        expect(
+          () => runWithOverrides(
+            () => git.cloneBare(url: url, outputDirectory: outputDirectory),
+          ),
+          throwsA(
+            isA<ProcessException>().having((e) => e.message, 'message', error),
+          ),
+        );
+      });
+    });
+
+    group('worktreeAdd', () {
+      const directory = './worktree';
+      const revision = 'abc123';
+      const repoDirectory = './repo';
+
+      test('executes correct command', () async {
+        await runWithOverrides(
+          () => git.worktreeAdd(
+            directory: directory,
+            revision: revision,
+            repoDirectory: repoDirectory,
+          ),
+        );
+        verify(
+          () => process.run('git', [
+            'worktree',
+            'add',
+            '--detach',
+            directory,
+            revision,
+          ], workingDirectory: repoDirectory),
+        ).called(1);
+      });
+
+      test('throws ProcessException if process exits with error', () async {
+        const error = 'oops';
+        when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        when(() => processResult.stderr).thenReturn(error);
+        expect(
+          () => runWithOverrides(
+            () => git.worktreeAdd(
+              directory: directory,
+              revision: revision,
+              repoDirectory: repoDirectory,
+            ),
+          ),
+          throwsA(
+            isA<ProcessException>().having((e) => e.message, 'message', error),
+          ),
+        );
+      });
+    });
+
+    group('worktreeRemove', () {
+      const directory = './worktree';
+      const repoDirectory = './repo';
+
+      test('executes correct command', () async {
+        await runWithOverrides(
+          () => git.worktreeRemove(
+            directory: directory,
+            repoDirectory: repoDirectory,
+          ),
+        );
+        verify(
+          () => process.run('git', [
+            'worktree',
+            'remove',
+            '--force',
+            directory,
+          ], workingDirectory: repoDirectory),
+        ).called(1);
+      });
+
+      test('throws ProcessException if process exits with error', () async {
+        const error = 'oops';
+        when(() => processResult.exitCode).thenReturn(ExitCode.software.code);
+        when(() => processResult.stderr).thenReturn(error);
+        expect(
+          () => runWithOverrides(
+            () => git.worktreeRemove(
+              directory: directory,
+              repoDirectory: repoDirectory,
+            ),
+          ),
+          throwsA(
+            isA<ProcessException>().having((e) => e.message, 'message', error),
+          ),
+        );
+      });
+    });
+
     group('isGitRepo', () {
       group('when git exits with code 0', () {
         setUp(() {

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -66,6 +66,32 @@ void main() {
         ),
       ).thenAnswer((_) async => {});
       when(
+        () => git.cloneBare(
+          url: any(named: 'url'),
+          outputDirectory: any(named: 'outputDirectory'),
+          args: any(named: 'args'),
+        ),
+      ).thenAnswer((_) async => {});
+      when(
+        () => git.fetch(
+          directory: any(named: 'directory'),
+          args: any(named: 'args'),
+        ),
+      ).thenAnswer((_) async => {});
+      when(
+        () => git.worktreeAdd(
+          directory: any(named: 'directory'),
+          revision: any(named: 'revision'),
+          repoDirectory: any(named: 'repoDirectory'),
+        ),
+      ).thenAnswer((_) async => {});
+      when(
+        () => git.worktreeRemove(
+          directory: any(named: 'directory'),
+          repoDirectory: any(named: 'repoDirectory'),
+        ),
+      ).thenAnswer((_) async => {});
+      when(
         () => git.checkout(
           directory: any(named: 'directory'),
           revision: any(named: 'revision'),
@@ -610,14 +636,6 @@ $revision
             runWithOverrides(shorebirdFlutter.getVersionString),
             throwsA(isA<ProcessException>()),
           );
-          verify(
-            () => git.forEachRef(
-              directory: p.join(flutterDirectory.parent.path, flutterRevision),
-              contains: flutterRevision,
-              format: '%(refname:short)',
-              pattern: 'refs/remotes/origin/flutter_release/*',
-            ),
-          ).called(1);
         });
       });
 
@@ -638,14 +656,6 @@ $revision
             runWithOverrides(shorebirdFlutter.getVersionString),
             completion(isNull),
           );
-          verify(
-            () => git.forEachRef(
-              directory: p.join(flutterDirectory.parent.path, flutterRevision),
-              contains: flutterRevision,
-              format: '%(refname:short)',
-              pattern: 'refs/remotes/origin/flutter_release/*',
-            ),
-          ).called(1);
         });
       });
 
@@ -655,14 +665,6 @@ $revision
             runWithOverrides(shorebirdFlutter.getVersionString),
             completion(equals('3.10.6')),
           );
-          verify(
-            () => git.forEachRef(
-              directory: p.join(flutterDirectory.parent.path, flutterRevision),
-              contains: flutterRevision,
-              format: '%(refname:short)',
-              pattern: 'refs/remotes/origin/flutter_release/*',
-            ),
-          ).called(1);
         });
       });
     });
@@ -764,7 +766,7 @@ origin/flutter_release/3.10.6''';
         );
         verify(
           () => git.forEachRef(
-            directory: p.join(flutterDirectory.parent.path, flutterRevision),
+            directory: any(named: 'directory'),
             format: format,
             pattern: pattern,
           ),
@@ -817,52 +819,100 @@ origin/flutter_release/3.10.6''';
         );
 
         verifyNever(
-          () => git.clone(
+          () => git.cloneBare(
             url: any(named: 'url'),
             outputDirectory: any(named: 'outputDirectory'),
             args: any(named: 'args'),
           ),
         );
         verifyNever(
-          () => process.run('flutter', any(that: contains('precache'))),
-        );
-      });
-
-      test('throws exception if unable to clone', () async {
-        final exception = Exception('oops');
-        when(
-          () => git.clone(
-            url: any(named: 'url'),
-            outputDirectory: any(named: 'outputDirectory'),
-            args: any(named: 'args'),
-          ),
-        ).thenThrow(exception);
-
-        await expectLater(
-          runWithOverrides(
-            () => shorebirdFlutter.installRevision(revision: revision),
-          ),
-          throwsA(exception),
-        );
-
-        verify(
-          () => git.clone(
-            url: ShorebirdFlutter.flutterGitUrl,
-            outputDirectory: p.join(flutterDirectory.parent.path, revision),
-            args: ['--filter=tree:0', '--no-checkout'],
-          ),
-        ).called(1);
-        verifyNever(
-          () => process.run('flutter', any(that: contains('precache'))),
-        );
-      });
-
-      test('throws exception if unable to checkout revision', () async {
-        final exception = Exception('oops');
-        when(
-          () => git.checkout(
+          () => git.worktreeAdd(
             directory: any(named: 'directory'),
             revision: any(named: 'revision'),
+            repoDirectory: any(named: 'repoDirectory'),
+          ),
+        );
+        verifyNever(
+          () => process.run('flutter', any(that: contains('precache'))),
+        );
+      });
+
+      test(
+        'updates last-used timestamp when revision is already installed',
+        () async {
+          Directory(
+            p.join(flutterDirectory.parent.path, revision),
+          ).createSync(recursive: true);
+
+          await runWithOverrides(
+            () => shorebirdFlutter.installRevision(revision: revision),
+          );
+
+          final lastUsedFile = File(
+            p.join(flutterDirectory.parent.path, '.last_used', revision),
+          );
+          expect(lastUsedFile.existsSync(), isTrue);
+        },
+      );
+
+      test('creates bare repo and uses worktree add for new revision',
+          () async {
+        await runWithOverrides(
+          () => shorebirdFlutter.installRevision(revision: revision),
+        );
+
+        final repoPath = p.join(flutterDirectory.parent.path, '.repo');
+        verify(
+          () => git.cloneBare(
+            url: ShorebirdFlutter.flutterGitUrl,
+            outputDirectory: repoPath,
+            args: ['--filter=tree:0'],
+          ),
+        ).called(1);
+        verify(
+          () => git.worktreeAdd(
+            directory: p.join(flutterDirectory.parent.path, revision),
+            revision: revision,
+            repoDirectory: repoPath,
+          ),
+        ).called(1);
+      });
+
+      test('fetches when bare repo already exists', () async {
+        // Create the bare repo directory.
+        final repoPath = p.join(flutterDirectory.parent.path, '.repo');
+        Directory(repoPath).createSync(recursive: true);
+
+        await runWithOverrides(
+          () => shorebirdFlutter.installRevision(revision: revision),
+        );
+
+        verifyNever(
+          () => git.cloneBare(
+            url: any(named: 'url'),
+            outputDirectory: any(named: 'outputDirectory'),
+            args: any(named: 'args'),
+          ),
+        );
+        verify(
+          () => git.fetch(directory: repoPath, args: ['--all']),
+        ).called(1);
+        verify(
+          () => git.worktreeAdd(
+            directory: p.join(flutterDirectory.parent.path, revision),
+            revision: revision,
+            repoDirectory: repoPath,
+          ),
+        ).called(1);
+      });
+
+      test('throws exception if worktree add fails', () async {
+        final exception = Exception('oops');
+        when(
+          () => git.worktreeAdd(
+            directory: any(named: 'directory'),
+            revision: any(named: 'revision'),
+            repoDirectory: any(named: 'repoDirectory'),
           ),
         ).thenThrow(exception);
 
@@ -872,19 +922,7 @@ origin/flutter_release/3.10.6''';
           ),
           throwsA(exception),
         );
-        verify(
-          () => git.clone(
-            url: ShorebirdFlutter.flutterGitUrl,
-            outputDirectory: p.join(flutterDirectory.parent.path, revision),
-            args: ['--filter=tree:0', '--no-checkout'],
-          ),
-        ).called(1);
-        verify(
-          () => git.checkout(
-            directory: p.join(flutterDirectory.parent.path, revision),
-            revision: revision,
-          ),
-        ).called(1);
+
         verify(
           () => logger.progress('Installing Flutter 3.10.6 (test-revis)'),
         ).called(1);
@@ -933,8 +971,8 @@ origin/flutter_release/3.10.6''';
         });
       });
 
-      group('when clone and checkout succeed', () {
-        test('completes successfully', () async {
+      group('when worktree add succeeds', () {
+        test('completes successfully and creates last-used file', () async {
           await expectLater(
             runWithOverrides(
               () => shorebirdFlutter.installRevision(revision: revision),
@@ -956,7 +994,45 @@ origin/flutter_release/3.10.6''';
           ).called(1);
           // Once for the installation and once for the precache.
           verify(progress.complete).called(2);
+
+          // Check that last-used file was created.
+          final lastUsedFile = File(
+            p.join(flutterDirectory.parent.path, '.last_used', revision),
+          );
+          expect(lastUsedFile.existsSync(), isTrue);
         });
+      });
+    });
+
+    group('gitQueryDirectory', () {
+      test('uses bare repo for forEachRef when .repo exists', () async {
+        final repoPath = p.join(flutterDirectory.parent.path, '.repo');
+        Directory(repoPath).createSync(recursive: true);
+
+        await runWithOverrides(shorebirdFlutter.getVersionString);
+
+        verify(
+          () => git.forEachRef(
+            directory: repoPath,
+            contains: flutterRevision,
+            format: '%(refname:short)',
+            pattern: 'refs/remotes/origin/flutter_release/*',
+          ),
+        ).called(1);
+      });
+
+      test('falls back to working directory when .repo does not exist',
+          () async {
+        await runWithOverrides(shorebirdFlutter.getVersionString);
+
+        verify(
+          () => git.forEachRef(
+            directory: p.join(flutterDirectory.parent.path, flutterRevision),
+            contains: flutterRevision,
+            format: '%(refname:short)',
+            pattern: 'refs/remotes/origin/flutter_release/*',
+          ),
+        ).called(1);
       });
     });
 
@@ -1050,6 +1126,199 @@ origin/flutter_release/3.10.6''';
             equals('unknown (771d07b2cf)'),
           );
         });
+      });
+    });
+
+    group('pruneOldRevisions', () {
+      test('returns 0 when no last_used directory exists', () async {
+        final result = await runWithOverrides(
+          () => shorebirdFlutter.pruneOldRevisions(),
+        );
+        expect(result, equals(0));
+      });
+
+      test('skips current revision', () async {
+        final lastUsedDir = Directory(
+          p.join(flutterDirectory.parent.path, '.last_used'),
+        )..createSync(recursive: true);
+
+        // Create a last-used file for the current revision with old timestamp.
+        final file = File(p.join(lastUsedDir.path, flutterRevision));
+        file.writeAsStringSync(
+          DateTime(2020).toIso8601String(),
+        );
+
+        // Create the revision directory.
+        Directory(
+          p.join(flutterDirectory.parent.path, flutterRevision),
+        ).createSync(recursive: true);
+
+        final result = await runWithOverrides(
+          () => shorebirdFlutter.pruneOldRevisions(),
+        );
+        expect(result, equals(0));
+
+        // Verify the directory still exists.
+        expect(
+          Directory(
+            p.join(flutterDirectory.parent.path, flutterRevision),
+          ).existsSync(),
+          isTrue,
+        );
+      });
+
+      test('prunes revisions older than maxAge', () async {
+        const oldRevision = 'old-revision-hash';
+        final lastUsedDir = Directory(
+          p.join(flutterDirectory.parent.path, '.last_used'),
+        )..createSync(recursive: true);
+
+        // Create a last-used file with old timestamp.
+        final now = DateTime(2026, 3, 9);
+        final oldTime = now.subtract(const Duration(days: 60));
+        File(p.join(lastUsedDir.path, oldRevision))
+            .writeAsStringSync(oldTime.toIso8601String());
+
+        // Create the revision directory.
+        Directory(
+          p.join(flutterDirectory.parent.path, oldRevision),
+        ).createSync(recursive: true);
+
+        final result = await runWithOverrides(
+          () => shorebirdFlutter.pruneOldRevisions(now: now),
+        );
+        expect(result, equals(1));
+
+        // Verify the directory was deleted.
+        expect(
+          Directory(
+            p.join(flutterDirectory.parent.path, oldRevision),
+          ).existsSync(),
+          isFalse,
+        );
+
+        // Verify the last-used file was deleted.
+        expect(
+          File(p.join(lastUsedDir.path, oldRevision)).existsSync(),
+          isFalse,
+        );
+      });
+
+      test('does not prune revisions newer than maxAge', () async {
+        const recentRevision = 'recent-revision-hash';
+        final lastUsedDir = Directory(
+          p.join(flutterDirectory.parent.path, '.last_used'),
+        )..createSync(recursive: true);
+
+        // Create a last-used file with recent timestamp.
+        final now = DateTime(2026, 3, 9);
+        final recentTime = now.subtract(const Duration(days: 5));
+        File(p.join(lastUsedDir.path, recentRevision))
+            .writeAsStringSync(recentTime.toIso8601String());
+
+        // Create the revision directory.
+        Directory(
+          p.join(flutterDirectory.parent.path, recentRevision),
+        ).createSync(recursive: true);
+
+        final result = await runWithOverrides(
+          () => shorebirdFlutter.pruneOldRevisions(now: now),
+        );
+        expect(result, equals(0));
+
+        // Verify the directory still exists.
+        expect(
+          Directory(
+            p.join(flutterDirectory.parent.path, recentRevision),
+          ).existsSync(),
+          isTrue,
+        );
+      });
+
+      test('tries worktree remove when bare repo exists', () async {
+        const oldRevision = 'old-revision-hash';
+        final lastUsedDir = Directory(
+          p.join(flutterDirectory.parent.path, '.last_used'),
+        )..createSync(recursive: true);
+
+        // Create bare repo.
+        final repoPath = p.join(flutterDirectory.parent.path, '.repo');
+        Directory(repoPath).createSync(recursive: true);
+
+        // Create old last-used file.
+        final now = DateTime(2026, 3, 9);
+        final oldTime = now.subtract(const Duration(days: 60));
+        File(p.join(lastUsedDir.path, oldRevision))
+            .writeAsStringSync(oldTime.toIso8601String());
+
+        // Create the revision directory.
+        Directory(
+          p.join(flutterDirectory.parent.path, oldRevision),
+        ).createSync(recursive: true);
+
+        final result = await runWithOverrides(
+          () => shorebirdFlutter.pruneOldRevisions(now: now),
+        );
+        expect(result, equals(1));
+
+        verify(
+          () => git.worktreeRemove(
+            directory: p.join(flutterDirectory.parent.path, oldRevision),
+            repoDirectory: repoPath,
+          ),
+        ).called(1);
+      });
+
+      test('falls back to directory delete when worktree remove fails',
+          () async {
+        const oldRevision = 'old-revision-hash';
+        final lastUsedDir = Directory(
+          p.join(flutterDirectory.parent.path, '.last_used'),
+        )..createSync(recursive: true);
+
+        // Create bare repo.
+        final repoPath = p.join(flutterDirectory.parent.path, '.repo');
+        Directory(repoPath).createSync(recursive: true);
+
+        // Create old last-used file.
+        final now = DateTime(2026, 3, 9);
+        final oldTime = now.subtract(const Duration(days: 60));
+        File(p.join(lastUsedDir.path, oldRevision))
+            .writeAsStringSync(oldTime.toIso8601String());
+
+        // Create the revision directory.
+        final revisionDir = Directory(
+          p.join(flutterDirectory.parent.path, oldRevision),
+        )..createSync(recursive: true);
+
+        when(
+          () => git.worktreeRemove(
+            directory: any(named: 'directory'),
+            repoDirectory: any(named: 'repoDirectory'),
+          ),
+        ).thenThrow(Exception('worktree remove failed'));
+
+        final result = await runWithOverrides(
+          () => shorebirdFlutter.pruneOldRevisions(now: now),
+        );
+        expect(result, equals(1));
+
+        // Directory should be deleted via fallback.
+        expect(revisionDir.existsSync(), isFalse);
+      });
+
+      test('skips entries with unparseable timestamps', () async {
+        final lastUsedDir = Directory(
+          p.join(flutterDirectory.parent.path, '.last_used'),
+        )..createSync(recursive: true);
+
+        File(p.join(lastUsedDir.path, 'bad-revision'))
+            .writeAsStringSync('not-a-date');
+
+        final result = await runWithOverrides(
+          () => shorebirdFlutter.pruneOldRevisions(),
+        );
+        expect(result, equals(0));
       });
     });
   });

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -855,28 +855,30 @@ origin/flutter_release/3.10.6''';
         },
       );
 
-      test('creates bare repo and uses worktree add for new revision',
-          () async {
-        await runWithOverrides(
-          () => shorebirdFlutter.installRevision(revision: revision),
-        );
+      test(
+        'creates bare repo and uses worktree add for new revision',
+        () async {
+          await runWithOverrides(
+            () => shorebirdFlutter.installRevision(revision: revision),
+          );
 
-        final repoPath = p.join(flutterDirectory.parent.path, '.repo');
-        verify(
-          () => git.cloneBare(
-            url: ShorebirdFlutter.flutterGitUrl,
-            outputDirectory: repoPath,
-            args: ['--filter=tree:0'],
-          ),
-        ).called(1);
-        verify(
-          () => git.worktreeAdd(
-            directory: p.join(flutterDirectory.parent.path, revision),
-            revision: revision,
-            repoDirectory: repoPath,
-          ),
-        ).called(1);
-      });
+          final repoPath = p.join(flutterDirectory.parent.path, '.repo');
+          verify(
+            () => git.cloneBare(
+              url: ShorebirdFlutter.flutterGitUrl,
+              outputDirectory: repoPath,
+              args: ['--filter=tree:0'],
+            ),
+          ).called(1);
+          verify(
+            () => git.worktreeAdd(
+              directory: p.join(flutterDirectory.parent.path, revision),
+              revision: revision,
+              repoDirectory: repoPath,
+            ),
+          ).called(1);
+        },
+      );
 
       test('fetches when bare repo already exists', () async {
         // Create the bare repo directory.
@@ -1021,19 +1023,21 @@ origin/flutter_release/3.10.6''';
         ).called(1);
       });
 
-      test('falls back to working directory when .repo does not exist',
-          () async {
-        await runWithOverrides(shorebirdFlutter.getVersionString);
+      test(
+        'falls back to working directory when .repo does not exist',
+        () async {
+          await runWithOverrides(shorebirdFlutter.getVersionString);
 
-        verify(
-          () => git.forEachRef(
-            directory: p.join(flutterDirectory.parent.path, flutterRevision),
-            contains: flutterRevision,
-            format: '%(refname:short)',
-            pattern: 'refs/remotes/origin/flutter_release/*',
-          ),
-        ).called(1);
-      });
+          verify(
+            () => git.forEachRef(
+              directory: p.join(flutterDirectory.parent.path, flutterRevision),
+              contains: flutterRevision,
+              format: '%(refname:short)',
+              pattern: 'refs/remotes/origin/flutter_release/*',
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('isPorcelain', () {
@@ -1176,8 +1180,9 @@ origin/flutter_release/3.10.6''';
         // Create a last-used file with old timestamp.
         final now = DateTime(2026, 3, 9);
         final oldTime = now.subtract(const Duration(days: 60));
-        File(p.join(lastUsedDir.path, oldRevision))
-            .writeAsStringSync(oldTime.toIso8601String());
+        File(
+          p.join(lastUsedDir.path, oldRevision),
+        ).writeAsStringSync(oldTime.toIso8601String());
 
         // Create the revision directory.
         Directory(
@@ -1213,8 +1218,9 @@ origin/flutter_release/3.10.6''';
         // Create a last-used file with recent timestamp.
         final now = DateTime(2026, 3, 9);
         final recentTime = now.subtract(const Duration(days: 5));
-        File(p.join(lastUsedDir.path, recentRevision))
-            .writeAsStringSync(recentTime.toIso8601String());
+        File(
+          p.join(lastUsedDir.path, recentRevision),
+        ).writeAsStringSync(recentTime.toIso8601String());
 
         // Create the revision directory.
         Directory(
@@ -1248,8 +1254,9 @@ origin/flutter_release/3.10.6''';
         // Create old last-used file.
         final now = DateTime(2026, 3, 9);
         final oldTime = now.subtract(const Duration(days: 60));
-        File(p.join(lastUsedDir.path, oldRevision))
-            .writeAsStringSync(oldTime.toIso8601String());
+        File(
+          p.join(lastUsedDir.path, oldRevision),
+        ).writeAsStringSync(oldTime.toIso8601String());
 
         // Create the revision directory.
         Directory(
@@ -1269,51 +1276,55 @@ origin/flutter_release/3.10.6''';
         ).called(1);
       });
 
-      test('falls back to directory delete when worktree remove fails',
-          () async {
-        const oldRevision = 'old-revision-hash';
-        final lastUsedDir = Directory(
-          p.join(flutterDirectory.parent.path, '.last_used'),
-        )..createSync(recursive: true);
+      test(
+        'falls back to directory delete when worktree remove fails',
+        () async {
+          const oldRevision = 'old-revision-hash';
+          final lastUsedDir = Directory(
+            p.join(flutterDirectory.parent.path, '.last_used'),
+          )..createSync(recursive: true);
 
-        // Create bare repo.
-        final repoPath = p.join(flutterDirectory.parent.path, '.repo');
-        Directory(repoPath).createSync(recursive: true);
+          // Create bare repo.
+          final repoPath = p.join(flutterDirectory.parent.path, '.repo');
+          Directory(repoPath).createSync(recursive: true);
 
-        // Create old last-used file.
-        final now = DateTime(2026, 3, 9);
-        final oldTime = now.subtract(const Duration(days: 60));
-        File(p.join(lastUsedDir.path, oldRevision))
-            .writeAsStringSync(oldTime.toIso8601String());
+          // Create old last-used file.
+          final now = DateTime(2026, 3, 9);
+          final oldTime = now.subtract(const Duration(days: 60));
+          File(
+            p.join(lastUsedDir.path, oldRevision),
+          ).writeAsStringSync(oldTime.toIso8601String());
 
-        // Create the revision directory.
-        final revisionDir = Directory(
-          p.join(flutterDirectory.parent.path, oldRevision),
-        )..createSync(recursive: true);
+          // Create the revision directory.
+          final revisionDir = Directory(
+            p.join(flutterDirectory.parent.path, oldRevision),
+          )..createSync(recursive: true);
 
-        when(
-          () => git.worktreeRemove(
-            directory: any(named: 'directory'),
-            repoDirectory: any(named: 'repoDirectory'),
-          ),
-        ).thenThrow(Exception('worktree remove failed'));
+          when(
+            () => git.worktreeRemove(
+              directory: any(named: 'directory'),
+              repoDirectory: any(named: 'repoDirectory'),
+            ),
+          ).thenThrow(Exception('worktree remove failed'));
 
-        final result = await runWithOverrides(
-          () => shorebirdFlutter.pruneOldRevisions(now: now),
-        );
-        expect(result, equals(1));
+          final result = await runWithOverrides(
+            () => shorebirdFlutter.pruneOldRevisions(now: now),
+          );
+          expect(result, equals(1));
 
-        // Directory should be deleted via fallback.
-        expect(revisionDir.existsSync(), isFalse);
-      });
+          // Directory should be deleted via fallback.
+          expect(revisionDir.existsSync(), isFalse);
+        },
+      );
 
       test('skips entries with unparseable timestamps', () async {
         final lastUsedDir = Directory(
           p.join(flutterDirectory.parent.path, '.last_used'),
         )..createSync(recursive: true);
 
-        File(p.join(lastUsedDir.path, 'bad-revision'))
-            .writeAsStringSync('not-a-date');
+        File(
+          p.join(lastUsedDir.path, 'bad-revision'),
+        ).writeAsStringSync('not-a-date');
 
         final result = await runWithOverrides(
           () => shorebirdFlutter.pruneOldRevisions(),


### PR DESCRIPTION
## Summary

- Switch Flutter revision installs from individual `git clone` to a single shared bare repo (`bin/cache/flutter/.repo/`) with `git worktree add`
- All worktrees share one object store — only one `git fetch` needed for new revisions instead of a full clone
- Old standalone clones (pre-migration) continue to work without migration
- Git query methods (`getVersionForRevision`, `resolveFlutterRevision`, etc.) prefer the bare repo when available
- Add usage tracking via `.last_used/<revision>` timestamp files
- Add `shorebird cache clean --prune` to remove revisions unused for 30+ days
- Add `cloneBare`, `worktreeAdd`, `worktreeRemove` to `Git` class

## Test plan

- [x] All existing tests updated and passing (94 tests across 3 test files)
- [ ] Manual test: delete `bin/cache/flutter/`, run `shorebird release` — should create `.repo/` + worktree
- [ ] Manual test: with existing old-style clones present, run `shorebird release` — old clones still work, new revision uses worktree
- [ ] Manual test: `shorebird cache clean --prune` removes old revisions, preserves current