### PR TITLE
fix: invalidate bootstrap stamp when Flutter version changes

### DIFF
--- a/bin/shorebird
+++ b/bin/shorebird
@@ -10,6 +10,15 @@ PROG_NAME="$BIN_DIR/$(basename "$BASH_SOURCE")"
 OS="$(uname -s)"
 
 FLUTTER_VERSION=`cat "$BIN_DIR/internal/flutter.version"`
+
+# If the Flutter SDK for the requested version hasn't been downloaded yet,
+# clear the bootstrap stamp so that shared.sh triggers a re-bootstrap.
+# shared.sh keys the stamp on the Shorebird git revision alone, so changing
+# flutter.version without a new commit would otherwise be ignored.
+if [[ ! -d "$BIN_DIR/cache/flutter/$FLUTTER_VERSION/bin" ]]; then
+  rm -f "$BIN_DIR/cache/shorebird.stamp"
+fi
+
 source "$BIN_DIR/../third_party/flutter/bin/internal/shared.sh"
 
 # We currently depend on a forked (3.7.8 stable) Flutter shared.sh script


### PR DESCRIPTION
## Summary
- `shared.sh` keys the bootstrap stamp on the Shorebird git revision alone
- Changing `bin/internal/flutter.version` without a new commit skips re-bootstrap, so the new Flutter SDK is never downloaded
- The CLI then fails with `dart: No such file or directory` because `DART_PATH` points into the non-existent SDK directory
- Fix: clear the stamp in the entrypoint script (`bin/shorebird`) when the Flutter SDK directory for the requested version doesn't exist yet

## Test plan
- [x] Manually verified: change `flutter.version` to a new hash, run `shorebird --version`, confirm it downloads the new SDK