### PR TITLE
feat: add .pkg distribution warning to macOS post-release instructions

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/macos_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/macos_releaser.dart
@@ -182,5 +182,7 @@ To change the version of this release, change your app's version in your pubspec
       '''
 
 macOS app created at ${artifactManager.getMacOSAppDirectory(flavor: flavor)!.path}.
+
+${styleBold.wrap('Note:')} If you distribute your app via the Mac App Store using a .pkg installer, the packaging process may modify the binary and cause patch failures. See ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/3223'))} for more information.
 ''';
 }

--- a/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
@@ -916,10 +916,16 @@ To change the version of this release, change your app's version in your pubspec
       test('prints xcarchive upload steps', () {
         expect(
           runWithOverrides(() => releaser.postReleaseInstructions),
-          equals('''
+          contains('macOS app created at ${appDirectory.path}.'),
+        );
+      });
 
-macOS app created at ${appDirectory.path}.
-'''),
+      test('includes .pkg distribution warning', () {
+        expect(
+          runWithOverrides(() => releaser.postReleaseInstructions),
+          contains(
+            'https://github.com/shorebirdtech/shorebird/issues/3223',
+          ),
         );
       });
     });


### PR DESCRIPTION
## Summary
- Adds a warning to macOS `postReleaseInstructions` about potential binary mismatch when distributing via `.pkg` for the Mac App Store
- Links to #3223 for more information

## Test plan
- [x] Existing tests updated and passing
- [ ] Verify the message renders correctly when running `shorebird release --platform macos`