### PR TITLE
fix: Resolve JWT issuer from ShorebirdEnv instead of from Auth URL

### DIFF
--- a/packages/shorebird_cli/lib/src/auth/shorebird_oauth.dart
+++ b/packages/shorebird_cli/lib/src/auth/shorebird_oauth.dart
@@ -8,6 +8,7 @@ import 'package:googleapis_auth/googleapis_auth.dart';
 import 'package:http/http.dart' as http;
 import 'package:jwt/jwt.dart';
 import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/shorebird_env.dart';
 
 /// Exception thrown when the Shorebird auth flow fails.
 class ShorebirdAuthException implements Exception {
@@ -165,7 +166,7 @@ Future<oauth2.AccessCredentials> refreshShorebirdCredentials(
     );
   }
 
-  return _parseTokenResponse(response.body, expectedIssuer: authBaseUrl);
+  return _parseTokenResponse(response.body);
 }
 
 /// Exchanges an auth code for tokens by POSTing to the auth service's
@@ -193,14 +194,14 @@ Future<oauth2.AccessCredentials> _exchangeAuthCode({
     );
   }
 
-  return _parseTokenResponse(response.body, expectedIssuer: authBaseUrl);
+  return _parseTokenResponse(response.body);
 }
 
 /// Parses the JSON token response from the auth service into
 /// [oauth2.AccessCredentials].
 ///
 /// Validates that the `access_token` is a well-formed JWT and that its
-/// issuer matches [expectedIssuer].
+/// issuer matches the expected JWT issuer from [ShorebirdEnv].
 ///
 /// Expected JSON shape:
 /// ```json
@@ -211,10 +212,7 @@ Future<oauth2.AccessCredentials> _exchangeAuthCode({
 ///   "expires_in": 900
 /// }
 /// ```
-oauth2.AccessCredentials _parseTokenResponse(
-  String responseBody, {
-  required Uri expectedIssuer,
-}) {
+oauth2.AccessCredentials _parseTokenResponse(String responseBody) {
   final json = jsonDecode(responseBody) as Map<String, dynamic>;
   final accessTokenValue = json['access_token'] as String;
   final refreshToken = json['refresh_token'] as String?;
@@ -230,10 +228,10 @@ oauth2.AccessCredentials _parseTokenResponse(
   }
 
   // Validate the issuer matches the expected auth service.
-  final issuer = expectedIssuer.toString();
-  if (jwt.payload.iss != issuer) {
+  final expectedIssuer = shorebirdEnv.jwtIssuer;
+  if (jwt.payload.iss != expectedIssuer) {
     throw ShorebirdAuthException(
-      'Token issuer mismatch: expected $issuer, '
+      'Token issuer mismatch: expected $expectedIssuer, '
       'got ${jwt.payload.iss}',
     );
   }

--- a/packages/shorebird_cli/test/src/auth/shorebird_oauth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/shorebird_oauth_test.dart
@@ -6,8 +6,12 @@ import 'package:googleapis_auth/auth_io.dart' as oauth2;
 import 'package:googleapis_auth/googleapis_auth.dart';
 import 'package:http/http.dart' as http;
 import 'package:mocktail/mocktail.dart';
+import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/auth/shorebird_oauth.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:test/test.dart';
+
+import '../mocks.dart';
 
 class MockHttpClient extends Mock implements http.Client {}
 
@@ -32,9 +36,25 @@ String _buildTestJwt({String issuer = 'https://auth.shorebird.dev'}) {
 }
 
 void main() {
+  late ShorebirdEnv shorebirdEnv;
+
   setUpAll(() {
     registerFallbackValue(Uri.parse(''));
   });
+
+  setUp(() {
+    shorebirdEnv = MockShorebirdEnv();
+    when(
+      () => shorebirdEnv.jwtIssuer,
+    ).thenReturn('https://auth.shorebird.dev');
+  });
+
+  R runWithOverrides<R>(R Function() body) {
+    return runScoped(
+      body,
+      values: {shorebirdEnvRef.overrideWith(() => shorebirdEnv)},
+    );
+  }
 
   group('obtainCredentialsViaLoopbackLogin', () {
     late MockHttpClient httpClient;
@@ -64,17 +84,19 @@ void main() {
         ),
       );
 
-      final credentials = await obtainCredentialsViaLoopbackLogin(
-        httpClient: httpClient,
-        authBaseUrl: authBaseUrl,
-        userPrompt: (url) {
-          final loginUri = Uri.parse(url);
-          final continueUrl = loginUri.queryParameters['continue']!;
-          // Simulate the browser redirect with an auth code.
-          unawaited(
-            http.get(Uri.parse('$continueUrl?code=test_code')),
-          );
-        },
+      final credentials = await runWithOverrides(
+        () => obtainCredentialsViaLoopbackLogin(
+          httpClient: httpClient,
+          authBaseUrl: authBaseUrl,
+          userPrompt: (url) {
+            final loginUri = Uri.parse(url);
+            final continueUrl = loginUri.queryParameters['continue']!;
+            // Simulate the browser redirect with an auth code.
+            unawaited(
+              http.get(Uri.parse('$continueUrl?code=test_code')),
+            );
+          },
+        ),
       );
 
       expect(credentials.accessToken.type, equals('Bearer'));
@@ -118,17 +140,19 @@ void main() {
       );
 
       late String capturedUrl;
-      await obtainCredentialsViaLoopbackLogin(
-        httpClient: httpClient,
-        authBaseUrl: authBaseUrl,
-        userPrompt: (url) {
-          capturedUrl = url;
-          final loginUri = Uri.parse(url);
-          final continueUrl = loginUri.queryParameters['continue']!;
-          unawaited(
-            http.get(Uri.parse('$continueUrl?code=test_code')),
-          );
-        },
+      await runWithOverrides(
+        () => obtainCredentialsViaLoopbackLogin(
+          httpClient: httpClient,
+          authBaseUrl: authBaseUrl,
+          userPrompt: (url) {
+            capturedUrl = url;
+            final loginUri = Uri.parse(url);
+            final continueUrl = loginUri.queryParameters['continue']!;
+            unawaited(
+              http.get(Uri.parse('$continueUrl?code=test_code')),
+            );
+          },
+        ),
       );
 
       final loginUri = Uri.parse(capturedUrl);
@@ -146,6 +170,9 @@ void main() {
     test('handles authBaseUrl with trailing slash', () async {
       final authBaseUrlWithSlash = Uri.parse('https://auth.shorebird.dev/v1/');
       final testJwt = _buildTestJwt(issuer: 'https://auth.shorebird.dev/v1/');
+      when(
+        () => shorebirdEnv.jwtIssuer,
+      ).thenReturn('https://auth.shorebird.dev/v1/');
 
       when(
         () => httpClient.post(
@@ -166,17 +193,19 @@ void main() {
       );
 
       late String capturedUrl;
-      await obtainCredentialsViaLoopbackLogin(
-        httpClient: httpClient,
-        authBaseUrl: authBaseUrlWithSlash,
-        userPrompt: (url) {
-          capturedUrl = url;
-          final loginUri = Uri.parse(url);
-          final continueUrl = loginUri.queryParameters['continue']!;
-          unawaited(
-            http.get(Uri.parse('$continueUrl?code=test_code')),
-          );
-        },
+      await runWithOverrides(
+        () => obtainCredentialsViaLoopbackLogin(
+          httpClient: httpClient,
+          authBaseUrl: authBaseUrlWithSlash,
+          userPrompt: (url) {
+            capturedUrl = url;
+            final loginUri = Uri.parse(url);
+            final continueUrl = loginUri.queryParameters['continue']!;
+            unawaited(
+              http.get(Uri.parse('$continueUrl?code=test_code')),
+            );
+          },
+        ),
       );
 
       final loginUri = Uri.parse(capturedUrl);
@@ -213,22 +242,24 @@ void main() {
         ),
       );
 
-      final credentials = await obtainCredentialsViaLoopbackLogin(
-        httpClient: httpClient,
-        authBaseUrl: authBaseUrl,
-        userPrompt: (url) {
-          final loginUri = Uri.parse(url);
-          final continueUrl = loginUri.queryParameters['continue']!;
-          final callbackUri = Uri.parse(continueUrl);
-          final baseUrl = 'http://localhost:${callbackUri.port}';
-          // Send a favicon request first — should be ignored.
-          // Use .ignore() because the server may close before responding.
-          http.get(Uri.parse('$baseUrl/favicon.ico')).ignore();
-          // Then send the actual callback with auth code.
-          unawaited(
-            http.get(Uri.parse('$continueUrl?code=test_code')),
-          );
-        },
+      final credentials = await runWithOverrides(
+        () => obtainCredentialsViaLoopbackLogin(
+          httpClient: httpClient,
+          authBaseUrl: authBaseUrl,
+          userPrompt: (url) {
+            final loginUri = Uri.parse(url);
+            final continueUrl = loginUri.queryParameters['continue']!;
+            final callbackUri = Uri.parse(continueUrl);
+            final baseUrl = 'http://localhost:${callbackUri.port}';
+            // Send a favicon request first — should be ignored.
+            // Use .ignore() because the server may close before responding.
+            http.get(Uri.parse('$baseUrl/favicon.ico')).ignore();
+            // Then send the actual callback with auth code.
+            unawaited(
+              http.get(Uri.parse('$continueUrl?code=test_code')),
+            );
+          },
+        ),
       );
 
       expect(credentials.accessToken.type, equals('Bearer'));
@@ -356,14 +387,16 @@ void main() {
       );
 
       await expectLater(
-        obtainCredentialsViaLoopbackLogin(
-          httpClient: httpClient,
-          authBaseUrl: authBaseUrl,
-          userPrompt: (url) {
-            final loginUri = Uri.parse(url);
-            final continueUrl = loginUri.queryParameters['continue']!;
-            http.get(Uri.parse('$continueUrl?code=test_code')).ignore();
-          },
+        runWithOverrides(
+          () => obtainCredentialsViaLoopbackLogin(
+            httpClient: httpClient,
+            authBaseUrl: authBaseUrl,
+            userPrompt: (url) {
+              final loginUri = Uri.parse(url);
+              final continueUrl = loginUri.queryParameters['continue']!;
+              http.get(Uri.parse('$continueUrl?code=test_code')).ignore();
+            },
+          ),
         ),
         throwsA(
           isA<ShorebirdAuthException>().having(
@@ -396,14 +429,16 @@ void main() {
       );
 
       await expectLater(
-        obtainCredentialsViaLoopbackLogin(
-          httpClient: httpClient,
-          authBaseUrl: authBaseUrl,
-          userPrompt: (url) {
-            final loginUri = Uri.parse(url);
-            final continueUrl = loginUri.queryParameters['continue']!;
-            http.get(Uri.parse('$continueUrl?code=test_code')).ignore();
-          },
+        runWithOverrides(
+          () => obtainCredentialsViaLoopbackLogin(
+            httpClient: httpClient,
+            authBaseUrl: authBaseUrl,
+            userPrompt: (url) {
+              final loginUri = Uri.parse(url);
+              final continueUrl = loginUri.queryParameters['continue']!;
+              http.get(Uri.parse('$continueUrl?code=test_code')).ignore();
+            },
+          ),
         ),
         throwsA(
           isA<ShorebirdAuthException>().having(
@@ -455,14 +490,16 @@ void main() {
       );
 
       await expectLater(
-        obtainCredentialsViaLoopbackLogin(
-          httpClient: httpClient,
-          authBaseUrl: authBaseUrl,
-          userPrompt: (url) {
-            final loginUri = Uri.parse(url);
-            final continueUrl = loginUri.queryParameters['continue']!;
-            http.get(Uri.parse('$continueUrl?code=test_code')).ignore();
-          },
+        runWithOverrides(
+          () => obtainCredentialsViaLoopbackLogin(
+            httpClient: httpClient,
+            authBaseUrl: authBaseUrl,
+            userPrompt: (url) {
+              final loginUri = Uri.parse(url);
+              final continueUrl = loginUri.queryParameters['continue']!;
+              http.get(Uri.parse('$continueUrl?code=test_code')).ignore();
+            },
+          ),
         ),
         throwsA(isA<FormatException>()),
       );
@@ -487,14 +524,16 @@ void main() {
       );
 
       await expectLater(
-        obtainCredentialsViaLoopbackLogin(
-          httpClient: httpClient,
-          authBaseUrl: authBaseUrl,
-          userPrompt: (url) {
-            final loginUri = Uri.parse(url);
-            final continueUrl = loginUri.queryParameters['continue']!;
-            http.get(Uri.parse('$continueUrl?code=test_code')).ignore();
-          },
+        runWithOverrides(
+          () => obtainCredentialsViaLoopbackLogin(
+            httpClient: httpClient,
+            authBaseUrl: authBaseUrl,
+            userPrompt: (url) {
+              final loginUri = Uri.parse(url);
+              final continueUrl = loginUri.queryParameters['continue']!;
+              http.get(Uri.parse('$continueUrl?code=test_code')).ignore();
+            },
+          ),
         ),
         throwsA(isA<TypeError>()),
       );
@@ -520,14 +559,16 @@ void main() {
       );
 
       await expectLater(
-        obtainCredentialsViaLoopbackLogin(
-          httpClient: httpClient,
-          authBaseUrl: authBaseUrl,
-          userPrompt: (url) {
-            final loginUri = Uri.parse(url);
-            final continueUrl = loginUri.queryParameters['continue']!;
-            http.get(Uri.parse('$continueUrl?code=test_code')).ignore();
-          },
+        runWithOverrides(
+          () => obtainCredentialsViaLoopbackLogin(
+            httpClient: httpClient,
+            authBaseUrl: authBaseUrl,
+            userPrompt: (url) {
+              final loginUri = Uri.parse(url);
+              final continueUrl = loginUri.queryParameters['continue']!;
+              http.get(Uri.parse('$continueUrl?code=test_code')).ignore();
+            },
+          ),
         ),
         throwsA(isA<TypeError>()),
       );
@@ -562,14 +603,16 @@ void main() {
         ),
       );
 
-      final credentials = await refreshShorebirdCredentials(
-        oauth2.AccessCredentials(
-          AccessToken('Bearer', '', DateTime.timestamp()),
-          'sb_rt_old',
-          [],
+      final credentials = await runWithOverrides(
+        () => refreshShorebirdCredentials(
+          oauth2.AccessCredentials(
+            AccessToken('Bearer', '', DateTime.timestamp()),
+            'sb_rt_old',
+            [],
+          ),
+          httpClient,
+          authBaseUrl: authBaseUrl,
         ),
-        httpClient,
-        authBaseUrl: authBaseUrl,
       );
 
       expect(credentials.accessToken.type, equals('Bearer'));
@@ -692,14 +735,16 @@ void main() {
       );
 
       await expectLater(
-        refreshShorebirdCredentials(
-          oauth2.AccessCredentials(
-            AccessToken('Bearer', '', DateTime.timestamp()),
-            'sb_rt_old',
-            [],
+        runWithOverrides(
+          () => refreshShorebirdCredentials(
+            oauth2.AccessCredentials(
+              AccessToken('Bearer', '', DateTime.timestamp()),
+              'sb_rt_old',
+              [],
+            ),
+            httpClient,
+            authBaseUrl: authBaseUrl,
           ),
-          httpClient,
-          authBaseUrl: authBaseUrl,
         ),
         throwsA(
           isA<ShorebirdAuthException>().having(
@@ -732,14 +777,16 @@ void main() {
       );
 
       await expectLater(
-        refreshShorebirdCredentials(
-          oauth2.AccessCredentials(
-            AccessToken('Bearer', '', DateTime.timestamp()),
-            'sb_rt_old',
-            [],
+        runWithOverrides(
+          () => refreshShorebirdCredentials(
+            oauth2.AccessCredentials(
+              AccessToken('Bearer', '', DateTime.timestamp()),
+              'sb_rt_old',
+              [],
+            ),
+            httpClient,
+            authBaseUrl: authBaseUrl,
           ),
-          httpClient,
-          authBaseUrl: authBaseUrl,
         ),
         throwsA(
           isA<ShorebirdAuthException>().having(
@@ -766,14 +813,16 @@ void main() {
       );
 
       await expectLater(
-        refreshShorebirdCredentials(
-          oauth2.AccessCredentials(
-            AccessToken('Bearer', '', DateTime.timestamp()),
-            'sb_rt_old',
-            [],
+        runWithOverrides(
+          () => refreshShorebirdCredentials(
+            oauth2.AccessCredentials(
+              AccessToken('Bearer', '', DateTime.timestamp()),
+              'sb_rt_old',
+              [],
+            ),
+            httpClient,
+            authBaseUrl: authBaseUrl,
           ),
-          httpClient,
-          authBaseUrl: authBaseUrl,
         ),
         throwsA(isA<FormatException>()),
       );
@@ -798,14 +847,16 @@ void main() {
       );
 
       await expectLater(
-        refreshShorebirdCredentials(
-          oauth2.AccessCredentials(
-            AccessToken('Bearer', '', DateTime.timestamp()),
-            'sb_rt_old',
-            [],
+        runWithOverrides(
+          () => refreshShorebirdCredentials(
+            oauth2.AccessCredentials(
+              AccessToken('Bearer', '', DateTime.timestamp()),
+              'sb_rt_old',
+              [],
+            ),
+            httpClient,
+            authBaseUrl: authBaseUrl,
           ),
-          httpClient,
-          authBaseUrl: authBaseUrl,
         ),
         throwsA(isA<TypeError>()),
       );
@@ -831,14 +882,16 @@ void main() {
       );
 
       await expectLater(
-        refreshShorebirdCredentials(
-          oauth2.AccessCredentials(
-            AccessToken('Bearer', '', DateTime.timestamp()),
-            'sb_rt_old',
-            [],
+        runWithOverrides(
+          () => refreshShorebirdCredentials(
+            oauth2.AccessCredentials(
+              AccessToken('Bearer', '', DateTime.timestamp()),
+              'sb_rt_old',
+              [],
+            ),
+            httpClient,
+            authBaseUrl: authBaseUrl,
           ),
-          httpClient,
-          authBaseUrl: authBaseUrl,
         ),
         throwsA(isA<TypeError>()),
       );


### PR DESCRIPTION
## Description

**This change only affects local development, and doesn't have any user-facing changes.** (Doesn't need to go in the changelog)

- Decouples JWT issuer validation from the auth base URL by reading the expected issuer from `ShorebirdEnv.jwtIssuer` instead of passing the `authBaseUrl` through to `_parseTokenResponse`
- Removes the `expectedIssuer` parameter from `_parseTokenResponse`, simplifying the call sites in both `refreshShorebirdCredentials` and `_exchangeAuthCode`
- Updates all tests to provide `ShorebirdEnv` via scoped overrides

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
