### PR TITLE
feat: Revoke sessions on CLI logout

### DIFF
--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -357,7 +357,41 @@ class Auth {
   }
 
   /// Logs out the user.
-  void logout() => _clearCredentials();
+  ///
+  /// If a Shorebird refresh token is available, revokes the server-side
+  /// session before clearing local credentials. Local credentials are always
+  /// cleared even if the server call fails.
+  Future<void> logout() async {
+    await _revokeSession();
+    _clearCredentials();
+  }
+
+  /// Sends the current refresh token to the auth service's logout endpoint
+  /// to revoke the server-side session. Failures are logged but swallowed
+  /// so that local logout always succeeds.
+  Future<void> _revokeSession() async {
+    final refreshToken = _credentials?.refreshToken;
+    if (refreshToken == null) return;
+
+    try {
+      final logoutUrl = _authServiceUri.replace(
+        path: p.url.join(_authServiceUri.path, 'api/logout'),
+      );
+      final response = await _httpClient.post(
+        logoutUrl,
+        headers: {'Authorization': 'Bearer $refreshToken'},
+      );
+      if (response.statusCode != 200) {
+        logger.detail(
+          'Session revocation returned ${response.statusCode}: '
+          '${response.body}',
+        );
+      }
+    } on Exception catch (e) {
+      // Best-effort — don't block logout if the server is unreachable.
+      logger.detail('Failed to revoke session: $e');
+    }
+  }
 
   oauth2.AccessCredentials? _credentials;
 

--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -381,7 +381,7 @@ class Auth {
         logoutUrl,
         headers: {'Authorization': 'Bearer $refreshToken'},
       );
-      if (response.statusCode != 200) {
+      if (response.statusCode < 200 || response.statusCode >= 300) {
         logger.detail(
           'Session revocation returned ${response.statusCode}: '
           '${response.body}',

--- a/packages/shorebird_cli/lib/src/commands/logout_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/logout_command.dart
@@ -23,7 +23,7 @@ class LogoutCommand extends ShorebirdCommand {
     }
 
     final logoutProgress = logger.progress('Logging out of shorebird.dev');
-    auth.logout();
+    await auth.logout();
     logoutProgress.complete();
 
     logger.info('${lightGreen.wrap('You are now logged out.')}');

--- a/packages/shorebird_cli/test/src/auth/auth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_test.dart
@@ -1126,11 +1126,104 @@ Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar e
         expect(auth.email, email);
         expect(auth.isAuthenticated, isTrue);
 
-        auth.logout();
+        when(
+          () => httpClient.post(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async => http.Response('{"ok":true}', 200),
+        );
+
+        await runWithOverrides(() => auth.logout());
         expect(auth.email, isNull);
         expect(auth.isAuthenticated, isFalse);
         expect(buildAuth().email, isNull);
         expect(buildAuth().isAuthenticated, isFalse);
+      });
+
+      test('revokes server session with refresh token', () async {
+        await runWithOverrides(
+          () => auth.login(AuthProvider.google, prompt: (_) {}),
+        );
+
+        when(
+          () => httpClient.post(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async => http.Response('{"ok":true}', 200),
+        );
+
+        await runWithOverrides(() => auth.logout());
+
+        final captured = verify(
+          () => httpClient.post(
+            captureAny(),
+            headers: captureAny(named: 'headers'),
+          ),
+        ).captured;
+
+        final uri = captured[0] as Uri;
+        expect(uri.path, contains('api/logout'));
+
+        final headers = captured[1] as Map<String, String>;
+        expect(headers['Authorization'], equals('Bearer $refreshToken'));
+      });
+
+      test('logs detail when server returns non-200', () async {
+        await runWithOverrides(
+          () => auth.login(AuthProvider.google, prompt: (_) {}),
+        );
+
+        when(
+          () => httpClient.post(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async => http.Response('{"error":"gone"}', 500),
+        );
+
+        await runWithOverrides(() => auth.logout());
+        expect(auth.isAuthenticated, isFalse);
+
+        verify(
+          () => logger.detail(
+            any(that: contains('Session revocation returned 500')),
+          ),
+        ).called(1);
+      });
+
+      test('clears credentials even if server revocation fails', () async {
+        await runWithOverrides(
+          () => auth.login(AuthProvider.google, prompt: (_) {}),
+        );
+        expect(auth.isAuthenticated, isTrue);
+
+        when(
+          () => httpClient.post(any(), headers: any(named: 'headers')),
+        ).thenThrow(const SocketException('no internet'));
+
+        await runWithOverrides(() => auth.logout());
+        expect(auth.email, isNull);
+        expect(auth.isAuthenticated, isFalse);
+      });
+
+      test('skips revocation when no refresh token', () async {
+        accessCredentials = oauth2.AccessCredentials(
+          accessToken,
+          null, // no refresh token
+          scopes,
+          idToken: idToken,
+        );
+        auth = buildAuth();
+        writeCredentials();
+        auth = buildAuth();
+
+        when(
+          () => httpClient.post(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async => http.Response('{"ok":true}', 200),
+        );
+
+        await runWithOverrides(() => auth.logout());
+
+        verifyNever(
+          () => httpClient.post(any(), headers: any(named: 'headers')),
+        );
       });
     });
 

--- a/packages/shorebird_cli/test/src/auth/auth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_test.dart
@@ -1166,7 +1166,7 @@ Please regenerate using `shorebird login:ci`, update the $shorebirdTokenEnvVar e
         expect(headers['Authorization'], equals('Bearer $refreshToken'));
       });
 
-      test('logs detail when server returns non-200', () async {
+      test('logs detail when server returns non-2xx', () async {
         await runWithOverrides(
           () => auth.login(AuthProvider.google, prompt: (_) {}),
         );

--- a/packages/shorebird_cli/test/src/commands/logout_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/logout_command_test.dart
@@ -47,6 +47,7 @@ void main() {
 
     test('exits with code 0 when logged out successfully', () async {
       when(() => auth.isAuthenticated).thenReturn(true);
+      when(() => auth.logout()).thenAnswer((_) async {});
 
       final progress = MockProgress();
       when(() => progress.complete(any())).thenAnswer((invocation) {});


### PR DESCRIPTION
## Description

(Doesn't need to go in changelog)

- `shorebird logout` now revokes the server-side session by POSTing the refresh token to the auth service's `/api/logout` endpoint before clearing local credentials
- Session revocation is best-effort - local credentials are always cleared, even if the server is unreachable or returns an error
- Revocation is skipped when no refresh token is present (e.g., API key auth)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
