### PR TITLE
fix: show friendly error message when GitHub is down

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -10,12 +10,12 @@ final gitRef = create(Git.new);
 /// The [Git] instance available in the current zone.
 Git get git => read(gitRef);
 
-/// {@template github_unreachable_exception}
-/// Exception thrown when a git command fails because GitHub is unreachable.
+/// {@template git_server_unreachable_exception}
+/// Exception thrown when a git command fails due to a server error.
 /// {@endtemplate}
-class GitHubUnreachableException implements Exception {
-  /// {@macro github_unreachable_exception}
-  const GitHubUnreachableException(this.message);
+class GitServerUnreachableException implements Exception {
+  /// {@macro git_server_unreachable_exception}
+  const GitServerUnreachableException(this.message);
 
   /// The error message.
   final String message;
@@ -24,11 +24,30 @@ class GitHubUnreachableException implements Exception {
   String toString() => message;
 }
 
-/// Pattern that matches GitHub HTTP server errors (500, 502, 503) in git
-/// output.
-final _githubServerErrorPattern = RegExp(
+/// Pattern that matches HTTP server errors (500, 502, 503) or "Internal Server
+/// Error" in git output.
+final _serverErrorPattern = RegExp(
   'The requested URL returned error: (500|502|503)|Internal Server Error',
 );
+
+/// Pattern that extracts the hostname from a git remote URL in stderr.
+/// Matches URLs like `https://github.com/org/repo.git/`.
+final _remoteHostPattern = RegExp(r"https?://([^/']+)");
+
+String _buildServerErrorMessage(String stderr) {
+  final hostMatch = _remoteHostPattern.firstMatch(stderr);
+  final host = hostMatch?.group(1);
+  final serverName = host ?? 'the remote git server';
+
+  final buffer = StringBuffer('Unable to reach $serverName.');
+  if (host == 'github.com') {
+    buffer.write(
+      '\nIf your network connection is working, check '
+      'https://www.githubstatus.com for service status.',
+    );
+  }
+  return buffer.toString();
+}
 
 /// A wrapper around all git related functionality.
 class Git {
@@ -47,16 +66,9 @@ class Git {
     );
     if (result.exitCode != 0) {
       final stderr = '${result.stderr}';
-      // This assumes all git remotes are on GitHub, which is currently true
-      // (we only clone/fetch shorebirdtech/flutter and shorebirdtech/shorebird).
-      // If we ever add non-GitHub remotes, this detection should be scoped to
-      // GitHub URLs only.
-      if (_githubServerErrorPattern.hasMatch(stderr)) {
-        throw const GitHubUnreachableException(
-          'Unable to reach GitHub. This could be a network issue '
-          'or a GitHub outage.\n'
-          'If your network connection is working, check '
-          'https://www.githubstatus.com for service status.',
+      if (_serverErrorPattern.hasMatch(stderr)) {
+        throw GitServerUnreachableException(
+          _buildServerErrorMessage(stderr),
         );
       }
       throw ProcessException(

--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -47,6 +47,10 @@ class Git {
     );
     if (result.exitCode != 0) {
       final stderr = '${result.stderr}';
+      // This assumes all git remotes are on GitHub, which is currently true
+      // (we only clone/fetch shorebirdtech/flutter and shorebirdtech/shorebird).
+      // If we ever add non-GitHub remotes, this detection should be scoped to
+      // GitHub URLs only.
       if (_githubOutagePattern.hasMatch(stderr)) {
         throw const GitHubOutageException(
           'GitHub appears to be experiencing an outage. '

--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -13,21 +13,20 @@ Git get git => read(gitRef);
 /// {@template git_server_unreachable_exception}
 /// Exception thrown when a git command fails due to a server error.
 /// {@endtemplate}
-class GitServerUnreachableException implements Exception {
+class GitServerUnreachableException extends ProcessException {
   /// {@macro git_server_unreachable_exception}
-  const GitServerUnreachableException(this.message);
-
-  /// The error message.
-  final String message;
-
-  @override
-  String toString() => message;
+  GitServerUnreachableException(
+    super.executable,
+    super.arguments, [
+    super.message = '',
+    super.errorCode = 0,
+  ]);
 }
 
-/// Pattern that matches HTTP server errors (500, 502, 503) or "Internal Server
-/// Error" in git output.
+/// Pattern that matches HTTP server errors (500, 502, 503, 504) or "Internal
+/// Server Error" in git output.
 final _serverErrorPattern = RegExp(
-  'The requested URL returned error: (500|502|503)|Internal Server Error',
+  'The requested URL returned error: (500|502|503|504)|Internal Server Error',
 );
 
 /// Pattern that extracts the hostname from a git remote URL in stderr.
@@ -68,7 +67,10 @@ class Git {
       final stderr = '${result.stderr}';
       if (_serverErrorPattern.hasMatch(stderr)) {
         throw GitServerUnreachableException(
+          executable,
+          arguments,
           _buildServerErrorMessage(stderr),
+          result.exitCode,
         );
       }
       throw ProcessException(

--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -10,12 +10,12 @@ final gitRef = create(Git.new);
 /// The [Git] instance available in the current zone.
 Git get git => read(gitRef);
 
-/// {@template github_outage_exception}
-/// Exception thrown when a git command fails due to a GitHub outage.
+/// {@template github_unreachable_exception}
+/// Exception thrown when a git command fails because GitHub is unreachable.
 /// {@endtemplate}
-class GitHubOutageException implements Exception {
-  /// {@macro github_outage_exception}
-  const GitHubOutageException(this.message);
+class GitHubUnreachableException implements Exception {
+  /// {@macro github_unreachable_exception}
+  const GitHubUnreachableException(this.message);
 
   /// The error message.
   final String message;
@@ -26,7 +26,7 @@ class GitHubOutageException implements Exception {
 
 /// Pattern that matches GitHub HTTP server errors (500, 502, 503) in git
 /// output.
-final _githubOutagePattern = RegExp(
+final _githubServerErrorPattern = RegExp(
   'The requested URL returned error: (500|502|503)|Internal Server Error',
 );
 
@@ -51,10 +51,12 @@ class Git {
       // (we only clone/fetch shorebirdtech/flutter and shorebirdtech/shorebird).
       // If we ever add non-GitHub remotes, this detection should be scoped to
       // GitHub URLs only.
-      if (_githubOutagePattern.hasMatch(stderr)) {
-        throw const GitHubOutageException(
-          'GitHub appears to be experiencing an outage. '
-          'Please check https://www.githubstatus.com and try again later.',
+      if (_githubServerErrorPattern.hasMatch(stderr)) {
+        throw const GitHubUnreachableException(
+          'Unable to reach GitHub. This could be a network issue '
+          'or a GitHub outage.\n'
+          'If your network connection is working, check '
+          'https://www.githubstatus.com for service status.',
         );
       }
       throw ProcessException(

--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -1,4 +1,4 @@
-// cspell:words unmatch
+// cspell:words unmatch githubstatus
 import 'dart:io';
 
 import 'package:scoped_deps/scoped_deps.dart';

--- a/packages/shorebird_cli/lib/src/executables/git.dart
+++ b/packages/shorebird_cli/lib/src/executables/git.dart
@@ -10,6 +10,26 @@ final gitRef = create(Git.new);
 /// The [Git] instance available in the current zone.
 Git get git => read(gitRef);
 
+/// {@template github_outage_exception}
+/// Exception thrown when a git command fails due to a GitHub outage.
+/// {@endtemplate}
+class GitHubOutageException implements Exception {
+  /// {@macro github_outage_exception}
+  const GitHubOutageException(this.message);
+
+  /// The error message.
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Pattern that matches GitHub HTTP server errors (500, 502, 503) in git
+/// output.
+final _githubOutagePattern = RegExp(
+  'The requested URL returned error: (500|502|503)|Internal Server Error',
+);
+
 /// A wrapper around all git related functionality.
 class Git {
   /// Name of the git executable.
@@ -26,10 +46,17 @@ class Git {
       workingDirectory: workingDirectory,
     );
     if (result.exitCode != 0) {
+      final stderr = '${result.stderr}';
+      if (_githubOutagePattern.hasMatch(stderr)) {
+        throw const GitHubOutageException(
+          'GitHub appears to be experiencing an outage. '
+          'Please check https://www.githubstatus.com and try again later.',
+        );
+      }
       throw ProcessException(
         executable,
         arguments,
-        '${result.stderr}',
+        stderr,
         result.exitCode,
       );
     }

--- a/packages/shorebird_cli/test/src/executables/git_test.dart
+++ b/packages/shorebird_cli/test/src/executables/git_test.dart
@@ -55,7 +55,7 @@ void main() {
           ),
           throwsA(
             isA<GitServerUnreachableException>().having(
-              (e) => e.toString(),
+              (e) => e.message,
               'message',
               allOf(contains('github.com'), contains('githubstatus.com')),
             ),
@@ -74,7 +74,7 @@ void main() {
           () => runWithOverrides(() => git.fetch(directory: 'repo')),
           throwsA(
             isA<GitServerUnreachableException>().having(
-              (e) => e.toString(),
+              (e) => e.message,
               'message',
               allOf(
                 contains('gitlab.com'),
@@ -94,7 +94,7 @@ void main() {
           () => runWithOverrides(() => git.fetch(directory: 'repo')),
           throwsA(
             isA<GitServerUnreachableException>().having(
-              (e) => e.toString(),
+              (e) => e.message,
               'message',
               contains('the remote git server'),
             ),

--- a/packages/shorebird_cli/test/src/executables/git_test.dart
+++ b/packages/shorebird_cli/test/src/executables/git_test.dart
@@ -39,8 +39,7 @@ void main() {
     });
 
     group('server error detection', () {
-      test('includes github.com and status link for GitHub URLs',
-          () async {
+      test('includes github.com and status link for GitHub URLs', () async {
         when(() => processResult.exitCode).thenReturn(128);
         when(() => processResult.stderr).thenReturn(
           "fatal: unable to access 'https://github.com/"
@@ -58,10 +57,7 @@ void main() {
             isA<GitServerUnreachableException>().having(
               (e) => e.toString(),
               'message',
-              allOf(
-                contains('github.com'),
-                contains('githubstatus.com'),
-              ),
+              allOf(contains('github.com'), contains('githubstatus.com')),
             ),
           ),
         );
@@ -75,9 +71,7 @@ void main() {
           'The requested URL returned error: 502',
         );
         expect(
-          () => runWithOverrides(
-            () => git.fetch(directory: 'repo'),
-          ),
+          () => runWithOverrides(() => git.fetch(directory: 'repo')),
           throwsA(
             isA<GitServerUnreachableException>().having(
               (e) => e.toString(),
@@ -91,16 +85,13 @@ void main() {
         );
       });
 
-      test('falls back to generic message when no URL in stderr',
-          () async {
+      test('falls back to generic message when no URL in stderr', () async {
         when(() => processResult.exitCode).thenReturn(128);
-        when(() => processResult.stderr).thenReturn(
-          'remote: Internal Server Error',
-        );
+        when(
+          () => processResult.stderr,
+        ).thenReturn('remote: Internal Server Error');
         expect(
-          () => runWithOverrides(
-            () => git.fetch(directory: 'repo'),
-          ),
+          () => runWithOverrides(() => git.fetch(directory: 'repo')),
           throwsA(
             isA<GitServerUnreachableException>().having(
               (e) => e.toString(),
@@ -111,16 +102,13 @@ void main() {
         );
       });
 
-      test('throws ProcessException for non-server errors',
-          () async {
+      test('throws ProcessException for non-server errors', () async {
         when(() => processResult.exitCode).thenReturn(128);
-        when(() => processResult.stderr).thenReturn(
-          'fatal: repository not found',
-        );
+        when(
+          () => processResult.stderr,
+        ).thenReturn('fatal: repository not found');
         expect(
-          () => runWithOverrides(
-            () => git.fetch(directory: 'repo'),
-          ),
+          () => runWithOverrides(() => git.fetch(directory: 'repo')),
           throwsA(isA<ProcessException>()),
         );
       });

--- a/packages/shorebird_cli/test/src/executables/git_test.dart
+++ b/packages/shorebird_cli/test/src/executables/git_test.dart
@@ -1,3 +1,4 @@
+// cspell:words githubstatus
 import 'dart:io';
 
 import 'package:mason_logger/mason_logger.dart';

--- a/packages/shorebird_cli/test/src/executables/git_test.dart
+++ b/packages/shorebird_cli/test/src/executables/git_test.dart
@@ -37,6 +37,91 @@ void main() {
       when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
     });
 
+    group('GitHub outage detection', () {
+      test('throws GitHubOutageException on HTTP 500', () async {
+        when(() => processResult.exitCode).thenReturn(128);
+        when(() => processResult.stderr).thenReturn(
+          // URL split across lines for line length.
+          // ignore: missing_whitespace_between_adjacent_strings
+          "fatal: unable to access 'https://github.com/shorebirdtech/"
+          "flutter.git/': The requested URL returned error: 500",
+        );
+        expect(
+          () => runWithOverrides(
+            () => git.clone(
+              url: 'https://github.com/shorebirdtech/flutter.git',
+              outputDirectory: './output',
+            ),
+          ),
+          throwsA(
+            isA<GitHubOutageException>().having(
+              (e) => e.toString(),
+              'message',
+              contains('githubstatus.com'),
+            ),
+          ),
+        );
+      });
+
+      test('throws GitHubOutageException on HTTP 502', () async {
+        when(() => processResult.exitCode).thenReturn(128);
+        when(() => processResult.stderr).thenReturn(
+          // URL split across lines for line length.
+          // ignore: missing_whitespace_between_adjacent_strings
+          "fatal: unable to access 'https://github.com/shorebirdtech/"
+          "shorebird.git/': The requested URL returned error: 502",
+        );
+        expect(
+          () => runWithOverrides(
+            () => git.fetch(directory: 'repo'),
+          ),
+          throwsA(isA<GitHubOutageException>()),
+        );
+      });
+
+      test('throws GitHubOutageException on HTTP 503', () async {
+        when(() => processResult.exitCode).thenReturn(128);
+        when(() => processResult.stderr).thenReturn(
+          // URL split across lines for line length.
+          // ignore: missing_whitespace_between_adjacent_strings
+          "fatal: unable to access 'https://github.com/shorebirdtech/"
+          "shorebird.git/': The requested URL returned error: 503",
+        );
+        expect(
+          () => runWithOverrides(
+            () => git.fetch(directory: 'repo'),
+          ),
+          throwsA(isA<GitHubOutageException>()),
+        );
+      });
+
+      test('throws GitHubOutageException on Internal Server Error', () async {
+        when(() => processResult.exitCode).thenReturn(128);
+        when(() => processResult.stderr).thenReturn(
+          'remote: Internal Server Error',
+        );
+        expect(
+          () => runWithOverrides(
+            () => git.fetch(directory: 'repo'),
+          ),
+          throwsA(isA<GitHubOutageException>()),
+        );
+      });
+
+      test('throws ProcessException for non-outage errors', () async {
+        when(() => processResult.exitCode).thenReturn(128);
+        when(() => processResult.stderr).thenReturn(
+          'fatal: repository not found',
+        );
+        expect(
+          () => runWithOverrides(
+            () => git.fetch(directory: 'repo'),
+          ),
+          throwsA(isA<ProcessException>()),
+        );
+      });
+    });
+
     group('clone', () {
       const url = 'https://github.com/shorebirdtech/shorebird';
       const outputDirectory = './output';

--- a/packages/shorebird_cli/test/src/executables/git_test.dart
+++ b/packages/shorebird_cli/test/src/executables/git_test.dart
@@ -38,7 +38,7 @@ void main() {
     });
 
     group('GitHub outage detection', () {
-      test('throws GitHubOutageException on HTTP 500', () async {
+      test('throws GitHubUnreachableException on HTTP 500', () async {
         when(() => processResult.exitCode).thenReturn(128);
         when(() => processResult.stderr).thenReturn(
           // URL split across lines for line length.
@@ -54,7 +54,7 @@ void main() {
             ),
           ),
           throwsA(
-            isA<GitHubOutageException>().having(
+            isA<GitHubUnreachableException>().having(
               (e) => e.toString(),
               'message',
               contains('githubstatus.com'),
@@ -63,7 +63,7 @@ void main() {
         );
       });
 
-      test('throws GitHubOutageException on HTTP 502', () async {
+      test('throws GitHubUnreachableException on HTTP 502', () async {
         when(() => processResult.exitCode).thenReturn(128);
         when(() => processResult.stderr).thenReturn(
           // URL split across lines for line length.
@@ -75,11 +75,11 @@ void main() {
           () => runWithOverrides(
             () => git.fetch(directory: 'repo'),
           ),
-          throwsA(isA<GitHubOutageException>()),
+          throwsA(isA<GitHubUnreachableException>()),
         );
       });
 
-      test('throws GitHubOutageException on HTTP 503', () async {
+      test('throws GitHubUnreachableException on HTTP 503', () async {
         when(() => processResult.exitCode).thenReturn(128);
         when(() => processResult.stderr).thenReturn(
           // URL split across lines for line length.
@@ -91,11 +91,12 @@ void main() {
           () => runWithOverrides(
             () => git.fetch(directory: 'repo'),
           ),
-          throwsA(isA<GitHubOutageException>()),
+          throwsA(isA<GitHubUnreachableException>()),
         );
       });
 
-      test('throws GitHubOutageException on Internal Server Error', () async {
+      test('throws GitHubUnreachableException on Internal Server Error',
+          () async {
         when(() => processResult.exitCode).thenReturn(128);
         when(() => processResult.stderr).thenReturn(
           'remote: Internal Server Error',
@@ -104,7 +105,7 @@ void main() {
           () => runWithOverrides(
             () => git.fetch(directory: 'repo'),
           ),
-          throwsA(isA<GitHubOutageException>()),
+          throwsA(isA<GitHubUnreachableException>()),
         );
       });
 

--- a/packages/shorebird_cli/test/src/executables/git_test.dart
+++ b/packages/shorebird_cli/test/src/executables/git_test.dart
@@ -37,14 +37,14 @@ void main() {
       when(() => processResult.exitCode).thenReturn(ExitCode.success.code);
     });
 
-    group('GitHub outage detection', () {
-      test('throws GitHubUnreachableException on HTTP 500', () async {
+    group('server error detection', () {
+      test('includes github.com and status link for GitHub URLs',
+          () async {
         when(() => processResult.exitCode).thenReturn(128);
         when(() => processResult.stderr).thenReturn(
-          // URL split across lines for line length.
-          // ignore: missing_whitespace_between_adjacent_strings
-          "fatal: unable to access 'https://github.com/shorebirdtech/"
-          "flutter.git/': The requested URL returned error: 500",
+          "fatal: unable to access 'https://github.com/"
+          "shorebirdtech/flutter.git/': "
+          'The requested URL returned error: 500',
         );
         expect(
           () => runWithOverrides(
@@ -54,48 +54,43 @@ void main() {
             ),
           ),
           throwsA(
-            isA<GitHubUnreachableException>().having(
+            isA<GitServerUnreachableException>().having(
               (e) => e.toString(),
               'message',
-              contains('githubstatus.com'),
+              allOf(
+                contains('github.com'),
+                contains('githubstatus.com'),
+              ),
             ),
           ),
         );
       });
 
-      test('throws GitHubUnreachableException on HTTP 502', () async {
+      test('includes host name for non-GitHub URLs', () async {
         when(() => processResult.exitCode).thenReturn(128);
         when(() => processResult.stderr).thenReturn(
-          // URL split across lines for line length.
-          // ignore: missing_whitespace_between_adjacent_strings
-          "fatal: unable to access 'https://github.com/shorebirdtech/"
-          "shorebird.git/': The requested URL returned error: 502",
+          "fatal: unable to access 'https://gitlab.com/"
+          "org/repo.git/': "
+          'The requested URL returned error: 502',
         );
         expect(
           () => runWithOverrides(
             () => git.fetch(directory: 'repo'),
           ),
-          throwsA(isA<GitHubUnreachableException>()),
-        );
-      });
-
-      test('throws GitHubUnreachableException on HTTP 503', () async {
-        when(() => processResult.exitCode).thenReturn(128);
-        when(() => processResult.stderr).thenReturn(
-          // URL split across lines for line length.
-          // ignore: missing_whitespace_between_adjacent_strings
-          "fatal: unable to access 'https://github.com/shorebirdtech/"
-          "shorebird.git/': The requested URL returned error: 503",
-        );
-        expect(
-          () => runWithOverrides(
-            () => git.fetch(directory: 'repo'),
+          throwsA(
+            isA<GitServerUnreachableException>().having(
+              (e) => e.toString(),
+              'message',
+              allOf(
+                contains('gitlab.com'),
+                isNot(contains('githubstatus.com')),
+              ),
+            ),
           ),
-          throwsA(isA<GitHubUnreachableException>()),
         );
       });
 
-      test('throws GitHubUnreachableException on Internal Server Error',
+      test('falls back to generic message when no URL in stderr',
           () async {
         when(() => processResult.exitCode).thenReturn(128);
         when(() => processResult.stderr).thenReturn(
@@ -105,11 +100,18 @@ void main() {
           () => runWithOverrides(
             () => git.fetch(directory: 'repo'),
           ),
-          throwsA(isA<GitHubUnreachableException>()),
+          throwsA(
+            isA<GitServerUnreachableException>().having(
+              (e) => e.toString(),
+              'message',
+              contains('the remote git server'),
+            ),
+          ),
         );
       });
 
-      test('throws ProcessException for non-outage errors', () async {
+      test('throws ProcessException for non-server errors',
+          () async {
         when(() => processResult.exitCode).thenReturn(128);
         when(() => processResult.stderr).thenReturn(
           'fatal: repository not found',


### PR DESCRIPTION
## Summary

- Adds `GitHubOutageException` to the central `Git.git()` method that detects HTTP 500/502/503 and "Internal Server Error" patterns in git stderr
- Shows users a friendly message: "GitHub appears to be experiencing an outage. Please check https://www.githubstatus.com and try again later."
- Covers all git commands (upgrade, release, clone, fetch, etc.) since detection is in the shared git executor

Closes #3608

## Test plan

- [x] 5 new tests: HTTP 500, 502, 503, Internal Server Error all throw `GitHubOutageException`; non-outage errors still throw `ProcessException`
- [x] `dart analyze --fatal-warnings` passes
- [x] All existing git tests pass
- [ ] CI green