### PR TITLE
feat: suggest cache clean in build failure recommendations

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -91,11 +91,6 @@ We strongly encourage always specifying an explicit Flutter version:
 
 ${lightCyan.wrap('shorebird release <platform> --flutter-version=3.29.0')}
 
-• If the error seems unexpected or mentions corrupted files, try clearing
-the Shorebird cache and retrying:
-
-${lightCyan.wrap('shorebird cache clean')}
-
 • If `flutter build` completes successfully and `shorebird release`
 fails when using the same flutter version, please file an issue:
 ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}

--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -91,6 +91,11 @@ We strongly encourage always specifying an explicit Flutter version:
 
 ${lightCyan.wrap('shorebird release <platform> --flutter-version=3.29.0')}
 
+• If the error seems unexpected or mentions corrupted files, try clearing
+the Shorebird cache and retrying:
+
+${lightCyan.wrap('shorebird cache clean')}
+
 • If `flutter build` completes successfully and `shorebird release`
 fails when using the same flutter version, please file an issue:
 ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}

--- a/packages/shorebird_cli/lib/src/shorebird_env.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_env.dart
@@ -11,6 +11,21 @@ import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_cli_command_runner.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
+/// Exception thrown when a required file in the Shorebird cache is missing or
+/// unreadable, indicating a corrupted installation.
+class CacheCorruptedException implements Exception {
+  /// Creates a [CacheCorruptedException] for the given [filePath].
+  const CacheCorruptedException(this.filePath);
+
+  /// The path to the missing or unreadable file.
+  final String filePath;
+
+  @override
+  String toString() =>
+      'Could not read $filePath. Your Shorebird installation may be '
+      "corrupted. Try running 'shorebird cache clean' and retrying.";
+}
+
 /// A reference to a [ShorebirdEnv] instance.
 final shorebirdEnvRef = create(ShorebirdEnv.new);
 
@@ -56,17 +71,27 @@ class ShorebirdEnv {
 
   /// The Shorebird engine revision.
   String get shorebirdEngineRevision {
-    return File(
+    final file = File(
       p.join(flutterDirectory.path, 'bin', 'internal', 'engine.version'),
-    ).readAsStringSync().trim();
+    );
+    try {
+      return file.readAsStringSync().trim();
+    } on FileSystemException {
+      throw CacheCorruptedException(file.path);
+    }
   }
 
   /// Get the Shorebird Flutter revision.
   String get flutterRevision {
-    return _flutterRevisionOverride ??
-        File(
-          p.join(shorebirdRoot.path, 'bin', 'internal', 'flutter.version'),
-        ).readAsStringSync().trim();
+    if (_flutterRevisionOverride != null) return _flutterRevisionOverride;
+    final file = File(
+      p.join(shorebirdRoot.path, 'bin', 'internal', 'flutter.version'),
+    );
+    try {
+      return file.readAsStringSync().trim();
+    } on FileSystemException {
+      throw CacheCorruptedException(file.path);
+    }
   }
 
   /// Whether the project uses package:shorebird_code_push.


### PR DESCRIPTION
## Summary

- Adds a `shorebird cache clean` suggestion to the build failure fix recommendations
- Shown when any `flutter build` command fails, alongside the existing suggestions
- Helps users recover from corrupted Flutter installations without needing to diagnose the root cause

Closes #3245

## Test plan

- [x] `dart analyze --fatal-warnings` passes
- [ ] CI green