### PR TITLE
feat: suppress Gradle welcome message during init

### DIFF
--- a/packages/shorebird_cli/lib/src/executables/gradlew.dart
+++ b/packages/shorebird_cli/lib/src/executables/gradlew.dart
@@ -1,3 +1,4 @@
+// cspell:words Dorg
 import 'dart:io';
 
 import 'package:collection/collection.dart';

--- a/packages/shorebird_cli/lib/src/executables/gradlew.dart
+++ b/packages/shorebird_cli/lib/src/executables/gradlew.dart
@@ -185,9 +185,12 @@ class Gradlew {
   }
 
   /// Starts the daemon if not running at [projectRoot].
-  /// Command: `./gradlew --daemon`
+  /// Command: `./gradlew --daemon -Dorg.gradle.welcome=never`
   Future<void> startDaemon(String projectRoot) async {
-    final exitCode = await _stream(['--daemon'], projectRoot);
+    final exitCode = await _stream([
+      '--daemon',
+      '-Dorg.gradle.welcome=never',
+    ], projectRoot);
     if (exitCode != 0) {
       throw Exception('Unable to start gradle daemon');
     }

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -585,7 +585,7 @@ No daemons are running.
         verify(
           () => process.stream(
             p.join(projectRoot.path, 'android', 'gradlew'),
-            ['--daemon'],
+            ['--daemon', '-Dorg.gradle.welcome=never'],
             runInShell: false,
             workingDirectory: p.join(projectRoot.path, 'android'),
             environment: {'JAVA_HOME': javaHome},

--- a/packages/shorebird_cli/test/src/executables/gradlew_test.dart
+++ b/packages/shorebird_cli/test/src/executables/gradlew_test.dart
@@ -1,3 +1,4 @@
+// cspell:words Dorg
 import 'dart:io' hide Platform;
 
 import 'package:mason_logger/mason_logger.dart';


### PR DESCRIPTION
## Summary

- Passes `-Dorg.gradle.welcome=never` when starting the Gradle daemon in `shorebird init`
- Suppresses the verbose "Welcome to Gradle X.Y.Z" banner while preserving the "Starting a Gradle Daemon" progress message
- Tested locally on Gradle 6.7 and 7.5 — the property works on both (silently ignored if unsupported)

Closes #3006

## Test plan

- [x] Verified on Gradle 6.7: no welcome message, daemon start message preserved
- [x] Verified on Gradle 7.5: no welcome message, daemon start message preserved
- [x] `dart analyze --fatal-warnings` passes
- [x] Existing gradlew tests have pre-existing failures unrelated to this change
- [ ] CI green