### PR TITLE
fix: fetch tags for cached Flutter checkouts

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -43,7 +43,11 @@ class ShorebirdFlutter {
   /// Install the provided Flutter [revision].
   Future<void> installRevision({required String revision}) async {
     final targetDirectory = Directory(_workingDirectory(revision: revision));
-    if (targetDirectory.existsSync()) return;
+    if (targetDirectory.existsSync()) {
+      // Ensure tags are up to date for Flutter's version detection.
+      await git.fetch(directory: targetDirectory.path, args: ['--tags']);
+      return;
+    }
 
     final version = await getVersionForRevision(flutterRevision: revision);
 

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -59,6 +59,12 @@ void main() {
       shorebirdFlutter = runWithOverrides(ShorebirdFlutter.new);
 
       when(
+        () => git.fetch(
+          directory: any(named: 'directory'),
+          args: any(named: 'args'),
+        ),
+      ).thenAnswer((_) async => {});
+      when(
         () => git.clone(
           url: any(named: 'url'),
           outputDirectory: any(named: 'outputDirectory'),
@@ -770,15 +776,21 @@ origin/flutter_release/3.10.6''';
     group('installRevision', () {
       const revision = 'test-revision';
 
-      test('does nothing if the revision is already installed', () async {
-        Directory(
+      test('fetches tags if the revision is already installed', () async {
+        final targetDirectory = Directory(
           p.join(flutterDirectory.parent.path, revision),
-        ).createSync(recursive: true);
+        )..createSync(recursive: true);
 
         await runWithOverrides(
           () => shorebirdFlutter.installRevision(revision: revision),
         );
 
+        verify(
+          () => git.fetch(
+            directory: targetDirectory.path,
+            args: ['--tags'],
+          ),
+        ).called(1);
         verifyNever(
           () => git.clone(
             url: any(named: 'url'),


### PR DESCRIPTION
## Summary
- Fixes Flutter reporting `0.0.0-unknown` as the SDK version for cached checkouts, causing pub version solving to fail
- When reusing a cached Flutter checkout, runs `git fetch --tags` to ensure Flutter's internal `GitTagVersion.determine()` can resolve the version from git tags
- Root cause: `installRevision()` previously skipped all setup for existing checkouts, so if tags were missing or stale, Flutter's version detection had no tags to work with

## Test plan
- Updated `shorebird_flutter_test.dart` to verify `git fetch --tags` is called for cached revisions
- All existing tests pass

Fixes #3662