### PR TITLE
feat: add DD table files to supplement file handling

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -60,15 +60,27 @@ final artifactBuilderRef = create(ArtifactBuilder.new);
 /// The [ArtifactBuilder] instance available in the current zone.
 ArtifactBuilder get artifactBuilder => read(artifactBuilderRef);
 
-extension on String {
-  /// Converts this base64-encoded public key into the `Map<String, String>`:
-  ///   {'SHOREBIRD_PUBLIC_KEY': this}
-  ///
-  /// SHOREBIRD_PUBLIC_KEY is the name expected by the Shorebird's Flutter tool
-  ///
-  /// This allow us to just call var?.toPublicKeyEnv() instead of doing
-  /// a ternary operation to check if the value is null.
-  Map<String, String> toPublicKeyEnv() => {'SHOREBIRD_PUBLIC_KEY': this};
+/// Builds the environment map for Flutter build subprocesses.
+///
+/// Merges the public key (if present) with any additional environment
+/// variables (e.g. DD table configuration).
+///
+/// Environment variables are used (rather than command-line flags) for
+/// backwards compatibility: older Flutter builds that don't recognize a
+/// variable will silently ignore it, whereas an unknown flag would cause
+/// a build failure.
+Map<String, String>? buildEnvironment({
+  String? base64PublicKey,
+  int? ddMaxBytes,
+}) {
+  final env = <String, String>{};
+  if (base64PublicKey != null) {
+    env['SHOREBIRD_PUBLIC_KEY'] = base64PublicKey;
+  }
+  if (ddMaxBytes != null) {
+    env['SHOREBIRD_DD_MAX_BYTES'] = ddMaxBytes.toString();
+  }
+  return env.isEmpty ? null : env;
 }
 
 /// @{template artifact_builder}
@@ -150,6 +162,7 @@ ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}
     Iterable<Arch>? targetPlatforms,
     List<String> args = const [],
     String? base64PublicKey,
+    int? ddMaxBytes,
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
@@ -168,7 +181,10 @@ ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}
       final exitCode = await process.stream(
         executable,
         arguments,
-        environment: base64PublicKey?.toPublicKeyEnv(),
+        environment: buildEnvironment(
+          base64PublicKey: base64PublicKey,
+          ddMaxBytes: ddMaxBytes,
+        ),
         // Never run in shell because we always have a fully resolved
         // executable path.
         runInShell: false,
@@ -217,6 +233,7 @@ Reason: Exited with code $exitCode.''',
     bool splitPerAbi = false,
     List<String> args = const [],
     String? base64PublicKey,
+    int? ddMaxBytes,
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
@@ -240,7 +257,10 @@ Reason: Exited with code $exitCode.''',
       final exitCode = await process.stream(
         executable,
         arguments,
-        environment: base64PublicKey?.toPublicKeyEnv(),
+        environment: buildEnvironment(
+          base64PublicKey: base64PublicKey,
+          ddMaxBytes: ddMaxBytes,
+        ),
         // Never run in shell because we always have a fully resolved
         // executable path.
         runInShell: false,
@@ -286,6 +306,7 @@ Reason: Exited with code $exitCode.''',
     Iterable<Arch>? targetPlatforms,
     List<String> args = const [],
     String? base64PublicKey,
+    int? ddMaxBytes,
   }) async {
     return _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
@@ -304,7 +325,10 @@ Reason: Exited with code $exitCode.''',
       final exitCode = await process.stream(
         executable,
         arguments,
-        environment: base64PublicKey?.toPublicKeyEnv(),
+        environment: buildEnvironment(
+          base64PublicKey: base64PublicKey,
+          ddMaxBytes: ddMaxBytes,
+        ),
         // Never run in shell because we always have a fully resolved
         // executable path.
         runInShell: false,
@@ -331,6 +355,7 @@ Reason: Exited with code $exitCode.''',
     String? target,
     List<String> args = const [],
     String? base64PublicKey,
+    int? ddMaxBytes,
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
@@ -346,7 +371,10 @@ Reason: Exited with code $exitCode.''',
       final exitCode = await process.stream(
         executable,
         arguments,
-        environment: base64PublicKey?.toPublicKeyEnv(),
+        environment: buildEnvironment(
+          base64PublicKey: base64PublicKey,
+          ddMaxBytes: ddMaxBytes,
+        ),
         // Never run in shell because we always have a fully resolved
         // executable path.
         runInShell: false,
@@ -376,6 +404,7 @@ Reason: Exited with code $exitCode.''',
     String? target,
     List<String> args = const [],
     String? base64PublicKey,
+    int? ddMaxBytes,
   }) async {
     final projectRoot = shorebirdEnv.getShorebirdProjectRoot()!;
     // Delete the .dart_tool directory to ensure that the app is rebuilt. This
@@ -401,7 +430,10 @@ Reason: Exited with code $exitCode.''',
       final exitCode = await process.stream(
         executable,
         arguments,
-        environment: base64PublicKey?.toPublicKeyEnv(),
+        environment: buildEnvironment(
+          base64PublicKey: base64PublicKey,
+          ddMaxBytes: ddMaxBytes,
+        ),
         // Never run in shell because we always have a fully resolved
         // executable path.
         runInShell: false,
@@ -442,6 +474,7 @@ Reason: Exited with code $exitCode.''',
     String? target,
     List<String> args = const [],
     String? base64PublicKey,
+    int? ddMaxBytes,
   }) async {
     final projectRoot = shorebirdEnv.getShorebirdProjectRoot()!;
     // Delete the .dart_tool directory to ensure that the app is rebuilt. This
@@ -469,7 +502,10 @@ Reason: Exited with code $exitCode.''',
       final exitCode = await process.stream(
         executable,
         arguments,
-        environment: base64PublicKey?.toPublicKeyEnv(),
+        environment: buildEnvironment(
+          base64PublicKey: base64PublicKey,
+          ddMaxBytes: ddMaxBytes,
+        ),
         // Never run in shell because we always have a fully resolved
         // executable path.
         runInShell: false,
@@ -506,6 +542,7 @@ Reason: Exited with code $exitCode.''',
   Future<AppleBuildResult> buildIosFramework({
     List<String> args = const [],
     String? base64PublicKey,
+    int? ddMaxBytes,
   }) async {
     final projectRoot = shorebirdEnv.getShorebirdProjectRoot()!;
     // Delete the .dart_tool directory to ensure that the app is rebuilt. This
@@ -530,7 +567,10 @@ Reason: Exited with code $exitCode.''',
       final exitCode = await process.stream(
         executable,
         arguments,
-        environment: base64PublicKey?.toPublicKeyEnv(),
+        environment: buildEnvironment(
+          base64PublicKey: base64PublicKey,
+          ddMaxBytes: ddMaxBytes,
+        ),
         // Never run in shell because we always have a fully resolved
         // executable path.
         runInShell: false,
@@ -790,6 +830,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
     String? target,
     List<String> args = const [],
     String? base64PublicKey,
+    int? ddMaxBytes,
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
@@ -805,7 +846,10 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
       final exitCode = await process.stream(
         executable,
         arguments,
-        environment: base64PublicKey?.toPublicKeyEnv(),
+        environment: buildEnvironment(
+          base64PublicKey: base64PublicKey,
+          ddMaxBytes: ddMaxBytes,
+        ),
         // Never run in shell because we always have a fully resolved
         // executable path.
         runInShell: false,

--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -16,6 +16,7 @@ import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
+import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/platform/platform.dart';
 import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_artifacts.dart';
@@ -206,6 +207,9 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
         ],
         aotOutputFile: File(_aotOutputPath),
         vmCodeFile: File(_vmcodeOutputPath),
+        ddMaxBytes: int.tryParse(
+          platform.environment['SHOREBIRD_PATCH_DD_MAX_BYTES'] ?? '',
+        ),
       );
       final linkPercentage = result.linkPercentage;
       final exitCode = result.exitCode;

--- a/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
@@ -80,6 +80,7 @@ class IosFrameworkReleaser extends Releaser with AppleReleaserMixin {
     await artifactBuilder.buildIosFramework(
       args: buildArgs,
       base64PublicKey: base64PublicKey,
+      ddMaxBytes: ddMaxBytes,
     );
     verifyObfuscationMap();
 

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -109,6 +109,7 @@ If left checked, Xcode will rewrite the build number in the uploaded IPA, so the
       target: target,
       args: buildArgs,
       base64PublicKey: base64PublicKey,
+      ddMaxBytes: ddMaxBytes,
     );
 
     verifyObfuscationMap();

--- a/packages/shorebird_cli/lib/src/commands/release/macos_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/macos_releaser.dart
@@ -79,6 +79,7 @@ class MacosReleaser extends Releaser with AppleReleaserMixin {
       target: target,
       args: buildArgs,
       base64PublicKey: base64PublicKey,
+      ddMaxBytes: ddMaxBytes,
     );
 
     verifyObfuscationMap();

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -159,6 +159,13 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
         CommonArguments.obfuscateArg.name,
         help: CommonArguments.obfuscateArg.description,
         negatable: false,
+      )
+      ..addOption(
+        'dd-max-bytes',
+        help: 'Override the Dynamic Dispatch table cascade byte threshold. '
+            'Functions whose transitive caller tree exceeds this many bytes '
+            'are routed through the indirect dispatch table. '
+            'Defaults to 10000 if not specified.',
       );
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -162,10 +162,12 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
       )
       ..addOption(
         'dd-max-bytes',
-        help: 'Override the Dynamic Dispatch table cascade byte threshold. '
+        defaultsTo: '10000',
+        help:
+            'Dynamic Dispatch table cascade byte threshold. '
             'Functions whose transitive caller tree exceeds this many bytes '
             'are routed through the indirect dispatch table. '
-            'Defaults to 10000 if not specified.',
+            'Set to 0 to disable.',
       );
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -163,6 +163,10 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
       ..addOption(
         'dd-max-bytes',
         defaultsTo: '10000',
+        // Hidden from --help: changing this off the default is almost never
+        // the right call for end users. The flag is here for internal
+        // testing of the cascade limiter against patch flows.
+        hide: true,
         help:
             'Dynamic Dispatch table cascade byte threshold. '
             'Functions whose transitive caller tree exceeds this many bytes '

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -101,16 +101,26 @@ abstract class Releaser {
   /// passed either to Shorebird directly or forwarded to Flutter.
   bool get useObfuscation => argResults.flagPresent('obfuscate');
 
-  /// Optional override for the DD table cascade byte threshold.
+  /// DD table cascade byte threshold for the release build.
   ///
   /// Passed to Flutter tools via the SHOREBIRD_DD_MAX_BYTES environment
   /// variable for backwards compatibility: older Flutter builds that don't
   /// recognize the variable will silently ignore it, whereas an unknown
   /// command-line flag would cause a build failure.
+  ///
+  /// The CLI option (`--dd-max-bytes`) carries `defaultsTo: '10000'`, so the
+  /// default-enabled case arrives here as the string `'10000'`. We rely on
+  /// the option-parsing default rather than re-defaulting null here, so
+  /// callers that explicitly stub `argResults['dd-max-bytes']` to null
+  /// (e.g. tests, programmatic invocations) get DD-disabled rather than
+  /// silently re-enabled.
+  ///
+  /// Returns null when DD should be disabled: the option is absent, or the
+  /// value is `0` (the user's "disable DD" knob), or the value is malformed.
   int? get ddMaxBytes {
     final value = argResults['dd-max-bytes'] as String?;
-    final parsed = value != null ? int.tryParse(value) : 10000;
-    // Return null if 0 (disabled) so the env var isn't set.
+    if (value == null) return null;
+    final parsed = int.tryParse(value);
     return (parsed != null && parsed > 0) ? parsed : null;
   }
 

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -109,7 +109,9 @@ abstract class Releaser {
   /// command-line flag would cause a build failure.
   int? get ddMaxBytes {
     final value = argResults['dd-max-bytes'] as String?;
-    return value != null ? int.tryParse(value) : null;
+    final parsed = value != null ? int.tryParse(value) : 10000;
+    // Return null if 0 (disabled) so the env var isn't set.
+    return (parsed != null && parsed > 0) ? parsed : null;
   }
 
   /// Path where the obfuscation map is saved during obfuscated builds.

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -101,6 +101,17 @@ abstract class Releaser {
   /// passed either to Shorebird directly or forwarded to Flutter.
   bool get useObfuscation => argResults.flagPresent('obfuscate');
 
+  /// Optional override for the DD table cascade byte threshold.
+  ///
+  /// Passed to Flutter tools via the SHOREBIRD_DD_MAX_BYTES environment
+  /// variable for backwards compatibility: older Flutter builds that don't
+  /// recognize the variable will silently ignore it, whereas an unknown
+  /// command-line flag would cause a build failure.
+  int? get ddMaxBytes {
+    final value = argResults['dd-max-bytes'] as String?;
+    return value != null ? int.tryParse(value) : null;
+  }
+
   /// Path where the obfuscation map is saved during obfuscated builds.
   String get obfuscationMapPath => p.join(
     projectRoot.path,

--- a/packages/shorebird_cli/lib/src/executables/aot_tools.dart
+++ b/packages/shorebird_cli/lib/src/executables/aot_tools.dart
@@ -335,6 +335,7 @@ class AotTools {
     required String outputPath,
     String? workingDirectory,
     String? dumpDebugInfoPath,
+    int? ddMaxBytes,
     List<String> additionalArgs = const [],
   }) async {
     // We use the json lines format. https://jsonlines.org
@@ -355,6 +356,7 @@ class AotTools {
           '--reporter=json',
           '--redirect-to=${p.join(outputDir, linkJson)}',
         ],
+        if (ddMaxBytes != null) '--dd-max-bytes=$ddMaxBytes',
         if (dumpDebugInfoPath != null) '--dump-debug-info=$dumpDebugInfoPath',
         if (additionalArgs.isNotEmpty) ...['--', ...additionalArgs],
       ], workingDirectory: workingDirectory);

--- a/packages/shorebird_cli/lib/src/platform/apple/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple/apple.dart
@@ -56,6 +56,9 @@ class Apple {
       'App.field_table.json',
       'App.dt.link',
       'App.dispatch_table.json',
+      // DD table files for cascade limiter (produced by 2-pass release build).
+      'App.dd.link',
+      'App.dd_callers.link',
     ];
 
     // This uses maybeCopy because not all versions of gen_snapshot/aot_tools

--- a/packages/shorebird_cli/lib/src/platform/apple/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple/apple.dart
@@ -184,7 +184,11 @@ class Apple {
       if (dumpDebugInfoDir == null) return;
 
       // Copy snapshots into the debug dump for offline diagnosis.
-      // 1 release snapshot + 3 patch compilation stages.
+      // 1 release snapshot + 4 patch compilation stages:
+      //   - out.aot:                 initial patch gen_snapshot output
+      //   - out.ct.aot:              CT-sorted intermediate
+      //   - out.preDdOptimized.aot:  CT + OP sort, no DD activation (voted on)
+      //   - out.optimized.aot:       final CT + OP sort + DD activation
       final snapshotsDir = Directory(p.join(dumpDebugInfoDir.path, 'snapshots'))
         ..createSync(recursive: true);
       void maybeCopySnapshot(File file, {String? destName}) {
@@ -202,6 +206,9 @@ class Apple {
       final patchBaseName = p.basenameWithoutExtension(aotOutputFile.path);
       maybeCopySnapshot(
         File(p.join(patchDir, '$patchBaseName.ct.aot')),
+      );
+      maybeCopySnapshot(
+        File(p.join(patchDir, '$patchBaseName.preDdOptimized.aot')),
       );
       maybeCopySnapshot(
         File(p.join(patchDir, '$patchBaseName.optimized.aot')),

--- a/packages/shorebird_cli/lib/src/platform/apple/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple/apple.dart
@@ -150,6 +150,7 @@ class Apple {
     required List<String> splitDebugInfoArgs,
     required File aotOutputFile,
     required File vmCodeFile,
+    int? ddMaxBytes,
   }) async {
     final patch = aotOutputFile;
     final buildDirectory = shorebirdEnv.buildDirectory;
@@ -253,6 +254,7 @@ $error''');
         workingDirectory: buildDirectory.path,
         kernel: kernelFile.path,
         dumpDebugInfoPath: dumpDebugInfoDir?.path,
+        ddMaxBytes: ddMaxBytes,
         additionalArgs: splitDebugInfoArgs,
       );
     } on Exception catch (error) {

--- a/packages/shorebird_cli/lib/src/platform/apple/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple/apple.dart
@@ -184,10 +184,13 @@ class Apple {
       if (dumpDebugInfoDir == null) return;
 
       // Copy snapshots into the debug dump for offline diagnosis.
-      // 1 release snapshot + 4 patch compilation stages:
+      // 1 release snapshot + up to 5 patch compilation stages:
       //   - out.aot:                 initial patch gen_snapshot output
       //   - out.ct.aot:              CT-sorted intermediate
       //   - out.preDdOptimized.aot:  CT + OP sort, no DD activation (voted on)
+      //   - out.ddOnly.aot:          CT + DD activation, no OP sort
+      //                              (source of the patch op.link consumed
+      //                               by the final pass's VM linker)
       //   - out.optimized.aot:       final CT + OP sort + DD activation
       final snapshotsDir = Directory(p.join(dumpDebugInfoDir.path, 'snapshots'))
         ..createSync(recursive: true);
@@ -209,6 +212,9 @@ class Apple {
       );
       maybeCopySnapshot(
         File(p.join(patchDir, '$patchBaseName.preDdOptimized.aot')),
+      );
+      maybeCopySnapshot(
+        File(p.join(patchDir, '$patchBaseName.ddOnly.aot')),
       );
       maybeCopySnapshot(
         File(p.join(patchDir, '$patchBaseName.optimized.aot')),

--- a/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/aar_patcher_test.dart
@@ -312,6 +312,7 @@ void main() {
               buildNumber: any(named: 'buildNumber'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async => {});
         });

--- a/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/android_patcher_test.dart
@@ -289,6 +289,7 @@ void main() {
             targetPlatforms: any(named: 'targetPlatforms'),
             args: any(named: 'args'),
             base64PublicKey: any(named: 'base64PublicKey'),
+            ddMaxBytes: any(named: 'ddMaxBytes'),
           ),
         ).thenAnswer((_) async => aabFile);
       });
@@ -339,6 +340,7 @@ void main() {
               targetPlatforms: any(named: 'targetPlatforms'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenThrow(exception);
         });

--- a/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_framework_patcher_test.dart
@@ -514,6 +514,7 @@ void main() {
               () => artifactBuilder.buildIosFramework(
                 args: any(named: 'args'),
                 base64PublicKey: any(named: 'base64PublicKey'),
+                ddMaxBytes: any(named: 'ddMaxBytes'),
               ),
             ).thenAnswer((_) async => AppleBuildResult(kernelFile: kernelFile));
           });

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -690,6 +690,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
               flavor: any(named: 'flavor'),
               target: any(named: 'target'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async => AppleBuildResult(kernelFile: kernelFile));
           when(() => artifactManager.getXcarchiveDirectory()).thenReturn(
@@ -872,6 +873,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
                 flavor: any(named: 'flavor'),
                 target: any(named: 'target'),
                 base64PublicKey: any(named: 'base64PublicKey'),
+                ddMaxBytes: any(named: 'ddMaxBytes'),
               ),
             ).captured;
 
@@ -902,6 +904,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
                 flavor: any(named: 'flavor'),
                 target: any(named: 'target'),
                 base64PublicKey: any(named: 'base64PublicKey'),
+                ddMaxBytes: any(named: 'ddMaxBytes'),
               ),
             ).captured;
 

--- a/packages/shorebird_cli/test/src/commands/patch/linux_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/linux_patcher_test.dart
@@ -271,6 +271,7 @@ void main() {
           when(
             () => artifactBuilder.buildLinuxApp(
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
               args: any(named: 'args'),
             ),
           ).thenAnswer((_) async => {});
@@ -286,6 +287,7 @@ void main() {
           final captured = verify(
             () => artifactBuilder.buildLinuxApp(
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
               args: captureAny(named: 'args'),
             ),
           ).captured;

--- a/packages/shorebird_cli/test/src/commands/patch/macos_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/macos_patcher_test.dart
@@ -747,6 +747,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
               flavor: any(named: 'flavor'),
               target: any(named: 'target'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async => AppleBuildResult(kernelFile: kernelFile));
           when(
@@ -912,6 +913,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
                 flavor: any(named: 'flavor'),
                 target: any(named: 'target'),
                 base64PublicKey: any(named: 'base64PublicKey'),
+                ddMaxBytes: any(named: 'ddMaxBytes'),
               ),
             ).captured;
 
@@ -942,6 +944,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
                 flavor: any(named: 'flavor'),
                 target: any(named: 'target'),
                 base64PublicKey: any(named: 'base64PublicKey'),
+                ddMaxBytes: any(named: 'ddMaxBytes'),
               ),
             ).captured;
 

--- a/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/windows_patcher_test.dart
@@ -295,6 +295,7 @@ void main() {
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenThrow(exception);
         });
@@ -324,6 +325,7 @@ void main() {
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async => releaseDir);
         });

--- a/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
@@ -397,6 +397,7 @@ void main() {
                 targetPlatforms: any(named: 'targetPlatforms'),
                 args: any(named: 'args'),
                 base64PublicKey: any(named: 'base64PublicKey'),
+                ddMaxBytes: any(named: 'ddMaxBytes'),
               ),
             ).thenAnswer((_) async => File(''));
 
@@ -439,6 +440,7 @@ void main() {
                 targetPlatforms: any(named: 'targetPlatforms'),
                 args: any(named: 'args'),
                 base64PublicKey: any(named: 'base64PublicKey'),
+                ddMaxBytes: any(named: 'ddMaxBytes'),
               ),
             ).thenAnswer((_) async => File(''));
 

--- a/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/android_releaser_test.dart
@@ -491,6 +491,7 @@ To change the version of this release, change your app's version in your pubspec
               targetPlatforms: any(named: 'targetPlatforms'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async => aabFile);
           when(
@@ -500,6 +501,7 @@ To change the version of this release, change your app's version in your pubspec
               targetPlatforms: any(named: 'targetPlatforms'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async => File(''));
 
@@ -581,6 +583,7 @@ To change the version of this release, change your app's version in your pubspec
               targetPlatforms: any(named: 'targetPlatforms'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async => aabFile);
 

--- a/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
@@ -353,6 +353,7 @@ void main() {
             () => artifactBuilder.buildIosFramework(
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer(
             (_) async =>
@@ -396,6 +397,7 @@ void main() {
             () => artifactBuilder.buildIosFramework(
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer(
             (_) async =>

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -423,6 +423,7 @@ $body
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer(
             (_) async =>
@@ -464,6 +465,7 @@ $body
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer(
             (_) async =>

--- a/packages/shorebird_cli/test/src/commands/release/linux_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/linux_releaser_test.dart
@@ -299,6 +299,7 @@ To change the version of this release, change your app's version in your pubspec
             target: any(named: 'target'),
             args: any(named: 'args'),
             base64PublicKey: any(named: 'base64PublicKey'),
+            ddMaxBytes: any(named: 'ddMaxBytes'),
           ),
         ).thenAnswer((_) async => projectRoot);
       });
@@ -415,6 +416,7 @@ To change the version of this release, change your app's version in your pubspec
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async {
             final mapPath = p.join(
@@ -437,6 +439,7 @@ To change the version of this release, change your app's version in your pubspec
               target: any(named: 'target'),
               args: captureAny(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).captured;
 
@@ -469,6 +472,7 @@ To change the version of this release, change your app's version in your pubspec
                 target: any(named: 'target'),
                 args: any(named: 'args'),
                 base64PublicKey: any(named: 'base64PublicKey'),
+                ddMaxBytes: any(named: 'ddMaxBytes'),
               ),
             ).thenAnswer((_) async {});
           });

--- a/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/macos_releaser_test.dart
@@ -289,6 +289,7 @@ To change the version of this release, change your app's version in your pubspec
             target: any(named: 'target'),
             args: any(named: 'args'),
             base64PublicKey: any(named: 'base64PublicKey'),
+            ddMaxBytes: any(named: 'ddMaxBytes'),
           ),
         ).thenAnswer(
           (_) async => AppleBuildResult(kernelFile: File('/path/to/app.dill')),
@@ -462,6 +463,7 @@ To change the version of this release, change your app's version in your pubspec
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async {
             final mapPath = p.join(
@@ -489,6 +491,7 @@ To change the version of this release, change your app's version in your pubspec
               target: any(named: 'target'),
               args: captureAny(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).captured;
 
@@ -513,6 +516,7 @@ To change the version of this release, change your app's version in your pubspec
               target: any(named: 'target'),
               args: captureAny(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).captured;
 
@@ -545,6 +549,7 @@ To change the version of this release, change your app's version in your pubspec
                 target: any(named: 'target'),
                 args: captureAny(named: 'args'),
                 base64PublicKey: any(named: 'base64PublicKey'),
+                ddMaxBytes: any(named: 'ddMaxBytes'),
               ),
             ).captured;
 
@@ -581,6 +586,7 @@ To change the version of this release, change your app's version in your pubspec
                 target: any(named: 'target'),
                 args: any(named: 'args'),
                 base64PublicKey: any(named: 'base64PublicKey'),
+                ddMaxBytes: any(named: 'ddMaxBytes'),
               ),
             ).thenAnswer(
               (_) async =>

--- a/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/windows_releaser_test.dart
@@ -356,6 +356,7 @@ To change the version of this release, change your app's version in your pubspec
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async => projectRoot);
           when(
@@ -388,6 +389,7 @@ To change the version of this release, change your app's version in your pubspec
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async => projectRoot);
           when(
@@ -430,6 +432,7 @@ To change the version of this release, change your app's version in your pubspec
               target: any(named: 'target'),
               args: any(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).thenAnswer((_) async {
             final mapPath = p.join(
@@ -453,6 +456,7 @@ To change the version of this release, change your app's version in your pubspec
               target: any(named: 'target'),
               args: captureAny(named: 'args'),
               base64PublicKey: any(named: 'base64PublicKey'),
+              ddMaxBytes: any(named: 'ddMaxBytes'),
             ),
           ).captured;
 
@@ -485,6 +489,7 @@ To change the version of this release, change your app's version in your pubspec
                 target: any(named: 'target'),
                 args: any(named: 'args'),
                 base64PublicKey: any(named: 'base64PublicKey'),
+                ddMaxBytes: any(named: 'ddMaxBytes'),
               ),
             ).thenAnswer((_) async => projectRoot);
           });

--- a/packages/shorebird_cli/test/src/platform/apple/apple_test.dart
+++ b/packages/shorebird_cli/test/src/platform/apple/apple_test.dart
@@ -125,6 +125,8 @@ Otherwise, to repair macos, run "flutter create . --platforms macos"''',
             'App.ct.link',
             'App.dt.link',
             'App.ft.link',
+            'App.dd.link',
+            'App.dd_callers.link',
           ];
 
           void createFiles(Directory dir) {
@@ -148,8 +150,8 @@ Otherwise, to repair macos, run "flutter create . --platforms macos"''',
               patchSnapshotDir: patchSnapshotDir,
             ),
           );
-          expect(Directory(releaseSnapshotDir.path).listSync(), hasLength(6));
-          expect(Directory(patchSnapshotDir.path).listSync(), hasLength(6));
+          expect(Directory(releaseSnapshotDir.path).listSync(), hasLength(8));
+          expect(Directory(patchSnapshotDir.path).listSync(), hasLength(8));
         });
 
         test('copies only some files next to snapshots', () {

--- a/packages/shorebird_cli/test/src/platform/apple/apple_test.dart
+++ b/packages/shorebird_cli/test/src/platform/apple/apple_test.dart
@@ -590,6 +590,8 @@ Otherwise, to repair macos, run "flutter create . --platforms macos"''',
           // Create intermediate patch snapshots alongside out.aot.
           File(p.join(buildDirectory.path, 'out.ct.aot'))
             ..writeAsStringSync('ct');
+          File(p.join(buildDirectory.path, 'out.preDdOptimized.aot'))
+            ..writeAsStringSync('preDdOptimized');
           File(p.join(buildDirectory.path, 'out.optimized.aot'))
             ..writeAsStringSync('optimized');
 
@@ -640,6 +642,7 @@ Otherwise, to repair macos, run "flutter create . --platforms macos"''',
               'App',
               'out.aot',
               'out.ct.aot',
+              'out.preDdOptimized.aot',
               'out.optimized.aot',
             ]),
           );


### PR DESCRIPTION
## Summary
- Adds `App.dd.link` and `App.dd_callers.link` to the supplement file list so they get copied between snapshot directories during patch builds.
- These files are produced by the 2-pass release build (in Flutter tooling) and consumed by `aot_tools` during patch linking for DD slot resolution via winner voting.

## Test plan
- [ ] Verify DD table files are copied during patch builds
- [ ] Run existing shorebird CLI tests