### PR TITLE
ci: scan composite actions under .github/actions/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,9 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
Tell Dependabot to scan composite actions under `.github/actions/` in addition to workflows under `.github/workflows/`. Uses the `directories:` (plural) field with a glob so future composite actions are covered automatically.