### PR TITLE
fix: fetch latest refs before resolving --flutter-version

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -420,6 +420,10 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
   Future<String> resolveTargetFlutterRevision() async {
     if (flutterVersionArg == 'latest') return shorebirdEnv.flutterRevision;
 
+    // Fetch the latest remote refs so that release branch pointers
+    // (e.g. flutter_release/3.38.5) are up to date.
+    await shorebirdFlutter.fetchRemoteRefs();
+
     final String? revision;
     try {
       revision = await shorebirdFlutter.resolveFlutterRevision(

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -268,6 +268,19 @@ class ShorebirdFlutter {
     }
   }
 
+  /// Fetches the latest remote refs for the Flutter clone so that
+  /// release branch pointers (e.g. `flutter_release/3.38.5`) are up to date.
+  Future<void> fetchRemoteRefs() async {
+    try {
+      await git.fetch(directory: _workingDirectory());
+    } on Exception {
+      logger.warn(
+        'Failed to fetch latest Flutter versions. '
+        'Resolving with potentially stale data.',
+      );
+    }
+  }
+
   /// Returns the git revision for the provided [version].
   /// e.g. 3.16.3 -> b9b23902966504a9778f4c07e3a3487fa84dcb2a
   Future<String?> getRevisionForVersion(String version) async {

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -193,6 +193,9 @@ void main() {
             shorebirdFlutter.installRevision(revision: any(named: 'revision')),
       ).thenAnswer((_) async => {});
       when(
+        () => shorebirdFlutter.fetchRemoteRefs(),
+      ).thenAnswer((_) async {});
+      when(
         () => shorebirdFlutter.resolveFlutterVersion(any()),
       ).thenAnswer((_) async => flutterVersion);
 
@@ -610,6 +613,17 @@ void main() {
       const flutterVersion = '3.16.3';
       setUp(() {
         when(() => argResults['flutter-version']).thenReturn(flutterVersion);
+      });
+
+      test('fetches remote refs before resolving', () async {
+        const revision = '771d07b2cf';
+        when(
+          () => shorebirdFlutter.resolveFlutterRevision(any()),
+        ).thenAnswer((_) async => revision);
+
+        await runWithOverrides(command.run);
+
+        verify(() => shorebirdFlutter.fetchRemoteRefs()).called(1);
       });
 
       group('when unable to determine flutter revision', () {

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -78,6 +78,9 @@ void main() {
         ),
       ).thenAnswer((_) async => '');
       when(
+        () => git.fetch(directory: any(named: 'directory')),
+      ).thenAnswer((_) async {});
+      when(
         () => git.revParse(
           revision: any(named: 'revision'),
           directory: any(named: 'directory'),
@@ -448,6 +451,40 @@ Tools • Dart 3.0.6 • DevTools 2.23.1''');
             () => shorebirdFlutter.resolveFlutterVersion('deadbeef'),
           );
           expect(revision, equals(Version(1, 2, 3)));
+        });
+      });
+    });
+
+    group('fetchRemoteRefs', () {
+      test('fetches from remote', () async {
+        when(
+          () => git.fetch(directory: any(named: 'directory')),
+        ).thenAnswer((_) async {});
+
+        await runWithOverrides(
+          () => shorebirdFlutter.fetchRemoteRefs(),
+        );
+
+        verify(
+          () => git.fetch(directory: any(named: 'directory')),
+        ).called(1);
+      });
+
+      group('when fetch fails', () {
+        setUp(() {
+          when(
+            () => git.fetch(directory: any(named: 'directory')),
+          ).thenThrow(Exception('no network'));
+        });
+
+        test('logs a warning', () async {
+          await runWithOverrides(
+            () => shorebirdFlutter.fetchRemoteRefs(),
+          );
+
+          verify(
+            () => logger.warn(any(that: contains('stale'))),
+          ).called(1);
         });
       });
     });


### PR DESCRIPTION
## Summary

- Adds a `git fetch` in `getRevisionForVersion()` before resolving a Flutter version string to a commit hash, ensuring `refs/remotes/origin/flutter_release/*` are up to date
- Logs a warning if the fetch fails (e.g., offline) so users know they may be building against stale data
- Previously, release branch refs were only updated during CLI bootstrap (`shared.sh`), which is gated on stamp invalidation — meaning users had to `shorebird upgrade` to pick up updated release branches

Closes #3693

## Test plan

- [x] Added test verifying `git.fetch` is called before `rev-parse`
- [x] Added test verifying warning is logged and resolution still works when fetch fails
- [x] All existing `shorebird_flutter_test.dart` tests pass (42/42)