### PR TITLE
fix(cli): detect --obfuscate and --split-debug-info after --

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -432,11 +432,7 @@ Building with Flutter $flutterVersionString to determine the release version...
     // If the user explicitly passed --obfuscate but the release has no
     // obfuscation map, the patch would be obfuscated against a non-obfuscated
     // release, producing a broken patch.
-    // Also check rest for `-- --obfuscate`, which bypasses the parser but
-    // still flows through forwardedArgs to the Flutter build command.
-    final userPassedObfuscate =
-        (results.wasParsed('obfuscate') && results['obfuscate'] == true) ||
-        results.rest.any((a) => a == '--obfuscate');
+    final userPassedObfuscate = results.flagPresent('obfuscate');
     if (userPassedObfuscate && obfuscationMapFile == null) {
       logger.err(
         '--obfuscate was passed, but the release was not built with '
@@ -475,9 +471,9 @@ Building with Flutter $flutterVersionString to determine the release version...
     // if --obfuscate will be in the build args (from the user or from
     // the obfuscation map injection above) but --split-debug-info is not.
     final hasObfuscate =
-        (results.wasParsed('obfuscate') && results['obfuscate'] == true) ||
+        results.flagPresent('obfuscate') ||
         extraBuildArgs.contains('--obfuscate');
-    final hasSplitDebugInfo = results.wasParsed('split-debug-info');
+    final hasSplitDebugInfo = results.optionPresent('split-debug-info');
     if (hasObfuscate && !hasSplitDebugInfo) {
       extraBuildArgs.add(
         '--split-debug-info=${p.join('build', 'shorebird', 'symbols')}',

--- a/packages/shorebird_cli/lib/src/commands/release/releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/releaser.dart
@@ -96,8 +96,10 @@ abstract class Releaser {
   /// Returns null if no public key is configured.
   Future<String?> getEncodedPublicKey() => argResults.getEncodedPublicKey();
 
-  /// Whether the user is building with obfuscation.
-  bool get useObfuscation => argResults['obfuscate'] == true;
+  /// Whether the user is building with obfuscation. Checks for `--obfuscate`
+  /// both as a parsed flag and after the `--` separator, since it can be
+  /// passed either to Shorebird directly or forwarded to Flutter.
+  bool get useObfuscation => argResults.flagPresent('obfuscate');
 
   /// Path where the obfuscation map is saved during obfuscated builds.
   String get obfuscationMapPath => p.join(

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -12,6 +12,27 @@ import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.da
 
 /// Extension on [ArgResults] to make it easier to work with options.
 extension OptionFinder on ArgResults {
+  /// Whether the boolean flag [name] is set, checking both the parsed
+  /// arguments and any `--$name` that appears after a `--` separator (which
+  /// lands in [rest] to be forwarded to the underlying Flutter command).
+  ///
+  /// Use this for flags that Shorebird and Flutter both understand
+  /// (e.g. `--obfuscate`), so users can pass them either before or after
+  /// `--` without changing behavior.
+  bool flagPresent(String name) =>
+      (wasParsed(name) && this[name] == true) ||
+      rest.any((a) => a == '--$name');
+
+  /// Whether the value-bearing option [name] was provided, checking both
+  /// the parsed arguments and any `--$name=value` or `--$name value` form
+  /// in [rest] (forwarded to the underlying Flutter command via `--`).
+  ///
+  /// Companion to [flagPresent] for options rather than boolean flags
+  /// (e.g. `--split-debug-info=path`). Abbreviations are not considered.
+  bool optionPresent(String name) =>
+      wasParsed(name) ||
+      rest.any((a) => a == '--$name' || a.startsWith('--$name='));
+
   /// Detects flags even when passed to underlying commands via a `--`
   /// separator.
   String? findOption(String name, {required ArgParser argParser}) {

--- a/packages/shorebird_cli/lib/src/extensions/arg_results.dart
+++ b/packages/shorebird_cli/lib/src/extensions/arg_results.dart
@@ -19,6 +19,10 @@ extension OptionFinder on ArgResults {
   /// Use this for flags that Shorebird and Flutter both understand
   /// (e.g. `--obfuscate`), so users can pass them either before or after
   /// `--` without changing behavior.
+  ///
+  /// Does not handle negation in [rest]: `--no-$name` after `--` is ignored,
+  /// and `-- --$name --no-$name` would incorrectly report the flag as set.
+  /// Safe for non-negatable flags; use a smarter scan if negation matters.
   bool flagPresent(String name) =>
       (wasParsed(name) && this[name] == true) ||
       rest.any((a) => a == '--$name');

--- a/packages/shorebird_cli/test/src/extensions/arg_results_test.dart
+++ b/packages/shorebird_cli/test/src/extensions/arg_results_test.dart
@@ -99,6 +99,84 @@ void main() {
         });
       });
     });
+
+    group('flagPresent', () {
+      late ArgParser flagParser;
+
+      setUp(() {
+        flagParser = ArgParser()..addFlag('obfuscate');
+      });
+
+      test('returns true when flag is parsed as true', () {
+        final results = flagParser.parse(['--obfuscate']);
+        expect(results.flagPresent('obfuscate'), isTrue);
+      });
+
+      test('returns false when flag is parsed as false', () {
+        final results = flagParser.parse(['--no-obfuscate']);
+        expect(results.flagPresent('obfuscate'), isFalse);
+      });
+
+      test('returns false when flag is absent', () {
+        final results = flagParser.parse([]);
+        expect(results.flagPresent('obfuscate'), isFalse);
+      });
+
+      test('returns true when flag appears after -- in rest', () {
+        final results = flagParser.parse(['--', '--obfuscate']);
+        expect(results.flagPresent('obfuscate'), isTrue);
+      });
+
+      test('returns true when flag is both parsed and in rest', () {
+        final results = flagParser.parse(['--obfuscate', '--', '--obfuscate']);
+        expect(results.flagPresent('obfuscate'), isTrue);
+      });
+
+      test(
+        'returns false when a different flag is in rest but not --name',
+        () {
+          final results = flagParser.parse(['--', '--no-obfuscate']);
+          expect(results.flagPresent('obfuscate'), isFalse);
+        },
+      );
+    });
+
+    group('optionPresent', () {
+      late ArgParser optionParser;
+
+      setUp(() {
+        optionParser = ArgParser()..addOption('split-debug-info');
+      });
+
+      test('returns true when option is parsed with a value', () {
+        final results = optionParser.parse(['--split-debug-info=foo']);
+        expect(results.optionPresent('split-debug-info'), isTrue);
+      });
+
+      test('returns false when option is absent', () {
+        final results = optionParser.parse([]);
+        expect(results.optionPresent('split-debug-info'), isFalse);
+      });
+
+      test('returns true for --name=value after --', () {
+        final results = optionParser.parse(['--', '--split-debug-info=foo']);
+        expect(results.optionPresent('split-debug-info'), isTrue);
+      });
+
+      test('returns true for bare --name after -- (space-separated value)', () {
+        final results = optionParser.parse([
+          '--',
+          '--split-debug-info',
+          'foo',
+        ]);
+        expect(results.optionPresent('split-debug-info'), isTrue);
+      });
+
+      test('does not match a similarly-prefixed flag in rest', () {
+        final results = optionParser.parse(['--', '--split-debug-info-extra']);
+        expect(results.optionPresent('split-debug-info'), isFalse);
+      });
+    });
   });
 
   group('forwardedArgs', () {


### PR DESCRIPTION
## Summary

Fixes #3695.

When users pass `--obfuscate` after the `--` separator (as fastlane and other wrappers do when forwarding flags to `flutter build`), the releaser's `useObfuscation` getter only checked `argResults['obfuscate']` and missed it. That caused `shorebird release` to:

- skip `--save-obfuscation-map` / `--strip` in gen_snapshot extra options
- skip uploading the obfuscation-map supplement artifact
- record the release as unobfuscated on the server

…while Flutter still saw `--obfuscate` in the forwarded args and obfuscated the shipped IPA. Every subsequent `shorebird patch` then failed with:

```
link_failure: base and patch snapshots have differing VM sections
vm_data_hash { base: …, patch: … }   // mismatch
vm_instructions_hash { base: …, patch: … }  // matches
```

Classic obfuscation-only mismatch: obfuscation changes string/symbol data (VM data section) but not instruction bytes.

## Fix

Adds two helpers to the existing \`OptionFinder\` extension on \`ArgResults\`, both of which consult parsed args AND \`rest\` (post-\`--\`):

- \`flagPresent(name)\` — boolean flags (\`--obfuscate\`)
- \`optionPresent(name)\` — value-bearing options (\`--split-debug-info\`), matching both \`--name=value\` and \`--name value\` forms, rejecting similar-prefix names like \`--name-extra\`

Applied at:
- \`releaser.useObfuscation\` — the actual bug fix
- \`patch_command\` \`userPassedObfuscate\` / \`hasObfuscate\` — collapses two existing inline checks that already did the same thing
- \`patch_command\` \`hasSplitDebugInfo\` — same class of bug for the companion option

## Test plan

- [x] 11 new unit tests cover \`flagPresent\` (parsed true/false/absent, in-rest, parsed+rest, \`--no-\` in rest) and \`optionPresent\` (parsed, absent, \`=\`-form in rest, space-form in rest, similar-prefix non-match)
- [x] \`dart test\` on the affected suites (\`arg_results_test\`, \`patch_command_test\`, \`ios_releaser_test\`, \`android_releaser_test\`): 127 passing
- [x] \`dart analyze\` clean on all edited files

## Follow-up (not in this PR)

While working on this I noticed \`patcher.dart:288\` uses \`argResults.options.containsAnyOf([buildName, buildNumber])\` which, in production, always matches because \`build-number\` has \`defaultsTo: '1.0'\` — so the \`buildNameAndNumberArgsFromReleaseVersion\` early-return always fires and the build-name/number injection intended by #2270 never runs. Existing tests stub \`options\` to \`[]\` and don't catch it. Worth a separate PR; didn't want to bundle a behavior change with this bugfix.