### PR TITLE
feat(protocol): add current_patch_number to PatchCheckRequest

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_request.dart
@@ -17,6 +17,7 @@ class PatchCheckRequest {
     this.patchNumber,
     this.patchHash,
     this.clientId,
+    this.currentPatchNumber,
   });
 
   /// Converts a `Map<String, dynamic>` to a [PatchCheckRequest].
@@ -33,6 +34,7 @@ class PatchCheckRequest {
         appId: json['app_id'] as String,
         channel: json['channel'] as String,
         clientId: json['client_id'] as String?,
+        currentPatchNumber: json['current_patch_number'] as int?,
       ),
     );
   }
@@ -73,6 +75,12 @@ class PatchCheckRequest {
   /// unique per app. Optional for backward compatibility.
   final String? clientId;
 
+  /// The number of the patch currently running on the device, if any.
+  ///
+  /// Reported by newer updaters for analytics (e.g. MAU breakdowns by patch).
+  /// Unlike [patchNumber], this does not affect the server's response.
+  final int? currentPatchNumber;
+
   /// Converts a [PatchCheckRequest] to a `Map<String, dynamic>`.
   Map<String, dynamic> toJson() {
     return {
@@ -84,6 +92,7 @@ class PatchCheckRequest {
       'app_id': appId,
       'channel': channel,
       'client_id': clientId,
+      'current_patch_number': currentPatchNumber,
     };
   }
 
@@ -97,6 +106,7 @@ class PatchCheckRequest {
     appId,
     channel,
     clientId,
+    currentPatchNumber,
   ]);
 
   @override
@@ -110,6 +120,7 @@ class PatchCheckRequest {
         arch == other.arch &&
         appId == other.appId &&
         channel == other.channel &&
-        clientId == other.clientId;
+        clientId == other.clientId &&
+        currentPatchNumber == other.currentPatchNumber;
   }
 }

--- a/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_request.dart
@@ -77,8 +77,10 @@ class PatchCheckRequest {
 
   /// The number of the patch currently running on the device, if any.
   ///
-  /// Reported by newer updaters for analytics (e.g. MAU breakdowns by patch).
-  /// Unlike [patchNumber], this does not affect the server's response.
+  /// Supersedes [patchNumber] for newer updater clients. Unlike
+  /// [patchNumber], this does not affect the server's response;
+  /// [patchNumber] is retained for compatibility with legacy clients that
+  /// rely on the server's short-circuit path.
   final int? currentPatchNumber;
 
   /// Converts a [PatchCheckRequest] to a `Map<String, dynamic>`.

--- a/packages/shorebird_code_push_protocol/test/src/messages/patch_check/patch_check_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/patch_check/patch_check_request_test.dart
@@ -13,6 +13,7 @@ void main() {
         appId: 'app_123',
         channel: 'channel_123',
         clientId: 'client_123',
+        currentPatchNumber: 4,
       );
       expect(
         PatchCheckRequest.fromJson(request.toJson()).toJson(),

--- a/packages/shorebird_code_push_protocol/test/src/messages/patch_check/patch_check_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/patch_check/patch_check_request_test.dart
@@ -3,8 +3,27 @@ import 'package:test/test.dart';
 
 void main() {
   group(PatchCheckRequest, () {
+    const request = PatchCheckRequest(
+      releaseVersion: '1',
+      patchNumber: 2,
+      patchHash: '3',
+      platform: ReleasePlatform.android,
+      arch: 'arm64',
+      appId: 'app_123',
+      channel: 'channel_123',
+      clientId: 'client_123',
+      currentPatchNumber: 4,
+    );
+
     test('can be (de)serialized', () {
-      const request = PatchCheckRequest(
+      expect(
+        PatchCheckRequest.fromJson(request.toJson()).toJson(),
+        equals(request.toJson()),
+      );
+    });
+
+    test('is equatable', () {
+      const copy = PatchCheckRequest(
         releaseVersion: '1',
         patchNumber: 2,
         patchHash: '3',
@@ -15,10 +34,20 @@ void main() {
         clientId: 'client_123',
         currentPatchNumber: 4,
       );
-      expect(
-        PatchCheckRequest.fromJson(request.toJson()).toJson(),
-        equals(request.toJson()),
+      const different = PatchCheckRequest(
+        releaseVersion: '1',
+        patchNumber: 2,
+        patchHash: '3',
+        platform: ReleasePlatform.android,
+        arch: 'arm64',
+        appId: 'app_123',
+        channel: 'channel_123',
+        clientId: 'client_123',
+        currentPatchNumber: 5,
       );
+
+      expect(request, equals(copy));
+      expect(request, isNot(equals(different)));
     });
   });
 }


### PR DESCRIPTION
## Description

Adds an optional `currentPatchNumber` field to `PatchCheckRequest`, serialized as `current_patch_number`.

This field supersedes the legacy `patchNumber` for newer clients. Unlike `patchNumber`, it does not affect the server's response — `patchNumber` is retained purely for compatibility with pre-[updater#189](https://github.com/shorebirdtech/updater/pull/189) Rust updater clients that still rely on the server's short-circuit response path (still ~0.7% of patch-check traffic, from Flutter ≤ 3.22.2).

Paired with:
- shorebirdtech/updater#343 (updater populates this field)
- shorebirdtech/_shorebird#2059 (server consumes this field)

## Type of Change

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix
- [ ] ❌ Breaking change
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🗑️ Chore