### PR TITLE
docs(cli): document why ShorebirdProcess.stream uses inheritStdio (#3703)

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -29,11 +29,20 @@ class ShorebirdProcess {
   final ProcessWrapper processWrapper;
 
   /// Starts a process, streams the output in real-time, and returns the exit
-  /// code. The child's stdout/stderr are forwarded via Dart sinks (not
-  /// inherited fds) so the `LoggingStdout` `IOOverrides` in
-  /// `bin/shorebird.dart` tees both into the shorebird log file — without
-  /// this, a failing `flutter build`'s stderr never reached the log (see
-  /// https://github.com/shorebirdtech/shorebird/issues/3703).
+  /// code.
+  ///
+  /// Uses `ProcessStartMode.inheritStdio` so the child (flutter, gradlew,
+  /// gen_snapshot) shares our terminal fds and can render its spinner + ANSI
+  /// output the way users expect. The cost: the child's bytes never pass
+  /// through the `LoggingStdout` `IOOverrides` installed in
+  /// `bin/shorebird.dart`, so `flutter build` stderr is absent from the
+  /// shorebird log file — on a build failure users see the real error on
+  /// screen but the log only has `Failed to build AAB. Exited with code 1`
+  /// (https://github.com/shorebirdtech/shorebird/issues/3703). Piping
+  /// through Dart would capture stderr but turns `stdout.hasTerminal` false
+  /// on the child side, regressing the interactive UX; a pty or per-fd
+  /// shell tee would fix both but costs a dependency / POSIX-only path.
+  /// Accepting the logging gap for now.
   Future<int> stream(
     String executable,
     List<String> arguments, {
@@ -48,13 +57,10 @@ class ShorebirdProcess {
       environment: environment,
       runInShell: runInShell,
       workingDirectory: workingDirectory,
+      mode: ProcessStartMode.inheritStdio,
     );
     onStart?.call(process);
-    final stdoutDrain = process.stdout.forEach(stdout.add);
-    final stderrDrain = process.stderr.forEach(stderr.add);
-    final exitCode = await process.exitCode;
-    await Future.wait([stdoutDrain, stderrDrain]);
-    return exitCode;
+    return process.exitCode;
   }
 
   /// Runs the process and returns the result.

--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -29,7 +29,11 @@ class ShorebirdProcess {
   final ProcessWrapper processWrapper;
 
   /// Starts a process, streams the output in real-time, and returns the exit
-  /// code.
+  /// code. The child's stdout/stderr are forwarded via Dart sinks (not
+  /// inherited fds) so the `LoggingStdout` `IOOverrides` in
+  /// `bin/shorebird.dart` tees both into the shorebird log file — without
+  /// this, a failing `flutter build`'s stderr never reached the log (see
+  /// https://github.com/shorebirdtech/shorebird/issues/3703).
   Future<int> stream(
     String executable,
     List<String> arguments, {
@@ -44,10 +48,13 @@ class ShorebirdProcess {
       environment: environment,
       runInShell: runInShell,
       workingDirectory: workingDirectory,
-      mode: ProcessStartMode.inheritStdio,
     );
     onStart?.call(process);
-    return process.exitCode;
+    final stdoutDrain = process.stdout.forEach(stdout.add);
+    final stderrDrain = process.stderr.forEach(stderr.add);
+    final exitCode = await process.exitCode;
+    await Future.wait([stdoutDrain, stderrDrain]);
+    return exitCode;
   }
 
   /// Runs the process and returns the result.

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -1,6 +1,4 @@
 // cspell:ignore asdfasdf
-import 'dart:async';
-import 'dart:convert';
 import 'dart:io' hide Platform;
 
 import 'package:mason_logger/mason_logger.dart';
@@ -433,27 +431,27 @@ void main() {
             any(),
             any(),
             environment: any(named: 'environment'),
+            mode: ProcessStartMode.inheritStdio,
           ),
         ).thenAnswer((_) async => streamProcess);
-        when(
-          () => streamProcess.stdout,
-        ).thenAnswer((_) => const Stream<List<int>>.empty());
-        when(
-          () => streamProcess.stderr,
-        ).thenAnswer((_) => const Stream<List<int>>.empty());
         when(
           () => streamProcess.exitCode,
         ).thenAnswer((_) async => ExitCode.success.code);
       });
 
-      test('starts the process with default (pipe) stdio mode', () async {
+      test('proxies to start with correct mode', () async {
         await expectLater(
           runWithOverrides(() => shorebirdProcess.stream('git', ['pull'])),
           completion(equals(ExitCode.success.code)),
         );
 
         verify(
-          () => processWrapper.start('git', ['pull'], environment: {}),
+          () => processWrapper.start(
+            'git',
+            ['pull'],
+            environment: {},
+            mode: ProcessStartMode.inheritStdio,
+          ),
         ).called(1);
       });
 
@@ -469,33 +467,6 @@ void main() {
 
         expect(exit, ExitCode.success.code);
         expect(identical(received, streamProcess), isTrue);
-      });
-
-      test('forwards child stdout and stderr to parent sinks', () async {
-        // Forwarding through the parent's stdout/stderr sinks is what lets
-        // the LoggingStdout IOOverrides tee both streams into the shorebird
-        // log file (issue #3703). Assert the bytes actually flow through.
-        final collectedStdout = <int>[];
-        final collectedStderr = <int>[];
-        final stdoutSink = _CollectingStdout(sink: collectedStdout);
-        final stderrSink = _CollectingStdout(sink: collectedStderr);
-        when(() => streamProcess.stdout).thenAnswer(
-          (_) => Stream<List<int>>.fromIterable([utf8.encode('out')]),
-        );
-        when(() => streamProcess.stderr).thenAnswer(
-          (_) => Stream<List<int>>.fromIterable([utf8.encode('err')]),
-        );
-
-        await IOOverrides.runZoned(
-          () => runWithOverrides(
-            () => shorebirdProcess.stream('git', ['pull']),
-          ),
-          stdout: () => stdoutSink,
-          stderr: () => stderrSink,
-        );
-
-        expect(utf8.decode(collectedStdout), equals('out'));
-        expect(utf8.decode(collectedStderr), equals('err'));
       });
     });
 
@@ -627,21 +598,4 @@ void main() {
       );
     });
   });
-}
-
-/// Stdout test double that appends every `add()` byte list into [sink] and
-/// no-ops everything else. Lets us verify that `ShorebirdProcess.stream`
-/// forwards child stdio through `stdout.add` / `stderr.add` (so the real
-/// `LoggingStdout` override can tee into the shorebird log file) rather
-/// than bypassing Dart via inherited fds.
-class _CollectingStdout implements Stdout {
-  _CollectingStdout({required this.sink});
-
-  final List<int> sink;
-
-  @override
-  void add(List<int> data) => sink.addAll(data);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -1,4 +1,6 @@
 // cspell:ignore asdfasdf
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io' hide Platform;
 
 import 'package:mason_logger/mason_logger.dart';
@@ -431,27 +433,27 @@ void main() {
             any(),
             any(),
             environment: any(named: 'environment'),
-            mode: ProcessStartMode.inheritStdio,
           ),
         ).thenAnswer((_) async => streamProcess);
+        when(
+          () => streamProcess.stdout,
+        ).thenAnswer((_) => const Stream<List<int>>.empty());
+        when(
+          () => streamProcess.stderr,
+        ).thenAnswer((_) => const Stream<List<int>>.empty());
         when(
           () => streamProcess.exitCode,
         ).thenAnswer((_) async => ExitCode.success.code);
       });
 
-      test('proxies to start with correct mode', () async {
+      test('starts the process with default (pipe) stdio mode', () async {
         await expectLater(
           runWithOverrides(() => shorebirdProcess.stream('git', ['pull'])),
           completion(equals(ExitCode.success.code)),
         );
 
         verify(
-          () => processWrapper.start(
-            'git',
-            ['pull'],
-            environment: {},
-            mode: ProcessStartMode.inheritStdio,
-          ),
+          () => processWrapper.start('git', ['pull'], environment: {}),
         ).called(1);
       });
 
@@ -467,6 +469,33 @@ void main() {
 
         expect(exit, ExitCode.success.code);
         expect(identical(received, streamProcess), isTrue);
+      });
+
+      test('forwards child stdout and stderr to parent sinks', () async {
+        // Forwarding through the parent's stdout/stderr sinks is what lets
+        // the LoggingStdout IOOverrides tee both streams into the shorebird
+        // log file (issue #3703). Assert the bytes actually flow through.
+        final collectedStdout = <int>[];
+        final collectedStderr = <int>[];
+        final stdoutSink = _CollectingStdout(sink: collectedStdout);
+        final stderrSink = _CollectingStdout(sink: collectedStderr);
+        when(() => streamProcess.stdout).thenAnswer(
+          (_) => Stream<List<int>>.fromIterable([utf8.encode('out')]),
+        );
+        when(() => streamProcess.stderr).thenAnswer(
+          (_) => Stream<List<int>>.fromIterable([utf8.encode('err')]),
+        );
+
+        await IOOverrides.runZoned(
+          () => runWithOverrides(
+            () => shorebirdProcess.stream('git', ['pull']),
+          ),
+          stdout: () => stdoutSink,
+          stderr: () => stderrSink,
+        );
+
+        expect(utf8.decode(collectedStdout), equals('out'));
+        expect(utf8.decode(collectedStderr), equals('err'));
       });
     });
 
@@ -598,4 +627,21 @@ void main() {
       );
     });
   });
+}
+
+/// Stdout test double that appends every `add()` byte list into [sink] and
+/// no-ops everything else. Lets us verify that `ShorebirdProcess.stream`
+/// forwards child stdio through `stdout.add` / `stderr.add` (so the real
+/// `LoggingStdout` override can tee into the shorebird log file) rather
+/// than bypassing Dart via inherited fds.
+class _CollectingStdout implements Stdout {
+  _CollectingStdout({required this.sink});
+
+  final List<int> sink;
+
+  @override
+  void add(List<int> data) => sink.addAll(data);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }


### PR DESCRIPTION
## Summary

Attempted to fix the stderr-in-log half of #3703 by switching `ShorebirdProcess.stream` from `ProcessStartMode.inheritStdio` to pipe mode + Dart-side forwarding. That would have captured stderr in the shorebird log — but turned `stdout.hasTerminal` false on the child side, which regresses Flutter's spinner, ANSI colors, and gradle's interactive progress. Losing that UX isn't worth the logging gain.

None of the alternatives that preserve both behaviors are cheap:
- pty: cross-platform pty dependency + Windows ConPTY work
- POSIX shell tee (`bash -c '... 2> >(tee … >&2)'`): POSIX-only, Windows needs a separate path
- Retry on failure with pipe capture: doubles failure time and can flake if pub_get / gradle cache state shifts between runs

So this PR is now just the revert plus a doc comment at the `inheritStdio` call site explaining the trade-off and pointing to #3703, so the next person who wonders finds the reasoning.

The upstream-gradle investigation documented previously also stands: no `flutter_tools/gradle` diff between 3.41.5 and 3.41.6, and our fork's only gradle-side edits are storage URL defaults + a snakeyaml dep — none of which can affect `com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION`. The reporter has a working subprojects workaround.

## Test plan

- [x] `dart test test/src/shorebird_process_test.dart` (all 27 pre-existing tests green)
- [x] `dart analyze --fatal-warnings --fatal-infos` clean on both edited files
- [x] No behavior change from `main` — only a doc comment lands