### PR TITLE
fix(shorebird_cli): gate build tracing on resolved version; drop the runtime flag probe

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -582,10 +582,13 @@ Reason: Exited with code $exitCode.''',
     final flutterVersion = await shorebirdFlutter.resolveFlutterVersion(
       revision,
     );
-    // Treat an unknown version (e.g. a pinned dev revision) as new enough,
-    // matching the pattern used for other version-gated features.
+    // When resolveFlutterVersion returns null (dev revision not on any
+    // flutter_release/* branch), the gate falls through to the allowlist.
+    // That's intentional: a dev pin predating the tracing PR would otherwise
+    // get `--shorebird-trace` passed to a flutter build that doesn't know
+    // the flag, and fail hard.
     final supportsTrace = buildTraceSupportConstraint.isSatisfiedBy(
-      version: flutterVersion ?? buildTraceSupportConstraint.minVersion,
+      version: flutterVersion,
       revision: revision,
     );
     if (!supportsTrace) {

--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -103,44 +103,6 @@ fails when using the same flutter version, please file an issue:
 ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}
 ''';
 
-  /// Cache of `flutter build <command>` help output checks for
-  /// `--shorebird-trace` support. Populated lazily by
-  /// [_supportsTraceFlag].
-  final _traceSupport = <String, bool>{};
-
-  /// Returns whether `flutter build <command>` accepts `--shorebird-trace`.
-  ///
-  /// Probes the command's help output and caches the result per [command]
-  /// so that subsequent calls for the same command are free.
-  /// Returns `false` if the help check fails for any reason.
-  Future<bool> _supportsTraceFlag(String command) async {
-    if (_traceSupport.containsKey(command)) return _traceSupport[command]!;
-
-    try {
-      final result = await process.run(
-        'flutter',
-        ['build', command, '-h'],
-        runInShell: false,
-      );
-      final supported = result.stdout.toString().contains('--shorebird-trace');
-      _traceSupport[command] = supported;
-      return supported;
-    } on Exception {
-      _traceSupport[command] = false;
-      return false;
-    }
-  }
-
-  /// Returns the `--shorebird-trace` argument if the current
-  /// [BuildTraceSession] has a trace file and the given [command]
-  /// supports it, or an empty list otherwise.
-  Future<List<String>> _traceArgs(String command) async {
-    final traceFile = buildTraceSession.traceFile;
-    if (traceFile == null) return const [];
-    if (!await _supportsTraceFlag(command)) return const [];
-    return ['--shorebird-trace=${traceFile.path}'];
-  }
-
   /// Builds an aab using `flutter build appbundle`. Runs `flutter pub get` with
   /// the system installation of Flutter to reset
   /// `.dart_tool/package_config.json` after the build completes or fails.
@@ -154,6 +116,7 @@ ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
       final targetPlatformArgs = targetPlatforms?.targetPlatformArg;
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'appbundle',
@@ -161,7 +124,7 @@ ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}
         if (flavor != null) '--flavor=$flavor',
         if (target != null) '--target=$target',
         if (targetPlatformArgs != null) '--target-platform=$targetPlatformArgs',
-        ...await _traceArgs('appbundle'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -221,6 +184,7 @@ Reason: Exited with code $exitCode.''',
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
       final targetPlatformArgs = targetPlatforms?.targetPlatformArg;
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'apk',
@@ -233,7 +197,7 @@ Reason: Exited with code $exitCode.''',
         // coverage:ignore-start
         if (splitPerAbi) '--split-per-abi',
         // coverage:ignore-end
-        ...await _traceArgs('apk'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -290,6 +254,7 @@ Reason: Exited with code $exitCode.''',
     return _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
       final targetPlatformArgs = targetPlatforms?.targetPlatformArg;
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'aar',
@@ -297,7 +262,7 @@ Reason: Exited with code $exitCode.''',
         '--no-profile',
         '--build-number=$buildNumber',
         if (targetPlatformArgs != null) '--target-platform=$targetPlatformArgs',
-        ...await _traceArgs('aar'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -334,12 +299,13 @@ Reason: Exited with code $exitCode.''',
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'linux',
         '--release',
         if (target != null) '--target=$target',
-        ...await _traceArgs('linux'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -387,6 +353,7 @@ Reason: Exited with code $exitCode.''',
     String? appDillPath;
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'macos',
@@ -394,7 +361,7 @@ Reason: Exited with code $exitCode.''',
         if (flavor != null) '--flavor=$flavor',
         if (target != null) '--target=$target',
         if (!codesign) '--no-codesign',
-        ...await _traceArgs('macos'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
       final buildStart = clock.now();
@@ -454,6 +421,7 @@ Reason: Exited with code $exitCode.''',
     String? appDillPath;
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'ipa',
@@ -461,7 +429,7 @@ Reason: Exited with code $exitCode.''',
         if (flavor != null) '--flavor=$flavor',
         if (target != null) '--target=$target',
         if (!codesign) '--no-codesign',
-        ...await _traceArgs('ipa'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -517,12 +485,13 @@ Reason: Exited with code $exitCode.''',
     String? appDillPath;
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'ios-framework',
         '--no-debug',
         '--no-profile',
-        ...await _traceArgs('ios-framework'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -796,12 +765,13 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'windows',
         '--release',
         if (target != null) '--target=$target',
-        ...await _traceArgs('windows'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 

--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -132,51 +132,6 @@ ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}
     return '${LegacyFlutterJarReference.recommendation(offenders)}\n$vanilla';
   }
 
-  /// Cache of `flutter build <command>` help output checks for
-  /// `--shorebird-trace` support. Populated lazily by
-  /// [_supportsTraceFlag].
-  final _traceSupport = <String, bool>{};
-
-  /// Returns whether `flutter build <command>` accepts `--shorebird-trace`.
-  ///
-  /// Probes the command's help output and caches the result per [command]
-  /// so that subsequent calls for the same command are free.
-  /// Returns `false` if the help check fails for any reason.
-  ///
-  /// The probe uses verbose help (`-h -v`): `--shorebird-trace` is registered
-  /// with `hide: !verboseHelp` in Flutter, so it does not appear in plain
-  /// `-h` output. Probing with `-h` alone therefore returned `false` even on
-  /// Flutter versions that fully support the flag, silently disabling build
-  /// tracing for everyone. `-h -v` lists hidden options so support is
-  /// detected correctly.
-  Future<bool> _supportsTraceFlag(String command) async {
-    if (_traceSupport.containsKey(command)) return _traceSupport[command]!;
-
-    try {
-      final result = await process.run(
-        'flutter',
-        ['build', command, '-h', '-v'],
-        runInShell: false,
-      );
-      final supported = result.stdout.toString().contains('--shorebird-trace');
-      _traceSupport[command] = supported;
-      return supported;
-    } on Exception {
-      _traceSupport[command] = false;
-      return false;
-    }
-  }
-
-  /// Returns the `--shorebird-trace` argument if the current
-  /// [BuildTraceSession] has a trace file and the given [command]
-  /// supports it, or an empty list otherwise.
-  Future<List<String>> _traceArgs(String command) async {
-    final traceFile = buildTraceSession.traceFile;
-    if (traceFile == null) return const [];
-    if (!await _supportsTraceFlag(command)) return const [];
-    return ['--shorebird-trace=${traceFile.path}'];
-  }
-
   /// Builds an aab using `flutter build appbundle`. Runs `flutter pub get` with
   /// the system installation of Flutter to reset
   /// `.dart_tool/package_config.json` after the build completes or fails.
@@ -191,6 +146,7 @@ ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
       final targetPlatformArgs = targetPlatforms?.targetPlatformArg;
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'appbundle',
@@ -198,7 +154,7 @@ ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}
         if (flavor != null) '--flavor=$flavor',
         if (target != null) '--target=$target',
         if (targetPlatformArgs != null) '--target-platform=$targetPlatformArgs',
-        ...await _traceArgs('appbundle'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -262,6 +218,7 @@ Reason: Exited with code $exitCode.''',
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
       final targetPlatformArgs = targetPlatforms?.targetPlatformArg;
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'apk',
@@ -274,7 +231,7 @@ Reason: Exited with code $exitCode.''',
         // coverage:ignore-start
         if (splitPerAbi) '--split-per-abi',
         // coverage:ignore-end
-        ...await _traceArgs('apk'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -335,6 +292,7 @@ Reason: Exited with code $exitCode.''',
     return _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
       final targetPlatformArgs = targetPlatforms?.targetPlatformArg;
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'aar',
@@ -342,7 +300,7 @@ Reason: Exited with code $exitCode.''',
         '--no-profile',
         '--build-number=$buildNumber',
         if (targetPlatformArgs != null) '--target-platform=$targetPlatformArgs',
-        ...await _traceArgs('aar'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -383,12 +341,13 @@ Reason: Exited with code $exitCode.''',
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'linux',
         '--release',
         if (target != null) '--target=$target',
-        ...await _traceArgs('linux'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -440,6 +399,7 @@ Reason: Exited with code $exitCode.''',
     String? appDillPath;
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'macos',
@@ -447,7 +407,7 @@ Reason: Exited with code $exitCode.''',
         if (flavor != null) '--flavor=$flavor',
         if (target != null) '--target=$target',
         if (!codesign) '--no-codesign',
-        ...await _traceArgs('macos'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
       final buildStart = clock.now();
@@ -511,6 +471,7 @@ Reason: Exited with code $exitCode.''',
     String? appDillPath;
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'ipa',
@@ -518,7 +479,7 @@ Reason: Exited with code $exitCode.''',
         if (flavor != null) '--flavor=$flavor',
         if (target != null) '--target=$target',
         if (!codesign) '--no-codesign',
-        ...await _traceArgs('ipa'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -578,12 +539,13 @@ Reason: Exited with code $exitCode.''',
     String? appDillPath;
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'ios-framework',
         '--no-debug',
         '--no-profile',
-        ...await _traceArgs('ios-framework'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 
@@ -861,12 +823,13 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
   }) async {
     await _runShorebirdBuildCommand(() async {
       const executable = 'flutter';
+      final traceFile = buildTraceSession.traceFile;
       final arguments = [
         'build',
         'windows',
         '--release',
         if (target != null) '--target=$target',
-        ...await _traceArgs('windows'),
+        if (traceFile != null) '--shorebird-trace=${traceFile.path}',
         ...args,
       ];
 

--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -646,10 +646,13 @@ Reason: Exited with code $exitCode.''',
     final flutterVersion = await shorebirdFlutter.resolveFlutterVersion(
       revision,
     );
-    // Treat an unknown version (e.g. a pinned dev revision) as new enough,
-    // matching the pattern used for other version-gated features.
+    // When resolveFlutterVersion returns null (dev revision not on any
+    // flutter_release/* branch), the gate falls through to the allowlist.
+    // That's intentional: a dev pin predating the tracing PR would otherwise
+    // get `--shorebird-trace` passed to a flutter build that doesn't know
+    // the flag, and fail hard.
     final supportsTrace = buildTraceSupportConstraint.isSatisfiedBy(
-      version: flutterVersion ?? buildTraceSupportConstraint.minVersion,
+      version: flutterVersion,
       revision: revision,
     );
     if (!supportsTrace) {

--- a/packages/shorebird_cli/lib/src/flutter_version_constraints.dart
+++ b/packages/shorebird_cli/lib/src/flutter_version_constraints.dart
@@ -61,8 +61,15 @@ class FlutterSupportConstraint {
   final Set<String> allowedRevisions;
 
   /// Whether the given [version]/[revision] pair satisfies this constraint.
-  bool isSatisfiedBy({required Version version, required String revision}) =>
-      version >= minVersion || allowedRevisions.contains(revision);
+  ///
+  /// A null [version] (e.g. a Shorebird-fork dev revision that isn't on any
+  /// `flutter_release/*` branch and so has no parseable upstream version)
+  /// can only satisfy the constraint via [allowedRevisions]. Gating on
+  /// `version ?? minVersion` would treat every unknown revision as new
+  /// enough, silently opting pre-feature dev pins into feature behavior.
+  bool isSatisfiedBy({required Version? version, required String revision}) =>
+      (version != null && version >= minVersion) ||
+      allowedRevisions.contains(revision);
 }
 
 /// Flutter support for `flutter build --shorebird-trace=<path>` for emitting
@@ -76,9 +83,15 @@ class FlutterSupportConstraint {
 final buildTraceSupportConstraint = FlutterSupportConstraint(
   minVersion: Version(3, 41, 7),
   allowedRevisions: {
-    // Current Shorebird Flutter pin (bin/internal/flutter.version). Can
-    // be removed once a flutter_release/3.41.7 branch ships with this
-    // (or a later tracing-enabled) commit at its tip.
+    // Shorebird-fork Flutter pins that ship the tracing feature but
+    // still report upstream version 3.41.6, so `resolveFlutterVersion`
+    // can't satisfy the floor via the version path.
+    //
+    // Add a new entry here every time `bin/internal/flutter.version`
+    // is bumped to a revision that carries the tracing PRs; entries
+    // stop mattering once a `flutter_release/3.41.7` branch ships
+    // them and the floor can be satisfied directly.
     '3b10eecea184bb381f1045a878eeff36548ed11e',
+    'c2c56ab2d5483bdf86152725342f55ca6faed946',
   },
 );

--- a/packages/shorebird_cli/lib/src/flutter_version_constraints.dart
+++ b/packages/shorebird_cli/lib/src/flutter_version_constraints.dart
@@ -61,8 +61,15 @@ class FlutterSupportConstraint {
   final Set<String> allowedRevisions;
 
   /// Whether the given [version]/[revision] pair satisfies this constraint.
-  bool isSatisfiedBy({required Version version, required String revision}) =>
-      version >= minVersion || allowedRevisions.contains(revision);
+  ///
+  /// A null [version] (e.g. a Shorebird-fork dev revision that isn't on any
+  /// `flutter_release/*` branch and so has no parseable upstream version)
+  /// can only satisfy the constraint via [allowedRevisions]. Gating on
+  /// `version ?? minVersion` would treat every unknown revision as new
+  /// enough, silently opting pre-feature dev pins into feature behavior.
+  bool isSatisfiedBy({required Version? version, required String revision}) =>
+      (version != null && version >= minVersion) ||
+      allowedRevisions.contains(revision);
 }
 
 /// Flutter support for downloading the `patch-darwin-arm64.zip` artifact
@@ -87,10 +94,16 @@ final arm64PatchSupportConstraint = FlutterSupportConstraint(
 final buildTraceSupportConstraint = FlutterSupportConstraint(
   minVersion: Version(3, 41, 7),
   allowedRevisions: {
-    // Current Shorebird Flutter pin (bin/internal/flutter.version). Can
-    // be removed once a flutter_release/3.41.7 branch ships with this
-    // (or a later tracing-enabled) commit at its tip.
+    // Shorebird-fork Flutter pins that ship the tracing feature but
+    // still report upstream version 3.41.6, so `resolveFlutterVersion`
+    // can't satisfy the floor via the version path.
+    //
+    // Add a new entry here every time `bin/internal/flutter.version`
+    // is bumped to a revision that carries the tracing PRs; entries
+    // stop mattering once a `flutter_release/3.41.7` branch ships
+    // them and the floor can be satisfied directly.
     '3b10eecea184bb381f1045a878eeff36548ed11e',
+    'c2c56ab2d5483bdf86152725342f55ca6faed946',
   },
 );
 

--- a/packages/shorebird_cli/lib/src/flutter_version_constraints.dart
+++ b/packages/shorebird_cli/lib/src/flutter_version_constraints.dart
@@ -96,7 +96,7 @@ final arm64PatchSupportConstraint = FlutterSupportConstraint(
 ///
 /// A revision that isn't on any `flutter_release/*` branch resolves to no
 /// version and is gated *off* unless allowlisted — passing the flag to a
-/// Flutter that doesn't register it is a hard argparse failure, so
+/// Flutter that doesn't register it is a hard argument-parsing failure, so
 /// "unknown" must not mean "new enough". Add the hash to
 /// [FlutterSupportConstraint.allowedRevisions] whenever
 /// `bin/internal/flutter.version` is bumped to a dev revision (one not yet

--- a/packages/shorebird_cli/lib/src/flutter_version_constraints.dart
+++ b/packages/shorebird_cli/lib/src/flutter_version_constraints.dart
@@ -86,24 +86,27 @@ final arm64PatchSupportConstraint = FlutterSupportConstraint(
 /// Flutter support for `flutter build --shorebird-trace=<path>` for emitting
 /// Chrome Trace Event Format build traces.
 ///
-/// Added in shorebirdtech/flutter#116. `minVersion` is set to the next
-/// minor past the latest Shorebird Flutter release (currently 3.41.6), so
-/// whenever that PR gets cut as 3.41.7 the floor covers it cleanly. Until
-/// then, the allowlist covers the current pin hash so users on it get
-/// tracing today.
+/// Added in shorebirdtech/flutter#116 and first shipped on the
+/// `flutter_release/3.41.7` branch, so every release-branch pin from there
+/// on satisfies the floor through its resolved version. The flag must be
+/// accepted by *every* `flutter build` subcommand the CLI invokes
+/// (shorebirdtech/flutter#136 extended it to aar, ios-framework and
+/// desktop), because the CLI passes it unconditionally once this
+/// constraint is satisfied.
+///
+/// A revision that isn't on any `flutter_release/*` branch resolves to no
+/// version and is gated *off* unless allowlisted — passing the flag to a
+/// Flutter that doesn't register it is a hard argparse failure, so
+/// "unknown" must not mean "new enough". Add the hash to
+/// [FlutterSupportConstraint.allowedRevisions] whenever
+/// `bin/internal/flutter.version` is bumped to a dev revision (one not yet
+/// cut into a release branch) that carries the tracing PRs.
 final buildTraceSupportConstraint = FlutterSupportConstraint(
   minVersion: Version(3, 41, 7),
   allowedRevisions: {
-    // Shorebird-fork Flutter pins that ship the tracing feature but
-    // still report upstream version 3.41.6, so `resolveFlutterVersion`
-    // can't satisfy the floor via the version path.
-    //
-    // Add a new entry here every time `bin/internal/flutter.version`
-    // is bumped to a revision that carries the tracing PRs; entries
-    // stop mattering once a `flutter_release/3.41.7` branch ships
-    // them and the floor can be satisfied directly.
+    // Dev pin from before flutter_release/3.41.7 was cut; kept so users
+    // who pinned it explicitly with --flutter-version still get tracing.
     '3b10eecea184bb381f1045a878eeff36548ed11e',
-    'c2c56ab2d5483bdf86152725342f55ca6faed946',
   },
 );
 

--- a/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
@@ -98,25 +98,6 @@ void main() {
       when(
         () => pubGetProcessResult.exitCode,
       ).thenReturn(ExitCode.success.code);
-      // Default stub for the `flutter build <command> -h` probe used by
-      // `_supportsTraceFlag`. Returns help text that includes
-      // `--shorebird-trace` so that trace tests pass when tracing is enabled.
-      // Tests that need to verify the flag is NOT passed should either use a
-      // Flutter version below the trace threshold (the default 3.0.0) or
-      // override this stub.
-      when(
-        () => shorebirdProcess.run(
-          'flutter',
-          any(),
-          runInShell: false,
-        ),
-      ).thenAnswer(
-        (_) async => ShorebirdProcessResult(
-          exitCode: ExitCode.success.code,
-          stdout: '--shorebird-trace',
-          stderr: '',
-        ),
-      );
       when(
         () => shorebirdProcess.stream(
           any(),
@@ -324,59 +305,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
               'appbundle',
               '--release',
               '--shorebird-trace=$expectedTracePath',
-            ],
-            environment: any(named: 'environment'),
-            runInShell: false,
-            onStart: any(named: 'onStart'),
-          ),
-        ).called(1);
-      });
-
-      test('caches trace flag probe result across calls', () async {
-        when(
-          () => shorebirdFlutter.resolveFlutterVersion(any()),
-        ).thenAnswer((_) async => Version(3, 41, 7));
-
-        await runWithOverrides(() async {
-          await builder.prepareBuildTrace(platform: 'android');
-          await builder.buildAppBundle();
-          await builder.buildAppBundle();
-        });
-
-        // The help probe should only be called once despite two builds.
-        verify(
-          () => shorebirdProcess.run(
-            'flutter',
-            ['build', 'appbundle', '-h'],
-            runInShell: false,
-          ),
-        ).called(1);
-      });
-
-      test('skips trace when help probe throws', () async {
-        when(
-          () => shorebirdFlutter.resolveFlutterVersion(any()),
-        ).thenAnswer((_) async => Version(3, 41, 7));
-        when(
-          () => shorebirdProcess.run(
-            'flutter',
-            ['build', 'appbundle', '-h'],
-            runInShell: false,
-          ),
-        ).thenThrow(Exception('process failed'));
-
-        await runWithOverrides(() async {
-          await builder.prepareBuildTrace(platform: 'android');
-          await builder.buildAppBundle();
-        });
-
-        verify(
-          () => shorebirdProcess.stream(
-            'flutter',
-            [
-              'build',
-              'appbundle',
-              '--release',
             ],
             environment: any(named: 'environment'),
             runInShell: false,
@@ -913,30 +841,24 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
       const buildNumber = '1.0';
 
       test(
-        'skips --shorebird-trace when help probe shows no support',
+        'passes --shorebird-trace when Flutter supports build tracing',
         () async {
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => Version(3, 41, 7));
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'aar', '-h'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: 0,
-              stdout: 'no trace flag here',
-              stderr: '',
-            ),
-          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'android');
             await builder.buildAar(buildNumber: buildNumber);
           });
 
+          final expectedTracePath = p.join(
+            projectRoot.path,
+            'build',
+            'shorebird',
+            'debug',
+            'build-trace-android.json',
+          );
           verify(
             () => shorebirdProcess.stream(
               'flutter',
@@ -946,6 +868,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
                 '--no-debug',
                 '--no-profile',
                 '--build-number=1.0',
+                '--shorebird-trace=$expectedTracePath',
               ],
               environment: any(named: 'environment'),
               runInShell: false,
@@ -1115,30 +1038,24 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
       });
 
       test(
-        'skips --shorebird-trace when help probe shows no support',
+        'passes --shorebird-trace when Flutter supports build tracing',
         () async {
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => Version(3, 41, 7));
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'linux', '-h'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: 0,
-              stdout: 'no trace flag here',
-              stderr: '',
-            ),
-          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'linux');
             await builder.buildLinuxApp();
           });
 
+          final expectedTracePath = p.join(
+            projectRoot.path,
+            'build',
+            'shorebird',
+            'debug',
+            'build-trace-linux.json',
+          );
           verify(
             () => shorebirdProcess.stream(
               'flutter',
@@ -1146,6 +1063,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
                 'build',
                 'linux',
                 '--release',
+                '--shorebird-trace=$expectedTracePath',
               ],
               environment: any(named: 'environment'),
               runInShell: false,
@@ -1292,30 +1210,24 @@ Reason: Exited with code 70.'''),
       });
 
       test(
-        'skips --shorebird-trace when help probe shows no support',
+        'passes --shorebird-trace when Flutter supports build tracing',
         () async {
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => Version(3, 41, 7));
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'macos', '-h'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: 0,
-              stdout: 'no trace flag here',
-              stderr: '',
-            ),
-          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'macos');
             await builder.buildMacos();
           });
 
+          final expectedTracePath = p.join(
+            projectRoot.path,
+            'build',
+            'shorebird',
+            'debug',
+            'build-trace-macos.json',
+          );
           verify(
             () => shorebirdProcess.stream(
               'flutter',
@@ -1323,6 +1235,7 @@ Reason: Exited with code 70.'''),
                 'build',
                 'macos',
                 '--release',
+                '--shorebird-trace=$expectedTracePath',
               ],
               environment: any(named: 'environment'),
               runInShell: false,
@@ -1781,30 +1694,24 @@ Reason: Exited with code 70.'''),
       });
 
       test(
-        'skips --shorebird-trace when help probe shows no support',
+        'passes --shorebird-trace when Flutter supports build tracing',
         () async {
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => Version(3, 41, 7));
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'ios-framework', '-h'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: 0,
-              stdout: 'no trace flag here',
-              stderr: '',
-            ),
-          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'ios');
             await builder.buildIosFramework();
           });
 
+          final expectedTracePath = p.join(
+            projectRoot.path,
+            'build',
+            'shorebird',
+            'debug',
+            'build-trace-ios.json',
+          );
           verify(
             () => shorebirdProcess.stream(
               'flutter',
@@ -1813,6 +1720,7 @@ Reason: Exited with code 70.'''),
                 'ios-framework',
                 '--no-debug',
                 '--no-profile',
+                '--shorebird-trace=$expectedTracePath',
               ],
               environment: any(named: 'environment'),
               runInShell: false,
@@ -2073,30 +1981,24 @@ Reason: Exited with code 70.'''),
       });
 
       test(
-        'skips --shorebird-trace when help probe shows no support',
+        'passes --shorebird-trace when Flutter supports build tracing',
         () async {
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => Version(3, 41, 7));
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'windows', '-h'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: 0,
-              stdout: 'no trace flag here',
-              stderr: '',
-            ),
-          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'windows');
             await builder.buildWindowsApp();
           });
 
+          final expectedTracePath = p.join(
+            projectRoot.path,
+            'build',
+            'shorebird',
+            'debug',
+            'build-trace-windows.json',
+          );
           verify(
             () => shorebirdProcess.stream(
               'flutter',
@@ -2104,6 +2006,7 @@ Reason: Exited with code 70.'''),
                 'build',
                 'windows',
                 '--release',
+                '--shorebird-trace=$expectedTracePath',
               ],
               environment: any(named: 'environment'),
               runInShell: false,

--- a/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
@@ -2266,14 +2266,36 @@ Reason: Exited with code 70.'''),
       );
 
       test(
-        'treats unresolved Flutter version as new enough (dev pin)',
+        'leaves traceFile null when version is unresolved and revision is not '
+        'allowlisted',
         () async {
           // resolveFlutterVersion returns null for revisions not on a
-          // flutter_release branch (e.g. a pinned dev revision). The
-          // minVersion fallback admits these.
+          // flutter_release branch (e.g. a pinned dev revision predating
+          // the tracing PR). Those must not opt into tracing, or flutter
+          // build will fail on an unknown --shorebird-trace option.
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => null);
+
+          await runWithOverrides(() async {
+            await builder.prepareBuildTrace(platform: 'android');
+            expect(buildTraceSession.traceFile, isNull);
+          });
+        },
+      );
+
+      test(
+        'sets traceFile when version is unresolved but revision is allowlisted',
+        () async {
+          // A current Shorebird dev pin that does include the tracing PR
+          // typically has no parseable version (not on a flutter_release
+          // branch) — the allowlist is the bridge that admits it.
+          when(
+            () => shorebirdFlutter.resolveFlutterVersion(any()),
+          ).thenAnswer((_) async => null);
+          when(() => shorebirdEnv.flutterRevision).thenReturn(
+            buildTraceSupportConstraint.allowedRevisions.first,
+          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'android');

--- a/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
@@ -98,25 +98,6 @@ void main() {
       when(
         () => pubGetProcessResult.exitCode,
       ).thenReturn(ExitCode.success.code);
-      // Default stub for the `flutter build <command> -h` probe used by
-      // `_supportsTraceFlag`. Returns help text that includes
-      // `--shorebird-trace` so that trace tests pass when tracing is enabled.
-      // Tests that need to verify the flag is NOT passed should either use a
-      // Flutter version below the trace threshold (the default 3.0.0) or
-      // override this stub.
-      when(
-        () => shorebirdProcess.run(
-          'flutter',
-          any(),
-          runInShell: false,
-        ),
-      ).thenAnswer(
-        (_) async => ShorebirdProcessResult(
-          exitCode: ExitCode.success.code,
-          stdout: '--shorebird-trace',
-          stderr: '',
-        ),
-      );
       when(
         () => shorebirdProcess.stream(
           any(),
@@ -324,125 +305,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
               'appbundle',
               '--release',
               '--shorebird-trace=$expectedTracePath',
-            ],
-            environment: any(named: 'environment'),
-            runInShell: false,
-            onStart: any(named: 'onStart'),
-          ),
-        ).called(1);
-      });
-
-      test('caches trace flag probe result across calls', () async {
-        when(
-          () => shorebirdFlutter.resolveFlutterVersion(any()),
-        ).thenAnswer((_) async => Version(3, 41, 7));
-
-        await runWithOverrides(() async {
-          await builder.prepareBuildTrace(platform: 'android');
-          await builder.buildAppBundle();
-          await builder.buildAppBundle();
-        });
-
-        // The help probe should only be called once despite two builds.
-        verify(
-          () => shorebirdProcess.run(
-            'flutter',
-            ['build', 'appbundle', '-h', '-v'],
-            runInShell: false,
-          ),
-        ).called(1);
-      });
-
-      test(
-        'detects --shorebird-trace even though it is hidden from -h',
-        () async {
-          when(
-            () => shorebirdFlutter.resolveFlutterVersion(any()),
-          ).thenAnswer((_) async => Version(3, 41, 7));
-          // Flutter registers --shorebird-trace with `hide: !verboseHelp`, so it
-          // only appears in verbose help. Model that: plain `-h` omits the flag,
-          // `-h -v` includes it. Probing without `-v` (the original bug) would
-          // miss it and silently disable tracing on every supported build.
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'appbundle', '-h'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: ExitCode.success.code,
-              stdout: '--release',
-              stderr: '',
-            ),
-          );
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'appbundle', '-h', '-v'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: ExitCode.success.code,
-              stdout: '--release\n--shorebird-trace',
-              stderr: '',
-            ),
-          );
-
-          await runWithOverrides(() async {
-            await builder.prepareBuildTrace(platform: 'android');
-            await builder.buildAppBundle();
-          });
-
-          final expectedTracePath = p.join(
-            projectRoot.path,
-            'build',
-            'shorebird',
-            'debug',
-            'build-trace-android.json',
-          );
-          verify(
-            () => shorebirdProcess.stream(
-              'flutter',
-              [
-                'build',
-                'appbundle',
-                '--release',
-                '--shorebird-trace=$expectedTracePath',
-              ],
-              environment: any(named: 'environment'),
-              runInShell: false,
-              onStart: any(named: 'onStart'),
-            ),
-          ).called(1);
-        },
-      );
-
-      test('skips trace when help probe throws', () async {
-        when(
-          () => shorebirdFlutter.resolveFlutterVersion(any()),
-        ).thenAnswer((_) async => Version(3, 41, 7));
-        when(
-          () => shorebirdProcess.run(
-            'flutter',
-            ['build', 'appbundle', '-h', '-v'],
-            runInShell: false,
-          ),
-        ).thenThrow(Exception('process failed'));
-
-        await runWithOverrides(() async {
-          await builder.prepareBuildTrace(platform: 'android');
-          await builder.buildAppBundle();
-        });
-
-        verify(
-          () => shorebirdProcess.stream(
-            'flutter',
-            [
-              'build',
-              'appbundle',
-              '--release',
             ],
             environment: any(named: 'environment'),
             runInShell: false,
@@ -1016,30 +878,24 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
       const buildNumber = '1.0';
 
       test(
-        'skips --shorebird-trace when help probe shows no support',
+        'passes --shorebird-trace when Flutter supports build tracing',
         () async {
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => Version(3, 41, 7));
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'aar', '-h', '-v'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: 0,
-              stdout: 'no trace flag here',
-              stderr: '',
-            ),
-          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'android');
             await builder.buildAar(buildNumber: buildNumber);
           });
 
+          final expectedTracePath = p.join(
+            projectRoot.path,
+            'build',
+            'shorebird',
+            'debug',
+            'build-trace-android.json',
+          );
           verify(
             () => shorebirdProcess.stream(
               'flutter',
@@ -1049,6 +905,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
                 '--no-debug',
                 '--no-profile',
                 '--build-number=1.0',
+                '--shorebird-trace=$expectedTracePath',
               ],
               environment: any(named: 'environment'),
               runInShell: false,
@@ -1218,30 +1075,24 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
       });
 
       test(
-        'skips --shorebird-trace when help probe shows no support',
+        'passes --shorebird-trace when Flutter supports build tracing',
         () async {
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => Version(3, 41, 7));
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'linux', '-h', '-v'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: 0,
-              stdout: 'no trace flag here',
-              stderr: '',
-            ),
-          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'linux');
             await builder.buildLinuxApp();
           });
 
+          final expectedTracePath = p.join(
+            projectRoot.path,
+            'build',
+            'shorebird',
+            'debug',
+            'build-trace-linux.json',
+          );
           verify(
             () => shorebirdProcess.stream(
               'flutter',
@@ -1249,6 +1100,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
                 'build',
                 'linux',
                 '--release',
+                '--shorebird-trace=$expectedTracePath',
               ],
               environment: any(named: 'environment'),
               runInShell: false,
@@ -1395,30 +1247,24 @@ Reason: Exited with code 70.'''),
       });
 
       test(
-        'skips --shorebird-trace when help probe shows no support',
+        'passes --shorebird-trace when Flutter supports build tracing',
         () async {
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => Version(3, 41, 7));
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'macos', '-h', '-v'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: 0,
-              stdout: 'no trace flag here',
-              stderr: '',
-            ),
-          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'macos');
             await builder.buildMacos();
           });
 
+          final expectedTracePath = p.join(
+            projectRoot.path,
+            'build',
+            'shorebird',
+            'debug',
+            'build-trace-macos.json',
+          );
           verify(
             () => shorebirdProcess.stream(
               'flutter',
@@ -1426,6 +1272,7 @@ Reason: Exited with code 70.'''),
                 'build',
                 'macos',
                 '--release',
+                '--shorebird-trace=$expectedTracePath',
               ],
               environment: any(named: 'environment'),
               runInShell: false,
@@ -1884,30 +1731,24 @@ Reason: Exited with code 70.'''),
       });
 
       test(
-        'skips --shorebird-trace when help probe shows no support',
+        'passes --shorebird-trace when Flutter supports build tracing',
         () async {
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => Version(3, 41, 7));
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'ios-framework', '-h', '-v'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: 0,
-              stdout: 'no trace flag here',
-              stderr: '',
-            ),
-          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'ios');
             await builder.buildIosFramework();
           });
 
+          final expectedTracePath = p.join(
+            projectRoot.path,
+            'build',
+            'shorebird',
+            'debug',
+            'build-trace-ios.json',
+          );
           verify(
             () => shorebirdProcess.stream(
               'flutter',
@@ -1916,6 +1757,7 @@ Reason: Exited with code 70.'''),
                 'ios-framework',
                 '--no-debug',
                 '--no-profile',
+                '--shorebird-trace=$expectedTracePath',
               ],
               environment: any(named: 'environment'),
               runInShell: false,
@@ -2176,30 +2018,24 @@ Reason: Exited with code 70.'''),
       });
 
       test(
-        'skips --shorebird-trace when help probe shows no support',
+        'passes --shorebird-trace when Flutter supports build tracing',
         () async {
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => Version(3, 41, 7));
-          when(
-            () => shorebirdProcess.run(
-              'flutter',
-              ['build', 'windows', '-h', '-v'],
-              runInShell: false,
-            ),
-          ).thenAnswer(
-            (_) async => ShorebirdProcessResult(
-              exitCode: 0,
-              stdout: 'no trace flag here',
-              stderr: '',
-            ),
-          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'windows');
             await builder.buildWindowsApp();
           });
 
+          final expectedTracePath = p.join(
+            projectRoot.path,
+            'build',
+            'shorebird',
+            'debug',
+            'build-trace-windows.json',
+          );
           verify(
             () => shorebirdProcess.stream(
               'flutter',
@@ -2207,6 +2043,7 @@ Reason: Exited with code 70.'''),
                 'build',
                 'windows',
                 '--release',
+                '--shorebird-trace=$expectedTracePath',
               ],
               environment: any(named: 'environment'),
               runInShell: false,

--- a/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
@@ -2369,14 +2369,36 @@ Reason: Exited with code 70.'''),
       );
 
       test(
-        'treats unresolved Flutter version as new enough (dev pin)',
+        'leaves traceFile null when version is unresolved and revision is not '
+        'allowlisted',
         () async {
           // resolveFlutterVersion returns null for revisions not on a
-          // flutter_release branch (e.g. a pinned dev revision). The
-          // minVersion fallback admits these.
+          // flutter_release branch (e.g. a pinned dev revision predating
+          // the tracing PR). Those must not opt into tracing, or flutter
+          // build will fail on an unknown --shorebird-trace option.
           when(
             () => shorebirdFlutter.resolveFlutterVersion(any()),
           ).thenAnswer((_) async => null);
+
+          await runWithOverrides(() async {
+            await builder.prepareBuildTrace(platform: 'android');
+            expect(buildTraceSession.traceFile, isNull);
+          });
+        },
+      );
+
+      test(
+        'sets traceFile when version is unresolved but revision is allowlisted',
+        () async {
+          // A current Shorebird dev pin that does include the tracing PR
+          // typically has no parseable version (not on a flutter_release
+          // branch) — the allowlist is the bridge that admits it.
+          when(
+            () => shorebirdFlutter.resolveFlutterVersion(any()),
+          ).thenAnswer((_) async => null);
+          when(() => shorebirdEnv.flutterRevision).thenReturn(
+            buildTraceSupportConstraint.allowedRevisions.first,
+          );
 
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'android');


### PR DESCRIPTION
Three commits, stacked. Rebased onto current main (2026-09-11).

## 1. `fix(cli): gate build tracing off for unknown Flutter versions`

`prepareBuildTrace` used `flutterVersion ?? minVersion` to handle revisions that aren't on any `flutter_release/*` branch (dev pins). That fallback is wrong for a feature-enable check: a Shorebird-fork dev revision predating the tracing PR would be treated as new enough, get `--shorebird-trace` forwarded to flutter, and fail argparse hard.

Flip `FlutterSupportConstraint.isSatisfiedBy` to accept `Version?` and require either a real version ≥ the floor **or** an allowlisted revision to satisfy it. Unknown + non-allowlisted now leaves the trace session off.

## 2. `Revert "fix: only pass --shorebird-trace to build commands that support it (#3708)"`

#3708 probed each `flutter build <cmd> -h -v` at runtime to decide whether to pass `--shorebird-trace`. That was a belt-and-suspenders guard around two real bugs:

1. The gate mis-classified unresolved versions (fixed by commit 1).
2. `flutter build aar` / `ios-framework` / `linux` / `macos` / `windows` didn't register the option (fixed by shorebirdtech/flutter#136, **merged** as `e137e182`).

With both fixes in place, every subcommand this CLI invokes accepts the flag when the gate admits tracing, and every subcommand refuses it when the gate rejects tracing — so the per-subcommand runtime probe (one extra flutter-tool startup per release/patch, plus its 8 per-command call-site detours and help-output cache) is dead weight.

## 3. `docs(cli): describe the build-trace gate as it stands today`

The `buildTraceSupportConstraint` comment still described the pre-3.41.7 world where every pin needed allowlisting. The current pin (`e16cf749`, tip of `flutter_release/3.47.2`) satisfies the floor through its resolved version, so only dev revisions need entries. Drops the superseded `c2c56ab2` entry.

## Landing order — still blocked on a pin bump

**Do not merge until `bin/internal/flutter.version` points at a revision that includes shorebirdtech/flutter#136 (`e137e182` or later).** The current pin `e16cf749` predates it, so with the probe removed, `shorebird release macos` / `ios-framework` / `aar` / `linux` / `windows` would crash with `Could not find an option named "--shorebird-trace"` (reproduced in the original test plan, Scenario C).

Two ways the bump can satisfy the gate:
- a new `flutter_release/3.47.x` branch cut at or after `e137e182` — resolves to a version ≥ 3.41.7, nothing else to do; or
- a dev-hash pin — add it to `allowedRevisions`, otherwise tracing is silently off for everyone on that pin.

## Test plan

- [x] `dart test packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart` — 93 pass after rebase (conflicts were all probe-only code that main had grown since April: the `-h -v` fix in #3708's follow-up and its tests).
- [x] `dart analyze` clean on touched files (one pre-existing `comment_references` info in `artifact_builder.dart`, untouched here).

Original end-to-end verification (April, on the then-current pin) is in the edit history; Scenarios A–C still describe the behavior.

https://claude.ai/code/session_01X2aY3kQvT2tgM1mYbN9c7W
