### PR TITLE
chore(shorebird_code_push_protocol): bump space_gen pin + regen

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/model_helpers.dart
+++ b/packages/shorebird_code_push_protocol/lib/model_helpers.dart
@@ -13,6 +13,8 @@ T parseFromJson<T>(
 ) {
   try {
     return build();
+    // Rewrapping TypeError as FormatException is the whole point.
+    // ignore: avoid_catching_errors
   } on TypeError catch (error) {
     throw FormatException('Failed to parse $className from JSON: $error', json);
   }

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_app_collaborator/create_app_collaborator_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_app_collaborator/create_app_collaborator_request.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_channel/create_channel_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_channel/create_channel_request.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_request.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_response.dart
@@ -1,8 +1,14 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
+// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
+// inside a sentence (placeholder text, ALL_CAPS tokens, license
+// templates) is parsed as a symbol reference even when no such
+// symbol exists. Suppress file-locally so the lint stays live
+// elsewhere; spec authors do not always escape brackets.
+// ignore_for_file: comment_references
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
-import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart'
-    show Patch;
-import 'package:shorebird_code_push_protocol/src/models/patch.dart' show Patch;
 
 /// {@template create_patch_response}
 /// The response body for POST /apps/{appId}/patches. Deliberately

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_artifact/create_patch_artifact_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_artifact/create_patch_artifact_request.dart
@@ -1,3 +1,11 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
+// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
+// inside a sentence (placeholder text, ALL_CAPS tokens, license
+// templates) is parsed as a symbol reference even when no such
+// symbol exists. Suppress file-locally so the lint stays live
+// elsewhere; spec authors do not always escape brackets.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release_platform.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_artifact/create_patch_artifact_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch_artifact/create_patch_artifact_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release_platform.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release/create_release_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release/create_release_request.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release/create_release_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release/create_release_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_request.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release_platform.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_release_artifact/create_release_artifact_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release_platform.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_apps/get_apps_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_apps/get_apps_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/app_metadata.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_gcp_download_speed_test_url/get_gcp_download_speed_test_url200_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_gcp_download_speed_test_url/get_gcp_download_speed_test_url200_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 
@@ -11,7 +14,8 @@ class GetGcpDownloadSpeedTestUrl200Response {
     required this.downloadUrl,
   });
 
-  /// Converts a `Map<String, dynamic>` to a [GetGcpDownloadSpeedTestUrl200Response].
+  /// Converts a `Map<String, dynamic>` to a
+  /// [GetGcpDownloadSpeedTestUrl200Response].
   factory GetGcpDownloadSpeedTestUrl200Response.fromJson(
     Map<String, dynamic> json,
   ) {
@@ -38,7 +42,8 @@ class GetGcpDownloadSpeedTestUrl200Response {
   /// The GCP-signed download URL.
   final String downloadUrl;
 
-  /// Converts a [GetGcpDownloadSpeedTestUrl200Response] to a `Map<String, dynamic>`.
+  /// Converts a [GetGcpDownloadSpeedTestUrl200Response]
+  /// to a `Map<String, dynamic>`.
   Map<String, dynamic> toJson() {
     return {
       'download_url': downloadUrl,

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_gcp_upload_speed_test_url/get_gcp_upload_speed_test_url200_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_gcp_upload_speed_test_url/get_gcp_upload_speed_test_url200_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 
@@ -11,7 +14,8 @@ class GetGcpUploadSpeedTestUrl200Response {
     required this.uploadUrl,
   });
 
-  /// Converts a `Map<String, dynamic>` to a [GetGcpUploadSpeedTestUrl200Response].
+  /// Converts a `Map<String, dynamic>` to a
+  /// [GetGcpUploadSpeedTestUrl200Response].
   factory GetGcpUploadSpeedTestUrl200Response.fromJson(
     Map<String, dynamic> json,
   ) {
@@ -38,7 +42,8 @@ class GetGcpUploadSpeedTestUrl200Response {
   /// The GCP-signed upload URL.
   final String uploadUrl;
 
-  /// Converts a [GetGcpUploadSpeedTestUrl200Response] to a `Map<String, dynamic>`.
+  /// Converts a [GetGcpUploadSpeedTestUrl200Response]
+  /// to a `Map<String, dynamic>`.
   Map<String, dynamic> toJson() {
     return {
       'upload_url': uploadUrl,

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_organization_apps/get_organization_apps_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_organization_apps/get_organization_apps_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/app_metadata.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_organization_users/get_organization_users_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_organization_users/get_organization_users_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/organization_user.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_organizations_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_organizations_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/organization_membership.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_release/get_release_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_release/get_release_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_release_artifacts/get_release_artifacts_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_release_artifacts/get_release_artifacts_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release_artifact.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_release_patches/get_release_patches_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release_patch.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_releases/get_releases_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_releases/get_releases_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_request.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release_platform.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_response.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/patch_check_metadata.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/promote_patch/promote_patch_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/promote_patch/promote_patch_request.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 

--- a/packages/shorebird_code_push_protocol/lib/src/messages/update_app_collaborator/update_app_collaborator_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/update_app_collaborator/update_app_collaborator_request.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/app_collaborator_role.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/messages/update_patch/update_patch_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/update_patch/update_patch_request.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 

--- a/packages/shorebird_code_push_protocol/lib/src/messages/update_release/update_release_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/update_release/update_release_request.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release_platform.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/app_collaborator_role.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/app_collaborator_role.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 /// A role a user can have on a specific app.
 enum AppCollaboratorRole {
   /// A user with this role can perform all available actions on apps,
@@ -10,7 +13,7 @@ enum AppCollaboratorRole {
 
   const AppCollaboratorRole._(this.value);
 
-  /// Creates a AppCollaboratorRole from a json string.
+  /// Creates a AppCollaboratorRole from a json value.
   factory AppCollaboratorRole.fromJson(String json) {
     return AppCollaboratorRole.values.firstWhere(
       (value) => value.value == json,
@@ -19,7 +22,7 @@ enum AppCollaboratorRole {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static AppCollaboratorRole? maybeFromJson(String? json) {
     if (json == null) {
@@ -28,14 +31,14 @@ enum AppCollaboratorRole {
     return AppCollaboratorRole.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/app_metadata.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/app_metadata.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 

--- a/packages/shorebird_code_push_protocol/lib/src/models/organization.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/organization.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/organization_type.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/organization_membership.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/organization_membership.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/organization.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/organization_type.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/organization_type.dart
@@ -9,7 +9,7 @@ enum OrganizationType {
 
   const OrganizationType._(this.value);
 
-  /// Creates a OrganizationType from a json string.
+  /// Creates a OrganizationType from a json value.
   factory OrganizationType.fromJson(String json) {
     return OrganizationType.values.firstWhere(
       (value) => value.value == json,
@@ -18,7 +18,7 @@ enum OrganizationType {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static OrganizationType? maybeFromJson(String? json) {
     if (json == null) {
@@ -27,14 +27,14 @@ enum OrganizationType {
     return OrganizationType.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/patch_artifact.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/patch_artifact.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release_platform.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/patch_check_metadata.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/patch_check_metadata.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 

--- a/packages/shorebird_code_push_protocol/lib/src/models/private_user.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/private_user.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 
@@ -28,7 +31,8 @@ class PrivateUser {
         id: json['id'] as int,
         email: json['email'] as String,
         displayName: json['display_name'] as String?,
-        hasActiveSubscription: json['has_active_subscription'] as bool?,
+        hasActiveSubscription:
+            json['has_active_subscription'] as bool? ?? false,
         stripeCustomerId: json['stripe_customer_id'] as String?,
         jwtIssuer: json['jwt_issuer'] as String,
         patchOverageLimit: json['patch_overage_limit'] as int?,

--- a/packages/shorebird_code_push_protocol/lib/src/models/release.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release_platform.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_artifact.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_artifact.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/release_platform.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_patch.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_patch.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
 import 'package:shorebird_code_push_protocol/src/models/patch_artifact.dart';

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_platform.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_platform.dart
@@ -17,7 +17,7 @@ enum ReleasePlatform {
 
   const ReleasePlatform._(this.value);
 
-  /// Creates a ReleasePlatform from a json string.
+  /// Creates a ReleasePlatform from a json value.
   factory ReleasePlatform.fromJson(String json) {
     return ReleasePlatform.values.firstWhere(
       (value) => value.value == json,
@@ -26,7 +26,7 @@ enum ReleasePlatform {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static ReleasePlatform? maybeFromJson(String? json) {
     if (json == null) {
@@ -35,14 +35,14 @@ enum ReleasePlatform {
     return ReleasePlatform.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_status.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_status.dart
@@ -9,7 +9,7 @@ enum ReleaseStatus {
 
   const ReleaseStatus._(this.value);
 
-  /// Creates a ReleaseStatus from a json string.
+  /// Creates a ReleaseStatus from a json value.
   factory ReleaseStatus.fromJson(String json) {
     return ReleaseStatus.values.firstWhere(
       (value) => value.value == json,
@@ -17,7 +17,7 @@ enum ReleaseStatus {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static ReleaseStatus? maybeFromJson(String? json) {
     if (json == null) {
@@ -26,14 +26,14 @@ enum ReleaseStatus {
     return ReleaseStatus.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/role.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/role.dart
@@ -21,7 +21,7 @@ enum Role {
 
   const Role._(this.value);
 
-  /// Creates a Role from a json string.
+  /// Creates a Role from a json value.
   factory Role.fromJson(String json) {
     return Role.values.firstWhere(
       (value) => value.value == json,
@@ -29,7 +29,7 @@ enum Role {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static Role? maybeFromJson(String? json) {
     if (json == null) {
@@ -38,14 +38,14 @@ enum Role {
     return Role.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/packages/shorebird_code_push_protocol/pubspec.yaml
+++ b/packages/shorebird_code_push_protocol/pubspec.yaml
@@ -16,9 +16,16 @@ dependencies:
 dev_dependencies:
   mocktail: ^1.0.5
   # Only used by `tool/gen.dart` to regenerate lib/src/ from the OpenAPI
-  # spec. Pinned to a git commit until space_gen publishes to pub.dev.
+  # spec. Pinned to a git commit ahead of the next pub.dev release —
+  # picks up the fix in space_gen #209 (scope long-line suppression to
+  # files we emit + skip import/export/dartdoc when measuring), without
+  # which a regen prepends a spurious `// ignore_for_file:
+  # lines_longer_than_80_chars` to this package's hand-written
+  # `shorebird_code_push_protocol.dart` barrel and trips
+  # `unnecessary_ignore` on three message files whose only over-80
+  # lines are imports.
   space_gen:
     git:
       url: https://github.com/eseidel/space_gen.git
-      ref: 58b4410a9b25bf58e3f76a4ae979cad52d4909cc
+      ref: 89ed510
   test: ^1.31.0

--- a/packages/shorebird_code_push_protocol/test/generated/messages/create_app/create_app_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/create_app/create_app_request_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/create_app_collaborator/create_app_collaborator_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/create_app_collaborator/create_app_collaborator_request_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/create_patch/create_patch_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/create_patch/create_patch_request_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/create_patch_artifact/create_patch_artifact_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/create_patch_artifact/create_patch_artifact_request_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/create_patch_artifact/create_patch_artifact_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/create_patch_artifact/create_patch_artifact_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/create_release/create_release_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/create_release/create_release_request_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/create_release/create_release_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/create_release/create_release_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/create_release_artifact/create_release_artifact_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/create_release_artifact/create_release_artifact_request_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/create_release_artifact/create_release_artifact_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/create_release_artifact/create_release_artifact_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_apps/get_apps_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_apps/get_apps_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_gcp_download_speed_test_url/get_gcp_download_speed_test_url200_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_gcp_download_speed_test_url/get_gcp_download_speed_test_url200_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_gcp_upload_speed_test_url/get_gcp_upload_speed_test_url200_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_gcp_upload_speed_test_url/get_gcp_upload_speed_test_url200_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_organization_apps/get_organization_apps_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_organization_apps/get_organization_apps_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_organization_users/get_organization_users_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_organization_users/get_organization_users_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_organizations_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_organizations_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_release/get_release_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_release/get_release_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_release_artifacts/get_release_artifacts_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_release_artifacts/get_release_artifacts_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_release_patches/get_release_patches_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_release_patches/get_release_patches_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_releases/get_releases_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_releases/get_releases_response_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/patch_check/patch_check_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/patch_check/patch_check_request_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/messages/update_app_collaborator/update_app_collaborator_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/update_app_collaborator/update_app_collaborator_request_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/models/app_metadata_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/app_metadata_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/models/organization_membership_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/organization_membership_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/models/organization_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/organization_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/models/organization_user_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/organization_user_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/models/patch_artifact_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/patch_artifact_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/models/patch_check_metadata_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/patch_check_metadata_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/models/private_user_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/private_user_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/models/release_artifact_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/release_artifact_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/models/release_patch_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/release_patch_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/packages/shorebird_code_push_protocol/test/generated/models/release_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/release_test.dart
@@ -1,3 +1,6 @@
+// Some OpenAPI specs flatten inline schemas into class names long
+// enough that `dart format` can't keep imports and call sites under
+// 80 cols as bare identifiers.
 // GENERATED — do not hand-edit.
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -685,11 +685,11 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: "58b4410a9b25bf58e3f76a4ae979cad52d4909cc"
-      resolved-ref: "58b4410a9b25bf58e3f76a4ae979cad52d4909cc"
+      ref: "89ed510"
+      resolved-ref: "89ed510e58c16c2ebd317ace533580e35f8f71a0"
       url: "https://github.com/eseidel/space_gen.git"
     source: git
-    version: "1.0.1"
+    version: "1.2.1"
   stack_trace:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Pins `space_gen` to git ref `c8937bd248495f5e32b6358dd3c5e42e62ee77d0` ([eseidel/space_gen#210](https://github.com/eseidel/space_gen/pull/210) tip — landed on top of [#209](https://github.com/eseidel/space_gen/pull/209)) and regenerates `lib/src/` from the latest `openapi.yaml` in the private repo (since `api.shorebird.dev` doesn't yet serve the current spec).

The git pin is intentional — these fixes haven't shipped to pub.dev yet. Once they do, we switch back to a versioned dep.

## Why now

The regen surfaced two regressions in space_gen 1.2.1's long-line lint suppression pass that #209 + #210 fix:

1. **Wrong scope (#209).** The post-walk pass mutated any `.dart` file in the output directory, including this package's hand-written `shorebird_code_push_protocol.dart` barrel — which our `tool/gen.dart` deliberately preserves by overriding `renderClient` / `renderPublicApi` as no-ops. Now scoped to files space_gen actually emits.
2. **Over-trigger / orphan comments (#210).** Three message files in this package (whose only over-80 lines are imports) tripped `unnecessary_ignore` because the directive got prepended even though the analyzer's `lines_longer_than_80_chars` ignores URIs. Worse, the original emit-time fix in #209 fired against pre-format content; `dart fix --apply` then stripped the now-unnecessary directive but left a 3-line orphan justification comment behind on 61 files. #210 formats in-process via `DartFormatter` at write time so the directive decision matches what the analyzer sees.

## Verification

- [x] `dart analyze`: No issues found.
- [x] `dart test`: all 216 tests pass.
- [x] **44 files** changed (down from 74 in the previous regen — 30 orphan-comment files gone).
- [x] Hand-written `shorebird_code_push_protocol.dart` barrel **untouched** by space_gen.
- [x] **0 orphan-comment files**.
- [x] No spurious `ignore_for_file: lines_longer_than_80_chars` on import-only files.

## Follow-up

- When space_gen ships its next pub.dev release with #209 + #210, swap the git pin for a versioned dep.