### PR TITLE
chore(shorebird_code_push_protocol): bump space_gen pin + regen

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/model_helpers.dart
+++ b/packages/shorebird_code_push_protocol/lib/model_helpers.dart
@@ -13,6 +13,8 @@ T parseFromJson<T>(
 ) {
   try {
     return build();
+    // Rewrapping TypeError as FormatException is the whole point.
+    // ignore: avoid_catching_errors
   } on TypeError catch (error) {
     throw FormatException('Failed to parse $className from JSON: $error', json);
   }

--- a/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/create_patch/create_patch_response.dart
@@ -1,8 +1,11 @@
+// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
+// inside a sentence (placeholder text, ALL_CAPS tokens, license
+// templates) is parsed as a symbol reference even when no such
+// symbol exists. Suppress file-locally so the lint stays live
+// elsewhere; spec authors do not always escape brackets.
+// ignore_for_file: comment_references
 import 'package:meta/meta.dart';
 import 'package:shorebird_code_push_protocol/model_helpers.dart';
-import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart'
-    show Patch;
-import 'package:shorebird_code_push_protocol/src/models/patch.dart' show Patch;
 
 /// {@template create_patch_response}
 /// The response body for POST /apps/{appId}/patches. Deliberately

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_gcp_download_speed_test_url/get_gcp_download_speed_test_url200_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_gcp_download_speed_test_url/get_gcp_download_speed_test_url200_response.dart
@@ -11,7 +11,8 @@ class GetGcpDownloadSpeedTestUrl200Response {
     required this.downloadUrl,
   });
 
-  /// Converts a `Map<String, dynamic>` to a [GetGcpDownloadSpeedTestUrl200Response].
+  /// Converts a `Map<String, dynamic>` to a
+  /// [GetGcpDownloadSpeedTestUrl200Response].
   factory GetGcpDownloadSpeedTestUrl200Response.fromJson(
     Map<String, dynamic> json,
   ) {
@@ -38,7 +39,8 @@ class GetGcpDownloadSpeedTestUrl200Response {
   /// The GCP-signed download URL.
   final String downloadUrl;
 
-  /// Converts a [GetGcpDownloadSpeedTestUrl200Response] to a `Map<String, dynamic>`.
+  /// Converts a [GetGcpDownloadSpeedTestUrl200Response]
+  /// to a `Map<String, dynamic>`.
   Map<String, dynamic> toJson() {
     return {
       'download_url': downloadUrl,

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_gcp_upload_speed_test_url/get_gcp_upload_speed_test_url200_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_gcp_upload_speed_test_url/get_gcp_upload_speed_test_url200_response.dart
@@ -11,7 +11,8 @@ class GetGcpUploadSpeedTestUrl200Response {
     required this.uploadUrl,
   });
 
-  /// Converts a `Map<String, dynamic>` to a [GetGcpUploadSpeedTestUrl200Response].
+  /// Converts a `Map<String, dynamic>` to a
+  /// [GetGcpUploadSpeedTestUrl200Response].
   factory GetGcpUploadSpeedTestUrl200Response.fromJson(
     Map<String, dynamic> json,
   ) {
@@ -38,7 +39,8 @@ class GetGcpUploadSpeedTestUrl200Response {
   /// The GCP-signed upload URL.
   final String uploadUrl;
 
-  /// Converts a [GetGcpUploadSpeedTestUrl200Response] to a `Map<String, dynamic>`.
+  /// Converts a [GetGcpUploadSpeedTestUrl200Response]
+  /// to a `Map<String, dynamic>`.
   Map<String, dynamic> toJson() {
     return {
       'upload_url': uploadUrl,

--- a/packages/shorebird_code_push_protocol/lib/src/models/app_collaborator_role.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/app_collaborator_role.dart
@@ -10,7 +10,7 @@ enum AppCollaboratorRole {
 
   const AppCollaboratorRole._(this.value);
 
-  /// Creates a AppCollaboratorRole from a json string.
+  /// Creates a AppCollaboratorRole from a json value.
   factory AppCollaboratorRole.fromJson(String json) {
     return AppCollaboratorRole.values.firstWhere(
       (value) => value.value == json,
@@ -19,7 +19,7 @@ enum AppCollaboratorRole {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static AppCollaboratorRole? maybeFromJson(String? json) {
     if (json == null) {
@@ -28,14 +28,14 @@ enum AppCollaboratorRole {
     return AppCollaboratorRole.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/organization_type.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/organization_type.dart
@@ -9,7 +9,7 @@ enum OrganizationType {
 
   const OrganizationType._(this.value);
 
-  /// Creates a OrganizationType from a json string.
+  /// Creates a OrganizationType from a json value.
   factory OrganizationType.fromJson(String json) {
     return OrganizationType.values.firstWhere(
       (value) => value.value == json,
@@ -18,7 +18,7 @@ enum OrganizationType {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static OrganizationType? maybeFromJson(String? json) {
     if (json == null) {
@@ -27,14 +27,14 @@ enum OrganizationType {
     return OrganizationType.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/private_user.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/private_user.dart
@@ -28,7 +28,8 @@ class PrivateUser {
         id: json['id'] as int,
         email: json['email'] as String,
         displayName: json['display_name'] as String?,
-        hasActiveSubscription: json['has_active_subscription'] as bool?,
+        hasActiveSubscription:
+            json['has_active_subscription'] as bool? ?? false,
         stripeCustomerId: json['stripe_customer_id'] as String?,
         jwtIssuer: json['jwt_issuer'] as String,
         patchOverageLimit: json['patch_overage_limit'] as int?,

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_platform.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_platform.dart
@@ -17,7 +17,7 @@ enum ReleasePlatform {
 
   const ReleasePlatform._(this.value);
 
-  /// Creates a ReleasePlatform from a json string.
+  /// Creates a ReleasePlatform from a json value.
   factory ReleasePlatform.fromJson(String json) {
     return ReleasePlatform.values.firstWhere(
       (value) => value.value == json,
@@ -26,7 +26,7 @@ enum ReleasePlatform {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static ReleasePlatform? maybeFromJson(String? json) {
     if (json == null) {
@@ -35,14 +35,14 @@ enum ReleasePlatform {
     return ReleasePlatform.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/release_status.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/release_status.dart
@@ -9,7 +9,7 @@ enum ReleaseStatus {
 
   const ReleaseStatus._(this.value);
 
-  /// Creates a ReleaseStatus from a json string.
+  /// Creates a ReleaseStatus from a json value.
   factory ReleaseStatus.fromJson(String json) {
     return ReleaseStatus.values.firstWhere(
       (value) => value.value == json,
@@ -17,7 +17,7 @@ enum ReleaseStatus {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static ReleaseStatus? maybeFromJson(String? json) {
     if (json == null) {
@@ -26,14 +26,14 @@ enum ReleaseStatus {
     return ReleaseStatus.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/packages/shorebird_code_push_protocol/lib/src/models/role.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/role.dart
@@ -21,7 +21,7 @@ enum Role {
 
   const Role._(this.value);
 
-  /// Creates a Role from a json string.
+  /// Creates a Role from a json value.
   factory Role.fromJson(String json) {
     return Role.values.firstWhere(
       (value) => value.value == json,
@@ -29,7 +29,7 @@ enum Role {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static Role? maybeFromJson(String? json) {
     if (json == null) {
@@ -38,14 +38,14 @@ enum Role {
     return Role.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/packages/shorebird_code_push_protocol/pubspec.yaml
+++ b/packages/shorebird_code_push_protocol/pubspec.yaml
@@ -16,9 +16,6 @@ dependencies:
 dev_dependencies:
   mocktail: ^1.0.5
   # Only used by `tool/gen.dart` to regenerate lib/src/ from the OpenAPI
-  # spec. Pinned to a git commit until space_gen publishes to pub.dev.
-  space_gen:
-    git:
-      url: https://github.com/eseidel/space_gen.git
-      ref: 58b4410a9b25bf58e3f76a4ae979cad52d4909cc
+  # spec.
+  space_gen: ^1.2.2
   test: ^1.31.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -676,12 +676,11 @@ packages:
   space_gen:
     dependency: transitive
     description:
-      path: "."
-      ref: "58b4410a9b25bf58e3f76a4ae979cad52d4909cc"
-      resolved-ref: "58b4410a9b25bf58e3f76a4ae979cad52d4909cc"
-      url: "https://github.com/eseidel/space_gen.git"
-    source: git
-    version: "1.0.1"
+      name: space_gen
+      sha256: "3aea8da8ffba5802110322093ef4e921e297d9b55ffa073a74b6cb38fd225ee1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
   stack_trace:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Bumps `space_gen` from a git pin to the released `^1.2.2` on pub.dev and regenerates `lib/src/` from the public spec at [api.shorebird.dev/openapi.json](https://api.shorebird.dev/openapi.json) (per the README's regen instructions).

## What landed in space_gen 1.2.2

This package's regen surfaced two regressions in 1.2.1's long-line lint suppression pass, both fixed in 1.2.2 ([eseidel/space_gen#209](https://github.com/eseidel/space_gen/pull/209) + [#210](https://github.com/eseidel/space_gen/pull/210)):

1. **Wrong scope.** The post-walk pass mutated any `.dart` file in the output directory, including this package's hand-written `shorebird_code_push_protocol.dart` barrel — which our `tool/gen.dart` deliberately preserves by overriding `renderClient` / `renderPublicApi` as no-ops. Now scoped to files space_gen actually emits, with URI imports/exports excluded so files whose only over-80 lines are imports don't trip `unnecessary_ignore`.
2. **Style mismatch + orphan comments.** The fix in #209 fired against pre-format content; `dart fix --apply` then stripped the now-unnecessary directive but left a 3-line orphan justification on 61 files. #210 formats in-process via `DartFormatter` at write time so the directive decision matches what the analyzer sees, with format settings resolved from this package's own `pubspec.lock` / `pubspec.yaml` (language version) and `analysis_options.yaml` (`formatter: page_width` and `trailing_commas`, with relative `include:` paths followed so the workspace's `formatter:` block at the workspace root applies). `comment_references` resolution also now looks at same-file field declarations — fixes the same orphan-justification problem on `/// The signature of the [hash].` (referring to `final String hash;`).

## Verification

- [x] `dart analyze`: No issues found.
- [x] `dart test`: all 216 tests pass.
- [x] Hand-written `shorebird_code_push_protocol.dart` barrel **untouched** by space_gen.
- [x] **0 orphan-comment files** (long-line or comment_references).
- [x] Trailing commas preserved per `analysis_options.yaml`'s `trailing_commas: preserve`.

## Side note

`https://api.shorebird.dev/openapi.yaml` returns `{"code":"upgrade_required", "details":"Missing x-version header."}` even though the README links to it for human review. The JSON URL works without any header; the YAML URL is going through the version-required middleware. Worth a small server-side fix in a separate PR.