### PR TITLE
fix(shorebird_cli): improve help text and add input validation for agentic use

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
+import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
@@ -31,7 +32,14 @@ class InitCommand extends ShorebirdCommand {
         help: 'Initialize the app even if a "shorebird.yaml" already exists.',
         negatable: false,
       )
-      ..addOption('display-name', help: 'The display name of the app.')
+      ..addOption(
+        'display-name',
+        help:
+            'The app name shown in the Shorebird dashboard '
+            '(defaults to the package name in pubspec.yaml). '
+            'Must be between ${CommonArguments.appDisplayNameMinLength} and '
+            '${CommonArguments.appDisplayNameMaxLength} characters.',
+      )
       ..addOption('organization-id', help: 'The organization ID to use.');
   }
 
@@ -245,6 +253,15 @@ Please make sure you are running "shorebird init" from within your Flutter proje
                   'prompting.',
             )
           : pubspecName;
+      if (displayName.isEmpty ||
+          displayName.length > CommonArguments.appDisplayNameMaxLength) {
+        logger.err(
+          'App display name must be between '
+          '${CommonArguments.appDisplayNameMinLength} and '
+          '${CommonArguments.appDisplayNameMaxLength} characters.',
+        );
+        return ExitCode.usage.code;
+      }
       final hasNoFlavors = productFlavors.isEmpty;
       final hasSomeFlavors =
           productFlavors.isNotEmpty &&

--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -37,7 +37,7 @@ class InitCommand extends ShorebirdCommand {
         help:
             'The app name shown in the Shorebird dashboard '
             '(defaults to the package name in pubspec.yaml). '
-            'Must be between ${CommonArguments.appDisplayNameMinLength} and '
+            'Must be between 1 and '
             '${CommonArguments.appDisplayNameMaxLength} characters.',
       )
       ..addOption('organization-id', help: 'The organization ID to use.');
@@ -256,8 +256,7 @@ Please make sure you are running "shorebird init" from within your Flutter proje
       if (displayName.isEmpty ||
           displayName.length > CommonArguments.appDisplayNameMaxLength) {
         logger.err(
-          'App display name must be between '
-          '${CommonArguments.appDisplayNameMinLength} and '
+          'App display name must be between 1 and '
           '${CommonArguments.appDisplayNameMaxLength} characters.',
         );
         return ExitCode.usage.code;

--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -253,7 +253,7 @@ Please make sure you are running "shorebird init" from within your Flutter proje
                   'prompting.',
             )
           : pubspecName;
-      if (displayName.isEmpty ||
+      if (displayName.length < CommonArguments.appDisplayNameMinLength ||
           displayName.length > CommonArguments.appDisplayNameMaxLength) {
         logger.err(
           'App display name must be between '

--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -253,7 +253,7 @@ Please make sure you are running "shorebird init" from within your Flutter proje
                   'prompting.',
             )
           : pubspecName;
-      if (displayName.length < CommonArguments.appDisplayNameMinLength ||
+      if (displayName.isEmpty ||
           displayName.length > CommonArguments.appDisplayNameMaxLength) {
         logger.err(
           'App display name must be between '

--- a/packages/shorebird_cli/lib/src/commands/logout_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/logout_command.dart
@@ -10,7 +10,7 @@ import 'package:shorebird_cli/src/shorebird_command.dart';
 /// {@endtemplate}
 class LogoutCommand extends ShorebirdCommand {
   @override
-  String get description => 'Logout of the current Shorebird user';
+  String get description => 'Logout of the current Shorebird user.';
 
   @override
   String get name => 'logout';

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -54,7 +54,7 @@ class PatchCommand extends ShorebirdCommand {
       ..addMultiOption(
         'platforms',
         abbr: 'p',
-        help: 'The platform(s) to to build this release for.',
+        help: 'The platform(s) to build this patch for.',
         allowed: ReleaseType.values.map((e) => e.cliName).toList(),
       )
       ..addOption(
@@ -165,7 +165,6 @@ To target the latest release (e.g. the release that was most recently updated) u
         CommonArguments.minLinkPercentage.name,
         help: CommonArguments.minLinkPercentage.description,
         defaultsTo: CommonArguments.minLinkPercentage.defaultValue,
-        allowed: [for (var i = 0; i <= 100; i++) '$i'],
       );
   }
 
@@ -183,7 +182,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
 
   @override
   String get description =>
-      'Creates a shorebird patch for the provided target platforms';
+      'Creates a shorebird patch for the provided target platforms.';
 
   @override
   String get name => 'patch';
@@ -687,9 +686,20 @@ Please re-run the release command for this version or create a new release.''');
     })();
 
     final linkPercentage = patcher.linkPercentage;
-    final minLinkPercentage = int.parse(
-      results[CommonArguments.minLinkPercentage.name] as String,
-    );
+    final minLinkPercentageRaw =
+        results[CommonArguments.minLinkPercentage.name] as String;
+    final minLinkPercentage = int.tryParse(minLinkPercentageRaw);
+    if (minLinkPercentage == null ||
+        minLinkPercentage < CommonArguments.minLinkPercentageMin ||
+        minLinkPercentage > CommonArguments.minLinkPercentageMax) {
+      logger.err(
+        '--min-link-percentage must be an integer between '
+        '${CommonArguments.minLinkPercentageMin} and '
+        '${CommonArguments.minLinkPercentageMax} '
+        '(got $minLinkPercentageRaw).',
+      );
+      throw ProcessExit(ExitCode.usage.code);
+    }
     if (linkPercentage != null && linkPercentage < minLinkPercentage) {
       logger.err(
         '''The link percentage of this patch ($linkPercentage%) is below the minimum threshold ($minLinkPercentage%). Exiting.''',

--- a/packages/shorebird_cli/lib/src/commands/patches/patches_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patches/patches_command.dart
@@ -15,5 +15,5 @@ class PatchesCommand extends ShorebirdCommand {
   String get name => 'patches';
 
   @override
-  String get description => 'Manage Shorebird patches';
+  String get description => 'Manage Shorebird patches.';
 }

--- a/packages/shorebird_cli/lib/src/commands/patches/promote_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patches/promote_command.dart
@@ -22,12 +22,12 @@ class PromoteCommand extends ShorebirdCommand {
       )
       ..addOption(
         'release-version',
-        help: 'The release being patched',
+        help: 'The release being patched.',
         mandatory: true,
       )
       ..addOption(
         'patch-number',
-        help: 'The number of the patch to promote to the stable channel',
+        help: 'The number of the patch to promote to the stable channel.',
         mandatory: true,
       );
   }

--- a/packages/shorebird_cli/lib/src/commands/patches/promote_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patches/promote_command.dart
@@ -22,7 +22,7 @@ class PromoteCommand extends ShorebirdCommand {
       )
       ..addOption(
         'release-version',
-        help: 'The release being patched.',
+        help: 'The version of the release the patch belongs to (e.g. "1.0.0+1").',
         mandatory: true,
       )
       ..addOption(

--- a/packages/shorebird_cli/lib/src/commands/patches/promote_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patches/promote_command.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
+import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
@@ -22,7 +23,7 @@ class PromoteCommand extends ShorebirdCommand {
       )
       ..addOption(
         'release-version',
-        help: 'The version of the release the patch belongs to (e.g. "1.0.0+1").',
+        help: CommonArguments.patchReleaseVersionDescription,
         mandatory: true,
       )
       ..addOption(

--- a/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
@@ -40,7 +40,8 @@ class SetTrackCommand extends ShorebirdCommand {
         'track',
         help:
             'The deployment track to move the patch to '
-            '("stable", "beta", "staging", or any custom track name).',
+            '("stable", "beta", "staging", or any custom track name '
+            'up to ${CommonArguments.trackNameMaxLength} characters).',
         mandatory: true,
       );
   }
@@ -67,6 +68,15 @@ class SetTrackCommand extends ShorebirdCommand {
     final flavor = results.findOption('flavor', argParser: argParser);
     final appId = shorebirdEnv.getShorebirdYaml()!.getAppId(flavor: flavor);
     final targetChannel = results['track'] as String;
+
+    if (targetChannel.isEmpty ||
+        targetChannel.length > CommonArguments.trackNameMaxLength) {
+      logger.err(
+        'Track name must be between 1 and '
+        '${CommonArguments.trackNameMaxLength} characters.',
+      );
+      return ExitCode.usage.code;
+    }
 
     final release = await codePushClientWrapper.getRelease(
       appId: appId,

--- a/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
+import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/logging/shorebird_logger.dart';
@@ -27,7 +28,7 @@ class SetTrackCommand extends ShorebirdCommand {
       )
       ..addOption(
         'release',
-        help: 'The version of the release the patch belongs to (e.g. "1.0.0+1").',
+        help: CommonArguments.patchReleaseVersionDescription,
         mandatory: true,
       )
       ..addOption(

--- a/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
@@ -39,8 +39,9 @@ class SetTrackCommand extends ShorebirdCommand {
       ..addOption(
         'track',
         help:
-            'The deployment track to move the patch to '
-            '(e.g. "stable", "beta", "staging").',
+            'The deployment track to move the patch to. '
+            'Any track name is valid; "stable", "beta", and "staging" are '
+            'the default tracks.',
         mandatory: true,
       );
   }

--- a/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
@@ -40,8 +40,8 @@ class SetTrackCommand extends ShorebirdCommand {
         'track',
         help:
             'The deployment track to move the patch to. '
-            'Any track name is valid; "stable", "beta", and "staging" are '
-            'the default tracks.',
+            'Built-in tracks are "stable", "beta", and "staging", '
+            'but any name is accepted.',
         mandatory: true,
       );
   }

--- a/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
@@ -39,9 +39,8 @@ class SetTrackCommand extends ShorebirdCommand {
       ..addOption(
         'track',
         help:
-            'The deployment track to move the patch to. '
-            'Built-in tracks are "stable", "beta", and "staging", '
-            'but any name is accepted.',
+            'The deployment track to move the patch to '
+            '("stable", "beta", "staging", or any custom track name).',
         mandatory: true,
       );
   }

--- a/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
@@ -27,17 +27,19 @@ class SetTrackCommand extends ShorebirdCommand {
       )
       ..addOption(
         'release',
-        help: 'The release version that the patch belongs to (ex: "1.0.0")',
+        help: 'The release version that the patch belongs to (ex: "1.0.0").',
         mandatory: true,
       )
       ..addOption(
         'patch',
-        help: 'The patch number to set the channel for (ex: "1")',
+        help: 'The patch number to set the channel for (ex: "1").',
         mandatory: true,
       )
       ..addOption(
         'track',
-        help: 'The channel to set the patch to',
+        help:
+            'The deployment track to move the patch to '
+            '(e.g. "stable", "beta", "staging").',
         mandatory: true,
       );
   }
@@ -46,7 +48,7 @@ class SetTrackCommand extends ShorebirdCommand {
   String get name => 'set-track';
 
   @override
-  String get description => 'Sets the track of a patch';
+  String get description => 'Sets the track of a patch.';
 
   @override
   Future<int> run() async {

--- a/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patches/set_track_command.dart
@@ -27,7 +27,7 @@ class SetTrackCommand extends ShorebirdCommand {
       )
       ..addOption(
         'release',
-        help: 'The release version that the patch belongs to (ex: "1.0.0").',
+        help: 'The version of the release the patch belongs to (e.g. "1.0.0+1").',
         mandatory: true,
       )
       ..addOption(

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -112,7 +112,7 @@ Defaults to "latest" which builds using the latest stable Flutter version.''',
       ..addMultiOption(
         'platforms',
         abbr: 'p',
-        help: 'The platform(s) to to build this release for.',
+        help: 'The platform(s) to build this release for.',
         allowed: ReleaseType.values.map((e) => e.cliName).toList(),
         // TODO(bryanoltman): uncomment this once https://github.com/dart-lang/args/pull/273 lands
         // mandatory: true.
@@ -166,7 +166,7 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
 
   @override
   String get description =>
-      'Creates a shorebird release for the provided target platforms';
+      'Creates a shorebird release for the provided target platforms.';
 
   @override
   String get name => 'release';

--- a/packages/shorebird_cli/lib/src/commands/releases/get_apks_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/releases/get_apks_command.dart
@@ -26,16 +26,16 @@ class GetApksCommand extends ShorebirdCommand {
     argParser
       ..addOption(
         CommonArguments.releaseVersionArg.name,
-        help: 'The release version to generate apks for',
+        help: 'The release version to generate apks for.',
       )
       ..addOption(
         CommonArguments.flavorArg.name,
-        help: 'The build flavor to generate an apks for',
+        help: 'The build flavor to generate apks for.',
       )
       ..addOption(
         'out',
         abbr: 'o',
-        help: 'The output directory for the generated apks',
+        help: 'The output directory for the generated apks.',
       )
       ..addFlag(
         'universal',
@@ -49,7 +49,7 @@ class GetApksCommand extends ShorebirdCommand {
 
   @override
   String get description =>
-      'Generates apk(s) for the specified release version';
+      'Generates apk(s) for the specified release version.';
 
   /// The shorebird app ID for the current project.
   String get appId => shorebirdEnv.getShorebirdYaml()!.getAppId(flavor: flavor);

--- a/packages/shorebird_cli/lib/src/commands/releases/get_apks_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/releases/get_apks_command.dart
@@ -26,7 +26,9 @@ class GetApksCommand extends ShorebirdCommand {
     argParser
       ..addOption(
         CommonArguments.releaseVersionArg.name,
-        help: 'The release version to generate apks for.',
+        help:
+            'The version of the release to generate APKs for '
+            '(e.g. "1.0.0+1"). Prompts for selection if omitted.',
       )
       ..addOption(
         CommonArguments.flavorArg.name,

--- a/packages/shorebird_cli/lib/src/commands/releases/releases_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/releases/releases_command.dart
@@ -14,5 +14,5 @@ class ReleasesCommand extends ShorebirdCommand {
   String get name => 'releases';
 
   @override
-  String get description => 'Manage Shorebird releases';
+  String get description => 'Manage Shorebird releases.';
 }

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -137,6 +137,11 @@ Command that reads data from stdin and outputs a base64 signature to stdout.
     description: 'The version of the release (e.g. "1.0.0").',
   );
 
+  /// Help text for release version arguments in patch commands, where the
+  /// version identifies which release the patch belongs to.
+  static const patchReleaseVersionDescription =
+      'The version of the release the patch belongs to (e.g. "1.0.0+1").';
+
   /// The Flutter --obfuscate argument.
   static const obfuscateArg = ArgumentDescriber(
     name: 'obfuscate',

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -167,6 +167,12 @@ Bypass all confirmation messages. It's generally not advised to use this unless 
 ''',
   );
 
+  /// Minimum character length for an app display name.
+  static const appDisplayNameMinLength = 1;
+
+  /// Maximum character length for an app display name.
+  static const appDisplayNameMaxLength = 128;
+
   /// Minimum valid value for [minLinkPercentage].
   static const minLinkPercentageMin = 0;
 

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -178,6 +178,9 @@ Bypass all confirmation messages. It's generally not advised to use this unless 
   /// Maximum character length for an app display name.
   static const appDisplayNameMaxLength = 128;
 
+  /// Maximum character length for a track name.
+  static const trackNameMaxLength = 128;
+
   /// Minimum valid value for [minLinkPercentage].
   static const minLinkPercentageMin = 0;
 

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -172,9 +172,6 @@ Bypass all confirmation messages. It's generally not advised to use this unless 
 ''',
   );
 
-  /// Minimum character length for an app display name.
-  static const appDisplayNameMinLength = 1;
-
   /// Maximum character length for an app display name.
   static const appDisplayNameMaxLength = 128;
 

--- a/packages/shorebird_cli/lib/src/common_arguments.dart
+++ b/packages/shorebird_cli/lib/src/common_arguments.dart
@@ -167,13 +167,20 @@ Bypass all confirmation messages. It's generally not advised to use this unless 
 ''',
   );
 
+  /// Minimum valid value for [minLinkPercentage].
+  static const minLinkPercentageMin = 0;
+
+  /// Maximum valid value for [minLinkPercentage].
+  static const minLinkPercentageMax = 100;
+
   /// An argument that allows the user to specify a minimum link percentage
   /// threshold.
   static const minLinkPercentage = ArgumentDescriber(
     name: 'min-link-percentage',
     defaultValue: '0',
-    description: '''
-The minimum link percentage (0-100) required in order to generate a patch (Apple platforms only).
+    description:
+        '''
+The minimum link percentage ($minLinkPercentageMin-$minLinkPercentageMax) required in order to generate a patch (Apple platforms only).
 
 Patches with a lower link percentage than what is provided here will fail.
 ''',

--- a/packages/shorebird_cli/test/src/commands/init_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/init_command_test.dart
@@ -9,7 +9,6 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/init_command.dart';
-import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';

--- a/packages/shorebird_cli/test/src/commands/init_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/init_command_test.dart
@@ -9,6 +9,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/init_command.dart';
+import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/doctor.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
@@ -656,6 +657,55 @@ Please make sure you are running "shorebird init" from within your Flutter proje
             ).called(1);
           },
         );
+
+        group('when display name is empty', () {
+          setUp(() {
+            when(() => argResults['display-name']).thenReturn('');
+          });
+
+          test('exits with usage error', () async {
+            final exitCode = await runWithOverrides(command.run);
+            expect(exitCode, equals(ExitCode.usage.code));
+            verify(
+              () => logger.err(
+                'App display name must be between '
+                '${CommonArguments.appDisplayNameMinLength} and '
+                '${CommonArguments.appDisplayNameMaxLength} characters.',
+              ),
+            ).called(1);
+          });
+        });
+
+        group('when display name exceeds max length', () {
+          setUp(() {
+            when(() => argResults['display-name'])
+                .thenReturn('a' * (CommonArguments.appDisplayNameMaxLength + 1));
+          });
+
+          test('exits with usage error', () async {
+            final exitCode = await runWithOverrides(command.run);
+            expect(exitCode, equals(ExitCode.usage.code));
+            verify(
+              () => logger.err(
+                'App display name must be between '
+                '${CommonArguments.appDisplayNameMinLength} and '
+                '${CommonArguments.appDisplayNameMaxLength} characters.',
+              ),
+            ).called(1);
+          });
+        });
+
+        group('when display name is exactly max length', () {
+          setUp(() {
+            when(() => argResults['display-name'])
+                .thenReturn('a' * CommonArguments.appDisplayNameMaxLength);
+          });
+
+          test('succeeds', () async {
+            final exitCode = await runWithOverrides(command.run);
+            expect(exitCode, equals(ExitCode.success.code));
+          });
+        });
       });
 
       test('creates shorebird for an app without flavors', () async {

--- a/packages/shorebird_cli/test/src/commands/init_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/init_command_test.dart
@@ -668,9 +668,7 @@ Please make sure you are running "shorebird init" from within your Flutter proje
             expect(exitCode, equals(ExitCode.usage.code));
             verify(
               () => logger.err(
-                'App display name must be between '
-                '${CommonArguments.appDisplayNameMinLength} and '
-                '${CommonArguments.appDisplayNameMaxLength} characters.',
+                'App display name must be between 1 and 128 characters.',
               ),
             ).called(1);
           });
@@ -678,8 +676,7 @@ Please make sure you are running "shorebird init" from within your Flutter proje
 
         group('when display name exceeds max length', () {
           setUp(() {
-            when(() => argResults['display-name'])
-                .thenReturn('a' * (CommonArguments.appDisplayNameMaxLength + 1));
+            when(() => argResults['display-name']).thenReturn('a' * 129);
           });
 
           test('exits with usage error', () async {
@@ -687,9 +684,7 @@ Please make sure you are running "shorebird init" from within your Flutter proje
             expect(exitCode, equals(ExitCode.usage.code));
             verify(
               () => logger.err(
-                'App display name must be between '
-                '${CommonArguments.appDisplayNameMinLength} and '
-                '${CommonArguments.appDisplayNameMaxLength} characters.',
+                'App display name must be between 1 and 128 characters.',
               ),
             ).called(1);
           });
@@ -697,8 +692,7 @@ Please make sure you are running "shorebird init" from within your Flutter proje
 
         group('when display name is exactly max length', () {
           setUp(() {
-            when(() => argResults['display-name'])
-                .thenReturn('a' * CommonArguments.appDisplayNameMaxLength);
+            when(() => argResults['display-name']).thenReturn('a' * 128);
           });
 
           test('succeeds', () async {

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -878,9 +878,7 @@ void main() {
               );
               verify(
                 () => logger.err(
-                  '--min-link-percentage must be an integer between '
-                  '${CommonArguments.minLinkPercentageMin} and '
-                  '${CommonArguments.minLinkPercentageMax} '
+                  '--min-link-percentage must be an integer between 0 and 100 '
                   '(got $value).',
                 ),
               ).called(1);

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -855,6 +855,84 @@ void main() {
               ).called(1);
             });
           });
+
+          group('when min-link-percentage is invalid', () {
+            void setMinLinkPercentage(String value) {
+              when(
+                () => argResults[CommonArguments.minLinkPercentage.name],
+              ).thenReturn(value);
+            }
+
+            Future<void> expectUsageError(String value) async {
+              setMinLinkPercentage(value);
+              await expectLater(
+                runWithOverrides(
+                  () => command.logPatchSummary(
+                    app: appMetadata,
+                    releaseVersion: releaseVersion,
+                    patcher: patcher,
+                    patchArtifactBundles: patchArtifactBundles,
+                  ),
+                ),
+                exitsWithCode(ExitCode.usage),
+              );
+              verify(
+                () => logger.err(
+                  '--min-link-percentage must be an integer between 0 and 100 '
+                  '(got $value).',
+                ),
+              ).called(1);
+            }
+
+            test('above 100 prints error and exits', () async {
+              await expectUsageError('101');
+            });
+
+            test('below 0 prints error and exits', () async {
+              await expectUsageError('-1');
+            });
+
+            test('float prints error and exits', () async {
+              await expectUsageError('50.5');
+            });
+          });
+
+          group('when min-link-percentage is at boundary', () {
+            test('0 is accepted', () async {
+              when(
+                () => argResults[CommonArguments.minLinkPercentage.name],
+              ).thenReturn('0');
+              await expectLater(
+                runWithOverrides(
+                  () => command.logPatchSummary(
+                    app: appMetadata,
+                    releaseVersion: releaseVersion,
+                    patcher: patcher,
+                    patchArtifactBundles: patchArtifactBundles,
+                  ),
+                ),
+                completes,
+              );
+            });
+
+            test('100 is accepted', () async {
+              when(
+                () => argResults[CommonArguments.minLinkPercentage.name],
+              ).thenReturn('100');
+              when(() => patcher.linkPercentage).thenReturn(100);
+              await expectLater(
+                runWithOverrides(
+                  () => command.logPatchSummary(
+                    app: appMetadata,
+                    releaseVersion: releaseVersion,
+                    patcher: patcher,
+                    patchArtifactBundles: patchArtifactBundles,
+                  ),
+                ),
+                completes,
+              );
+            });
+          });
         });
       });
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -878,7 +878,9 @@ void main() {
               );
               verify(
                 () => logger.err(
-                  '--min-link-percentage must be an integer between 0 and 100 '
+                  '--min-link-percentage must be an integer between '
+                  '${CommonArguments.minLinkPercentageMin} and '
+                  '${CommonArguments.minLinkPercentageMax} '
                   '(got $value).',
                 ),
               ).called(1);

--- a/packages/shorebird_cli/test/src/commands/patches/set_track_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patches/set_track_command_test.dart
@@ -156,6 +156,34 @@ void main() {
       });
     });
 
+    group('when track name is empty', () {
+      setUp(() {
+        when(() => argResults['track']).thenReturn('');
+      });
+
+      test('exits with usage error', () async {
+        final result = await runWithOverrides(command.run);
+        expect(result, equals(ExitCode.usage.code));
+        verify(
+          () => logger.err('Track name must be between 1 and 128 characters.'),
+        ).called(1);
+      });
+    });
+
+    group('when track name exceeds max length', () {
+      setUp(() {
+        when(() => argResults['track']).thenReturn('a' * 129);
+      });
+
+      test('exits with usage error', () async {
+        final result = await runWithOverrides(command.run);
+        expect(result, equals(ExitCode.usage.code));
+        verify(
+          () => logger.err('Track name must be between 1 and 128 characters.'),
+        ).called(1);
+      });
+    });
+
     group('when release has no patches', () {
       setUp(() {
         when(

--- a/packages/shorebird_cli/test/src/commands/patches/set_track_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patches/set_track_command_test.dart
@@ -130,7 +130,7 @@ void main() {
     });
 
     test('description is correct', () {
-      expect(command.description, 'Sets the track of a patch');
+      expect(command.description, 'Sets the track of a patch.');
     });
 
     group('when validation fails', () {


### PR DESCRIPTION
## Summary / Reasoning

Follow-up to #3720 and #3717. Agents reading `--help` output need accurate, complete descriptions to invoke commands correctly. This PR audits every command's help output from an agent's perspective and fixes what's vague, missing, or incorrect.

- Improves `--display-name` help text in `shorebird init` to describe what the field controls and its constraints; adds length validation (1–128 chars) with a clear error message
- Improves `--release-version` / `--release` help text across `patches promote`, `patches set-track`, and `releases get-apks` to show the version format (`"1.0.0+1"`) and clarify the patch ownership relationship; `releases get-apks` also notes it prompts for selection if omitted
- Improves `--track` help text in `patches set-track` to name the built-in tracks and clarify any custom name is accepted; adds length validation (1–128 chars, matching the `app_channel_.name` column)
- Removes the `allowed` list on `patch --min-link-percentage` (which produced an unhelpful parse error for out-of-range values) and replaces it with explicit runtime validation with a clear error message; extracts `minLinkPercentageMin/Max` constants
- Fixes grammar: trailing periods and a "to to" typo across several command descriptions
- Extracts `CommonArguments.patchReleaseVersionDescription` to avoid duplicating the same help string across `patches promote` and `patches set-track`

## Testing

- Ran `shorebird <cmd> --help` for every command and subcommand against the dev build
- `dart test` — 110 tests pass across the 3 affected test files