### PR TITLE
fix(shorebird_cli): ignore non-deterministic UUIDs in Assets.car diff

### DIFF
--- a/packages/shorebird_cli/lib/src/archive_analysis/apple_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/apple_archive_differ.dart
@@ -1,4 +1,4 @@
-// cspell:words xcframeworks xcasset unsign codesign assetutil pubspec xcassets
+// cspell:words xcframeworks xcasset unsign codesign assetutil pubspec xcassets actool
 import 'dart:io';
 import 'dart:isolate';
 import 'dart:typed_data';

--- a/packages/shorebird_cli/lib/src/archive_analysis/apple_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/apple_archive_differ.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 import 'package:archive/archive_io.dart';
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/archive_analysis/archive_differ.dart';
 import 'package:shorebird_cli/src/archive_analysis/file_set_diff.dart';
@@ -161,14 +162,32 @@ class AppleArchiveDiffer extends ArchiveDiffer {
   }
 
   /// Uses assetutil to write a json description of a .car file to disk and
-  /// diffs the contents of that file, less a timestamp line that changes based
-  /// on when the .car file was created.
+  /// hashes the contents of that file, less the lines that vary build-to-build
+  /// for reasons unrelated to asset content.
   Future<String> _sanitizedCarFileHash(ArchiveFile file) async {
     final jsonFile = await _carJsonFile(file);
     final lines = jsonFile.readAsLinesSync();
+    return _hash(sanitizeCarJson(lines).codeUnits);
+  }
+
+  /// Strips non-deterministic content from the lines of an
+  /// `assetutil --info` JSON dump so two builds of the same assets hash the
+  /// same. Currently removes:
+  ///
+  ///   * The `Timestamp` line, which records when the .car file was built.
+  ///   * UUIDs that `actool` embeds in the rendition file names of iOS 18
+  ///     layered icon (.icon) bundles, which are regenerated every build.
+  @visibleForTesting
+  static String sanitizeCarJson(List<String> lines) {
     final timestampRegex = RegExp(r'^\W+"Timestamp" : \d+$');
-    final linesToKeep = lines.whereNot(timestampRegex.hasMatch);
-    return _hash(linesToKeep.join('\n').codeUnits);
+    final uuidRegex = RegExp(
+      '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-'
+      '[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}',
+    );
+    return lines
+        .whereNot(timestampRegex.hasMatch)
+        .map((line) => line.replaceAll(uuidRegex, '<uuid>'))
+        .join('\n');
   }
 
   @override

--- a/packages/shorebird_cli/test/src/archive_analysis/apple_archive_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/apple_archive_differ_test.dart
@@ -92,6 +92,51 @@ void main() {
       });
     });
 
+    group('sanitizeCarJson', () {
+      test('strips Timestamp lines', () {
+        final input = [
+          '{',
+          '  "Timestamp" : 1234567890',
+          '  "Name" : "AppIcon"',
+          '}',
+        ];
+        expect(
+          AppleArchiveDiffer.sanitizeCarJson(input),
+          '{\n  "Name" : "AppIcon"\n}',
+        );
+      });
+
+      test('hashes equivalently when only layered icon UUIDs differ', () {
+        // actool generates a fresh UUID for each build of an iOS 18
+        // layered icon (.icon) bundle, which appears in the
+        // RenditionName/Name fields of the assetutil --info output.
+        const uuidA = '1FB87FB1-9D9F-4F60-B3C3-6E63B0B0E3DD';
+        const uuidB = 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE';
+        final buildA = [
+          '  "Name" : "AppIcon-$uuidA"',
+          '  "RenditionName" : "AppIcon-$uuidA.png"',
+        ];
+        final buildB = [
+          '  "Name" : "AppIcon-$uuidB"',
+          '  "RenditionName" : "AppIcon-$uuidB.png"',
+        ];
+        expect(
+          AppleArchiveDiffer.sanitizeCarJson(buildA),
+          AppleArchiveDiffer.sanitizeCarJson(buildB),
+        );
+      });
+
+      test('still detects rendition name changes that are not just UUIDs', () {
+        const uuid = '1FB87FB1-9D9F-4F60-B3C3-6E63B0B0E3DD';
+        final before = ['  "RenditionName" : "AppIcon-$uuid.png"'];
+        final after = ['  "RenditionName" : "AppIconDark-$uuid.png"'];
+        expect(
+          AppleArchiveDiffer.sanitizeCarJson(before),
+          isNot(AppleArchiveDiffer.sanitizeCarJson(after)),
+        );
+      });
+    });
+
     group('xcarchive', () {
       group('changedPaths', () {
         test('finds no differences between the same xcarchive', () async {

--- a/packages/shorebird_cli/test/src/archive_analysis/apple_archive_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/apple_archive_differ_test.dart
@@ -1,4 +1,4 @@
-// cspell:words xcarchive xcarchives xcframeworks xcframework
+// cspell:words xcarchive xcarchives xcframeworks xcframework actool assetutil
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped_deps/scoped_deps.dart';


### PR DESCRIPTION
## Summary

- `actool` regenerates a fresh UUID into the rendition file names of iOS 18 layered icon (`.icon`) bundles on every build, which appears in the `Name`/`RenditionName` fields of the `assetutil --info` output we hash for the patch diff check.
- The result: any iOS app with layered icons (e.g., the `very_good create` template's `AppIcon-stg.icon`) trips the asset-diff warning on every `shorebird patch ios`, even with zero source changes.
- Strips UUID matches from the sanitized `assetutil` output alongside the existing `Timestamp` filter so identical sources hash identically.

Fixes #3637

## Test plan

- [x] New unit tests in `apple_archive_differ_test.dart` covering: timestamp stripping, UUID-only differences hash equally, and non-UUID rendition name changes still differ.
- [x] `dart analyze --fatal-warnings` clean on `lib/src/archive_analysis` and `test/src/archive_analysis`.
- [x] `dart test test/src/archive_analysis/apple_archive_differ_test.dart` — all 21 tests pass.
- [ ] Manual: reproduce per the issue (`very_good create` → `shorebird release ios` → `shorebird patch ios`) and confirm no asset-diff warning.