### PR TITLE
ci: add triage automation workflow

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -3,25 +3,22 @@ name: Triage automation
 on:
   issues:
     types: [opened]
-  pull_request_target:
-    types: [opened]
   issue_comment:
     types: [created]
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   add-needs-triage:
-    if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
+    if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
       - name: Add needs-triage label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          NUMBER: ${{ github.event.issue.number }}
         run: |
           gh api -X POST "repos/$REPO/issues/$NUMBER/labels" \
             -f 'labels[]=needs-triage'
@@ -29,6 +26,7 @@ jobs:
   customer-replied:
     if: >-
       github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request == null &&
       github.event.comment.user.login == github.event.issue.user.login
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -1,0 +1,46 @@
+name: Triage automation
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  add-needs-triage:
+    if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add needs-triage label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          gh api -X POST "repos/$REPO/issues/$NUMBER/labels" \
+            -f 'labels[]=needs-triage'
+
+  customer-replied:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.comment.user.login == github.event.issue.user.login
+    runs-on: ubuntu-latest
+    steps:
+      - name: Swap waiting-for-response to needs-triage on author reply
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+        run: |
+          has_waiting=$(gh api "repos/$REPO/issues/$NUMBER/labels" \
+            --jq '[.[].name] | any(. == "waiting for response")')
+          if [ "$has_waiting" = "true" ]; then
+            gh api -X DELETE "repos/$REPO/issues/$NUMBER/labels/waiting%20for%20response"
+            gh api -X POST "repos/$REPO/issues/$NUMBER/labels" -f 'labels[]=needs-triage'
+          fi


### PR DESCRIPTION
## Summary

Adds `.github/workflows/triage.yaml` to support a new weekly issue triage process.

The workflow does two things:

1. **On `issues.opened`** — applies a `needs-triage` label so the issue surfaces in the triage queue for the next meeting.
2. **On `issue_comment.created` from the issue author** — if the issue currently has the `waiting for response` label, swap it back to `needs-triage` so the customer reply re-enters the queue.

PRs aren't labeled — they'll be tracked by age via saved GitHub search queries instead.

## Context

One of two PRs (this + `_shorebird`) rolling out the workflow. New labels (`needs-triage`, `P0`, `P1`, `P2`) were created across both repos to support this. The triage meeting itself runs against org-wide GitHub search URLs; no project board is involved.

## Test plan

- [ ] Merge → verify next opened issue gets `needs-triage` automatically
- [ ] Manually label an issue `waiting for response`, comment as the issue author, verify the workflow swaps the labels