### PR TITLE
chore: add 'mmap' to cspell dictionary

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -79,6 +79,7 @@ words:
   - mget # From ./packages/redis_client
   - metadatas
   - mktemp
+  - mmap # Unix system call — referenced in RELEASE_NOTES (libapp.so mmap-from-APK)
   - mocktail
   - mset # From ./packages/redis_client
   - multioption


### PR DESCRIPTION
## Summary

Unblocks CSpell on `main`. The `1.6.98` entry in `RELEASE_NOTES.md` references `mmap` (the Unix syscall) when describing the Android updater change to mmap `libapp.so` out of the APK; cspell's full-repo scan in `.github/workflows/main.yaml` flags the word and the `CSpell` GitHub-Actions check has been failing on `main` for every push since that release note landed.

## What this changes

One line: adds `mmap` to the alphabetical word list in `cspell.config.yaml`, between `mktemp` and `mocktail`.

```diff
   - mktemp
+  - mmap # Unix `mmap` syscall — referenced in RELEASE_NOTES (libapp.so mmap-from-APK)
   - mocktail
```

## Why the global config and not inline-scoping

`RELEASE_NOTES.md` already has an inline `<!-- cspell:words ... -->` directive at the top, so inline-scoping was an option. I went with the global config because:

- `mmap` is a generic Unix term (sits naturally next to `mktemp` in the existing list).
- The Rust updater's `mmap` work is likely to surface in future Dart code, comments, log messages, or release notes — adding it once globally avoids whack-a-mole later.
- Other syscalls / low-level terms (`dyld`, `dylib`, `mktemp`) live in the global config too; this matches the convention.

## Verification

`gh api repos/shorebirdtech/shorebird/check-runs/<id>/annotations` for the most recent failing CSpell run on `main` reported a single annotation:

```
RELEASE_NOTES.md:13:14 — Unknown word (mmap)
```

That annotation is the only failure surfaced by the check, so this should fully unblock CSpell on `main`. Discovered while debugging cspell on shorebirdtech/shorebird#3750 — that PR's incremental-only check (GitHub Actions) is green; the full-repo `CSpell` (Shorebird-internal CI) inherits this `main` failure.

## Test plan

- [x] Annotation contents inspected on the latest failing CSpell run for main.
- [x] Word added in alphabetical position next to existing similar entries.
- [ ] CI: CSpell now green on this PR (will land on push).