### PR TITLE
ci: bump e2e cli FLUTTER_VERSION to 3.41.9

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,7 +12,7 @@ on:
 
 env:
   SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
-  FLUTTER_VERSION: 3.35.5
+  FLUTTER_VERSION: 3.41.9
 
 jobs:
   patch:


### PR DESCRIPTION
## Summary

Unblocks the nightly e2e cli matrix, which has been failing every run since at least 2026-05-02 (six consecutive nightly failures as of this PR). All six jobs ({macos, windows, ubuntu} × {stable, main}) fail at `dart test integration_test` with:

```
The current Dart SDK version is 3.9.2.

Because very_good_analysis 10.2.0 requires SDK version ^3.11.0 and no
versions of very_good_analysis match >10.2.0 <11.0.0,
very_good_analysis ^10.2.0 is forbidden.
So, because _ depends on very_good_analysis ^10.2.0, version solving
failed.
```

## Why

Two changes drifted out of sync:

- **#3661 (2026-03-21):** Dependabot bumped `very_good_analysis` from `^10.0.0` to `^10.2.0` in the workspace root pubspec. `very_good_analysis@10.2.0` requires Dart SDK `^3.11.0`.
- **`.github/workflows/e2e.yaml:15`:** still pins `FLUTTER_VERSION: 3.35.5`. Flutter 3.35.5 ships Dart **3.9.2**, which doesn't satisfy `^3.11.0`.

The cli matrix runs `dart test integration_test` from `packages/shorebird_cli/`, which forces a workspace-wide pub solve. The solve fails because the workspace root requires `very_good_analysis ^10.2.0`, which requires Dart ≥ 3.11.

The patch matrix is unaffected because each patch job uses `shorebird release` / `shorebird patch` against a pinned Flutter, and those commands use Flutter's bundled Dart rather than going through the workspace pubspec — that's why the patch matrix has been green while the cli matrix has been entirely red.

## What this changes

```diff
 env:
   SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
-  FLUTTER_VERSION: 3.35.5
+  FLUTTER_VERSION: 3.41.9
```

3.41.9 is the **current latest stable on the official Flutter release feed** (verified via `https://storage.googleapis.com/flutter_infra_release/releases/releases_macos.json`). It ships Dart 3.11.5, which satisfies the workspace constraint. Aligns the cli e2e with what customers actually run.

## Alternative considered

Revert `very_good_analysis` to `^10.0.0`. Skipped — the rest of the codebase has been on 10.2.x for ~6 weeks, and 3.35.5 is no longer representative of customer installs anyway. Bumping FLUTTER_VERSION is the more forward-looking fix.

## Test plan

- [x] Diagnosis verified by reading the failure log on the most recent failed run (run id `25530616665`, job id `74935918586`). The pub-solve error is the only failure mode; once the SDK constraint is satisfied the matrix should go green.
- [x] 3.41.9 confirmed published on the official Flutter release feed (the action `subosito/flutter-action@v2` pulls from there, not from the Shorebird fork).
- [ ] Workflow is `schedule:` cron (nightly at 00:00 UTC) plus `workflow_dispatch`. After merge, kick off via `gh workflow run e2e.yaml --repo shorebirdtech/shorebird` (or wait for the next nightly) to confirm.