### PR TITLE
revert: forward --flavor to flutter build aar and ios-framework (#3748)

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -283,7 +283,6 @@ Reason: Exited with code $exitCode.''',
   /// after the build completes or fails.
   Future<void> buildAar({
     required String buildNumber,
-    String? flavor,
     Iterable<Arch>? targetPlatforms,
     List<String> args = const [],
     String? base64PublicKey,
@@ -297,7 +296,6 @@ Reason: Exited with code $exitCode.''',
         '--no-debug',
         '--no-profile',
         '--build-number=$buildNumber',
-        if (flavor != null) '--flavor=$flavor',
         if (targetPlatformArgs != null) '--target-platform=$targetPlatformArgs',
         ...await _traceArgs('aar'),
         ...args,
@@ -506,7 +504,6 @@ Reason: Exited with code $exitCode.''',
 
   /// Builds a release iOS framework (.xcframework) for the current project.
   Future<AppleBuildResult> buildIosFramework({
-    String? flavor,
     List<String> args = const [],
     String? base64PublicKey,
   }) async {
@@ -525,7 +522,6 @@ Reason: Exited with code $exitCode.''',
         'ios-framework',
         '--no-debug',
         '--no-profile',
-        if (flavor != null) '--flavor=$flavor',
         ...await _traceArgs('ios-framework'),
         ...args,
       ];

--- a/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/aar_releaser.dart
@@ -88,7 +88,6 @@ class AarReleaser extends Releaser {
     addObfuscationMapArgs(buildArgs);
     await artifactBuilder.buildAar(
       buildNumber: buildNumber,
-      flavor: flavor,
       targetPlatforms: architectures,
       args: buildArgs,
       base64PublicKey: base64PublicKey,

--- a/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_framework_releaser.dart
@@ -78,7 +78,6 @@ class IosFrameworkReleaser extends Releaser with AppleReleaserMixin {
     addSplitDebugInfoDefault(buildArgs);
     addObfuscationMapArgs(buildArgs);
     await artifactBuilder.buildIosFramework(
-      flavor: flavor,
       args: buildArgs,
       base64PublicKey: base64PublicKey,
     );

--- a/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
@@ -1005,33 +1005,6 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
         ).called(1);
       });
 
-      test(
-        'forwards --flavor to flutter build when flavor is provided',
-        () async {
-          await runWithOverrides(
-            () =>
-                builder.buildAar(buildNumber: buildNumber, flavor: 'internal'),
-          );
-
-          verify(
-            () => shorebirdProcess.stream(
-              'flutter',
-              [
-                'build',
-                'aar',
-                '--no-debug',
-                '--no-profile',
-                '--build-number=1.0',
-                '--flavor=internal',
-              ],
-              environment: any(named: 'environment'),
-              runInShell: false,
-              onStart: any(named: 'onStart'),
-            ),
-          ).called(1);
-        },
-      );
-
       group('when base64PublicKey is not null', () {
         const base64PublicKey = 'base64PublicKey';
 
@@ -1899,31 +1872,6 @@ Reason: Exited with code 70.'''),
           ),
         ).called(1);
       });
-
-      test(
-        'forwards --flavor to flutter build when flavor is provided',
-        () async {
-          await runWithOverrides(
-            () => builder.buildIosFramework(flavor: 'internal'),
-          );
-
-          verify(
-            () => shorebirdProcess.stream(
-              'flutter',
-              [
-                'build',
-                'ios-framework',
-                '--no-debug',
-                '--no-profile',
-                '--flavor=internal',
-              ],
-              environment: any(named: 'environment'),
-              runInShell: false,
-              onStart: any(named: 'onStart'),
-            ),
-          ).called(1);
-        },
-      );
 
       group('when base64PublicKey is not null', () {
         const base64PublicKey = 'base64PublicKey';

--- a/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/aar_releaser_test.dart
@@ -374,39 +374,6 @@ void main() {
           ).called(1);
         });
 
-        group('with flavor', () {
-          const flavor = 'internal';
-
-          setUp(() {
-            aarReleaser = AarReleaser(
-              argResults: argResults,
-              flavor: flavor,
-              target: null,
-            );
-            when(
-              () => artifactBuilder.buildAar(
-                buildNumber: any(named: 'buildNumber'),
-                flavor: any(named: 'flavor'),
-                targetPlatforms: any(named: 'targetPlatforms'),
-                args: any(named: 'args'),
-              ),
-            ).thenAnswer((_) async => File(''));
-          });
-
-          test('forwards flavor to buildAar', () async {
-            await runWithOverrides(() => aarReleaser.buildReleaseArtifacts());
-
-            verify(
-              () => artifactBuilder.buildAar(
-                buildNumber: buildNumber,
-                flavor: flavor,
-                targetPlatforms: Arch.values.toSet(),
-                args: [],
-              ),
-            ).called(1);
-          });
-        });
-
         group('when a patch signing key path is provided', () {
           const base64PublicKey = 'base64PublicKey';
 

--- a/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_framework_releaser_test.dart
@@ -479,35 +479,6 @@ void main() {
         verify(() => artifactBuilder.buildIosFramework(args: [])).called(1);
       });
 
-      group('with flavor', () {
-        const flavor = 'internal';
-
-        setUp(() {
-          iosFrameworkReleaser = IosFrameworkReleaser(
-            argResults: argResults,
-            flavor: flavor,
-            target: null,
-          );
-          when(
-            () => artifactBuilder.buildIosFramework(
-              flavor: any(named: 'flavor'),
-              args: any(named: 'args'),
-            ),
-          ).thenAnswer(
-            (_) async =>
-                AppleBuildResult(kernelFile: File('/path/to/app.dill')),
-          );
-        });
-
-        test('forwards flavor to buildIosFramework', () async {
-          await runWithOverrides(iosFrameworkReleaser.buildReleaseArtifacts);
-
-          verify(
-            () => artifactBuilder.buildIosFramework(flavor: flavor, args: []),
-          ).called(1);
-        });
-      });
-
       group('when --obfuscate is passed', () {
         setUp(() {
           when(() => argResults['obfuscate']).thenReturn(true);


### PR DESCRIPTION
## Summary

Reverts #3748. That PR forwarded `--flavor=$flavor` to `flutter build aar` and `flutter build ios-framework` to fix an existing bug where the AAR shipped with the top-level `app_id` baked into its compiled `shorebird.yaml` instead of the flavor's id.

The fix worked for Flutter **apps** with matching gradle product flavors, but breaks Flutter **modules** — the typical AAR audience — because their auto-generated `.android/` project has no product flavors, so `flutter build aar --flavor X` makes gradle fail looking for `assembleAar<X>Release`. Reported in #3746 (comment: https://github.com/shorebirdtech/shorebird/issues/3746#issuecomment).

Reverting unbreaks the typical-module case. The original baked-in-id bug from #3746 returns, but it's the bug that existed for years; nobody is worse off than 48 hours ago.

The proper fix routes around Flutter's `--flavor` mechanism entirely — likely an env var into the asset bundler, similar to the `library_version` plumbing currently in flight — so the resolved `app_id` lands in the AAR without depending on gradle product flavors.

## Test plan

- [x] CI green (revert removes only the new code paths added in #3748; existing tests retained)