### PR TITLE
chore(shorebird_cli): drop dead progress stub from account command tests

### DIFF
--- a/packages/shorebird_cli/test/src/commands/account/apps_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account/apps_command_test.dart
@@ -37,7 +37,6 @@ void main() {
     late CodePushClientWrapper codePushClientWrapper;
     late ShorebirdValidator shorebirdValidator;
     late ShorebirdLogger logger;
-    late Progress progress;
     late AppsCommand command;
 
     R runWithOverrides<R>(R Function() body) {
@@ -56,11 +55,9 @@ void main() {
       argResults = MockArgResults();
       codePushClientWrapper = MockCodePushClientWrapper();
       logger = MockShorebirdLogger();
-      progress = MockProgress();
       shorebirdValidator = MockShorebirdValidator();
       command = runWithOverrides(AppsCommand.new)..testArgResults = argResults;
 
-      when(() => logger.progress(any())).thenReturn(progress);
       when(() => argResults.rest).thenReturn([]);
       when(
         () => shorebirdValidator.validatePreconditions(

--- a/packages/shorebird_cli/test/src/commands/account/orgs_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account/orgs_command_test.dart
@@ -43,7 +43,6 @@ void main() {
     late CodePushClientWrapper codePushClientWrapper;
     late ShorebirdValidator shorebirdValidator;
     late ShorebirdLogger logger;
-    late Progress progress;
     late OrgsCommand command;
 
     R runWithOverrides<R>(R Function() body) {
@@ -62,11 +61,9 @@ void main() {
       argResults = MockArgResults();
       codePushClientWrapper = MockCodePushClientWrapper();
       logger = MockShorebirdLogger();
-      progress = MockProgress();
       shorebirdValidator = MockShorebirdValidator();
       command = runWithOverrides(OrgsCommand.new)..testArgResults = argResults;
 
-      when(() => logger.progress(any())).thenReturn(progress);
       when(() => argResults.rest).thenReturn([]);
       when(
         () => shorebirdValidator.validatePreconditions(


### PR DESCRIPTION
## Summary
- The `progress` field, `MockProgress` instantiation, and `logger.progress(any())` stub were introduced in #3742 (orgs) and #3743 (apps), but never executed because `codePushClientWrapper` is mocked at the wrapper boundary, so the progress code inside the wrapper never runs.
- Caught by bdero's review bot on #3743 and waived there as a follow-up. This change closes that follow-up.

## Testing
- `dart test test/src/commands/account/apps_command_test.dart test/src/commands/account/orgs_command_test.dart` → 20/20 pass
- `dart analyze --fatal-warnings lib test` → no new findings in the changed files
- Coverage on `apps_command.dart` and `orgs_command.dart` stays at 33/33 lines w/ updated tests