### PR TITLE
feat(cli): add App.dd_resolution.tsv to supplement file handling

### DIFF
--- a/packages/shorebird_cli/lib/src/platform/apple/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple/apple.dart
@@ -59,6 +59,8 @@ class Apple {
       // DD table files for cascade limiter (produced by 2-pass release build).
       'App.dd.link',
       'App.dd_callers.link',
+      // Per-slot DD resolution outcome diagnostic (TSV).
+      'App.dd_resolution.tsv',
     ];
 
     // This uses maybeCopy because not all versions of gen_snapshot/aot_tools


### PR DESCRIPTION
## Summary

Tiny follow-up to #3671. Adds `App.dd_resolution.tsv` to the known supplement-file list in `Apple.copySupplementFilesToSnapshotDirs` so the per-slot DD table resolution diagnostic (TSV) gets carried alongside the existing `App.dd.link` / `App.dd_callers.link` files.

## Companion changes

The TSV is produced by gen_snapshot's new `--print_dd_resolution_to=` flag in cascade-limiter (shorebirdtech/dart-sdk#785), invoked by the 2-pass DD release build in shorebirdtech/flutter#119. It's a diagnostic dump used to figure out *which specific slots* got dropped (sentinel-filled) during DD resolution — useful for investigating patch link-percentage regressions where the aggregate count alone (`8 sentinel-filled`) doesn't tell you which 8 slots.

## Backwards compatibility

`copySupplementFilesToSnapshotDirs` uses `maybeCopy` which silently skips missing files. Older Flutter/engine pins that don't produce `App.dd_resolution.tsv` are unaffected.

## Test plan

- [ ] CI passes (the existing supplement-list tests cover the loop semantics, and the new entry is just one more `maybeCopy` invocation).
- [ ] Verified locally that a Wonderous patch with the cascade-limiter Flutter pin produces `App.dd_resolution.tsv` in the supplement upload, and the file lands in the patch debug zip.