### PR TITLE
fix(shorebird_cli): isInteractive falls back to stdioType for unsized PTYs

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -57,6 +57,7 @@ words:
   - ints
   - iokit
   - iphoneos
+  - isatty
   - keyalg # From .github/workflows/e2e.yaml
   - keypass # From .github/workflows/e2e.yaml
   - keysize # From .github/workflows/e2e.yaml
@@ -154,6 +155,7 @@ words:
   - VCRUNTIME
   - Verdana
   - vmcode
+  - winsize
   - worktrees
   - writeln
   - WRONGPASS

--- a/packages/shorebird_cli/lib/src/interactive_mode.dart
+++ b/packages/shorebird_cli/lib/src/interactive_mode.dart
@@ -9,9 +9,17 @@ import 'package:shorebird_cli/src/json_output.dart';
 /// (`chooseOne`/`confirm`/`prompt`).
 ///
 /// Returns `false` when any of the following is true:
-///   * stdout is not connected to a terminal (`!stdout.hasTerminal`).
+///   * stdout is not connected to a terminal.
 ///   * `--json` was passed (machine-readable output expected).
-bool get isInteractive => io.stdout.hasTerminal && !isJsonMode;
+///
+/// `Stdout.hasTerminal` is winsize-based, not isatty-based, so PTYs with
+/// default 0x0 winsize fail it. `stdioType(stdout) == StdioType.terminal`
+/// uses isatty semantics and catches them.
+bool get isInteractive {
+  if (isJsonMode) return false;
+  if (io.stdout.hasTerminal) return true;
+  return io.stdioType(io.stdout) == io.StdioType.terminal;
+}
 
 /// The default hint emitted when an interactive prompt is reached in a
 /// non-interactive context and no per-site hint was provided.


### PR DESCRIPTION
## Summary

Fixes #3765. When `stdout.hasTerminal` returns false, fall back to `stdioType(stdout) == StdioType.terminal` before declaring the context non-interactive.

`Stdout.hasTerminal` is implemented in Dart as `_getTerminalSize(fd) is List`: it calls `ioctl(TIOCGWINSZ)` and returns false when both `ws_col` and `ws_row` are zero. PTYs allocated without an explicit winsize (Ruby's `PTY.spawn` and equivalents in other languages) default to 0x0 and fail that check despite `isatty(fd)` being true. The gate added in #3720 then throws `InteractivePromptRequiredException` on prompts despite stdout being a valid terminal.

`stdioType(stdout) == StdioType.terminal` is backed by stat-based handle classification plus `isatty()`, which matches the gate's intent. Adding it as a fallback means:

- Sized terminals still hit the fast `hasTerminal` path, so behavior is unchanged.
- Unsized PTYs (the bug) now resolve to the fallback and return true.
- Non-terminals (pipes, files, /dev/null) still fail both checks, so behavior is unchanged.

## Why a fallback rather than a swap

A clean swap (`isInteractive = stdioType(stdout) == StdioType.terminal && !isJsonMode`) is the architecturally cleaner shape, but would have required updates to `test/src/helpers.dart`. The existing `CapturingStdout.hasTerminalOverride` mock affects `Stdout.hasTerminal` (overridable via `IOOverrides`), but `stdioType()` is a top-level function backed by the real fd, so it can't be mocked through `IOOverrides`. Three tests in `shorebird_cli_command_runner_test.dart` would have broken because their `hasTerminal: true` overrides would no longer flow through to `isInteractive`.

Happy to do the swap and add an injection point (a `@visibleForTesting` `stdioTypeProbe` field, or a scoped-deps injection) if maintainers prefer; this PR keeps the change surgical.

## Testing

- `dart test test/src/logging/shorebird_logger_test.dart`: 21 tests pass.
- `dart test test/src/shorebird_cli_command_runner_test.dart`: 38 tests pass, including the three `interactive mode` tests that exercise `isInteractive` via the runner.

The new fallback branch (`hasTerminal=false` AND `stdioType=terminal`) isn't directly covered by these unit tests because the test infrastructure only mocks `hasTerminal` and `stdioType()` reads the real fd 1 (which `dart test` typically pipes). If explicit coverage is wanted, the path forward is the injection point mentioned above, and I'm happy to add it.
