### PR TITLE
feat(ci): regen shorebird_ci workflows

### DIFF
--- a/.github/workflows/_shorebird_ci_dart.yaml
+++ b/.github/workflows/_shorebird_ci_dart.yaml
@@ -43,7 +43,7 @@ jobs:
       - working-directory: ${{ inputs.package_path }}
         run: dart format --set-exit-if-changed .
       - working-directory: ${{ inputs.package_path }}
-        run: dart analyze .
+        run: dart analyze --fatal-warnings .
       - name: Bloc Lint
         if: inputs.has_bloc_lint
         working-directory: ${{ inputs.package_path }}
@@ -60,3 +60,4 @@ jobs:
         with:
           flags: ${{ inputs.package_name }}
           working-directory: ${{ inputs.package_path }}
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/_shorebird_ci_dart.yaml
+++ b/.github/workflows/_shorebird_ci_dart.yaml
@@ -60,4 +60,3 @@ jobs:
         with:
           flags: ${{ inputs.package_name }}
           working-directory: ${{ inputs.package_path }}
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/shorebird_ci.yaml
+++ b/.github/workflows/shorebird_ci.yaml
@@ -83,7 +83,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   dex:
     needs: changes
@@ -95,7 +94,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   discord_gcp_alerts:
     needs: changes
@@ -107,7 +105,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   flutter_version_resolver:
     needs: changes
@@ -119,7 +116,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   jwt:
     needs: changes
@@ -131,7 +127,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   scoped_deps:
     needs: changes
@@ -143,7 +138,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   shorebird_build_trace:
     needs: changes
@@ -155,7 +149,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   shorebird_ci:
     needs: changes
@@ -167,7 +160,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   shorebird_cli:
     needs: changes
@@ -179,7 +171,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   shorebird_code_push_client:
     needs: changes
@@ -191,7 +182,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   shorebird_code_push_protocol:
     needs: changes
@@ -203,7 +193,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   shorebird_redis_client:
     needs: changes
@@ -215,7 +204,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   stripe_api:
     needs: changes
@@ -227,7 +215,6 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
-    secrets: inherit
 
   cspell:
     name: CSpell

--- a/.github/workflows/shorebird_ci.yaml
+++ b/.github/workflows/shorebird_ci.yaml
@@ -83,6 +83,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   dex:
     needs: changes
@@ -94,6 +95,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   discord_gcp_alerts:
     needs: changes
@@ -105,6 +107,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   flutter_version_resolver:
     needs: changes
@@ -116,6 +119,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   jwt:
     needs: changes
@@ -127,6 +131,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   scoped_deps:
     needs: changes
@@ -138,6 +143,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   shorebird_build_trace:
     needs: changes
@@ -149,6 +155,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   shorebird_ci:
     needs: changes
@@ -160,6 +167,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   shorebird_cli:
     needs: changes
@@ -171,6 +179,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   shorebird_code_push_client:
     needs: changes
@@ -182,6 +191,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   shorebird_code_push_protocol:
     needs: changes
@@ -193,6 +203,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   shorebird_redis_client:
     needs: changes
@@ -204,6 +215,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   stripe_api:
     needs: changes
@@ -215,6 +227,7 @@ jobs:
       has_bloc_lint: false
       has_unit_tests: true
       subpackages: ""
+    secrets: inherit
 
   cspell:
     name: CSpell


### PR DESCRIPTION
## Summary

- Regenerated the `shorebird_ci`-managed static workflows using `shorebird_ci 0.2.2`.
- The reusable Dart workflow now runs `dart analyze --fatal-warnings .` explicitly. Behavior-preserving since the Dart SDK already defaults to fatal-warnings. I went w/ explicit emission to document intent and survive any future SDK default flip.

## Testing

- `shorebird_ci verify` clean. All packages still have CI coverage in `shorebird_ci.yaml`.
- No code or config changes outside the two generated workflow files.
- Regen command:
  ```
  shorebird_ci generate --style static
  ```