### PR TITLE
feat(shorebird_cli): warn by provider when SHOREBIRD_TOKEN is legacy

### DIFF
--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -360,16 +360,10 @@ class Auth {
         return;
       }
 
-      // Legacy CiToken format — still supported, but deprecated.
+      // CiToken format — Shorebird-issued tokens are still current; tokens
+      // backed by a Google or Microsoft account are legacy.
       try {
         _token = CiToken.fromBase64(trimmed);
-        logger.warn(
-          'SHOREBIRD_TOKEN contains a legacy CI token from '
-          '`shorebird login:ci`. '
-          'This format is deprecated and will stop working in a future '
-          'release. '
-          'Create an API key at https://console.shorebird.dev instead.',
-        );
       } on FormatException catch (e) {
         logger
           ..err(
@@ -380,7 +374,9 @@ class Auth {
         rethrow;
       }
 
-      logger.detail('[env] $shorebirdTokenEnvVar parsed as legacy CiToken');
+      _maybeWarnLegacyProvider(_token!.authProvider);
+
+      logger.detail('[env] $shorebirdTokenEnvVar parsed as CiToken');
       return;
     }
 
@@ -396,6 +392,22 @@ class Auth {
         // Swallow json decode exceptions.
       }
     }
+  }
+
+  void _maybeWarnLegacyProvider(AuthProvider provider) {
+    final providerName = switch (provider) {
+      AuthProvider.google => 'Google',
+      AuthProvider.microsoft => 'Microsoft',
+      AuthProvider.shorebird => null,
+    };
+    if (providerName == null) return;
+    logger.warn(
+      '''
+SHOREBIRD_TOKEN is backed by a legacy $providerName account.
+This sign-in method is deprecated and will stop working in a future release.
+Create a new Shorebird API key at https://console.shorebird.dev and replace SHOREBIRD_TOKEN with it.
+Learn more: https://shorebird.dev/blog/introducing-shorebirds-upgraded-auth-service''',
+    );
   }
 
   void _flushCredentials(oauth2.AccessCredentials credentials) {

--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -395,17 +395,12 @@ class Auth {
   }
 
   void _maybeWarnLegacyProvider(AuthProvider provider) {
-    final providerName = switch (provider) {
-      AuthProvider.google => 'Google',
-      AuthProvider.microsoft => 'Microsoft',
-      AuthProvider.shorebird => null,
-    };
-    if (providerName == null) return;
+    if (provider == AuthProvider.shorebird) return;
     logger.warn(
       '''
-SHOREBIRD_TOKEN is backed by a legacy $providerName account.
-This sign-in method is deprecated and will stop working in a future release.
-Create a new Shorebird API key at https://console.shorebird.dev and replace SHOREBIRD_TOKEN with it.
+SHOREBIRD_TOKEN is a legacy token and will stop working in a future release.
+Upgrade to a Shorebird API key for better control, visibility, and revocation.
+Create one at https://console.shorebird.dev and replace SHOREBIRD_TOKEN with it.
 Learn more: https://shorebird.dev/blog/introducing-shorebirds-upgraded-auth-service''',
     );
   }

--- a/packages/shorebird_cli/test/src/auth/auth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_test.dart
@@ -971,9 +971,9 @@ void main() {
         verify(
           () => logger.warn(
             '''
-SHOREBIRD_TOKEN is backed by a legacy Google account.
-This sign-in method is deprecated and will stop working in a future release.
-Create a new Shorebird API key at https://console.shorebird.dev and replace SHOREBIRD_TOKEN with it.
+SHOREBIRD_TOKEN is a legacy token and will stop working in a future release.
+Upgrade to a Shorebird API key for better control, visibility, and revocation.
+Create one at https://console.shorebird.dev and replace SHOREBIRD_TOKEN with it.
 Learn more: https://shorebird.dev/blog/introducing-shorebirds-upgraded-auth-service''',
           ),
         ).called(1);
@@ -984,7 +984,7 @@ Learn more: https://shorebird.dev/blog/introducing-shorebirds-upgraded-auth-serv
         ).called(1);
       });
 
-      test('warns and names Microsoft when CiToken is Microsoft-backed', () {
+      test('warns when CiToken is Microsoft-backed', () {
         const microsoftCiToken = CiToken(
           refreshToken: 'ms-refresh',
           authProvider: AuthProvider.microsoft,
@@ -997,9 +997,9 @@ Learn more: https://shorebird.dev/blog/introducing-shorebirds-upgraded-auth-serv
         verify(
           () => logger.warn(
             '''
-SHOREBIRD_TOKEN is backed by a legacy Microsoft account.
-This sign-in method is deprecated and will stop working in a future release.
-Create a new Shorebird API key at https://console.shorebird.dev and replace SHOREBIRD_TOKEN with it.
+SHOREBIRD_TOKEN is a legacy token and will stop working in a future release.
+Upgrade to a Shorebird API key for better control, visibility, and revocation.
+Create one at https://console.shorebird.dev and replace SHOREBIRD_TOKEN with it.
 Learn more: https://shorebird.dev/blog/introducing-shorebirds-upgraded-auth-service''',
           ),
         ).called(1);

--- a/packages/shorebird_cli/test/src/auth/auth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_test.dart
@@ -926,7 +926,7 @@ void main() {
             ).called(1);
             verifyNever(
               () => logger.detail(
-                '[env] $shorebirdTokenEnvVar parsed as legacy CiToken',
+                '[env] $shorebirdTokenEnvVar parsed as CiToken',
               ),
             );
           },
@@ -970,18 +970,48 @@ void main() {
         ).called(1);
         verify(
           () => logger.warn(
-            'SHOREBIRD_TOKEN contains a legacy CI token from '
-            '`shorebird login:ci`. '
-            'This format is deprecated and will stop working in a future '
-            'release. '
-            'Create an API key at https://console.shorebird.dev instead.',
+            '''
+SHOREBIRD_TOKEN is backed by a legacy Google account.
+This sign-in method is deprecated and will stop working in a future release.
+Create a new Shorebird API key at https://console.shorebird.dev and replace SHOREBIRD_TOKEN with it.
+Learn more: https://shorebird.dev/blog/introducing-shorebirds-upgraded-auth-service''',
           ),
         ).called(1);
         verify(
           () => logger.detail(
-            '[env] $shorebirdTokenEnvVar parsed as legacy CiToken',
+            '[env] $shorebirdTokenEnvVar parsed as CiToken',
           ),
         ).called(1);
+      });
+
+      test('warns and names Microsoft when CiToken is Microsoft-backed', () {
+        const microsoftCiToken = CiToken(
+          refreshToken: 'ms-refresh',
+          authProvider: AuthProvider.microsoft,
+        );
+        when(() => platform.environment).thenReturn(<String, String>{
+          shorebirdTokenEnvVar: microsoftCiToken.toBase64(),
+        });
+        auth = buildAuth();
+        expect(auth.isAuthenticated, isTrue);
+        verify(
+          () => logger.warn(
+            '''
+SHOREBIRD_TOKEN is backed by a legacy Microsoft account.
+This sign-in method is deprecated and will stop working in a future release.
+Create a new Shorebird API key at https://console.shorebird.dev and replace SHOREBIRD_TOKEN with it.
+Learn more: https://shorebird.dev/blog/introducing-shorebirds-upgraded-auth-service''',
+          ),
+        ).called(1);
+      });
+
+      test('does not warn when CiToken is Shorebird-issued', () {
+        when(() => platform.environment).thenReturn(<String, String>{
+          shorebirdTokenEnvVar: shorebirdCiToken.toBase64(),
+        });
+        auth = buildAuth();
+        expect(auth.isAuthenticated, isTrue);
+        verifyNever(() => logger.warn(any()));
       });
 
       test(


### PR DESCRIPTION
## Summary

Replaces the generic "legacy CI token" warning in `auth.dart` with one gated on the backing OAuth provider:

- **Shorebird-issued `CiToken`** (`authProvider == shorebird`) — no longer warns. These are part of the new auth system.
- **Google- or Microsoft-backed `CiToken`** — warns with a single shared message:

  > SHOREBIRD_TOKEN is a legacy token and will stop working in a future release.
  > Upgrade to a Shorebird API key for better control, visibility, and revocation.
  > Create one at https://console.shorebird.dev and replace SHOREBIRD_TOKEN with it.
  > Learn more: https://shorebird.dev/blog/introducing-shorebirds-upgraded-auth-service

The warning now points users at the actual fix — creating a new API key at `console.shorebird.dev` (since `shorebird logout`/`login` doesn't help when the env var is still set) — and links to the upgrade blog post.

## Blocker before landing

The blog link points at `https://shorebird.dev/blog/introducing-shorebirds-upgraded-auth-service`, which **does not exist yet**. The post needs to be published (or the slug confirmed) before this merges.

## Test plan

- [x] `dart test test/src/auth/auth_test.dart` — 48/48 pass.
- [x] Updated existing Google-CiToken test to match new wording.
- [x] New test: Microsoft-backed CiToken — warning fires with the same wording.
- [x] New test: Shorebird-issued CiToken — `verifyNever(logger.warn)`.
- [x] `dart analyze --fatal-warnings lib/src/auth/auth.dart test/src/auth/auth_test.dart` — only pre-existing `applicationConfigHome` deprecation infos.