### PR TITLE
feat(protocol): Add prefetch candidate release versions

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_response.dart
@@ -12,6 +12,7 @@ class PatchCheckResponse {
     required this.patchAvailable,
     this.patch,
     this.rolledBackPatchNumbers,
+    this.availableReleaseVersions,
   });
 
   /// Converts a `Map<String, dynamic>` to a [PatchCheckResponse].
@@ -26,6 +27,8 @@ class PatchCheckResponse {
         ),
         rolledBackPatchNumbers: (json['rolled_back_patch_numbers'] as List?)
             ?.cast<int>(),
+        availableReleaseVersions: (json['available_release_versions'] as List?)
+            ?.cast<String>(),
       ),
     );
   }
@@ -50,12 +53,17 @@ class PatchCheckResponse {
   /// release.
   final List<int>? rolledBackPatchNumbers;
 
+  /// Server-selected release versions on the same app/channel/platform/arch
+  /// that the client may prefetch before the native binary updates.
+  final List<String>? availableReleaseVersions;
+
   /// Converts a [PatchCheckResponse] to a `Map<String, dynamic>`.
   Map<String, dynamic> toJson() {
     return {
       'patch_available': patchAvailable,
       'patch': patch?.toJson(),
       'rolled_back_patch_numbers': rolledBackPatchNumbers,
+      'available_release_versions': availableReleaseVersions,
     };
   }
 
@@ -64,6 +72,7 @@ class PatchCheckResponse {
     patchAvailable,
     patch,
     listHash(rolledBackPatchNumbers),
+    listHash(availableReleaseVersions),
   ]);
 
   @override
@@ -72,6 +81,7 @@ class PatchCheckResponse {
     return other is PatchCheckResponse &&
         patchAvailable == other.patchAvailable &&
         patch == other.patch &&
-        listsEqual(rolledBackPatchNumbers, other.rolledBackPatchNumbers);
+        listsEqual(rolledBackPatchNumbers, other.rolledBackPatchNumbers) &&
+        listsEqual(availableReleaseVersions, other.availableReleaseVersions);
   }
 }

--- a/packages/shorebird_code_push_protocol/test/src/messages/patch_check/patch_check_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/patch_check/patch_check_response_test.dart
@@ -26,6 +26,7 @@ void main() {
         'patch_available': true,
         'patch': null,
         'rolled_back_patch_numbers': null,
+        'available_release_versions': null,
       });
     });
 
@@ -81,6 +82,7 @@ void main() {
           'hash_signature': null,
         },
         'rolled_back_patch_numbers': null,
+        'available_release_versions': null,
       });
     });
 
@@ -104,6 +106,7 @@ void main() {
             'hash_signature': 'signature',
           },
           'rolled_back_patch_numbers': null,
+          'available_release_versions': null,
         });
       });
     });
@@ -118,6 +121,7 @@ void main() {
           'patch_available': true,
           'patch': null,
           'rolled_back_patch_numbers': [1, 2, 3],
+          'available_release_versions': null,
         });
       });
 
@@ -127,6 +131,32 @@ void main() {
           'rolled_back_patch_numbers': [1, 2, 3],
         });
         expect(response.rolledBackPatchNumbers, equals([1, 2, 3]));
+      });
+    });
+
+    group('when available release versions are provided', () {
+      test('includes the available release versions', () {
+        const response = PatchCheckResponse(
+          patchAvailable: false,
+          availableReleaseVersions: ['1.0.1+2', '1.0.2+3'],
+        );
+        expect(response.toJson(), {
+          'patch_available': false,
+          'patch': null,
+          'rolled_back_patch_numbers': null,
+          'available_release_versions': ['1.0.1+2', '1.0.2+3'],
+        });
+      });
+
+      test('parses available release versions from json', () {
+        final response = PatchCheckResponse.fromJson(const {
+          'patch_available': false,
+          'available_release_versions': ['1.0.1+2', '1.0.2+3'],
+        });
+        expect(
+          response.availableReleaseVersions,
+          equals(['1.0.1+2', '1.0.2+3']),
+        );
       });
     });
   });


### PR DESCRIPTION
Part of a proposed solution to close shorebirdtech/shorebird#3755, along with shorebirdtech/updater#357.

## Summary

Adds an optional `available_release_versions` field to `PatchCheckResponse`, exposed in Dart as `availableReleaseVersions`, so the server can advertise same app/channel/platform/arch release versions that clients may prefetch before a native binary update.

This is intentionally a draft because `shorebird_code_push_protocol` is generated from the public OpenAPI schema, and the live schema at https://api.shorebird.dev/openapi.json does not expose this field yet. The final version should likely come from the server/OpenAPI source of truth and then regenerate this package.

## Why this exists

The updater-side proof of concept in shorebirdtech/updater#357 can consume server-advertised prefetch candidates, but the updater cannot safely infer future release versions on its own. Release versions are app/store strings, and the backend should own candidate selection for the same track.

## Scope

- Adds `PatchCheckResponse.availableReleaseVersions`.
- Includes the field in JSON serialization/deserialization, equality, and hash code.
- Adds tests for JSON behavior and parsing.

## Still required elsewhere

- Private API/server work to populate `available_release_versions`, or an equivalent server-owned candidate field.
- Public OpenAPI regeneration so this package is updated from the actual schema source.
- Updater-side client behavior in shorebirdtech/updater#357.

## Test plan

- `dart format --set-exit-if-changed packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_response.dart packages/shorebird_code_push_protocol/test/src/messages/patch_check/patch_check_response_test.dart`
- `dart analyze packages/shorebird_code_push_protocol`
- `dart test packages/shorebird_code_push_protocol`

Local result: `dart test packages/shorebird_code_push_protocol` passes with 233 tests.
