### PR TITLE
feat(artifact_proxy): allow Flutter 3.44+ iOS USB dependency URLs

### DIFF
--- a/packages/artifact_proxy/lib/config.dart
+++ b/packages/artifact_proxy/lib/config.dart
@@ -122,6 +122,7 @@ final engineArtifactPatterns = {
 
 /// Patterns for Flutter artifacts which don't depend on an engine revision.
 final flutterArtifactPatterns = {
+  // Pre-3.44 layout: ios-usb-dependencies/<artifact>/<hash>/<artifact>.zip
   r'flutter_infra_release\/ios-usb-dependencies\/usbmuxd\/(.*)\/usbmuxd\.zip',
   r'flutter_infra_release\/ios-usb-dependencies\/libusbmuxd\/(.*)\/libusbmuxd\.zip',
   r'flutter_infra_release\/ios-usb-dependencies\/openssl\/(.*)\/openssl\.zip',
@@ -129,6 +130,17 @@ final flutterArtifactPatterns = {
   r'flutter_infra_release\/ios-usb-dependencies\/libimobiledevice\/(.*)\/libimobiledevice\.zip',
   r'flutter_infra_release\/ios-usb-dependencies\/libimobiledeviceglue\/(.*)\/libimobiledeviceglue\.zip',
   r'flutter_infra_release\/ios-usb-dependencies\/ios-deploy\/(.*)\/ios-deploy\.zip',
+  // 3.44+ layout: ios-usb-dependencies/arm64_x86_64/<artifact>/<hash>/<artifact>.zip
+  // Flutter 3.44 (flutter/flutter#181539 + related) reorganized iOS USB
+  // dependency URLs to namespace by architecture. Upstream GCS serves both
+  // layouts; we list both so customers on either Flutter version resolve.
+  r'flutter_infra_release\/ios-usb-dependencies\/arm64_x86_64\/usbmuxd\/(.*)\/usbmuxd\.zip',
+  r'flutter_infra_release\/ios-usb-dependencies\/arm64_x86_64\/libusbmuxd\/(.*)\/libusbmuxd\.zip',
+  r'flutter_infra_release\/ios-usb-dependencies\/arm64_x86_64\/openssl\/(.*)\/openssl\.zip',
+  r'flutter_infra_release\/ios-usb-dependencies\/arm64_x86_64\/libplist\/(.*)\/libplist\.zip',
+  r'flutter_infra_release\/ios-usb-dependencies\/arm64_x86_64\/libimobiledevice\/(.*)\/libimobiledevice\.zip',
+  r'flutter_infra_release\/ios-usb-dependencies\/arm64_x86_64\/libimobiledeviceglue\/(.*)\/libimobiledeviceglue\.zip',
+  r'flutter_infra_release\/ios-usb-dependencies\/arm64_x86_64\/ios-deploy\/(.*)\/ios-deploy\.zip',
   r'flutter_infra_release\/gradle-wrapper\/(.*)\/gradle-wrapper\.tgz',
   r'flutter_infra_release\/flutter\/fonts\/(.*)\/fonts\.zip',
   r'flutter_infra_release\/cipd\/flutter\/web\/canvaskit_bundle\/\+\/(.*)',


### PR DESCRIPTION
Flutter 3.44 reorganized iOS USB artifact URLs from

```
ios-usb-dependencies/<artifact>/<hash>/<artifact>.zip
```

to

```
ios-usb-dependencies/arm64_x86_64/<artifact>/<hash>/<artifact>.zip
```

(see flutter/flutter#181539 and related). Upstream GCS serves both layouts indefinitely, but the proxy's allowlist only recognized the pre-3.44 shape. Without this change, every 3.44+ customer hits `404` on their first iOS or Android build during `flutter precache` (libimobiledevice, ios-deploy, etc.).

Reproduction before the fix:

```
$ curl -sI https://download.shorebird.dev/flutter_infra_release/ios-usb-dependencies/arm64_x86_64/libimobiledevice/0bf0f9e941c85d06ce4b5909d7a61b3a4f2a6a05/libimobiledevice.zip | head -1
HTTP/2 404
```

This adds an `arm64_x86_64/` variant of each of the seven `ios-usb-dependencies` patterns. The pre-3.44 patterns are preserved so customers pinned to older Flutter versions keep resolving against the old layout.

Blocker for Flutter 3.44 release. Customers' first iOS/Android build on a 3.44 pin will 404 until this deploys.

## Test plan

- [x] `dart analyze lib/` clean
- [x] `dart test` (11/11 existing proxy tests still pass)
- [ ] After deploy: `curl -sI .../arm64_x86_64/libimobiledevice/<hash>/libimobiledevice.zip` returns 302 to storage.googleapis.com
- [ ] After deploy: `curl -sI .../libimobiledevice/<hash>/libimobiledevice.zip` (no arm64_x86_64 segment) still returns 302