### PR TITLE
feat(ci): add required aggregator job to shorebird_ci workflow

### DIFF
--- a/.github/workflows/shorebird_ci.yaml
+++ b/.github/workflows/shorebird_ci.yaml
@@ -228,3 +228,32 @@ jobs:
           incremental_files_only: false
           config: cspell.config.yaml
 
+  required:
+    name: required
+    if: ${{ always() }}
+    needs:
+      - changes
+      - artifact_proxy
+      - dex
+      - discord_gcp_alerts
+      - flutter_version_resolver
+      - jwt
+      - scoped_deps
+      - shorebird_build_trace
+      - shorebird_ci
+      - shorebird_cli
+      - shorebird_code_push_client
+      - shorebird_code_push_protocol
+      - shorebird_redis_client
+      - stripe_api
+      - cspell
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required jobs
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed (or were skipped because nothing changed)."
+


### PR DESCRIPTION
## Summary
- Adds a single `required` job that depends on every other job in `shorebird_ci.yaml`. Use it as the one required check in branch protection so per-package jobs can stay path-filtered (skipped jobs don't block merges, but real failures still do).
- Generated w/ `shorebird_ci generate --style static --required`.

## Testing
- `shorebird_ci verify` passes — `required.needs` matches the job list