### PR TITLE
ci(publish): start redis container before testing shorebird_redis_client

### DIFF
--- a/.github/workflows/publish_dart_package.yaml
+++ b/.github/workflows/publish_dart_package.yaml
@@ -14,6 +14,13 @@ on:
         description: |
           Tag prefix expected for this package (e.g., "shorebird_ci-v"). The
           version after the prefix must match the version in pubspec.yaml.
+      needs_redis:
+        required: false
+        default: false
+        type: boolean
+        description: |
+          Start a redis/redis-stack-server container before running tests.
+          Required for packages whose test suite connects to Redis.
 
 jobs:
   publish:
@@ -25,6 +32,12 @@ jobs:
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v6
+
+      - name: 🐳 Run Redis
+        if: inputs.needs_redis
+        run: |
+          docker pull redis/redis-stack-server:latest
+          docker run --name test_redis -d -p 6379:6379 --rm -e REDIS_ARGS="--requirepass password" redis/redis-stack-server:latest
 
       - name: 🎯 Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/publish_shorebird_redis_client.yaml
+++ b/.github/workflows/publish_shorebird_redis_client.yaml
@@ -11,5 +11,6 @@ jobs:
     with:
       working_directory: packages/redis_client
       tag_prefix: shorebird_redis_client-v
+      needs_redis: true
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary

The shared `publish_dart_package.yaml` workflow runs `dart test` as a pre-publish gate but did not start a Redis instance. That caused the `shorebird_redis_client` v0.0.13 publish to fail w/ `Connection retry limit exceeded` on every test that connects.

- Added a `needs_redis` boolean input to `publish_dart_package.yaml`, default `false`. When true, the workflow starts `redis/redis-stack-server:latest` before tests, byte-for-byte the same step `main.yaml` and `_shorebird_ci_dart.yaml` already use
- `publish_shorebird_redis_client.yaml` opts in. The other two callers (`publish_shorebird_ci.yaml`, `publish_scoped_deps.yaml`) leave the flag unset and behave identically
- No pubspec or CHANGELOG churn. The v0.0.13 tag never reached pub.dev, so I'll delete and recreate it at the new `main` HEAD after this lands. v0.0.13 keeps its number

## Testing

- Same docker step ran for ~50s in CI on PR #3796 and produced 22 passing tests against a live Redis. The publish workflow runs `dart test`, which is exactly that suite