### PR TITLE
feat(shorebird_code_push_protocol): add unique-users metric API surface

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -74,6 +74,7 @@ words:
   - LOCALAPPDATA
   - logcat
   - longpaths
+  - lookback # active-hours "best time to release" lookback window
   - lproj
   - madd # From ./packages/redis_client
   - mbps

--- a/packages/shorebird_code_push_protocol/lib/shorebird_code_push_protocol.dart
+++ b/packages/shorebird_code_push_protocol/lib/shorebird_code_push_protocol.dart
@@ -23,6 +23,7 @@ export 'package:shorebird_code_push_protocol/src/messages/create_release_artifac
 export 'package:shorebird_code_push_protocol/src/messages/create_release_artifact/create_release_artifact_response.dart';
 export 'package:shorebird_code_push_protocol/src/messages/create_user/create_user_request.dart';
 export 'package:shorebird_code_push_protocol/src/messages/error_response.dart';
+export 'package:shorebird_code_push_protocol/src/messages/get_active_hours/get_active_hours_response.dart';
 export 'package:shorebird_code_push_protocol/src/messages/get_apps/get_apps_response.dart';
 export 'package:shorebird_code_push_protocol/src/messages/get_gcp_download_speed_test_url/get_gcp_download_speed_test_url200_response.dart';
 export 'package:shorebird_code_push_protocol/src/messages/get_gcp_upload_speed_test_url/get_gcp_upload_speed_test_url200_response.dart';
@@ -41,6 +42,7 @@ export 'package:shorebird_code_push_protocol/src/messages/promote_patch/promote_
 export 'package:shorebird_code_push_protocol/src/messages/update_app_collaborator/update_app_collaborator_request.dart';
 export 'package:shorebird_code_push_protocol/src/messages/update_patch/update_patch_request.dart';
 export 'package:shorebird_code_push_protocol/src/messages/update_release/update_release_request.dart';
+export 'package:shorebird_code_push_protocol/src/models/active_hour_entry.dart';
 export 'package:shorebird_code_push_protocol/src/models/app.dart';
 export 'package:shorebird_code_push_protocol/src/models/app_collaborator_role.dart';
 export 'package:shorebird_code_push_protocol/src/models/app_metadata.dart';

--- a/packages/shorebird_code_push_protocol/lib/shorebird_code_push_protocol.dart
+++ b/packages/shorebird_code_push_protocol/lib/shorebird_code_push_protocol.dart
@@ -35,6 +35,7 @@ export 'package:shorebird_code_push_protocol/src/messages/get_release/get_releas
 export 'package:shorebird_code_push_protocol/src/messages/get_release_artifacts/get_release_artifacts_response.dart';
 export 'package:shorebird_code_push_protocol/src/messages/get_release_patches/get_release_patches_response.dart';
 export 'package:shorebird_code_push_protocol/src/messages/get_releases/get_releases_response.dart';
+export 'package:shorebird_code_push_protocol/src/messages/get_unique_users/get_unique_users_response.dart';
 export 'package:shorebird_code_push_protocol/src/messages/get_version_distribution/get_version_distribution_response.dart';
 export 'package:shorebird_code_push_protocol/src/messages/patch_check/patch_check_request.dart';
 export 'package:shorebird_code_push_protocol/src/messages/patch_check/patch_check_response.dart';
@@ -48,6 +49,8 @@ export 'package:shorebird_code_push_protocol/src/models/app_collaborator_role.da
 export 'package:shorebird_code_push_protocol/src/models/app_metadata.dart';
 export 'package:shorebird_code_push_protocol/src/models/channel.dart';
 export 'package:shorebird_code_push_protocol/src/models/get_patch_adoption_parameter3.dart';
+export 'package:shorebird_code_push_protocol/src/models/get_unique_users_parameter2.dart';
+export 'package:shorebird_code_push_protocol/src/models/get_unique_users_parameter3.dart';
 export 'package:shorebird_code_push_protocol/src/models/latest_release.dart';
 export 'package:shorebird_code_push_protocol/src/models/organization.dart';
 export 'package:shorebird_code_push_protocol/src/models/organization_membership.dart';
@@ -69,6 +72,9 @@ export 'package:shorebird_code_push_protocol/src/models/release_patch.dart';
 export 'package:shorebird_code_push_protocol/src/models/release_platform.dart';
 export 'package:shorebird_code_push_protocol/src/models/release_status.dart';
 export 'package:shorebird_code_push_protocol/src/models/role.dart';
+export 'package:shorebird_code_push_protocol/src/models/unique_users_breakdown_entry.dart';
+export 'package:shorebird_code_push_protocol/src/models/unique_users_range.dart';
+export 'package:shorebird_code_push_protocol/src/models/unique_users_time_series_entry.dart';
 export 'package:shorebird_code_push_protocol/src/models/version_distribution_entry.dart';
 
 /// Parsed JSON data.

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_active_hours/get_active_hours_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_active_hours/get_active_hours_response.dart
@@ -1,0 +1,110 @@
+import 'package:meta/meta.dart';
+import 'package:shorebird_code_push_protocol/model_helpers.dart';
+import 'package:shorebird_code_push_protocol/src/models/active_hour_entry.dart';
+
+/// {@template get_active_hours_response}
+/// The response body for GET /apps/{appId}/metrics/active-hours. Powers the
+/// "best time to release" recommendation: the consecutive low-activity UTC
+/// window when the app's users are least active.
+/// {@endtemplate}
+@immutable
+class GetActiveHoursResponse {
+  /// {@macro get_active_hours_response}
+  const GetActiveHoursResponse({
+    required this.hourly,
+    required this.recommendedWindowStartUtc,
+    required this.recommendedWindowLengthHours,
+    required this.busiestHourUtc,
+    required this.lookbackDays,
+    required this.asOf,
+  });
+
+  /// Converts a `Map<String, dynamic>` to a [GetActiveHoursResponse].
+  factory GetActiveHoursResponse.fromJson(Map<String, dynamic> json) {
+    return parseFromJson(
+      'GetActiveHoursResponse',
+      json,
+      () => GetActiveHoursResponse(
+        hourly: (json['hourly'] as List)
+            .map<ActiveHourEntry>(
+              (e) => ActiveHourEntry.fromJson(e as Map<String, dynamic>),
+            )
+            .toList(),
+        recommendedWindowStartUtc:
+            checkedKey(json, 'recommended_window_start_utc') as int?,
+        recommendedWindowLengthHours:
+            json['recommended_window_length_hours'] as int,
+        busiestHourUtc: checkedKey(json, 'busiest_hour_utc') as int?,
+        lookbackDays: json['lookback_days'] as int,
+        asOf: DateTime.parse(json['as_of'] as String),
+      ),
+    );
+  }
+
+  /// Convenience to create a nullable type from a nullable json object.
+  /// Useful when parsing optional fields.
+  static GetActiveHoursResponse? maybeFromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return null;
+    }
+    return GetActiveHoursResponse.fromJson(json);
+  }
+
+  /// One entry per UTC hour: 24 entries, hour_utc 0–23, zero-filled,
+  /// ordered by hour_utc ascending.
+  final List<ActiveHourEntry> hourly;
+
+  /// Start hour (UTC, 0–23) of the lowest-activity consecutive window —
+  /// the recommended time to release. The window wraps past midnight.
+  /// Null when there is insufficient data (fewer than 7 days).
+  final int? recommendedWindowStartUtc;
+
+  /// Length of the recommended window in hours. Fixed at 2 in v1.
+  final int recommendedWindowLengthHours;
+
+  /// UTC hour (0–23) with the highest average active devices, for
+  /// contrast in the recommendation copy. Null when insufficient data.
+  final int? busiestHourUtc;
+
+  /// Number of days of history the profile is computed over.
+  final int lookbackDays;
+
+  /// Server's UTC timestamp at the moment the response was constructed.
+  /// Not a freshness indicator for the underlying data, which is
+  /// refreshed by an hourly scheduled query and may lag by up to ~1 hour.
+  final DateTime asOf;
+
+  /// Converts a [GetActiveHoursResponse] to a `Map<String, dynamic>`.
+  Map<String, dynamic> toJson() {
+    return {
+      'hourly': hourly.map((e) => e.toJson()).toList(),
+      'recommended_window_start_utc': recommendedWindowStartUtc,
+      'recommended_window_length_hours': recommendedWindowLengthHours,
+      'busiest_hour_utc': busiestHourUtc,
+      'lookback_days': lookbackDays,
+      'as_of': asOf.toIso8601String(),
+    };
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+    listHash(hourly),
+    recommendedWindowStartUtc,
+    recommendedWindowLengthHours,
+    busiestHourUtc,
+    lookbackDays,
+    asOf,
+  ]);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetActiveHoursResponse &&
+        listsEqual(hourly, other.hourly) &&
+        recommendedWindowStartUtc == other.recommendedWindowStartUtc &&
+        recommendedWindowLengthHours == other.recommendedWindowLengthHours &&
+        busiestHourUtc == other.busiestHourUtc &&
+        lookbackDays == other.lookbackDays &&
+        asOf == other.asOf;
+  }
+}

--- a/packages/shorebird_code_push_protocol/lib/src/messages/get_unique_users/get_unique_users_response.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/get_unique_users/get_unique_users_response.dart
@@ -1,0 +1,114 @@
+import 'package:meta/meta.dart';
+import 'package:shorebird_code_push_protocol/model_helpers.dart';
+import 'package:shorebird_code_push_protocol/src/models/unique_users_breakdown_entry.dart';
+import 'package:shorebird_code_push_protocol/src/models/unique_users_range.dart';
+import 'package:shorebird_code_push_protocol/src/models/unique_users_time_series_entry.dart';
+
+/// {@template get_unique_users_response}
+/// The response body for GET /apps/{appId}/metrics/unique-users.
+/// {@endtemplate}
+@immutable
+class GetUniqueUsersResponse {
+  /// {@macro get_unique_users_response}
+  const GetUniqueUsersResponse({
+    required this.uniqueUsers,
+    required this.granularity,
+    required this.range,
+    required this.asOf,
+    this.timeSeries,
+    this.breakdown,
+  });
+
+  /// Converts a `Map<String, dynamic>` to a [GetUniqueUsersResponse].
+  factory GetUniqueUsersResponse.fromJson(Map<String, dynamic> json) {
+    return parseFromJson(
+      'GetUniqueUsersResponse',
+      json,
+      () => GetUniqueUsersResponse(
+        uniqueUsers: json['unique_users'] as int,
+        granularity: checkedKey(json, 'granularity') as String?,
+        range: UniqueUsersRange.fromJson(json['range'] as Map<String, dynamic>),
+        asOf: DateTime.parse(json['as_of'] as String),
+        timeSeries: (json['time_series'] as List?)
+            ?.map<UniqueUsersTimeSeriesEntry>(
+              (e) => UniqueUsersTimeSeriesEntry.fromJson(
+                e as Map<String, dynamic>,
+              ),
+            )
+            .toList(),
+        breakdown: (json['breakdown'] as List?)
+            ?.map<UniqueUsersBreakdownEntry>(
+              (e) =>
+                  UniqueUsersBreakdownEntry.fromJson(e as Map<String, dynamic>),
+            )
+            .toList(),
+      ),
+    );
+  }
+
+  /// Convenience to create a nullable type from a nullable json object.
+  /// Useful when parsing optional fields.
+  static GetUniqueUsersResponse? maybeFromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return null;
+    }
+    return GetUniqueUsersResponse.fromJson(json);
+  }
+
+  /// Distinct active devices over the whole window (an HLL count).
+  final int uniqueUsers;
+
+  /// The time-series bucket resolution (`hour`, `day`, `week`, or
+  /// `month`), or null when no time series was requested.
+  final String? granularity;
+
+  /// The window the unique-users response covers.
+  final UniqueUsersRange range;
+
+  /// Server's UTC timestamp at the moment the response was constructed.
+  /// Not a freshness indicator for the underlying data, which is
+  /// refreshed by an hourly scheduled query and may lag by up to ~1 hour.
+  final DateTime asOf;
+
+  /// The top-level time series, present only when a `granularity` was
+  /// requested; otherwise null.
+  final List<UniqueUsersTimeSeriesEntry>? timeSeries;
+
+  /// Per-group unique users, present only when a `group_by` was
+  /// requested; otherwise null.
+  final List<UniqueUsersBreakdownEntry>? breakdown;
+
+  /// Converts a [GetUniqueUsersResponse] to a `Map<String, dynamic>`.
+  Map<String, dynamic> toJson() {
+    return {
+      'unique_users': uniqueUsers,
+      'granularity': granularity,
+      'range': range.toJson(),
+      'as_of': asOf.toIso8601String(),
+      'time_series': timeSeries?.map((e) => e.toJson()).toList(),
+      'breakdown': breakdown?.map((e) => e.toJson()).toList(),
+    };
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+    uniqueUsers,
+    granularity,
+    range,
+    asOf,
+    listHash(timeSeries),
+    listHash(breakdown),
+  ]);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetUniqueUsersResponse &&
+        uniqueUsers == other.uniqueUsers &&
+        granularity == other.granularity &&
+        range == other.range &&
+        asOf == other.asOf &&
+        listsEqual(timeSeries, other.timeSeries) &&
+        listsEqual(breakdown, other.breakdown);
+  }
+}

--- a/packages/shorebird_code_push_protocol/lib/src/models/active_hour_entry.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/active_hour_entry.dart
@@ -1,0 +1,67 @@
+import 'package:meta/meta.dart';
+import 'package:shorebird_code_push_protocol/model_helpers.dart';
+
+/// {@template active_hour_entry}
+/// Average number of distinct active devices during one UTC hour-of-day,
+/// averaged across all days in the lookback window (days with no activity
+/// in that hour count as zero).
+/// {@endtemplate}
+@immutable
+class ActiveHourEntry {
+  /// {@macro active_hour_entry}
+  const ActiveHourEntry({
+    required this.hourUtc,
+    required this.averageActiveDevices,
+  });
+
+  /// Converts a `Map<String, dynamic>` to an [ActiveHourEntry].
+  factory ActiveHourEntry.fromJson(Map<String, dynamic> json) {
+    return parseFromJson(
+      'ActiveHourEntry',
+      json,
+      () => ActiveHourEntry(
+        hourUtc: json['hour_utc'] as int,
+        averageActiveDevices: (json['average_active_devices'] as num)
+            .toDouble(),
+      ),
+    );
+  }
+
+  /// Convenience to create a nullable type from a nullable json object.
+  /// Useful when parsing optional fields.
+  static ActiveHourEntry? maybeFromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return null;
+    }
+    return ActiveHourEntry.fromJson(json);
+  }
+
+  /// Hour of day in UTC, 0–23.
+  final int hourUtc;
+
+  /// Mean distinct active devices seen during this UTC hour, averaged
+  /// over the lookback window with implicit zeros included.
+  final double averageActiveDevices;
+
+  /// Converts an [ActiveHourEntry] to a `Map<String, dynamic>`.
+  Map<String, dynamic> toJson() {
+    return {
+      'hour_utc': hourUtc,
+      'average_active_devices': averageActiveDevices,
+    };
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+    hourUtc,
+    averageActiveDevices,
+  ]);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ActiveHourEntry &&
+        hourUtc == other.hourUtc &&
+        averageActiveDevices == other.averageActiveDevices;
+  }
+}

--- a/packages/shorebird_code_push_protocol/lib/src/models/get_unique_users_parameter2.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/get_unique_users_parameter2.dart
@@ -1,0 +1,38 @@
+enum GetUniqueUsersParameter2 {
+  hour._('hour'),
+  day._('day'),
+  week._('week'),
+  month._('month');
+
+  const GetUniqueUsersParameter2._(this.value);
+
+  /// Creates a GetUniqueUsersParameter2 from a json value.
+  factory GetUniqueUsersParameter2.fromJson(String json) {
+    return GetUniqueUsersParameter2.values.firstWhere(
+      (value) => value.value == json,
+      orElse: () => throw FormatException(
+        'Unknown GetUniqueUsersParameter2 value: $json',
+      ),
+    );
+  }
+
+  /// Convenience to create a nullable type from a nullable json value.
+  /// Useful when parsing optional fields.
+  static GetUniqueUsersParameter2? maybeFromJson(String? json) {
+    if (json == null) {
+      return null;
+    }
+    return GetUniqueUsersParameter2.fromJson(json);
+  }
+
+  /// The value of the enum.  This is the exact value
+  /// from the OpenAPI spec and will be used for network transport.
+  final String value;
+
+  /// Converts the enum to its json value.
+  String toJson() => value;
+
+  /// Returns the string form of the enum.
+  @override
+  String toString() => value;
+}

--- a/packages/shorebird_code_push_protocol/lib/src/models/get_unique_users_parameter3.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/get_unique_users_parameter3.dart
@@ -1,0 +1,35 @@
+enum GetUniqueUsersParameter3 {
+  platform._('platform');
+
+  const GetUniqueUsersParameter3._(this.value);
+
+  /// Creates a GetUniqueUsersParameter3 from a json value.
+  factory GetUniqueUsersParameter3.fromJson(String json) {
+    return GetUniqueUsersParameter3.values.firstWhere(
+      (value) => value.value == json,
+      orElse: () => throw FormatException(
+        'Unknown GetUniqueUsersParameter3 value: $json',
+      ),
+    );
+  }
+
+  /// Convenience to create a nullable type from a nullable json value.
+  /// Useful when parsing optional fields.
+  static GetUniqueUsersParameter3? maybeFromJson(String? json) {
+    if (json == null) {
+      return null;
+    }
+    return GetUniqueUsersParameter3.fromJson(json);
+  }
+
+  /// The value of the enum.  This is the exact value
+  /// from the OpenAPI spec and will be used for network transport.
+  final String value;
+
+  /// Converts the enum to its json value.
+  String toJson() => value;
+
+  /// Returns the string form of the enum.
+  @override
+  String toString() => value;
+}

--- a/packages/shorebird_code_push_protocol/lib/src/models/unique_users_breakdown_entry.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/unique_users_breakdown_entry.dart
@@ -1,0 +1,89 @@
+import 'package:meta/meta.dart';
+import 'package:shorebird_code_push_protocol/model_helpers.dart';
+import 'package:shorebird_code_push_protocol/src/models/unique_users_time_series_entry.dart';
+
+/// {@template unique_users_breakdown_entry}
+/// Unique users for one value of the `group_by` dimension (e.g. one
+/// platform), optionally with its own time series.
+/// {@endtemplate}
+@immutable
+class UniqueUsersBreakdownEntry {
+  /// {@macro unique_users_breakdown_entry}
+  const UniqueUsersBreakdownEntry({
+    required this.groupBy,
+    required this.groupValue,
+    required this.uniqueUsers,
+    this.timeSeries,
+  });
+
+  /// Converts a `Map<String, dynamic>` to a [UniqueUsersBreakdownEntry].
+  factory UniqueUsersBreakdownEntry.fromJson(Map<String, dynamic> json) {
+    return parseFromJson(
+      'UniqueUsersBreakdownEntry',
+      json,
+      () => UniqueUsersBreakdownEntry(
+        groupBy: json['group_by'] as String,
+        groupValue: json['group_value'] as String,
+        uniqueUsers: json['unique_users'] as int,
+        timeSeries: (json['time_series'] as List?)
+            ?.map<UniqueUsersTimeSeriesEntry>(
+              (e) => UniqueUsersTimeSeriesEntry.fromJson(
+                e as Map<String, dynamic>,
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+
+  /// Convenience to create a nullable type from a nullable json object.
+  /// Useful when parsing optional fields.
+  static UniqueUsersBreakdownEntry? maybeFromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return null;
+    }
+    return UniqueUsersBreakdownEntry.fromJson(json);
+  }
+
+  /// The dimension this entry breaks down by (e.g. "platform").
+  final String groupBy;
+
+  /// The value within `group_by` (e.g. "android").
+  final String groupValue;
+
+  /// Distinct active devices for this group over the window (an HLL
+  /// count).
+  final int uniqueUsers;
+
+  /// Per-bucket series for this group, present only when a `granularity`
+  /// was requested; otherwise null.
+  final List<UniqueUsersTimeSeriesEntry>? timeSeries;
+
+  /// Converts a [UniqueUsersBreakdownEntry] to a `Map<String, dynamic>`.
+  Map<String, dynamic> toJson() {
+    return {
+      'group_by': groupBy,
+      'group_value': groupValue,
+      'unique_users': uniqueUsers,
+      'time_series': timeSeries?.map((e) => e.toJson()).toList(),
+    };
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+    groupBy,
+    groupValue,
+    uniqueUsers,
+    listHash(timeSeries),
+  ]);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is UniqueUsersBreakdownEntry &&
+        groupBy == other.groupBy &&
+        groupValue == other.groupValue &&
+        uniqueUsers == other.uniqueUsers &&
+        listsEqual(timeSeries, other.timeSeries);
+  }
+}

--- a/packages/shorebird_code_push_protocol/lib/src/models/unique_users_range.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/unique_users_range.dart
@@ -1,0 +1,63 @@
+import 'package:meta/meta.dart';
+import 'package:shorebird_code_push_protocol/model_helpers.dart';
+
+/// {@template unique_users_range}
+/// The window the unique-users response covers.
+/// {@endtemplate}
+@immutable
+class UniqueUsersRange {
+  /// {@macro unique_users_range}
+  const UniqueUsersRange({
+    required this.start,
+    required this.end,
+  });
+
+  /// Converts a `Map<String, dynamic>` to a [UniqueUsersRange].
+  factory UniqueUsersRange.fromJson(Map<String, dynamic> json) {
+    return parseFromJson(
+      'UniqueUsersRange',
+      json,
+      () => UniqueUsersRange(
+        start: DateTime.parse(json['start'] as String),
+        end: DateTime.parse(json['end'] as String),
+      ),
+    );
+  }
+
+  /// Convenience to create a nullable type from a nullable json object.
+  /// Useful when parsing optional fields.
+  static UniqueUsersRange? maybeFromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return null;
+    }
+    return UniqueUsersRange.fromJson(json);
+  }
+
+  /// Window start (UTC, inclusive).
+  final DateTime start;
+
+  /// Window end (UTC, exclusive).
+  final DateTime end;
+
+  /// Converts a [UniqueUsersRange] to a `Map<String, dynamic>`.
+  Map<String, dynamic> toJson() {
+    return {
+      'start': start.toIso8601String(),
+      'end': end.toIso8601String(),
+    };
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+    start,
+    end,
+  ]);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is UniqueUsersRange &&
+        start == other.start &&
+        end == other.end;
+  }
+}

--- a/packages/shorebird_code_push_protocol/lib/src/models/unique_users_time_series_entry.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/models/unique_users_time_series_entry.dart
@@ -1,0 +1,64 @@
+import 'package:meta/meta.dart';
+import 'package:shorebird_code_push_protocol/model_helpers.dart';
+
+/// {@template unique_users_time_series_entry}
+/// One bucket of a unique-users time series: the HLL count of distinct
+/// active devices in the bucket starting at `period`.
+/// {@endtemplate}
+@immutable
+class UniqueUsersTimeSeriesEntry {
+  /// {@macro unique_users_time_series_entry}
+  const UniqueUsersTimeSeriesEntry({
+    required this.period,
+    required this.uniqueUsers,
+  });
+
+  /// Converts a `Map<String, dynamic>` to a [UniqueUsersTimeSeriesEntry].
+  factory UniqueUsersTimeSeriesEntry.fromJson(Map<String, dynamic> json) {
+    return parseFromJson(
+      'UniqueUsersTimeSeriesEntry',
+      json,
+      () => UniqueUsersTimeSeriesEntry(
+        period: DateTime.parse(json['period'] as String),
+        uniqueUsers: json['unique_users'] as int,
+      ),
+    );
+  }
+
+  /// Convenience to create a nullable type from a nullable json object.
+  /// Useful when parsing optional fields.
+  static UniqueUsersTimeSeriesEntry? maybeFromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return null;
+    }
+    return UniqueUsersTimeSeriesEntry.fromJson(json);
+  }
+
+  /// The bucket start (UTC).
+  final DateTime period;
+
+  /// Distinct active devices in this bucket (an HLL count).
+  final int uniqueUsers;
+
+  /// Converts a [UniqueUsersTimeSeriesEntry] to a `Map<String, dynamic>`.
+  Map<String, dynamic> toJson() {
+    return {
+      'period': period.toIso8601String(),
+      'unique_users': uniqueUsers,
+    };
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+    period,
+    uniqueUsers,
+  ]);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is UniqueUsersTimeSeriesEntry &&
+        period == other.period &&
+        uniqueUsers == other.uniqueUsers;
+  }
+}

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_active_hours/get_active_hours_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_active_hours/get_active_hours_response_test.dart
@@ -1,0 +1,34 @@
+// GENERATED — do not hand-edit.
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GetActiveHoursResponse', () {
+    test('round-trips via maybeFromJson/toJson', () {
+      final instance = GetActiveHoursResponse(
+        hourly: const <ActiveHourEntry>[
+          ActiveHourEntry(hourUtc: 0, averageActiveDevices: 0),
+        ],
+        recommendedWindowStartUtc: 0,
+        recommendedWindowLengthHours: 0,
+        busiestHourUtc: 0,
+        lookbackDays: 0,
+        asOf: DateTime.utc(2024),
+      );
+      final parsed = GetActiveHoursResponse.maybeFromJson(instance.toJson())!;
+      expect(parsed, equals(instance));
+      expect(parsed.hashCode, equals(instance.hashCode));
+    });
+
+    test('maybeFromJson returns null on null input', () {
+      expect(GetActiveHoursResponse.maybeFromJson(null), isNull);
+    });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => GetActiveHoursResponse.maybeFromJson(<String, dynamic>{}),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/packages/shorebird_code_push_protocol/test/generated/messages/get_unique_users/get_unique_users_response_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/messages/get_unique_users/get_unique_users_response_test.dart
@@ -1,0 +1,33 @@
+// GENERATED — do not hand-edit.
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GetUniqueUsersResponse', () {
+    test('round-trips via maybeFromJson/toJson', () {
+      final instance = GetUniqueUsersResponse(
+        uniqueUsers: 0,
+        granularity: 'example',
+        range: UniqueUsersRange(
+          start: DateTime.utc(2024),
+          end: DateTime.utc(2024),
+        ),
+        asOf: DateTime.utc(2024),
+      );
+      final parsed = GetUniqueUsersResponse.maybeFromJson(instance.toJson());
+      expect(parsed, equals(instance));
+      expect(parsed.hashCode, equals(instance.hashCode));
+    });
+
+    test('maybeFromJson returns null on null input', () {
+      expect(GetUniqueUsersResponse.maybeFromJson(null), isNull);
+    });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => GetUniqueUsersResponse.maybeFromJson(<String, dynamic>{}),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/packages/shorebird_code_push_protocol/test/generated/models/active_hour_entry_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/active_hour_entry_test.dart
@@ -1,0 +1,25 @@
+// GENERATED — do not hand-edit.
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ActiveHourEntry', () {
+    test('round-trips via maybeFromJson/toJson', () {
+      const instance = ActiveHourEntry(hourUtc: 0, averageActiveDevices: 0);
+      final parsed = ActiveHourEntry.maybeFromJson(instance.toJson())!;
+      expect(parsed, equals(instance));
+      expect(parsed.hashCode, equals(instance.hashCode));
+    });
+
+    test('maybeFromJson returns null on null input', () {
+      expect(ActiveHourEntry.maybeFromJson(null), isNull);
+    });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => ActiveHourEntry.maybeFromJson(<String, dynamic>{}),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/packages/shorebird_code_push_protocol/test/generated/models/get_unique_users_parameter2_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/get_unique_users_parameter2_test.dart
@@ -1,0 +1,40 @@
+// GENERATED — do not hand-edit.
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GetUniqueUsersParameter2', () {
+    test('round-trips via maybeFromJson/toJson', () {
+      final instance = GetUniqueUsersParameter2.values.first;
+      final parsed = GetUniqueUsersParameter2.maybeFromJson(instance.toJson());
+      expect(parsed, equals(instance));
+      expect(parsed.hashCode, equals(instance.hashCode));
+    });
+
+    test('maybeFromJson returns null on null input', () {
+      expect(GetUniqueUsersParameter2.maybeFromJson(null), isNull);
+    });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => GetUniqueUsersParameter2.maybeFromJson('__invalid_enum_value__'),
+        throwsFormatException,
+      );
+    });
+
+    test('toString matches toJson for every value', () {
+      for (final value in GetUniqueUsersParameter2.values) {
+        expect(value.toString(), equals(value.toJson()));
+      }
+    });
+
+    test('fromJson round-trips every value', () {
+      for (final value in GetUniqueUsersParameter2.values) {
+        expect(
+          GetUniqueUsersParameter2.fromJson(value.toJson()),
+          equals(value),
+        );
+      }
+    });
+  });
+}

--- a/packages/shorebird_code_push_protocol/test/generated/models/get_unique_users_parameter3_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/get_unique_users_parameter3_test.dart
@@ -1,0 +1,40 @@
+// GENERATED — do not hand-edit.
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GetUniqueUsersParameter3', () {
+    test('round-trips via maybeFromJson/toJson', () {
+      final instance = GetUniqueUsersParameter3.values.first;
+      final parsed = GetUniqueUsersParameter3.maybeFromJson(instance.toJson());
+      expect(parsed, equals(instance));
+      expect(parsed.hashCode, equals(instance.hashCode));
+    });
+
+    test('maybeFromJson returns null on null input', () {
+      expect(GetUniqueUsersParameter3.maybeFromJson(null), isNull);
+    });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => GetUniqueUsersParameter3.maybeFromJson('__invalid_enum_value__'),
+        throwsFormatException,
+      );
+    });
+
+    test('toString matches toJson for every value', () {
+      for (final value in GetUniqueUsersParameter3.values) {
+        expect(value.toString(), equals(value.toJson()));
+      }
+    });
+
+    test('fromJson round-trips every value', () {
+      for (final value in GetUniqueUsersParameter3.values) {
+        expect(
+          GetUniqueUsersParameter3.fromJson(value.toJson()),
+          equals(value),
+        );
+      }
+    });
+  });
+}

--- a/packages/shorebird_code_push_protocol/test/generated/models/unique_users_breakdown_entry_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/unique_users_breakdown_entry_test.dart
@@ -1,0 +1,31 @@
+// GENERATED — do not hand-edit.
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('UniqueUsersBreakdownEntry', () {
+    test('round-trips via maybeFromJson/toJson', () {
+      final instance = UniqueUsersBreakdownEntry(
+        groupBy: 'example',
+        groupValue: 'example',
+        uniqueUsers: 0,
+      );
+      final parsed = UniqueUsersBreakdownEntry.maybeFromJson(
+        instance.toJson(),
+      );
+      expect(parsed, equals(instance));
+      expect(parsed.hashCode, equals(instance.hashCode));
+    });
+
+    test('maybeFromJson returns null on null input', () {
+      expect(UniqueUsersBreakdownEntry.maybeFromJson(null), isNull);
+    });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => UniqueUsersBreakdownEntry.maybeFromJson(<String, dynamic>{}),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/packages/shorebird_code_push_protocol/test/generated/models/unique_users_range_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/unique_users_range_test.dart
@@ -1,0 +1,28 @@
+// GENERATED — do not hand-edit.
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('UniqueUsersRange', () {
+    test('round-trips via maybeFromJson/toJson', () {
+      final instance = UniqueUsersRange(
+        start: DateTime.utc(2024),
+        end: DateTime.utc(2024),
+      );
+      final parsed = UniqueUsersRange.maybeFromJson(instance.toJson());
+      expect(parsed, equals(instance));
+      expect(parsed.hashCode, equals(instance.hashCode));
+    });
+
+    test('maybeFromJson returns null on null input', () {
+      expect(UniqueUsersRange.maybeFromJson(null), isNull);
+    });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => UniqueUsersRange.maybeFromJson(<String, dynamic>{}),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/packages/shorebird_code_push_protocol/test/generated/models/unique_users_time_series_entry_test.dart
+++ b/packages/shorebird_code_push_protocol/test/generated/models/unique_users_time_series_entry_test.dart
@@ -1,0 +1,30 @@
+// GENERATED — do not hand-edit.
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('UniqueUsersTimeSeriesEntry', () {
+    test('round-trips via maybeFromJson/toJson', () {
+      final instance = UniqueUsersTimeSeriesEntry(
+        period: DateTime.utc(2024),
+        uniqueUsers: 0,
+      );
+      final parsed = UniqueUsersTimeSeriesEntry.maybeFromJson(
+        instance.toJson(),
+      );
+      expect(parsed, equals(instance));
+      expect(parsed.hashCode, equals(instance.hashCode));
+    });
+
+    test('maybeFromJson returns null on null input', () {
+      expect(UniqueUsersTimeSeriesEntry.maybeFromJson(null), isNull);
+    });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => UniqueUsersTimeSeriesEntry.maybeFromJson(<String, dynamic>{}),
+        throwsFormatException,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Goal

Move the MAU ("unique users") metric onto the new generated-DTO metrics pattern already used by `version-distribution` and `patch-adoption`. This PR adds the generated protocol surface that the new `GET /apps/{appId}/metrics/unique-users` server route compiles against.

## Summary

- Adds the generated `GetUniqueUsersResponse` message and the `UniqueUsersRange`, `UniqueUsersTimeSeriesEntry`, and `UniqueUsersBreakdownEntry` models, plus the `granularity` / `group_by` parameter enums.
- Generated from the OpenAPI spec via `space_gen`; the barrel re-exports the new types and generated round-trip tests are included.
- No hand-edits under `lib/src/`. Envelope mirrors `GetPatchAdoptionResponse` (`range` + `as_of` + nullable `granularity`).
