### PR TITLE
fix: add GLES to cspell words

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 <!--
-cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkishan appbundle proto tlsv kingdomseed Peetee Aditya serde bipatch
+cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkishan appbundle proto tlsv kingdomseed Peetee Aditya serde bipatch GLES
  -->
 
 ## 1.6.109 (June 22, 2026)


### PR DESCRIPTION
cspell was failing on `main`: `RELEASE_NOTES.md:15` — `TextureGLES` split into `Texture` + `GLES`, and `GLES` was not a known word.

Added `GLES` to the inline `cspell:words` list at the top of `RELEASE_NOTES.md`. `cspell` now passes locally (exit 0).