### PR TITLE
chore(shorebird_code_push_protocol): remove unused patchHash

### DIFF
--- a/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_request.dart
+++ b/packages/shorebird_code_push_protocol/lib/src/messages/patch_check/patch_check_request.dart
@@ -15,7 +15,6 @@ class PatchCheckRequest {
     required this.appId,
     required this.channel,
     this.patchNumber,
-    this.patchHash,
     this.clientId,
     this.currentPatchNumber,
   });
@@ -28,7 +27,6 @@ class PatchCheckRequest {
       () => PatchCheckRequest(
         releaseVersion: json['release_version'] as String,
         patchNumber: json['patch_number'] as int?,
-        patchHash: json['patch_hash'] as String?,
         platform: ReleasePlatform.fromJson(json['platform'] as String),
         arch: json['arch'] as String,
         appId: json['app_id'] as String,
@@ -56,9 +54,6 @@ class PatchCheckRequest {
   /// number. If omitted, the server returns the latest available.
   final int? patchNumber;
 
-  /// The current patch hash of the app.
-  final String? patchHash;
-
   /// A platform to which a Shorebird release can be deployed.
   final ReleasePlatform platform;
 
@@ -85,7 +80,6 @@ class PatchCheckRequest {
     return {
       'release_version': releaseVersion,
       'patch_number': patchNumber,
-      'patch_hash': patchHash,
       'platform': platform.toJson(),
       'arch': arch,
       'app_id': appId,
@@ -99,7 +93,6 @@ class PatchCheckRequest {
   int get hashCode => Object.hashAll([
     releaseVersion,
     patchNumber,
-    patchHash,
     platform,
     arch,
     appId,
@@ -114,7 +107,6 @@ class PatchCheckRequest {
     return other is PatchCheckRequest &&
         releaseVersion == other.releaseVersion &&
         patchNumber == other.patchNumber &&
-        patchHash == other.patchHash &&
         platform == other.platform &&
         arch == other.arch &&
         appId == other.appId &&

--- a/packages/shorebird_code_push_protocol/test/src/messages/patch_check/patch_check_request_test.dart
+++ b/packages/shorebird_code_push_protocol/test/src/messages/patch_check/patch_check_request_test.dart
@@ -6,7 +6,6 @@ void main() {
     const request = PatchCheckRequest(
       releaseVersion: '1',
       patchNumber: 2,
-      patchHash: '3',
       platform: ReleasePlatform.android,
       arch: 'arm64',
       appId: 'app_123',
@@ -26,7 +25,6 @@ void main() {
       const copy = PatchCheckRequest(
         releaseVersion: '1',
         patchNumber: 2,
-        patchHash: '3',
         platform: ReleasePlatform.android,
         arch: 'arm64',
         appId: 'app_123',
@@ -37,7 +35,6 @@ void main() {
       const different = PatchCheckRequest(
         releaseVersion: '1',
         patchNumber: 2,
-        patchHash: '3',
         platform: ReleasePlatform.android,
         arch: 'arm64',
         appId: 'app_123',


### PR DESCRIPTION
## Summary

Removes the unused `patchHash` field from `PatchCheckRequest`. Regenerated from a spec version that drops `patch_hash`. No first-party client sends the field and no server code reads it.

## Testing

- `dart analyze --fatal-warnings` on `shorebird_code_push_protocol`: same 38 pre-existing infos on unrelated files, none introduced by this change
- `dart test` on `test/src/messages/patch_check` and `test/generated/messages/patch_check`: 17/17 pass