### PR TITLE
fix(shorebird_cli): probe verbose help so hidden --shorebird-trace is detected

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -125,13 +125,20 @@ ${link(uri: Uri.parse('https://github.com/shorebirdtech/shorebird/issues/new'))}
   /// Probes the command's help output and caches the result per [command]
   /// so that subsequent calls for the same command are free.
   /// Returns `false` if the help check fails for any reason.
+  ///
+  /// The probe uses verbose help (`-h -v`): `--shorebird-trace` is registered
+  /// with `hide: !verboseHelp` in Flutter, so it does not appear in plain
+  /// `-h` output. Probing with `-h` alone therefore returned `false` even on
+  /// Flutter versions that fully support the flag, silently disabling build
+  /// tracing for everyone. `-h -v` lists hidden options so support is
+  /// detected correctly.
   Future<bool> _supportsTraceFlag(String command) async {
     if (_traceSupport.containsKey(command)) return _traceSupport[command]!;
 
     try {
       final result = await process.run(
         'flutter',
-        ['build', command, '-h'],
+        ['build', command, '-h', '-v'],
         runInShell: false,
       );
       final supported = result.stdout.toString().contains('--shorebird-trace');

--- a/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
@@ -347,11 +347,77 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
         verify(
           () => shorebirdProcess.run(
             'flutter',
-            ['build', 'appbundle', '-h'],
+            ['build', 'appbundle', '-h', '-v'],
             runInShell: false,
           ),
         ).called(1);
       });
+
+      test(
+        'detects --shorebird-trace even though it is hidden from -h',
+        () async {
+          when(
+            () => shorebirdFlutter.resolveFlutterVersion(any()),
+          ).thenAnswer((_) async => Version(3, 41, 7));
+          // Flutter registers --shorebird-trace with `hide: !verboseHelp`, so it
+          // only appears in verbose help. Model that: plain `-h` omits the flag,
+          // `-h -v` includes it. Probing without `-v` (the original bug) would
+          // miss it and silently disable tracing on every supported build.
+          when(
+            () => shorebirdProcess.run(
+              'flutter',
+              ['build', 'appbundle', '-h'],
+              runInShell: false,
+            ),
+          ).thenAnswer(
+            (_) async => ShorebirdProcessResult(
+              exitCode: ExitCode.success.code,
+              stdout: '--release',
+              stderr: '',
+            ),
+          );
+          when(
+            () => shorebirdProcess.run(
+              'flutter',
+              ['build', 'appbundle', '-h', '-v'],
+              runInShell: false,
+            ),
+          ).thenAnswer(
+            (_) async => ShorebirdProcessResult(
+              exitCode: ExitCode.success.code,
+              stdout: '--release\n--shorebird-trace',
+              stderr: '',
+            ),
+          );
+
+          await runWithOverrides(() async {
+            await builder.prepareBuildTrace(platform: 'android');
+            await builder.buildAppBundle();
+          });
+
+          final expectedTracePath = p.join(
+            projectRoot.path,
+            'build',
+            'shorebird',
+            'debug',
+            'build-trace-android.json',
+          );
+          verify(
+            () => shorebirdProcess.stream(
+              'flutter',
+              [
+                'build',
+                'appbundle',
+                '--release',
+                '--shorebird-trace=$expectedTracePath',
+              ],
+              environment: any(named: 'environment'),
+              runInShell: false,
+              onStart: any(named: 'onStart'),
+            ),
+          ).called(1);
+        },
+      );
 
       test('skips trace when help probe throws', () async {
         when(
@@ -360,7 +426,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
         when(
           () => shorebirdProcess.run(
             'flutter',
-            ['build', 'appbundle', '-h'],
+            ['build', 'appbundle', '-h', '-v'],
             runInShell: false,
           ),
         ).thenThrow(Exception('process failed'));
@@ -921,7 +987,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
           when(
             () => shorebirdProcess.run(
               'flutter',
-              ['build', 'aar', '-h'],
+              ['build', 'aar', '-h', '-v'],
               runInShell: false,
             ),
           ).thenAnswer(
@@ -1123,7 +1189,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
           when(
             () => shorebirdProcess.run(
               'flutter',
-              ['build', 'linux', '-h'],
+              ['build', 'linux', '-h', '-v'],
               runInShell: false,
             ),
           ).thenAnswer(
@@ -1300,7 +1366,7 @@ Reason: Exited with code 70.'''),
           when(
             () => shorebirdProcess.run(
               'flutter',
-              ['build', 'macos', '-h'],
+              ['build', 'macos', '-h', '-v'],
               runInShell: false,
             ),
           ).thenAnswer(
@@ -1789,7 +1855,7 @@ Reason: Exited with code 70.'''),
           when(
             () => shorebirdProcess.run(
               'flutter',
-              ['build', 'ios-framework', '-h'],
+              ['build', 'ios-framework', '-h', '-v'],
               runInShell: false,
             ),
           ).thenAnswer(
@@ -2081,7 +2147,7 @@ Reason: Exited with code 70.'''),
           when(
             () => shorebirdProcess.run(
               'flutter',
-              ['build', 'windows', '-h'],
+              ['build', 'windows', '-h', '-v'],
               runInShell: false,
             ),
           ).thenAnswer(


### PR DESCRIPTION
## Problem

Build tracing (`--shorebird-trace`) has been silently disabled for essentially all users since **#3708** (2026-04-21), the day after the feature landed (#3692).

`#3708` added a support probe that runs `flutter build <cmd> -h` and checks the help output for `--shorebird-trace` before passing the flag. But the flag is registered in Flutter with `hide: !verboseHelp`, so it **never appears in plain `-h` output**. The probe therefore returns `false` on every build — including builds whose Flutter fully supports the flag — so `--shorebird-trace` is never passed, no build trace is produced, and the resulting summary has `flutterBuildMs = 0`.

The help-check was meant to *gracefully skip* unsupported Flutter versions; instead it produced a **universal false negative**, because a supported flag that's intentionally hidden looks identical to an unsupported one.

### Impact
Real-world trace capture collapsed to near-zero after #3708. Builds still upload a `build_trace_summary`, but it contains only shorebird_cli's own spans (no Flutter build events), so build-timing dashboards show almost no data. The only builds still capturing real timing are ones on CLI versions predating #3708.

## Fix

Probe with **verbose** help (`-h -v`), which lists `hide`-flagged options, so support is detected correctly — while the flag stays hidden from normal `flutter build` help.

```diff
-        ['build', command, '-h'],
+        ['build', command, '-h', '-v'],
```

Adds a regression test that models the real behavior (flag absent from `-h`, present in `-h -v`) and asserts `--shorebird-trace` is still passed — so a revert to the non-verbose probe fails the suite.

## Test
`dart test test/src/artifact_builder/artifact_builder_test.dart` — all trace tests pass (15), including the new `detects --shorebird-trace even though it is hidden from -h`.
