### PR TITLE
chore: prepare for release 1.6.113

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,12 @@
 cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkishan appbundle proto tlsv kingdomseed Peetee Aditya serde bipatch GLES
  -->
 
+## 1.6.113 (July 10, 2026)
+
+- 🐛 Fix `--shorebird-trace` build tracing being silently disabled even on
+  Flutter versions that support it, caused by probing plain `flutter build -h`
+  output where the flag is hidden.
+
 ## 1.6.112 (July 10, 2026)
 
 - 🐦 Flutter 3.44.6 / Dart 3.12.2 support

--- a/packages/shorebird_cli/lib/src/version.dart
+++ b/packages/shorebird_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.6.112';
+const packageVersion = '1.6.113';

--- a/packages/shorebird_cli/pubspec.yaml
+++ b/packages/shorebird_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_cli
 description: Command-line tool to interact with Shorebird's services.
-version: 1.6.112
+version: 1.6.113
 repository: https://github.com/shorebirdtech/shorebird
 resolution: workspace
 


### PR DESCRIPTION
Bumps `shorebird_cli` to **1.6.113**.

## Changes since 1.6.112
- `d6647dbf` — fix(shorebird_cli): probe verbose help so hidden `--shorebird-trace` is detected (#3848)

## Release notes
- 🐛 Fix `--shorebird-trace` build tracing being silently disabled even on Flutter versions that support it, caused by probing plain `flutter build -h` output where the flag is hidden.

## Diff
- `packages/shorebird_cli/lib/src/version.dart`: 1.6.112 → 1.6.113
- `packages/shorebird_cli/pubspec.yaml`: 1.6.112 → 1.6.113
- `RELEASE_NOTES.md`: new 1.6.113 entry