### PR TITLE
feat(shorebird_cli): record warm/cold + output artifact size in build trace

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/artifact_builder.dart
@@ -650,6 +650,50 @@ Reason: Exited with code $exitCode.''',
     );
     traceFile.parent.createSync(recursive: true);
     buildTraceSession.traceFile = traceFile;
+
+    // Snapshot warm-vs-cold *before* the build mutates `build/`. A fresh
+    // checkout (the common CI case) has no `build/` yet; a repeat local
+    // build does. `writeBuildTraceSummary` reads this back later.
+    buildTraceSession.nativeOutputsPresentAtStart = _nativeOutputsPresent();
+  }
+
+  /// Whether Flutter's `build/` output directory already exists and is
+  /// non-empty, a warm-build proxy. Null when the project root can't be
+  /// resolved. Called from [prepareBuildTrace] before the build runs.
+  bool? _nativeOutputsPresent() {
+    final root = shorebirdEnv.getShorebirdProjectRoot();
+    if (root == null) return null;
+    final buildDir = Directory(p.join(root.path, 'build'));
+    if (!buildDir.existsSync()) return false;
+    return buildDir.listSync().isNotEmpty;
+  }
+
+  /// Best-effort size in bytes of the primary build output for [platform]
+  /// (the `.aab` on Android, the `.ipa` on iOS). Searches the standard
+  /// Flutter output locations for the largest matching artifact modified
+  /// since the command started (so a stale artifact from an earlier build
+  /// isn't picked up on warm builds). Null when nothing matches or the
+  /// project root can't be resolved.
+  int? _outputArtifactBytes(String platform) {
+    final root = shorebirdEnv.getShorebirdProjectRoot();
+    if (root == null) return null;
+    final (dir, ext) = switch (platform) {
+      'android' => (p.join(root.path, 'build', 'app', 'outputs'), '.aab'),
+      'ios' => (p.join(root.path, 'build', 'ios', 'ipa'), '.ipa'),
+      _ => (null, null),
+    };
+    if (dir == null || ext == null) return null;
+    final searchDir = Directory(dir);
+    if (!searchDir.existsSync()) return null;
+    final startedAt = buildTraceSession.commandStartedAt;
+    int? largest;
+    for (final entry in searchDir.listSync(recursive: true)) {
+      if (entry is! File || !entry.path.toLowerCase().endsWith(ext)) continue;
+      final stat = entry.statSync();
+      if (stat.modified.isBefore(startedAt)) continue;
+      if (largest == null || stat.size > largest) largest = stat.size;
+    }
+    return largest;
   }
 
   /// Emits a flow-start event (`ph: "s"`) on the shorebird_cli tracer
@@ -735,6 +779,9 @@ Reason: Exited with code $exitCode.''',
           ? Duration.zero
           : shorebirdOverhead,
       environment: environment,
+      nativeOutputsPresentAtStart:
+          buildTraceSession.nativeOutputsPresentAtStart,
+      outputArtifactBytes: _outputArtifactBytes(buildPlatform),
     );
 
     // Cache for the release/patch metadata uploader to read without

--- a/packages/shorebird_cli/lib/src/artifact_builder/build_trace_session.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/build_trace_session.dart
@@ -29,6 +29,19 @@ class BuildTraceSession {
   /// platform-specific accumulators in the summary.
   String? platform;
 
+  /// Whether Flutter's `build/` output directory already existed and was
+  /// non-empty when the build started — a warm-build proxy. A fresh
+  /// checkout (the common CI case) has no `build/`, so this is false; a
+  /// repeat local build is true. Null when tracing wasn't set up or the
+  /// project root couldn't be resolved.
+  ///
+  /// Snapshotted by `ArtifactBuilder.prepareBuildTrace` *before* the build
+  /// runs (the only point at which pre-build state is still observable);
+  /// read by `writeBuildTraceSummary`. Lets field data separate cold
+  /// builds from locally-warm ones, which otherwise skew the release
+  /// baselines a native build cache is measured against.
+  bool? nativeOutputsPresentAtStart;
+
   /// The [BuildTraceSummary] produced by the most recent
   /// `writeBuildTraceSummary` call, or null if no summary was written
   /// (unsupported Flutter pin, trace file malformed, etc.).

--- a/packages/shorebird_cli/lib/src/artifact_builder/build_trace_summary.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/build_trace_summary.dart
@@ -33,6 +33,8 @@ class BuildTraceSummary {
     this.android,
     this.ios,
     this.environment,
+    this.nativeOutputsPresentAtStart,
+    this.outputArtifactBytes,
   });
 
   /// Build a summary from the raw list of trace events written by Flutter
@@ -47,6 +49,8 @@ class BuildTraceSummary {
     required String platform,
     Duration? shorebirdOverhead,
     BuildEnvironment? environment,
+    bool? nativeOutputsPresentAtStart,
+    int? outputArtifactBytes,
   }) {
     final acc = _Accumulator();
     for (final e in events) {
@@ -61,6 +65,8 @@ class BuildTraceSummary {
       platform: platform,
       shorebirdOverhead: shorebirdOverhead,
       environment: environment,
+      nativeOutputsPresentAtStart: nativeOutputsPresentAtStart,
+      outputArtifactBytes: outputArtifactBytes,
     );
   }
 
@@ -158,6 +164,8 @@ class BuildTraceSummary {
     required String platform,
     Duration? shorebirdOverhead,
     BuildEnvironment? environment,
+    bool? nativeOutputsPresentAtStart,
+    int? outputArtifactBytes,
   }) {
     final flutterBuild = acc.flutterBuild;
     return BuildTraceSummary(
@@ -176,6 +184,8 @@ class BuildTraceSummary {
       android: platform == 'android' ? _androidStats(acc) : null,
       ios: platform == 'ios' ? _iosStats(acc) : null,
       environment: environment,
+      nativeOutputsPresentAtStart: nativeOutputsPresentAtStart,
+      outputArtifactBytes: outputArtifactBytes,
     );
   }
 
@@ -270,6 +280,8 @@ class BuildTraceSummary {
     required String platform,
     Duration? shorebirdOverhead,
     BuildEnvironment? environment,
+    bool? nativeOutputsPresentAtStart,
+    int? outputArtifactBytes,
   }) {
     final events = tryReadEvents(traceFile);
     if (events == null) return null;
@@ -278,6 +290,8 @@ class BuildTraceSummary {
       platform: platform,
       shorebirdOverhead: shorebirdOverhead,
       environment: environment,
+      nativeOutputsPresentAtStart: nativeOutputsPresentAtStart,
+      outputArtifactBytes: outputArtifactBytes,
     );
   }
 
@@ -376,6 +390,20 @@ class BuildTraceSummary {
   /// "slow despite caching being on" in field data.
   final BuildEnvironment? environment;
 
+  /// Whether Flutter's `build/` output directory already existed and was
+  /// non-empty when the build started (a warm-build proxy). Null when it
+  /// couldn't be observed. Lets us drop or bucket locally-warm builds so
+  /// they don't skew the cold-build baselines a native build cache is
+  /// measured against.
+  final bool? nativeOutputsPresentAtStart;
+
+  /// Size in bytes of the primary build output (the `.aab` on Android,
+  /// the `.ipa` on iOS), best-effort. Null when no matching artifact was
+  /// found. Sizes the artifact a remote native-shell cache would move,
+  /// which decides whether a cache pull can beat a rebuild over the
+  /// network.
+  final int? outputArtifactBytes;
+
   /// Shorebird CLI's wall-clock time around Flutter with network I/O
   /// subtracted — i.e. what Shorebird spent doing local work (file I/O,
   /// hashing, archive assembly, aot_tools link/gen_snapshot bookkeeping
@@ -402,7 +430,7 @@ class BuildTraceSummary {
   /// subtraction (`flutterBuildMs - dart.totalMs`) — kept out of the
   /// on-wire shape so there's exactly one way to read each value.
   Map<String, Object?> toJson() => <String, Object?>{
-    'version': 8,
+    'version': 9,
     'platform': platform,
     'totalMs': total.inMilliseconds,
     'flutterBuildMs': flutterBuild.inMilliseconds,
@@ -416,6 +444,8 @@ class BuildTraceSummary {
     'android': ?android?.toJson(),
     'ios': ?ios?.toJson(),
     'environment': ?environment?.toJson(),
+    'nativeOutputsPresentAtStart': ?nativeOutputsPresentAtStart,
+    'outputArtifactBytes': ?outputArtifactBytes,
   };
 }
 

--- a/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
@@ -799,7 +799,7 @@ Either run `flutter pub get` manually, or follow the steps in ${cannotRunInVSCod
                 jsonDecode(summaryFile.readAsStringSync())
                     as Map<String, Object?>;
             expect(summary['platform'], 'android');
-            expect(summary['version'], 8);
+            expect(summary['version'], 9);
             // 500ms kernel + 200ms aot
             expect((summary['dart'] as Map)['totalMs'], 700);
             expect(summary['flutterBuildMs'], 3000);

--- a/packages/shorebird_cli/test/src/artifact_builder/build_trace_summary_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/build_trace_summary_test.dart
@@ -303,7 +303,7 @@ void main() {
       ];
       final s = BuildTraceSummary.fromEvents(events, platform: 'android');
       final j = s.toJson();
-      expect(j['version'], 8);
+      expect(j['version'], 9);
       expect(j['platform'], 'android');
       expect(j['android'], isA<Map<String, Object?>>());
       expect(j.containsKey('ios'), isFalse);
@@ -314,6 +314,44 @@ void main() {
       expect(flat.contains('"path"'), isFalse);
       expect(flat.contains('"file"'), isFalse);
       expect(flat.contains('"user"'), isFalse);
+    });
+
+    test('omits warm/cold and artifact-size keys when not provided', () {
+      final events = [
+        _event(
+          name: 'flutter build appbundle',
+          cat: 'flutter',
+          ts: 0,
+          dur: 10_000_000,
+          tid: 1,
+        ),
+      ];
+      final j = BuildTraceSummary.fromEvents(
+        events,
+        platform: 'android',
+      ).toJson();
+      expect(j.containsKey('nativeOutputsPresentAtStart'), isFalse);
+      expect(j.containsKey('outputArtifactBytes'), isFalse);
+    });
+
+    test('emits warm/cold and artifact-size when provided', () {
+      final events = [
+        _event(
+          name: 'flutter build appbundle',
+          cat: 'flutter',
+          ts: 0,
+          dur: 10_000_000,
+          tid: 1,
+        ),
+      ];
+      final j = BuildTraceSummary.fromEvents(
+        events,
+        platform: 'android',
+        nativeOutputsPresentAtStart: false,
+        outputArtifactBytes: 42_000_000,
+      ).toJson();
+      expect(j['nativeOutputsPresentAtStart'], isFalse);
+      expect(j['outputArtifactBytes'], 42_000_000);
     });
 
     group('tryFromFile', () {


### PR DESCRIPTION
## What

Adds two privacy-safe fields to the build-trace summary (schema **v8 → v9**), as groundwork for the Flutter native build cache investigation:

- **`nativeOutputsPresentAtStart`** (bool) — snapshots whether Flutter's `build/` dir was non-empty *before* the build ran (a warm-build proxy). Captured in `prepareBuildTrace` because pre-build state isn't observable afterward. Lets field data separate cold builds (fresh CI checkout) from locally-warm ones so they don't skew the cold-build baselines a native build cache is measured against.
- **`outputArtifactBytes`** (int) — best-effort size of the primary build output (`.aab`/`.ipa`). Sizes what a remote native-shell cache would have to move over the network.

Both are computed entirely CLI-side; no trace-producer/fork changes. New fields are omitted (not nulled) when unavailable, so old consumers are unaffected.

## Notes / open question

- `outputArtifactBytes` measures the **full built app artifact**, located via a best-effort glob. On **release** this equals the uploaded artifact; on **patch** it does *not* (patch uploads a per-arch diff, this measures the full `.aab`/`.ipa`) — intentional, since the cache-sizing question is about the full native artifact, not the code-push diff. Open to switching to the exact known artifact path (`findAab` etc.) if we prefer exactness over the glob.

## Not included (follow-ups)

- Surfacing these fields in the admin build-timing dashboard (separate web repo; deferred until data accrues).
- Finer sub-measurements (signing span, iOS `xcode_subsection` split) — spans the flutter fork and touches privacy-sensitive subsection titles; separate PR.

## Test

`dart analyze` clean (no new issues), `dart format` clean, 121 tests pass (added serialization coverage for the new fields; bumped two `version` assertions to 9).