### PR TITLE
fix: improve error handling for release command

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -198,7 +198,14 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
         .map(createRelease);
 
     for (final future in releaserFutures) {
-      await future;
+      try {
+        await future;
+      } on ProcessExit {
+        rethrow;
+      } catch (error) {
+        logger.err(error.toString());
+        return ExitCode.software.code;
+      }
     }
 
     return ExitCode.success.code;


### PR DESCRIPTION
This PR wraps the release process in a try-catch block to prevent uncaught exceptions from bubbling up as stack traces and instead logs a clear error message.