### PR TITLE
fix: properly forward flutter args containing spaces on Windows

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -296,6 +296,13 @@ class ShorebirdProcessResult {
 // coverage:ignore-start
 @visibleForTesting
 class ProcessWrapper {
+  List<String> _prepareArgs(List<String> args, bool runInShell) {
+    if (Platform.isWindows && runInShell) {
+      return args.map((arg) => arg.contains(' ') ? '"$arg"' : arg).toList();
+    }
+    return args;
+  }
+
   /// Runs the process and returns the result.
   Future<ShorebirdProcessResult> run(
     String executable,
@@ -304,12 +311,13 @@ class ProcessWrapper {
     String? workingDirectory,
     bool? runInShell,
   }) async {
+    final useShell = runInShell ?? Platform.isWindows;
     final result = await Process.run(
       executable,
-      arguments,
+      _prepareArgs(arguments, useShell),
       environment: environment,
       // TODO(felangel): refactor to never runInShell
-      runInShell: runInShell ?? Platform.isWindows,
+      runInShell: useShell,
       workingDirectory: workingDirectory,
     );
     return ShorebirdProcessResult(
@@ -326,11 +334,12 @@ class ProcessWrapper {
     Map<String, String>? environment,
     String? workingDirectory,
   }) {
+    final useShell = Platform.isWindows;
     final result = Process.runSync(
       executable,
-      arguments,
+      _prepareArgs(arguments, useShell),
       environment: environment,
-      runInShell: Platform.isWindows,
+      runInShell: useShell,
       workingDirectory: workingDirectory,
     );
     return ShorebirdProcessResult(
@@ -349,16 +358,7 @@ class ProcessWrapper {
     String? workingDirectory,
     ProcessStartMode mode = ProcessStartMode.normal,
   }) {
+    final useShell = runInShell ?? Platform.isWindows;
     return Process.start(
       executable,
-      arguments,
-      // TODO(felangel): refactor to never runInShell
-      runInShell: runInShell ?? Platform.isWindows,
-      environment: environment,
-      workingDirectory: workingDirectory,
-      mode: mode,
-    );
-  }
-}
-
 // coverage:ignore-end


### PR DESCRIPTION
This PR fixes an issue where arguments forwarded to the flutter process via -- were incorrectly parsed on Windows when runInShell was true. Spaces are now properly escaped with double quotes.