### PR TITLE
fix: android build failing missing architecture artifacts error logging

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -513,8 +513,8 @@ Looked in:
       );
       final artifact = File(artifactPath);
       if (!artifact.existsSync()) {
-        logger.detail(
-          'Skipping ${arch.arch}: no libapp.so at $artifactPath. '
+        logger.err(
+          'Expected architecture ${arch.arch} was not found at $artifactPath. '
           'This is expected if the project filters this ABI via '
           'ndk.abiFilters, splits.abi, or jniLibs.excludes.',
         );


### PR DESCRIPTION
This PR enhances the error messaging when Android architecture artifacts are missing by logging them via logger.err so they are clearly visible before the build fails.