### PR TITLE
chore(shorebird_cli): drop the build-trace revision allowlist

### DIFF
--- a/packages/shorebird_cli/lib/src/flutter_version_constraints.dart
+++ b/packages/shorebird_cli/lib/src/flutter_version_constraints.dart
@@ -79,19 +79,10 @@ final arm64PatchSupportConstraint = FlutterSupportConstraint(
 /// Flutter support for `flutter build --shorebird-trace=<path>` for emitting
 /// Chrome Trace Event Format build traces.
 ///
-/// Added in shorebirdtech/flutter#116. `minVersion` is set to the next
-/// minor past the latest Shorebird Flutter release (currently 3.41.6), so
-/// whenever that PR gets cut as 3.41.7 the floor covers it cleanly. Until
-/// then, the allowlist covers the current pin hash so users on it get
-/// tracing today.
+/// Added in shorebirdtech/flutter#116, which shipped in
+/// `flutter_release/3.41.7` and every subsequent release branch.
 final buildTraceSupportConstraint = FlutterSupportConstraint(
   minVersion: Version(3, 41, 7),
-  allowedRevisions: {
-    // Current Shorebird Flutter pin (bin/internal/flutter.version). Can
-    // be removed once a flutter_release/3.41.7 branch ships with this
-    // (or a later tracing-enabled) commit at its tip.
-    '3b10eecea184bb381f1045a878eeff36548ed11e',
-  },
 );
 
 /// Flutter versions where the Android Gradle Plugin (AGP) is the entity

--- a/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/artifact_builder_test.dart
@@ -2302,8 +2302,7 @@ Reason: Exited with code 70.'''),
         'leaves traceFile null when Flutter pin does not support tracing',
         () async {
           // shorebirdFlutter.resolveFlutterVersion default in setUp is 3.0.0,
-          // which is below buildTraceSupportConstraint.minVersion, and the
-          // default flutterRevision stub ('1234') isn't in the allowlist.
+          // which is below buildTraceSupportConstraint.minVersion.
           await runWithOverrides(() async {
             await builder.prepareBuildTrace(platform: 'android');
             expect(buildTraceSession.traceFile, isNull);
@@ -2312,24 +2311,16 @@ Reason: Exited with code 70.'''),
         },
       );
 
-      test(
-        'sets traceFile for an allowlisted revision below the floor',
-        () async {
-          // Version is strictly below the min floor, so only the
-          // allowlist can admit this combination.
-          when(
-            () => shorebirdFlutter.resolveFlutterVersion(any()),
-          ).thenAnswer((_) async => Version(3, 41, 6));
-          when(() => shorebirdEnv.flutterRevision).thenReturn(
-            buildTraceSupportConstraint.allowedRevisions.first,
-          );
+      test('sets traceFile for a version at the floor', () async {
+        when(
+          () => shorebirdFlutter.resolveFlutterVersion(any()),
+        ).thenAnswer((_) async => buildTraceSupportConstraint.minVersion);
 
-          await runWithOverrides(() async {
-            await builder.prepareBuildTrace(platform: 'android');
-            expect(buildTraceSession.traceFile, isNotNull);
-          });
-        },
-      );
+        await runWithOverrides(() async {
+          await builder.prepareBuildTrace(platform: 'android');
+          expect(buildTraceSession.traceFile, isNotNull);
+        });
+      });
 
       test(
         'treats unresolved Flutter version as new enough (dev pin)',


### PR DESCRIPTION
## Description

`buildTraceSupportConstraint` carries an `allowedRevisions` escape hatch holding one pinned Flutter hash (`3b10eece`). It was added so users on the then-current pin got `--shorebird-trace` before a release branch shipped the change:

```dart
final buildTraceSupportConstraint = FlutterSupportConstraint(
  minVersion: Version(3, 41, 7),
  allowedRevisions: {
    // Current Shorebird Flutter pin (bin/internal/flutter.version). Can
    // be removed once a flutter_release/3.41.7 branch ships with this
    // (or a later tracing-enabled) commit at its tip.
    '3b10eecea184bb381f1045a878eeff36548ed11e',
  },
);
```

That condition has been met. shorebirdtech/flutter#116 shipped in `flutter_release/3.41.7` and every later release branch, so the `>=3.41.7` floor covers tracing on its own, and `bin/internal/flutter.version` is now `c15ef637` — well past the allowlisted hash. The entry is dead code, and its own comment says to remove it at this point.

This removes the allowlist entry, drops the test that only the allowlist could satisfy (a version *below* the floor admitted by hash), and folds the remaining coverage into a test at the version floor.

**Verification** — on this branch, against `main`:

- `dart analyze --fatal-warnings .` → exit 0, and the issue set is identical to `main`'s existing 86 (no new findings)
- `dart test` in `packages/shorebird_cli` → 2066 passed, 1 skipped, 0 failed
- `test/src/artifact_builder/` specifically → 139 passed

Happy to adjust the test split if you'd rather keep an explicit allowlist case for the mechanism itself, since `FlutterSupportConstraint.allowedRevisions` remains a supported field used by other constraints.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests
