### PR TITLE
feat(shorebird_cli): use PKCE in the loopback login flow

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -98,6 +98,7 @@ words:
   - pbxproj
   - pinact # Third-party action-pinning tool referenced in shorebird_ci
   - Perfetto # Chrome trace viewer at ui.perfetto.dev
+  - pkce # Proof Key for Code Exchange (RFC 7636)
   - pkcs
   - podfile
   - podspec

--- a/packages/shorebird_cli/lib/src/auth/pkce.dart
+++ b/packages/shorebird_cli/lib/src/auth/pkce.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:meta/meta.dart';
+
+/// A PKCE (RFC 7636) verifier and the S256 challenge derived from it.
+///
+/// The CLI is a public OAuth client: it holds no secret, and it receives its
+/// authorization code on a loopback redirect. Anything able to observe that
+/// redirect — another process that binds the callback port first, a browser
+/// extension, a shell history dump — could otherwise replay the code against
+/// the auth service and obtain a full session.
+///
+/// PKCE binds the code to [verifier], which stays in this process until the
+/// token exchange. A stolen code is useless without it.
+@immutable
+class PkcePair {
+  const PkcePair._({required this.verifier, required this.challenge});
+
+  /// Generates a fresh pair from a cryptographically secure source.
+  factory PkcePair.generate() {
+    // 32 random bytes encode to 43 base64url characters, the shortest verifier
+    // RFC 7636 section 4.1 permits and the exact length of an S256 challenge.
+    final random = Random.secure();
+    final bytes = List<int>.generate(32, (_) => random.nextInt(256));
+    final verifier = _base64Url(bytes);
+    return PkcePair._(
+      verifier: verifier,
+      challenge: _base64Url(sha256.convert(utf8.encode(verifier)).bytes),
+    );
+  }
+
+  /// The secret held by this process, sent only in the token exchange.
+  final String verifier;
+
+  /// `BASE64URL(SHA256(verifier))`, sent in the authorization request.
+  final String challenge;
+
+  /// RFC 7636 requires unpadded base64url for both values; `base64UrlEncode`
+  /// pads.
+  static String _base64Url(List<int> bytes) =>
+      base64UrlEncode(bytes).replaceAll('=', '');
+}

--- a/packages/shorebird_cli/lib/src/auth/shorebird_oauth.dart
+++ b/packages/shorebird_cli/lib/src/auth/shorebird_oauth.dart
@@ -8,6 +8,7 @@ import 'package:googleapis_auth/googleapis_auth.dart';
 import 'package:http/http.dart' as http;
 import 'package:jwt/jwt.dart';
 import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/auth/pkce.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 
 /// Exception thrown when the Shorebird auth flow fails.
@@ -45,9 +46,18 @@ Future<oauth2.AccessCredentials> obtainCredentialsViaLoopbackLogin({
   try {
     final port = server.port;
     const callbackPath = '/callback';
+    // The challenge travels in the authorization request. The auth service
+    // binds it to the code it mints and then requires the matching verifier
+    // at the exchange, so a code observed on the loopback redirect cannot be
+    // redeemed by anyone else.
+    final pkce = PkcePair.generate();
     final loginUrl = authBaseUrl.replace(
       path: p.url.join(authBaseUrl.path, 'login'),
-      queryParameters: {'continue': 'http://localhost:$port$callbackPath'},
+      queryParameters: {
+        'continue': 'http://localhost:$port$callbackPath',
+        'code_challenge': pkce.challenge,
+        'code_challenge_method': 'S256',
+      },
     );
 
     userPrompt(loginUrl.toString());
@@ -63,6 +73,7 @@ Future<oauth2.AccessCredentials> obtainCredentialsViaLoopbackLogin({
       httpClient: httpClient,
       authBaseUrl: authBaseUrl,
       code: code,
+      codeVerifier: pkce.verifier,
     );
   } finally {
     await server.close();
@@ -171,10 +182,15 @@ Future<oauth2.AccessCredentials> refreshShorebirdCredentials(
 
 /// Exchanges an auth code for tokens by POSTing to the auth service's
 /// /token endpoint.
+///
+/// [codeVerifier] is the PKCE secret whose challenge accompanied the
+/// authorization request. The auth service requires it whenever a challenge
+/// is bound to the code being redeemed.
 Future<oauth2.AccessCredentials> _exchangeAuthCode({
   required http.Client httpClient,
   required Uri authBaseUrl,
   required String code,
+  required String codeVerifier,
 }) async {
   final tokenUrl = authBaseUrl.replace(
     path: p.url.join(authBaseUrl.path, 'token'),
@@ -185,6 +201,7 @@ Future<oauth2.AccessCredentials> _exchangeAuthCode({
     body: {
       'grant_type': 'authorization_code',
       'code': code,
+      'code_verifier': codeVerifier,
     },
   );
 

--- a/packages/shorebird_cli/test/src/auth/pkce_test.dart
+++ b/packages/shorebird_cli/test/src/auth/pkce_test.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:shorebird_cli/src/auth/pkce.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(PkcePair, () {
+    test('derives the challenge as base64url(sha256(verifier))', () {
+      final pair = PkcePair.generate();
+      final expected = base64UrlEncode(
+        sha256.convert(utf8.encode(pair.verifier)).bytes,
+      ).replaceAll('=', '');
+      expect(pair.challenge, equals(expected));
+    });
+
+    test('produces a verifier within the RFC 7636 length bounds', () {
+      final pair = PkcePair.generate();
+      expect(pair.verifier.length, greaterThanOrEqualTo(43));
+      expect(pair.verifier.length, lessThanOrEqualTo(128));
+    });
+
+    test('produces a 43-character challenge', () {
+      // A SHA-256 digest is 32 bytes, exactly 43 unpadded base64url
+      // characters, which is the length the auth service validates.
+      expect(PkcePair.generate().challenge.length, equals(43));
+    });
+
+    test('emits unpadded base64url only', () {
+      // The auth service checks both values against the unreserved character
+      // set, so `+`, `/`, and `=` would be rejected.
+      final unreserved = RegExp(r'^[A-Za-z0-9\-._~]+$');
+      final pair = PkcePair.generate();
+      expect(unreserved.hasMatch(pair.verifier), isTrue);
+      expect(unreserved.hasMatch(pair.challenge), isTrue);
+    });
+
+    test('generates a distinct verifier per call', () {
+      final verifiers = List.generate(50, (_) => PkcePair.generate().verifier);
+      expect(verifiers.toSet(), hasLength(50));
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/auth/shorebird_oauth_test.dart
+++ b/packages/shorebird_cli/test/src/auth/shorebird_oauth_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:googleapis_auth/auth_io.dart' as oauth2;
 import 'package:googleapis_auth/googleapis_auth.dart';
 import 'package:http/http.dart' as http;
@@ -163,6 +164,71 @@ void main() {
         allOf(
           startsWith('http://localhost:'),
           contains('/callback'),
+        ),
+      );
+    });
+
+    test('sends a PKCE challenge and the matching verifier', () async {
+      final testJwt = _buildTestJwt();
+      when(
+        () => httpClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            'access_token': testJwt,
+            'refresh_token': 'rt',
+            'token_type': 'Bearer',
+            'expires_in': 900,
+          }),
+          HttpStatus.ok,
+        ),
+      );
+
+      late String capturedUrl;
+      await runWithOverrides(
+        () => obtainCredentialsViaLoopbackLogin(
+          httpClient: httpClient,
+          authBaseUrl: authBaseUrl,
+          userPrompt: (url) {
+            capturedUrl = url;
+            final loginUri = Uri.parse(url);
+            final continueUrl = loginUri.queryParameters['continue']!;
+            unawaited(
+              http.get(Uri.parse('$continueUrl?code=test_code')),
+            );
+          },
+        ),
+      );
+
+      final loginUri = Uri.parse(capturedUrl);
+      final challenge = loginUri.queryParameters['code_challenge'];
+      expect(loginUri.queryParameters['code_challenge_method'], equals('S256'));
+      expect(challenge, isNotNull);
+
+      final body =
+          verify(
+                () => httpClient.post(
+                  any(),
+                  headers: any(named: 'headers'),
+                  body: captureAny(named: 'body'),
+                ),
+              ).captured.single
+              as Map<String, String>;
+      final verifier = body['code_verifier'];
+      expect(verifier, isNotNull);
+
+      // If the pair ever drifts apart, every login fails at the token
+      // endpoint, so assert the relationship rather than mere presence.
+      expect(
+        challenge,
+        equals(
+          base64UrlEncode(
+            sha256.convert(utf8.encode(verifier!)).bytes,
+          ).replaceAll('=', ''),
         ),
       );
     });


### PR DESCRIPTION
## What

The CLI now uses PKCE ([RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636)) in the loopback login flow. Each login generates an S256 verifier/challenge pair, sends the challenge on the authorization request, and sends the verifier when exchanging the authorization code.

## Why

`shorebird_cli` is a public OAuth client. It holds no client secret, and it receives its authorization code on a `http://localhost:<port>` redirect rather than a server-to-server callback. PKCE ties the code to a secret that never leaves the CLI process until the exchange, so possessing the code alone is not enough to redeem it.

This is standard practice for native and CLI clients, and it is a prerequisite for the OAuth flows we want to support next.

## Compatibility

No coordination needed with a server rollout, in either direction:

- The auth service already accepts `code_challenge` / `code_challenge_method` on the authorization request.
- It requires a `code_verifier` **only** when a challenge was bound to the code being redeemed, and that binding happens server-side rather than being read off the token request.

So a CLI that sends a challenge gets the protection, and a CLI that does not keeps working exactly as before. Nothing in this PR makes PKCE mandatory.

## Changes

- `lib/src/auth/pkce.dart` — new. Generates the pair from `Random.secure()`, 32 bytes of entropy, unpadded base64url as the RFC requires.
- `lib/src/auth/shorebird_oauth.dart` — sends `code_challenge` + `code_challenge_method=S256` on the login URL, and `code_verifier` in the token exchange.

## Tests

- `test/src/auth/pkce_test.dart` — challenge is `base64url(sha256(verifier))`, verifier is within the RFC's 43-128 character bounds, both values stay inside the unreserved character set, and each call produces a distinct verifier.
- `test/src/auth/shorebird_oauth_test.dart` — end-to-end through the loopback flow, asserting the challenge on the login URL and that the verifier sent at the exchange is the one that challenge was derived from. Asserting the relationship rather than mere presence: if the two ever drift apart, every login fails at the token endpoint.

Full package suite passes (2072 tests). `dart analyze --fatal-warnings .` clean, `dart format` clean, and every line added here is covered.
