### PR TITLE
feat(stripe_api): subscription list, create, and cancel

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 <!--
-cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkishan appbundle proto tlsv kingdomseed Peetee Aditya serde bipatch GLES lipo
+cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkishan appbundle proto tlsv kingdomseed Peetee Aditya serde bipatch GLES lipo impellerc
  -->
 
 ## 1.6.119 (August 21, 2026)

--- a/packages/stripe_api/lib/src/models/internal/paged_response.dart
+++ b/packages/stripe_api/lib/src/models/internal/paged_response.dart
@@ -7,7 +7,7 @@ part 'paged_response.g.dart';
 /// more data available.
 /// See https://stripe.com/docs/api/pagination.
 /// {@endtemplate}
-@JsonSerializable()
+@JsonSerializable(createToJson: false)
 class PagedResponse {
   /// {@macro paged_response}
   PagedResponse({required this.data, required this.hasMore});

--- a/packages/stripe_api/lib/src/models/internal/paged_response.g.dart
+++ b/packages/stripe_api/lib/src/models/internal/paged_response.g.dart
@@ -16,6 +16,3 @@ PagedResponse _$PagedResponseFromJson(Map<String, dynamic> json) =>
       );
       return val;
     }, fieldKeyMap: const {'hasMore': 'has_more'});
-
-Map<String, dynamic> _$PagedResponseToJson(PagedResponse instance) =>
-    <String, dynamic>{'data': instance.data, 'has_more': instance.hasMore};

--- a/packages/stripe_api/lib/src/models/models.dart
+++ b/packages/stripe_api/lib/src/models/models.dart
@@ -3,6 +3,7 @@ export 'stripe_checkout_session.dart';
 export 'stripe_customer.dart';
 export 'stripe_event.dart';
 export 'stripe_meter_event_summary.dart';
+export 'stripe_payment_method.dart';
 export 'stripe_price.dart';
 export 'stripe_price_tier.dart';
 export 'stripe_subscription.dart';

--- a/packages/stripe_api/lib/src/models/stripe_payment_method.dart
+++ b/packages/stripe_api/lib/src/models/stripe_payment_method.dart
@@ -1,0 +1,43 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'stripe_payment_method.g.dart';
+
+/// {@template stripe_payment_method}
+/// A payment method in Stripe.
+///
+/// Only the fields needed to pick a collection method are modeled. [card] is
+/// null for non-card payment methods.
+///
+/// See https://docs.stripe.com/api/payment_methods/object
+/// {@endtemplate}
+@JsonSerializable(createToJson: false)
+class StripePaymentMethod {
+  /// {@macro stripe_payment_method}
+  const StripePaymentMethod({required this.id, this.card});
+
+  /// Converts a JSON object to a [StripePaymentMethod].
+  factory StripePaymentMethod.fromJson(Map<String, dynamic> json) =>
+      _$StripePaymentMethodFromJson(json);
+
+  /// The unique identifier for this object.
+  final String id;
+
+  /// Card details, when this payment method is a card.
+  final StripePaymentMethodCard? card;
+}
+
+/// {@template stripe_payment_method_card}
+/// Card details on a [StripePaymentMethod].
+/// {@endtemplate}
+@JsonSerializable(createToJson: false)
+class StripePaymentMethodCard {
+  /// {@macro stripe_payment_method_card}
+  const StripePaymentMethodCard({this.country});
+
+  /// Converts a JSON object to a [StripePaymentMethodCard].
+  factory StripePaymentMethodCard.fromJson(Map<String, dynamic> json) =>
+      _$StripePaymentMethodCardFromJson(json);
+
+  /// Two-letter ISO country code of the issuing bank, e.g. `IN`.
+  final String? country;
+}

--- a/packages/stripe_api/lib/src/models/stripe_payment_method.g.dart
+++ b/packages/stripe_api/lib/src/models/stripe_payment_method.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, require_trailing_commas, cast_nullable_to_non_nullable, lines_longer_than_80_chars, unnecessary_lambdas
+
+part of 'stripe_payment_method.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StripePaymentMethod _$StripePaymentMethodFromJson(Map<String, dynamic> json) =>
+    $checkedCreate('StripePaymentMethod', json, ($checkedConvert) {
+      final val = StripePaymentMethod(
+        id: $checkedConvert('id', (v) => v as String),
+        card: $checkedConvert(
+          'card',
+          (v) => v == null
+              ? null
+              : StripePaymentMethodCard.fromJson(v as Map<String, dynamic>),
+        ),
+      );
+      return val;
+    });
+
+StripePaymentMethodCard _$StripePaymentMethodCardFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('StripePaymentMethodCard', json, ($checkedConvert) {
+  final val = StripePaymentMethodCard(
+    country: $checkedConvert('country', (v) => v as String?),
+  );
+  return val;
+});

--- a/packages/stripe_api/lib/src/models/stripe_price.dart
+++ b/packages/stripe_api/lib/src/models/stripe_price.dart
@@ -39,6 +39,25 @@ enum UsageType {
   metered,
 }
 
+/// {@template recurring_interval}
+/// The unit of time between a recurring [StripePrice]'s billings.
+/// https://docs.stripe.com/api/prices/object#price_object-recurring-interval
+/// {@endtemplate}
+@JsonEnum()
+enum RecurringInterval {
+  /// Bills every [StripePrice.intervalCount] days.
+  day,
+
+  /// Bills every [StripePrice.intervalCount] weeks.
+  week,
+
+  /// Bills every [StripePrice.intervalCount] months.
+  month,
+
+  /// Bills every [StripePrice.intervalCount] years.
+  year,
+}
+
 /// {@template stripe_price}
 /// A partial Dart representation of the Price object from Stripe's API.
 ///
@@ -56,6 +75,8 @@ class StripePrice {
     this.unitAmountDecimal,
     this.tiers,
     this.usageType,
+    this.interval,
+    this.intervalCount,
     this.metadata = const {},
     this.meterId,
     this.nickname,
@@ -116,6 +137,25 @@ class StripePrice {
   static Object? _readUsageType(Map<dynamic, dynamic> json, String _) {
     final recurring = json['recurring'] as Map<String, dynamic>?;
     return recurring?['usage_type'];
+  }
+
+  /// The unit of time between billings. Null for a one-time price.
+  @JsonKey(readValue: _readInterval)
+  final RecurringInterval? interval;
+
+  static Object? _readInterval(Map<dynamic, dynamic> json, String _) {
+    final recurring = json['recurring'] as Map<String, dynamic>?;
+    return recurring?['interval'];
+  }
+
+  /// How many [interval]s pass between billings: `3` with
+  /// [RecurringInterval.month] bills quarterly. Null for a one-time price.
+  @JsonKey(readValue: _readIntervalCount)
+  final int? intervalCount;
+
+  static Object? _readIntervalCount(Map<dynamic, dynamic> json, String _) {
+    final recurring = json['recurring'] as Map<String, dynamic>?;
+    return recurring?['interval_count'];
   }
 }
 

--- a/packages/stripe_api/lib/src/models/stripe_price.g.dart
+++ b/packages/stripe_api/lib/src/models/stripe_price.g.dart
@@ -36,6 +36,16 @@ StripePrice _$StripePriceFromJson(Map<String, dynamic> json) => $checkedCreate(
         (v) => $enumDecodeNullable(_$UsageTypeEnumMap, v),
         readValue: StripePrice._readUsageType,
       ),
+      interval: $checkedConvert(
+        'interval',
+        (v) => $enumDecodeNullable(_$RecurringIntervalEnumMap, v),
+        readValue: StripePrice._readInterval,
+      ),
+      intervalCount: $checkedConvert(
+        'interval_count',
+        (v) => (v as num?)?.toInt(),
+        readValue: StripePrice._readIntervalCount,
+      ),
       metadata: $checkedConvert(
         'metadata',
         (v) => v as Map<String, dynamic>? ?? const {},
@@ -55,6 +65,7 @@ StripePrice _$StripePriceFromJson(Map<String, dynamic> json) => $checkedCreate(
     'unitAmount': 'unit_amount',
     'unitAmountDecimal': 'unit_amount_decimal',
     'usageType': 'usage_type',
+    'intervalCount': 'interval_count',
     'meterId': 'meter_id',
   },
 );
@@ -67,4 +78,11 @@ const _$BillingSchemeEnumMap = {
 const _$UsageTypeEnumMap = {
   UsageType.licensed: 'licensed',
   UsageType.metered: 'metered',
+};
+
+const _$RecurringIntervalEnumMap = {
+  RecurringInterval.day: 'day',
+  RecurringInterval.week: 'week',
+  RecurringInterval.month: 'month',
+  RecurringInterval.year: 'year',
 };

--- a/packages/stripe_api/lib/src/models/stripe_subscription.dart
+++ b/packages/stripe_api/lib/src/models/stripe_subscription.dart
@@ -62,6 +62,7 @@ class StripeSubscription {
     this.currency,
     this.defaultPaymentMethod,
     this.automaticTaxEnabled = false,
+    this.collectionMethod,
   });
 
   /// Converts a `Map<String, dynamic>` to a [StripeSubscription].
@@ -145,6 +146,10 @@ class StripeSubscription {
   /// invoices.
   @JsonKey(name: 'automatic_tax', fromJson: _automaticTaxEnabledFromJson)
   final bool automaticTaxEnabled;
+
+  /// How this subscription's invoices collect payment:
+  /// `charge_automatically` or `send_invoice`.
+  final String? collectionMethod;
 
   /// Whether this subscription is in an active or trialing state.
   bool get isActiveOrTrial =>

--- a/packages/stripe_api/lib/src/models/stripe_subscription.dart
+++ b/packages/stripe_api/lib/src/models/stripe_subscription.dart
@@ -36,6 +36,23 @@ enum StripeSubscriptionStatus {
   paused,
 }
 
+/// How a [StripeSubscription]'s invoices collect payment.
+///
+/// See https://docs.stripe.com/api/subscriptions/object#subscription_object-collection_method.
+@JsonEnum(fieldRename: FieldRename.snake)
+enum StripeCollectionMethod {
+  /// Stripe charges the payment method on file when an invoice finalizes.
+  chargeAutomatically('charge_automatically'),
+
+  /// Stripe emails a hosted invoice and waits for the customer to pay it.
+  sendInvoice('send_invoice');
+
+  const StripeCollectionMethod(this.value);
+
+  /// The value Stripe uses for this method on the wire.
+  final String value;
+}
+
 /// {@template stripe_subscription}
 /// A partial Dart representation of the Subscription object from Stripe's API.
 ///
@@ -147,9 +164,8 @@ class StripeSubscription {
   @JsonKey(name: 'automatic_tax', fromJson: _automaticTaxEnabledFromJson)
   final bool automaticTaxEnabled;
 
-  /// How this subscription's invoices collect payment:
-  /// `charge_automatically` or `send_invoice`.
-  final String? collectionMethod;
+  /// How this subscription's invoices collect payment.
+  final StripeCollectionMethod? collectionMethod;
 
   /// Whether this subscription is in an active or trialing state.
   bool get isActiveOrTrial =>

--- a/packages/stripe_api/lib/src/models/stripe_subscription.dart
+++ b/packages/stripe_api/lib/src/models/stripe_subscription.dart
@@ -58,6 +58,10 @@ class StripeSubscription {
     this.canceledAt,
     this.trialStart,
     this.trialEnd,
+    this.metadata = const {},
+    this.currency,
+    this.defaultPaymentMethod,
+    this.automaticTaxEnabled = false,
   });
 
   /// Converts a `Map<String, dynamic>` to a [StripeSubscription].
@@ -124,6 +128,24 @@ class StripeSubscription {
   @JsonKey(fromJson: _subscriptionItemsFromJson)
   final List<StripeSubscriptionItem> items;
 
+  /// Set of key-value pairs attached to the subscription.
+  final Map<String, String> metadata;
+
+  /// Three-letter ISO currency code, in lowercase.
+  final String? currency;
+
+  /// ID of the payment method used to pay this subscription's invoices.
+  ///
+  /// Not expanded, so this is the payment method id. Null when the
+  /// subscription bills against the customer's default payment method
+  /// instead of one of its own.
+  final String? defaultPaymentMethod;
+
+  /// Whether Stripe calculates tax automatically on this subscription's
+  /// invoices.
+  @JsonKey(name: 'automatic_tax', fromJson: _automaticTaxEnabledFromJson)
+  final bool automaticTaxEnabled;
+
   /// Whether this subscription is in an active or trialing state.
   bool get isActiveOrTrial =>
       status == StripeSubscriptionStatus.active ||
@@ -139,6 +161,9 @@ class StripeSubscription {
   bool get hasMeteredBilling =>
       items.any((item) => item.price.usageType == UsageType.metered);
 }
+
+bool _automaticTaxEnabledFromJson(Map<String, dynamic>? json) =>
+    json?['enabled'] as bool? ?? false;
 
 List<StripeSubscriptionItem> _subscriptionItemsFromJson(
   Map<String, dynamic>? json,

--- a/packages/stripe_api/lib/src/models/stripe_subscription.g.dart
+++ b/packages/stripe_api/lib/src/models/stripe_subscription.g.dart
@@ -94,6 +94,10 @@ StripeSubscription _$StripeSubscriptionFromJson(Map<String, dynamic> json) =>
                 ? false
                 : _automaticTaxEnabledFromJson(v as Map<String, dynamic>?),
           ),
+          collectionMethod: $checkedConvert(
+            'collection_method',
+            (v) => v as String?,
+          ),
         );
         return val;
       },
@@ -109,6 +113,7 @@ StripeSubscription _$StripeSubscriptionFromJson(Map<String, dynamic> json) =>
         'trialEnd': 'trial_end',
         'defaultPaymentMethod': 'default_payment_method',
         'automaticTaxEnabled': 'automatic_tax',
+        'collectionMethod': 'collection_method',
       },
     );
 

--- a/packages/stripe_api/lib/src/models/stripe_subscription.g.dart
+++ b/packages/stripe_api/lib/src/models/stripe_subscription.g.dart
@@ -75,6 +75,25 @@ StripeSubscription _$StripeSubscriptionFromJson(Map<String, dynamic> json) =>
               const TimestampConverter().fromJson,
             ),
           ),
+          metadata: $checkedConvert(
+            'metadata',
+            (v) =>
+                (v as Map<String, dynamic>?)?.map(
+                  (k, e) => MapEntry(k, e as String),
+                ) ??
+                const {},
+          ),
+          currency: $checkedConvert('currency', (v) => v as String?),
+          defaultPaymentMethod: $checkedConvert(
+            'default_payment_method',
+            (v) => v as String?,
+          ),
+          automaticTaxEnabled: $checkedConvert(
+            'automatic_tax',
+            (v) => v == null
+                ? false
+                : _automaticTaxEnabledFromJson(v as Map<String, dynamic>?),
+          ),
         );
         return val;
       },
@@ -88,6 +107,8 @@ StripeSubscription _$StripeSubscriptionFromJson(Map<String, dynamic> json) =>
         'canceledAt': 'canceled_at',
         'trialStart': 'trial_start',
         'trialEnd': 'trial_end',
+        'defaultPaymentMethod': 'default_payment_method',
+        'automaticTaxEnabled': 'automatic_tax',
       },
     );
 

--- a/packages/stripe_api/lib/src/models/stripe_subscription.g.dart
+++ b/packages/stripe_api/lib/src/models/stripe_subscription.g.dart
@@ -96,7 +96,7 @@ StripeSubscription _$StripeSubscriptionFromJson(Map<String, dynamic> json) =>
           ),
           collectionMethod: $checkedConvert(
             'collection_method',
-            (v) => v as String?,
+            (v) => $enumDecodeNullable(_$StripeCollectionMethodEnumMap, v),
           ),
         );
         return val;
@@ -132,3 +132,8 @@ Value? _$JsonConverterFromJson<Json, Value>(
   Object? json,
   Value? Function(Json json) fromJson,
 ) => json == null ? null : fromJson(json as Json);
+
+const _$StripeCollectionMethodEnumMap = {
+  StripeCollectionMethod.chargeAutomatically: 'charge_automatically',
+  StripeCollectionMethod.sendInvoice: 'send_invoice',
+};

--- a/packages/stripe_api/lib/src/stripe_api.dart
+++ b/packages/stripe_api/lib/src/stripe_api.dart
@@ -69,6 +69,96 @@ class StripeApi {
     );
   }
 
+  /// Lists every subscription belonging to [customerId] that has not been
+  /// canceled, regardless of status.
+  ///
+  /// Prices are not expanded, so [StripePrice.tiers] is null on the returned
+  /// subscriptions. Use [fetchSubscription] when tiers are needed.
+  Future<List<StripeSubscription>> listSubscriptions({
+    required String customerId,
+  }) => _fetchAllPages(
+    path: 'subscriptions',
+    queryParameters: {'customer': customerId},
+    fromJson: StripeSubscription.fromJson,
+    getId: (e) => e.id,
+  );
+
+  /// Creates a subscription for [customerId] on [priceId].
+  ///
+  /// [idempotencyKey] must be unique per logical creation attempt: Stripe
+  /// replays the original response for a reused key for ~24 hours, so a key
+  /// derived from stable identity would return an earlier subscription instead
+  /// of creating one.
+  ///
+  /// A null [currency] or [defaultPaymentMethod] is omitted from the request
+  /// rather than sent empty, which leaves Stripe to fall back to the
+  /// customer's own currency and default payment method.
+  ///
+  /// See https://docs.stripe.com/api/subscriptions/create.
+  Future<StripeSubscription> createSubscription({
+    required String customerId,
+    required String priceId,
+    required bool automaticTaxEnabled,
+    required Map<String, String> metadata,
+    required String idempotencyKey,
+    String? currency,
+    String? defaultPaymentMethod,
+  }) async {
+    final uri = _stripeUri(path: 'subscriptions');
+    final response = await _client.post(
+      uri,
+      headers: {..._authHeaders, 'Idempotency-Key': idempotencyKey},
+      body: {
+        'customer': customerId,
+        'items[0][price]': priceId,
+        'currency': ?currency,
+        'default_payment_method': ?defaultPaymentMethod,
+        'automatic_tax[enabled]': '$automaticTaxEnabled',
+        for (final entry in metadata.entries)
+          'metadata[${entry.key}]': entry.value,
+      },
+    );
+
+    if (response.statusCode != HttpStatus.ok) {
+      throw StripeApiException.fromResponse(
+        response,
+        message:
+            'Failed to create subscription on $priceId for customer '
+            '$customerId',
+      );
+    }
+
+    return StripeSubscription.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+  }
+
+  /// Immediately cancels the subscription with the given [subscriptionId].
+  ///
+  /// [invoiceNow] and [prorate] control whether pending metered usage is
+  /// invoiced on cancellation; Stripe does neither by default.
+  ///
+  /// See https://docs.stripe.com/api/subscriptions/cancel.
+  Future<void> cancelSubscription({
+    required String subscriptionId,
+    required bool invoiceNow,
+    required bool prorate,
+  }) async {
+    final uri = _stripeUri(path: 'subscriptions/$subscriptionId');
+    final response = await _client.delete(
+      uri,
+      headers: _authHeaders,
+      body: {'invoice_now': '$invoiceNow', 'prorate': '$prorate'},
+    );
+
+    if (response.statusCode != HttpStatus.ok) {
+      throw StripeApiException.fromResponse(
+        response,
+        message: 'Failed to cancel subscription with id $subscriptionId',
+      );
+    }
+  }
+
   /// Retrieves all [StripeBillingMeter]s associated with the Stripe account.
   Future<List<StripeBillingMeter>> fetchActiveBillingMeters() async {
     return _fetchAllPages(
@@ -143,13 +233,13 @@ ${response.body}
     while (true) {
       final uri = _stripeUri(
         path: path,
-        queryParameters: queryParameters
-          ..addAll({
-            // 100 is the max, as per https://docs.stripe.com/api/pagination
-            'limit': '100',
-            if (pagedObjects.isNotEmpty)
-              'starting_after': getId(pagedObjects.last),
-          }),
+        queryParameters: {
+          ...queryParameters,
+          // 100 is the max, as per https://docs.stripe.com/api/pagination
+          'limit': '100',
+          if (pagedObjects.isNotEmpty)
+            'starting_after': getId(pagedObjects.last),
+        },
       );
 
       final response = await _client.get(uri, headers: _authHeaders);

--- a/packages/stripe_api/lib/src/stripe_api.dart
+++ b/packages/stripe_api/lib/src/stripe_api.dart
@@ -116,9 +116,9 @@ class StripeApi {
   /// customer's own currency and default payment method.
   ///
   /// [collectionMethod] selects how invoices collect: null leaves Stripe's
-  /// default (`charge_automatically`); `send_invoice` emails a hosted invoice
-  /// instead of charging the payment method, and Stripe then requires
-  /// [daysUntilDue].
+  /// default ([StripeCollectionMethod.chargeAutomatically]);
+  /// [StripeCollectionMethod.sendInvoice] emails a hosted invoice instead of
+  /// charging the payment method, and Stripe then requires [daysUntilDue].
   ///
   /// See https://docs.stripe.com/api/subscriptions/create.
   Future<StripeSubscription> createSubscription({
@@ -129,7 +129,7 @@ class StripeApi {
     required String idempotencyKey,
     String? currency,
     String? defaultPaymentMethod,
-    String? collectionMethod,
+    StripeCollectionMethod? collectionMethod,
     int? daysUntilDue,
   }) async {
     final uri = _stripeUri(path: 'subscriptions');
@@ -141,7 +141,7 @@ class StripeApi {
         'items[0][price]': priceId,
         'currency': ?currency,
         'default_payment_method': ?defaultPaymentMethod,
-        'collection_method': ?collectionMethod,
+        'collection_method': ?collectionMethod?.value,
         'days_until_due': ?daysUntilDue?.toString(),
         'automatic_tax[enabled]': '$automaticTaxEnabled',
         for (final entry in metadata.entries)
@@ -163,13 +163,14 @@ class StripeApi {
     );
   }
 
-  /// Immediately cancels the subscription with the given [subscriptionId].
+  /// Immediately cancels the subscription with the given [subscriptionId] and
+  /// returns it as Stripe reports it after the cancellation.
   ///
   /// [invoiceNow] and [prorate] control whether pending metered usage is
   /// invoiced on cancellation; Stripe does neither by default.
   ///
   /// See https://docs.stripe.com/api/subscriptions/cancel.
-  Future<void> cancelSubscription({
+  Future<StripeSubscription> cancelSubscription({
     required String subscriptionId,
     required bool invoiceNow,
     required bool prorate,
@@ -187,6 +188,10 @@ class StripeApi {
         message: 'Failed to cancel subscription with id $subscriptionId',
       );
     }
+
+    return StripeSubscription.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
   }
 
   /// Retrieves all [StripeBillingMeter]s associated with the Stripe account.

--- a/packages/stripe_api/lib/src/stripe_api.dart
+++ b/packages/stripe_api/lib/src/stripe_api.dart
@@ -69,6 +69,27 @@ class StripeApi {
     );
   }
 
+  /// Retrieves a [StripePaymentMethod] with the given [paymentMethodId].
+  ///
+  /// See https://docs.stripe.com/api/payment_methods/retrieve.
+  Future<StripePaymentMethod> fetchPaymentMethod({
+    required String paymentMethodId,
+  }) async {
+    final uri = _stripeUri(path: 'payment_methods/$paymentMethodId');
+
+    final response = await _client.get(uri, headers: _authHeaders);
+    if (response.statusCode != HttpStatus.ok) {
+      throw StripeApiException.fromResponse(
+        response,
+        message: 'Failed to retrieve payment method with id $paymentMethodId',
+      );
+    }
+
+    return StripePaymentMethod.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+  }
+
   /// Lists every subscription belonging to [customerId] that has not been
   /// canceled, regardless of status.
   ///
@@ -94,6 +115,11 @@ class StripeApi {
   /// rather than sent empty, which leaves Stripe to fall back to the
   /// customer's own currency and default payment method.
   ///
+  /// [collectionMethod] selects how invoices collect: null leaves Stripe's
+  /// default (`charge_automatically`); `send_invoice` emails a hosted invoice
+  /// instead of charging the payment method, and Stripe then requires
+  /// [daysUntilDue].
+  ///
   /// See https://docs.stripe.com/api/subscriptions/create.
   Future<StripeSubscription> createSubscription({
     required String customerId,
@@ -103,6 +129,8 @@ class StripeApi {
     required String idempotencyKey,
     String? currency,
     String? defaultPaymentMethod,
+    String? collectionMethod,
+    int? daysUntilDue,
   }) async {
     final uri = _stripeUri(path: 'subscriptions');
     final response = await _client.post(
@@ -113,6 +141,8 @@ class StripeApi {
         'items[0][price]': priceId,
         'currency': ?currency,
         'default_payment_method': ?defaultPaymentMethod,
+        'collection_method': ?collectionMethod,
+        'days_until_due': ?daysUntilDue?.toString(),
         'automatic_tax[enabled]': '$automaticTaxEnabled',
         for (final entry in metadata.entries)
           'metadata[${entry.key}]': entry.value,

--- a/packages/stripe_api/test/fixtures/stripe/json/payment_method.json
+++ b/packages/stripe_api/test/fixtures/stripe/json/payment_method.json
@@ -1,0 +1,14 @@
+{
+  "id": "pm_123",
+  "object": "payment_method",
+  "type": "card",
+  "card": {
+    "brand": "visa",
+    "country": "IN",
+    "exp_month": 8,
+    "exp_year": 2030,
+    "last4": "4242"
+  },
+  "customer": "cus_123",
+  "livemode": false
+}

--- a/packages/stripe_api/test/fixtures/stripe/json/payment_method_no_card.json
+++ b/packages/stripe_api/test/fixtures/stripe/json/payment_method_no_card.json
@@ -1,0 +1,10 @@
+{
+  "id": "pm_456",
+  "object": "payment_method",
+  "type": "link",
+  "link": {
+    "email": "test@example.com"
+  },
+  "customer": "cus_123",
+  "livemode": false
+}

--- a/packages/stripe_api/test/fixtures/stripe/stripe_fixtures.dart
+++ b/packages/stripe_api/test/fixtures/stripe/stripe_fixtures.dart
@@ -37,6 +37,12 @@ String get customerWithInactiveSubscriptionJsonString => File(
   '$stripeJsonPath/customer_with_inactive_subscription.json',
 ).readAsStringSync();
 
+String get paymentMethodJsonString =>
+    File('$stripeJsonPath/payment_method.json').readAsStringSync();
+
+String get paymentMethodNoCardJsonString =>
+    File('$stripeJsonPath/payment_method_no_card.json').readAsStringSync();
+
 String get subscriptionJsonString =>
     File('$stripeJsonPath/subscription.json').readAsStringSync();
 

--- a/packages/stripe_api/test/src/models/stripe_price_test.dart
+++ b/packages/stripe_api/test/src/models/stripe_price_test.dart
@@ -21,7 +21,24 @@ void main() {
         expect(price.unitAmountDecimal, Decimal.fromInt(1500));
         expect(price.tiers, isNull);
         expect(price.usageType, UsageType.licensed);
+        expect(price.interval, RecurringInterval.month);
+        expect(price.intervalCount, 1);
         expect(price.meterId, isNull);
+      });
+
+      test('deserializes a one-time price with no interval', () {
+        final items =
+            (subscriptionJson['items'] as Map<String, dynamic>)['data'] as List;
+        final priceJson =
+            ((items.first as Map<String, dynamic>)['price']
+                  as Map<String, dynamic>)
+              ..remove('recurring');
+
+        final price = StripePrice.fromJson(priceJson);
+
+        expect(price.usageType, isNull);
+        expect(price.interval, isNull);
+        expect(price.intervalCount, isNull);
       });
 
       test('can be deserialized from json (pay as you go)', () {
@@ -40,6 +57,8 @@ void main() {
         expect(price.unitAmountDecimal, Decimal.parse('0.04'));
         expect(price.tiers, isNull);
         expect(price.usageType, UsageType.metered);
+        expect(price.interval, RecurringInterval.month);
+        expect(price.intervalCount, 1);
         expect(price.meterId, 'mtr_test_61QvSUDTnLya5cdwG41HSA9cXarIc144');
       });
     });

--- a/packages/stripe_api/test/src/models/stripe_subscription_test.dart
+++ b/packages/stripe_api/test/src/models/stripe_subscription_test.dart
@@ -33,7 +33,10 @@ void main() {
       expect(subscription.status, StripeSubscriptionStatus.active);
       expect(subscription.trialStart, isNull);
       expect(subscription.trialEnd, isNull);
-      expect(subscription.collectionMethod, 'charge_automatically');
+      expect(
+        subscription.collectionMethod,
+        StripeCollectionMethod.chargeAutomatically,
+      );
     });
 
     test('deserializes a null collection method when absent', () {
@@ -114,7 +117,10 @@ void main() {
         expect(subscription.endedAt, null);
         expect(subscription.startDate, isNotNull);
         expect(subscription.status, StripeSubscriptionStatus.trialing);
-        expect(subscription.collectionMethod, 'send_invoice');
+        expect(
+          subscription.collectionMethod,
+          StripeCollectionMethod.sendInvoice,
+        );
         expect(
           subscription.trialStart,
           DateTime.fromMillisecondsSinceEpoch(1725845719000),

--- a/packages/stripe_api/test/src/models/stripe_subscription_test.dart
+++ b/packages/stripe_api/test/src/models/stripe_subscription_test.dart
@@ -33,6 +33,15 @@ void main() {
       expect(subscription.status, StripeSubscriptionStatus.active);
       expect(subscription.trialStart, isNull);
       expect(subscription.trialEnd, isNull);
+      expect(subscription.collectionMethod, 'charge_automatically');
+    });
+
+    test('deserializes a null collection method when absent', () {
+      final json = subscriptionJson..remove('collection_method');
+
+      final subscription = StripeSubscription.fromJson(json);
+
+      expect(subscription.collectionMethod, isNull);
     });
 
     test('deserializes metadata', () {
@@ -105,6 +114,7 @@ void main() {
         expect(subscription.endedAt, null);
         expect(subscription.startDate, isNotNull);
         expect(subscription.status, StripeSubscriptionStatus.trialing);
+        expect(subscription.collectionMethod, 'send_invoice');
         expect(
           subscription.trialStart,
           DateTime.fromMillisecondsSinceEpoch(1725845719000),

--- a/packages/stripe_api/test/src/models/stripe_subscription_test.dart
+++ b/packages/stripe_api/test/src/models/stripe_subscription_test.dart
@@ -35,6 +35,36 @@ void main() {
       expect(subscription.trialEnd, isNull);
     });
 
+    test('deserializes metadata', () {
+      final json = subscriptionJson
+        ..['metadata'] = {'shorebird_role': 'overage'};
+
+      final subscription = StripeSubscription.fromJson(json);
+
+      expect(subscription.metadata, {'shorebird_role': 'overage'});
+    });
+
+    test('deserializes currency, payment method, and automatic tax', () {
+      final json = subscriptionJson
+        ..['default_payment_method'] = 'pm_123'
+        ..['automatic_tax'] = {'enabled': true};
+
+      final subscription = StripeSubscription.fromJson(json);
+
+      expect(subscription.currency, 'usd');
+      expect(subscription.defaultPaymentMethod, 'pm_123');
+      expect(subscription.automaticTaxEnabled, isTrue);
+    });
+
+    test('defaults automaticTaxEnabled to false when unset', () {
+      final json = subscriptionJson..['automatic_tax'] = <String, dynamic>{};
+
+      final subscription = StripeSubscription.fromJson(json);
+
+      expect(subscription.defaultPaymentMethod, isNull);
+      expect(subscription.automaticTaxEnabled, isFalse);
+    });
+
     test('deserializes from json with missing items data', () {
       final updatedSubscriptionJson = subscriptionJson;
       (updatedSubscriptionJson['items'] as Map<String, dynamic>).remove('data');

--- a/packages/stripe_api/test/src/stripe_api_test.dart
+++ b/packages/stripe_api/test/src/stripe_api_test.dart
@@ -369,6 +369,35 @@ void main() {
         ).called(1);
       });
 
+      test('sends collection method and days until due when given', () async {
+        await stripeApi.createSubscription(
+          customerId: 'cus_123',
+          priceId: 'price_123',
+          automaticTaxEnabled: true,
+          metadata: const {},
+          idempotencyKey: 'key_123',
+          collectionMethod: 'send_invoice',
+          daysUntilDue: 30,
+        );
+
+        verify(
+          () => httpClient.post(
+            uri,
+            headers: {
+              ...expectedAuthHeaders,
+              'Idempotency-Key': 'key_123',
+            },
+            body: {
+              'customer': 'cus_123',
+              'items[0][price]': 'price_123',
+              'collection_method': 'send_invoice',
+              'days_until_due': '30',
+              'automatic_tax[enabled]': 'true',
+            },
+          ),
+        ).called(1);
+      });
+
       test('omits currency and payment method when null', () async {
         await stripeApi.createSubscription(
           customerId: 'cus_123',
@@ -421,6 +450,53 @@ void main() {
             throwsException,
           );
         });
+      });
+    });
+
+    group('fetchPaymentMethod', () {
+      final uri = Uri.parse('https://api.stripe.com/v1/payment_methods/pm_123');
+
+      test('throws exception if Stripe returns a non-200 response', () {
+        when(
+          () => httpClient.get(uri, headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async => http.Response('Not found', HttpStatus.notFound),
+        );
+
+        expect(
+          () => stripeApi.fetchPaymentMethod(paymentMethodId: 'pm_123'),
+          throwsException,
+        );
+      });
+
+      test('returns a payment method with card country', () async {
+        when(
+          () => httpClient.get(uri, headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async => http.Response(paymentMethodJsonString, HttpStatus.ok),
+        );
+
+        final paymentMethod = await stripeApi.fetchPaymentMethod(
+          paymentMethodId: 'pm_123',
+        );
+
+        expect(paymentMethod.id, equals('pm_123'));
+        expect(paymentMethod.card?.country, equals('IN'));
+      });
+
+      test('returns a null card for a non-card payment method', () async {
+        when(
+          () => httpClient.get(uri, headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async =>
+              http.Response(paymentMethodNoCardJsonString, HttpStatus.ok),
+        );
+
+        final paymentMethod = await stripeApi.fetchPaymentMethod(
+          paymentMethodId: 'pm_123',
+        );
+
+        expect(paymentMethod.card, isNull);
       });
     });
 

--- a/packages/stripe_api/test/src/stripe_api_test.dart
+++ b/packages/stripe_api/test/src/stripe_api_test.dart
@@ -272,6 +272,215 @@ void main() {
       );
     });
 
+    group('listSubscriptions', () {
+      // cspell:disable-next-line
+      const subscriptionId = 'sub_1MvjPuHSA9cXarIcaWYNaezR';
+
+      setUp(() {
+        when(
+          () => httpClient.get(
+            Uri.parse(
+              'https://api.stripe.com/v1/subscriptions?customer=cus_123&limit=100',
+            ),
+            headers: any(named: 'headers'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode({
+              'object': 'list',
+              'data': [subscriptionJson],
+              'has_more': true,
+            }),
+            HttpStatus.ok,
+          ),
+        );
+
+        when(
+          () => httpClient.get(
+            Uri.parse(
+              'https://api.stripe.com/v1/subscriptions?customer=cus_123&limit=100&starting_after=$subscriptionId',
+            ),
+            headers: any(named: 'headers'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode({
+              'object': 'list',
+              'data': [trialingSubscriptionJson],
+              'has_more': false,
+            }),
+            HttpStatus.ok,
+          ),
+        );
+      });
+
+      test('returns all pages of subscriptions', () async {
+        final subscriptions = await stripeApi.listSubscriptions(
+          customerId: 'cus_123',
+        );
+
+        expect(subscriptions, hasLength(2));
+        expect(subscriptions.first.id, subscriptionId);
+      });
+    });
+
+    group('createSubscription', () {
+      final uri = Uri.parse('https://api.stripe.com/v1/subscriptions');
+
+      setUp(() {
+        when(
+          () => httpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(subscriptionJsonString, HttpStatus.ok),
+        );
+      });
+
+      test('sends the correct request', () async {
+        await stripeApi.createSubscription(
+          customerId: 'cus_123',
+          priceId: 'price_123',
+          currency: 'usd',
+          defaultPaymentMethod: 'pm_123',
+          automaticTaxEnabled: true,
+          metadata: {'shorebird_role': 'overage'},
+          idempotencyKey: 'key_123',
+        );
+
+        verify(
+          () => httpClient.post(
+            uri,
+            headers: {
+              ...expectedAuthHeaders,
+              'Idempotency-Key': 'key_123',
+            },
+            body: {
+              'customer': 'cus_123',
+              'items[0][price]': 'price_123',
+              'currency': 'usd',
+              'default_payment_method': 'pm_123',
+              'automatic_tax[enabled]': 'true',
+              'metadata[shorebird_role]': 'overage',
+            },
+          ),
+        ).called(1);
+      });
+
+      test('omits currency and payment method when null', () async {
+        await stripeApi.createSubscription(
+          customerId: 'cus_123',
+          priceId: 'price_123',
+          automaticTaxEnabled: false,
+          metadata: const {},
+          idempotencyKey: 'key_123',
+        );
+
+        verify(
+          () => httpClient.post(
+            uri,
+            headers: {
+              ...expectedAuthHeaders,
+              'Idempotency-Key': 'key_123',
+            },
+            body: {
+              'customer': 'cus_123',
+              'items[0][price]': 'price_123',
+              'automatic_tax[enabled]': 'false',
+            },
+          ),
+        ).called(1);
+      });
+
+      group('when response has non-success status code', () {
+        setUp(() {
+          when(
+            () => httpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => http.Response('Not found', HttpStatus.notFound),
+          );
+        });
+
+        test('throws exception', () async {
+          await expectLater(
+            () => stripeApi.createSubscription(
+              customerId: 'cus_123',
+              priceId: 'price_123',
+              currency: 'usd',
+              defaultPaymentMethod: 'pm_123',
+              automaticTaxEnabled: true,
+              metadata: const {},
+              idempotencyKey: 'key_123',
+            ),
+            throwsException,
+          );
+        });
+      });
+    });
+
+    group('cancelSubscription', () {
+      final uri = Uri.parse('https://api.stripe.com/v1/subscriptions/sub_123');
+
+      setUp(() {
+        when(
+          () => httpClient.delete(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(subscriptionJsonString, HttpStatus.ok),
+        );
+      });
+
+      test('sends the correct request', () async {
+        await stripeApi.cancelSubscription(
+          subscriptionId: 'sub_123',
+          invoiceNow: true,
+          prorate: true,
+        );
+
+        verify(
+          () => httpClient.delete(
+            uri,
+            headers: expectedAuthHeaders,
+            body: {'invoice_now': 'true', 'prorate': 'true'},
+          ),
+        ).called(1);
+      });
+
+      group('when response has non-success status code', () {
+        setUp(() {
+          when(
+            () => httpClient.delete(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => http.Response('Not found', HttpStatus.notFound),
+          );
+        });
+
+        test('throws exception', () async {
+          await expectLater(
+            () => stripeApi.cancelSubscription(
+              subscriptionId: 'sub_123',
+              invoiceNow: false,
+              prorate: false,
+            ),
+            throwsException,
+          );
+        });
+      });
+    });
+
     group('fetchBillingMeters', () {
       const meterId = 'mtr_test_61QvSUDTnLya5cdwG41HSA9cXarIc144';
       setUp(() {

--- a/packages/stripe_api/test/src/stripe_api_test.dart
+++ b/packages/stripe_api/test/src/stripe_api_test.dart
@@ -376,7 +376,7 @@ void main() {
           automaticTaxEnabled: true,
           metadata: const {},
           idempotencyKey: 'key_123',
-          collectionMethod: 'send_invoice',
+          collectionMethod: StripeCollectionMethod.sendInvoice,
           daysUntilDue: 30,
         );
 
@@ -515,13 +515,15 @@ void main() {
         );
       });
 
-      test('sends the correct request', () async {
-        await stripeApi.cancelSubscription(
+      test('sends the correct request and returns the subscription', () async {
+        final subscription = await stripeApi.cancelSubscription(
           subscriptionId: 'sub_123',
           invoiceNow: true,
           prorate: true,
         );
 
+        // cspell:disable-next-line
+        expect(subscription.id, 'sub_1MvjPuHSA9cXarIcaWYNaezR');
         verify(
           () => httpClient.delete(
             uri,


### PR DESCRIPTION
Adds the subscription operations the code push server needs to bill annual overages on a second, monthly metered subscription: `listSubscriptions` (paginated `GET /v1/subscriptions`), plus the package's first write support — `createSubscription` (price, metadata, payment method, tax, currency, collection method with `days_until_due`, `Idempotency-Key` header), `cancelSubscription` with an immediate final invoice (`invoice_now`/`prorate`) that returns the canceled subscription as Stripe reports it, and `fetchPaymentMethod`, exposing a payment method's card country.

`StripeSubscription` gains read-only `metadata`, `currency`, `default_payment_method`, `automatic_tax`, and `collection_method` fields. The server copies these from a customer's existing subscription onto the new one, so it has to be able to read them. A null currency or payment method is left out of the create request so Stripe falls back to the customer's own defaults. `collection_method` is a `StripeCollectionMethod` enum on the model and on `createSubscription`, so a misspelt method fails to compile instead of failing at Stripe.

`StripePrice` gains `interval` and `intervalCount` from `recurring`. The console currently guesses a plan's billing cadence from the length of its current period; reading it off the price the customer bought removes the guess.

Also fixes a small pre-existing bug in `_fetchAllPages`: it added its paging parameters to the caller's own query map instead of a copy. No caller was actually affected; fixed while in the file.

The four existing `fetchActiveSubscriptions` tests stand unmodified. New tests cover the list query string and pagination, the create parameters and idempotency header (`collection_method`/`days_until_due` sent only when asked), the cancel request and the subscription it returns, the payment-method fetch, the new subscription fields, and the price interval fields including a one-time price with no `recurring` block.
