### PR TITLE
chore: remove the Shorebird CI badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Discord](https://img.shields.io/discord/1030243211995791380?style=for-the-badge&logo=discord&color=blue)](https://discord.gg/shorebird)
 <a href="https://www.producthunt.com/posts/shorebird-code-push?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-shorebird&#0045;code&#0045;push" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=449946&theme=neutral" alt="Shorebird&#0032;Code&#0032;Push - Flutter&#0032;over&#0032;the&#0032;air&#0032;updates | Product Hunt" style="width: 128px; height: 27px;" width="128" height="27" /></a>
 
-[![shorebird ci](https://api.shorebird.dev/api/v1/github/shorebirdtech/shorebird/badge.svg)](https://console.shorebird.dev/ci)
 [![ci](https://github.com/shorebirdtech/shorebird/actions/workflows/main.yaml/badge.svg)](https://github.com/shorebirdtech/shorebird/actions/workflows/main.yaml)
 [![e2e](https://github.com/shorebirdtech/shorebird/actions/workflows/e2e.yaml/badge.svg)](https://github.com/shorebirdtech/shorebird/actions/workflows/e2e.yaml)
 [![codecov](https://codecov.io/gh/shorebirdtech/shorebird/branch/main/graph/badge.svg)](https://codecov.io/gh/shorebirdtech/shorebird)


### PR DESCRIPTION
## Summary

The hosted Shorebird CI service is retired, so this badge renders a broken image linked to a page that no longer exists. Removing it rather than repointing it, since there is no replacement to point at.

## Testing

- Swept the repo for the badge endpoint and the console link. No other references.