### PR TITLE
fix(ci): unbreak cspell, e2e, and the shorebird_cli build

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,6 +6,15 @@ concurrency:
 
 on:
   workflow_dispatch:
+    inputs:
+      cli_ref:
+        description: >-
+          Ref the cli job checks out, for verifying a fix before it lands.
+          Defaults to each matrix branch. Setting it skips the patch matrix
+          and pins the cli job to the dev API, so a dispatch never writes to
+          production.
+        required: false
+        type: string
   schedule:
     # At the end of every day
     - cron: "0 0 * * *"
@@ -18,6 +27,9 @@ env:
 
 jobs:
   patch:
+    # A cli_ref dispatch is verifying the cli job, so the patch matrix would be
+    # dozens of production jobs of pure collateral.
+    if: ${{ !inputs.cli_ref }}
     strategy:
       fail-fast: false
       matrix:
@@ -135,7 +147,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        branch: [stable, main]
+        # branch selects the API host as well as the ref, so a cli_ref dispatch
+        # drops the stable leg rather than pointing unreleased code at prod.
+        branch: ${{ inputs.cli_ref && fromJSON('["main"]') || fromJSON('["stable", "main"]') }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -147,7 +161,7 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ matrix.branch }}
+          ref: ${{ inputs.cli_ref || matrix.branch }}
 
       - name: 🖥️ Add Shorebird to macOS/Linux PATH
         shell: bash

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,8 +27,8 @@ env:
 
 jobs:
   patch:
-    # A cli_ref dispatch is verifying the cli job, so the patch matrix would be
-    # dozens of production jobs of pure collateral.
+    # A cli_ref dispatch is verifying the cli job; the patch matrix is dozens of
+    # unrelated jobs that would only burn runner time.
     if: ${{ !inputs.cli_ref }}
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,7 +12,9 @@ on:
 
 env:
   SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
-  FLUTTER_VERSION: 3.41.9
+  # Host toolchain for `dart test integration_test`, not the version under test.
+  # Must ship a Dart new enough for the SDK constraints in the root pubspec.
+  FLUTTER_VERSION: 3.47.1
 
 jobs:
   patch:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 <!--
-cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkishan appbundle proto tlsv kingdomseed Peetee Aditya serde bipatch GLES lipo
+cspell:words pubspec erickzanardo xcframeworks cupertino codesign codecov rkishan appbundle proto tlsv kingdomseed Peetee Aditya serde bipatch GLES lipo impellerc
  -->
 
 ## 1.6.119 (August 21, 2026)

--- a/packages/shorebird_cli/integration_test/shorebird_cli_integration_test.dart
+++ b/packages/shorebird_cli/integration_test/shorebird_cli_integration_test.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_cli/src/artifact_builder/shorebird_tracer.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/http_client/http_client.dart';
@@ -19,7 +20,16 @@ import 'package:uuid/uuid.dart';
 R runWithOverrides<R>(R Function() body) {
   return runScoped(
     body,
-    values: {authRef, httpClientRef, loggerRef, platformRef, shorebirdEnvRef},
+    values: {
+      authRef,
+      httpClientRef,
+      loggerRef,
+      platformRef,
+      shorebirdEnvRef,
+      // TracingClient wraps the auth client and reads the ambient tracer on
+      // every request, so any scope that issues HTTP has to seed it.
+      shorebirdTracerRef,
+    },
   );
 }
 

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -663,7 +663,9 @@ Please re-run the release command for this version or create a new release.''');
     required Patcher patcher,
   }) async {
     try {
-      return patcher.assertUnpatchableDiffs(
+      // Must be awaited inside the try, otherwise the catch clauses below never
+      // see the failure and the patch exits with an unhandled exception.
+      return await patcher.assertUnpatchableDiffs(
         releaseArtifact: releaseArtifact,
         releaseArchive: releaseArchive,
         patchArchive: patchArchive,

--- a/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
+++ b/packages/shorebird_cli/test/src/executables/aot_tools_test.dart
@@ -669,7 +669,7 @@ stderr: error'''),
         });
 
         test(
-          'throws LinkFailureException with hint on VM data mismatch',
+          'throws LinkFailureException when VM sections differ',
           () async {
             workingDirectory = Directory.systemTemp.createTempSync();
             when(
@@ -754,14 +754,10 @@ stderr: error'''),
                       'toString',
                       contains('differing VM sections'),
                     )
-                    .having(
-                      (e) => e.hint,
-                      'hint',
-                      allOf(
-                        contains('--dart-define'),
-                        contains('--obfuscate'),
-                      ),
-                    ),
+                    // The version and features checks are what carry a
+                    // remediation hint. Neither reports on this signature, so
+                    // the failure surfaces without one.
+                    .having((e) => e.hint, 'hint', isNull),
               ),
             );
           },
@@ -1418,49 +1414,48 @@ Run "aot_tools help <command>" for more information about a command.
         expect(build({'type': 'link_failure'}).hint, isNull);
       });
 
-      test('is null when hash fields are not maps', () {
-        expect(
-          build({
-            'details': {'vm_data_hash': 'oops', 'vm_instructions_hash': 0},
-          }).hint,
-          isNull,
-        );
-      });
-
-      test('is null when instructions also differ', () {
+      test('is null when no check that carries a hint reported', () {
         expect(
           build({
             'details': {
               'vm_data_hash': {'base': 1, 'patch': 2},
-              'vm_instructions_hash': {'base': 3, 'patch': 4},
+              'vm_instructions_hash': {'base': 3, 'patch': 3},
             },
           }).hint,
           isNull,
         );
       });
 
-      test('is null when data matches', () {
+      test('blames the SDK when dart_version differs', () {
         expect(
           build({
             'details': {
-              'vm_data_hash': {'base': 1, 'patch': 1},
-              'vm_instructions_hash': {'base': 2, 'patch': 2},
+              'dart_version': {'base': '3.9.0', 'patch': '3.10.0'},
             },
           }).hint,
-          isNull,
+          contains('different Dart SDKs'),
         );
       });
 
-      test('is set for the VM-data-only mismatch signature', () {
+      test('blames the SDK when snapshot_version differs', () {
+        expect(
+          build({
+            'details': {
+              'snapshot_version': {'base': 'abc', 'patch': 'def'},
+            },
+          }).hint,
+          contains('different Dart SDKs'),
+        );
+      });
+
+      test('blames build flags when features differ', () {
         final hint = build({
           'details': {
-            'vm_data_hash': {'base': 1, 'patch': 2},
-            'vm_instructions_hash': {'base': 3, 'patch': 3},
+            'features': {'base': 'a', 'patch': 'b'},
           },
         }).hint;
-        expect(hint, isNotNull);
-        expect(hint, contains('--dart-define'));
-        expect(hint, contains('--obfuscate'));
+        expect(hint, contains('different build flags'));
+        expect(hint, contains('--dwarf-stack-traces'));
       });
     });
 


### PR DESCRIPTION
## Summary

Gets main's required job green, and unblocks every PR touching shorebird_cli
along the way. cspell fails on `impellerc` in the 1.6.119 notes, and the e2e cli
job has been red since June 30 when very_good_analysis raised the SDK floor above
the pinned Flutter 3.41.9. Each fix uncovered another, so this covers five
failures, two of which are real defects rather than config drift. I added cli_ref
because the cli job checks out matrix.branch, which left the e2e fixes
unverifiable before merge.

- `impellerc` added to the RELEASE_NOTES cspell directive
- e2e cli host Flutter goes 3.41.9 to 3.47.1, which ships Dart 3.13.1, and the
  integration test scope now seeds `shorebirdTracerRef`
- `assertUnpatchableDiffs` is awaited inside its try, so the
  UserCancelledException and UnpatchableChangeException handlers actually run
- aot_tools hint tests now match the branches 119406bb left in place, and cover
  dart_version, snapshot_version, and features, which had no tests
- New `cli_ref` dispatch input overrides the cli checkout, skips the patch
  matrix, and drops the stable leg so unreleased code never reaches prod

## Testing

- Dispatched e2e w/ `cli_ref`. All three cli jobs green on ubuntu, macOS, and
  Windows, each publishing a release and a patch against dev
- The await fix changes behavior, but its existing tests pass before and after,
  because the mocks throw synchronously. Only a genuinely async rejection reached
  the bug, which is why it went unnoticed
- Reproduced CI's 87 analyze issues locally on Dart 3.13.1. Exactly one is a
  warning, so `--fatal-warnings` was failing on that alone. The other 86 are
  infos and are left untouched
- Both aot_tools failures reproduce on unmodified origin/main under 3.12.2 as
  well as 3.13.1, so they predate this branch and are not SDK related
- Expanded both matrix branches w/ act. No input gives 6 cli jobs, 3 stable and
  3 main, plus the 30 patch jobs, matching the old literal
