### PR TITLE
fix(shorebird_cli): precache and resume the requested Flutter install

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_env.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_env.dart
@@ -13,21 +13,29 @@ import 'package:shorebird_cli/src/shorebird_cli_command_runner.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
 /// Exception thrown when the Shorebird cache appears to be corrupted.
-///
-/// Surfaces a user-actionable message directing the user to run
-/// `shorebird cache clean` and retry.
 class CacheCorruptedException implements Exception {
   /// Creates a [CacheCorruptedException] explaining why the cache is
   /// considered corrupted via [reason] (a complete sentence).
-  const CacheCorruptedException(this.reason);
+  ///
+  /// [remedy] is the advice shown after [reason]. It defaults to wiping the
+  /// whole cache, which is the right answer only when nothing narrower is
+  /// known: that wipe takes every installed Flutter revision with it, so a
+  /// caller that can name a smaller repair should pass it.
+  const CacheCorruptedException(
+    this.reason, {
+    this.remedy =
+        'Your Shorebird installation may be corrupted. '
+        "Try running 'shorebird cache clean' and retrying.",
+  });
 
   /// Human-readable explanation of why the cache is considered corrupted.
   final String reason;
 
+  /// Human-readable advice on how to recover.
+  final String remedy;
+
   @override
-  String toString() =>
-      '$reason Your Shorebird installation may be corrupted. '
-      "Try running 'shorebird cache clean' and retrying.";
+  String toString() => '$reason $remedy';
 }
 
 /// A reference to a [ShorebirdEnv] instance.

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -148,6 +148,20 @@ class ShorebirdFlutter {
     }
   }
 
+  /// Whether [directory] definitely does not hold a usable install.
+  ///
+  /// A finished checkout always contains the Flutter launcher, so its absence
+  /// is proof the directory is unusable. The converse does not hold, which is
+  /// why this only ever condemns a directory and never certifies one: a
+  /// checkout interrupted after the launcher was written looks identical to a
+  /// finished one from the outside. Installs published by [_cloneAndCheckout]
+  /// do not need certifying, since a partial one is never published at all.
+  bool _isUnusableInstall(Directory directory) {
+    if (!directory.existsSync()) return false;
+    final launcher = platform.isWindows ? 'flutter.bat' : 'flutter';
+    return !File(p.join(directory.path, 'bin', launcher)).existsSync();
+  }
+
   /// Install the provided Flutter [revision].
   ///
   /// Installing is two steps, each with its own durable record, so an
@@ -160,6 +174,11 @@ class ShorebirdFlutter {
   /// Precache is idempotent, so a missing stamp re-runs it rather than
   /// re-cloning.
   ///
+  /// Directories left by versions that installed in place predate that
+  /// guarantee, so a demonstrably unusable one is discarded and reinstalled
+  /// rather than sending the user to `shorebird cache clean`, which would
+  /// take every other installed revision with it.
+  ///
   /// Precache runs on install as a convenience so the first build is not
   /// unexpectedly slow. A precache failure is treated as a corrupted install:
   /// Flutter's stamp-based cache will otherwise trust a partial extraction and
@@ -168,6 +187,18 @@ class ShorebirdFlutter {
   Future<void> installRevision({required String revision}) async {
     final targetDirectory = Directory(_workingDirectory(revision: revision));
     final precacheStamp = File(p.join(targetDirectory.path, precacheStampName));
+
+    if (_isUnusableInstall(targetDirectory)) {
+      logger.info(
+        '''Flutter ${shortRevisionString(revision)} is incompletely installed. Reinstalling it.''',
+      );
+      _deleteIgnoringErrors(targetDirectory);
+      if (targetDirectory.existsSync()) {
+        throw CacheCorruptedException(
+          'Could not remove ${targetDirectory.path}.',
+        );
+      }
+    }
 
     final isCheckedOut = targetDirectory.existsSync();
     if (isCheckedOut && precacheStamp.existsSync()) return;

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -53,9 +53,34 @@ class ShorebirdFlutter {
   /// Suffix identifying a directory an install is still writing into.
   static const _stagingSuffix = '.tmp';
 
-  /// How long a staging directory must sit untouched before another install
+  /// How long a staging directory must have existed before another install
   /// treats it as abandoned rather than as a peer's work in progress.
   static const _stagingMaxAge = Duration(days: 1);
+
+  /// Names a directory the sweep can reclaim once it is old enough.
+  ///
+  /// The creation time is carried in the name rather than read back from the
+  /// filesystem. A directory's mtime is not ours to depend on: an unrelated
+  /// write can bump it, a rename does not touch it at all, and what it means
+  /// varies across platforms. This name is written once, by this code, and
+  /// never changes afterwards.
+  String _reclaimablePath(String path, {String? tag}) {
+    final stamp = clock.now().millisecondsSinceEpoch;
+    return '${[path, '$pid', ?tag].join('.')}.$stamp$_stagingSuffix';
+  }
+
+  /// Reads back the time [_reclaimablePath] wrote into [name], or null if
+  /// [name] was not written by it.
+  DateTime? _reclaimableSince({required String name, required String prefix}) {
+    if (!name.startsWith(prefix) || !name.endsWith(_stagingSuffix)) return null;
+    final stamp = name
+        .substring(prefix.length, name.length - _stagingSuffix.length)
+        .split('.')
+        .last;
+    final millis = int.tryParse(stamp);
+    if (millis == null) return null;
+    return DateTime.fromMillisecondsSinceEpoch(millis);
+  }
 
   /// Clones and checks out [revision], publishing it at [targetDirectory]
   /// only once both have succeeded.
@@ -73,17 +98,10 @@ class ShorebirdFlutter {
       'Installing Flutter $version (${shortRevisionString(revision)})',
     );
 
-    final stagingDirectory = Directory(
-      '${targetDirectory.path}.$pid$_stagingSuffix',
-    );
+    // Carries this instant, so no earlier run's staging directory can share
+    // the name and no directory has to be cleared before the clone.
+    final stagingDirectory = Directory(_reclaimablePath(targetDirectory.path));
     try {
-      _reclaimStrandedStagingDirectories(targetDirectory);
-      // A normal install has nothing here, and reporting a failure to remove
-      // what was never there would put a spurious error in every run's log.
-      if (stagingDirectory.existsSync()) {
-        _deleteIgnoringErrors(stagingDirectory);
-      }
-
       // Clone the Shorebird Flutter repo into the staging directory.
       await git.clone(
         url: flutterGitUrl,
@@ -98,8 +116,13 @@ class ShorebirdFlutter {
       installProgress.complete();
     } catch (error) {
       // Another process publishing the same revision first is not a failure.
-      // Its checkout is as good as ours, so adopt it.
-      if (targetDirectory.existsSync()) {
+      // Its checkout is as good as ours, so adopt it. A directory that is
+      // demonstrably unusable is not a peer's finished work, so it does not
+      // count: the shell bootstrap clones into this path in place, and
+      // adopting it mid-clone would precache and stamp a partial checkout.
+      final published =
+          targetDirectory.existsSync() && !_isUnusableInstall(targetDirectory);
+      if (published) {
         installProgress.complete();
         _deleteIgnoringErrors(stagingDirectory);
         return;
@@ -126,9 +149,12 @@ class ShorebirdFlutter {
   ///
   /// Publishing by rename means an interrupted install strands its staging
   /// directory instead of poisoning the target, so something has to reclaim
-  /// it. A concurrent install's staging directory looks identical to a
-  /// stranded one, so only entries untouched for [_stagingMaxAge] are
-  /// removed. A clone finishes in minutes.
+  /// it. A concurrent install's staging directory is indistinguishable from a
+  /// stranded one except by age, so only entries older than [_stagingMaxAge]
+  /// are removed. A clone finishes in minutes.
+  ///
+  /// A name this code did not write is left alone, so an unparseable or
+  /// unrecognized sibling is never a candidate.
   void _reclaimStrandedStagingDirectories(Directory targetDirectory) {
     final prefix = '${p.basename(targetDirectory.path)}.';
     final cutoff = clock.now().subtract(_stagingMaxAge);
@@ -141,9 +167,11 @@ class ShorebirdFlutter {
     }
 
     for (final sibling in siblings.whereType<Directory>()) {
-      final name = p.basename(sibling.path);
-      if (!name.startsWith(prefix) || !name.endsWith(_stagingSuffix)) continue;
-      if (sibling.statSync().modified.isAfter(cutoff)) continue;
+      final since = _reclaimableSince(
+        name: p.basename(sibling.path),
+        prefix: prefix,
+      );
+      if (since == null || since.isAfter(cutoff)) continue;
       _deleteIgnoringErrors(sibling);
     }
   }
@@ -162,6 +190,31 @@ class ShorebirdFlutter {
     return !File(p.join(directory.path, 'bin', launcher)).existsSync();
   }
 
+  /// Moves an unusable install out of the way so a fresh one can take its
+  /// place, and hands the remains to [_reclaimStrandedStagingDirectories].
+  ///
+  /// Renamed rather than deleted because a launcher-less directory is also
+  /// what the shell bootstrap's in-place `git clone --no-checkout` looks like
+  /// while it runs, and there is no lock this side can take to tell the two
+  /// apart. A rename never destroys bytes another process is still writing.
+  /// The new name stamps this instant, so the sweep's age gate starts from
+  /// the rename rather than from whenever the directory was first written.
+  void _discardUnusableInstall(Directory directory) {
+    try {
+      directory.renameSync(_reclaimablePath(directory.path, tag: 'old'));
+    } on PathNotFoundException {
+      // A peer condemned it first. Its absence is the outcome wanted here.
+      return;
+    } on FileSystemException catch (error) {
+      final exception = CacheCorruptedException(
+        'Could not move ${directory.path} aside: $error.',
+        remedy: 'Remove ${directory.path} and run this command again.',
+      );
+      logger.err('$exception');
+      throw exception;
+    }
+  }
+
   /// Install the provided Flutter [revision].
   ///
   /// Installing is two steps, each with its own durable record, so an
@@ -169,8 +222,8 @@ class ShorebirdFlutter {
   /// for a finished install.
   ///
   /// The checkout records itself by existing: [_cloneAndCheckout] publishes
-  /// [targetDirectory] with a rename, so the directory is either a finished
-  /// checkout or absent. Precaching records itself with [precacheStampName].
+  /// the target directory with a rename, so it is either a finished checkout
+  /// or absent. Precaching records itself with [precacheStampName].
   /// Precache is idempotent, so a missing stamp re-runs it rather than
   /// re-cloning.
   ///
@@ -188,22 +241,31 @@ class ShorebirdFlutter {
     final targetDirectory = Directory(_workingDirectory(revision: revision));
     final precacheStamp = File(p.join(targetDirectory.path, precacheStampName));
 
-    if (_isUnusableInstall(targetDirectory)) {
+    // Runs ahead of the already-installed early return below. A run killed
+    // mid-clone publishes on its retry, and nothing would ever clone that
+    // revision again to reclaim what the killed run left behind.
+    _reclaimStrandedStagingDirectories(targetDirectory);
+
+    final isUnusable = _isUnusableInstall(targetDirectory);
+    if (!isUnusable &&
+        targetDirectory.existsSync() &&
+        precacheStamp.existsSync()) {
+      return;
+    }
+
+    // Read the version before condemning anything. getVersionForRevision runs
+    // git in the active revision's checkout, which is this very directory
+    // whenever the revision being installed is the active one.
+    final version = await getVersionForRevision(flutterRevision: revision);
+
+    if (isUnusable) {
       logger.info(
         '''Flutter ${shortRevisionString(revision)} is incompletely installed. Reinstalling it.''',
       );
-      _deleteIgnoringErrors(targetDirectory);
-      if (targetDirectory.existsSync()) {
-        throw CacheCorruptedException(
-          'Could not remove ${targetDirectory.path}.',
-        );
-      }
+      _discardUnusableInstall(targetDirectory);
     }
 
     final isCheckedOut = targetDirectory.existsSync();
-    if (isCheckedOut && precacheStamp.existsSync()) return;
-
-    final version = await getVersionForRevision(flutterRevision: revision);
 
     if (!isCheckedOut) {
       await _cloneAndCheckout(
@@ -240,25 +302,35 @@ class ShorebirdFlutter {
       );
     } on Exception catch (error) {
       precacheProgress.fail('Failed to precache Flutter $version');
-      throw CacheCorruptedException(
+      // The checkout itself is intact and precache re-runs on a missing
+      // stamp, so retrying is the whole repair.
+      final exception = CacheCorruptedException(
         'Failed to precache Flutter $version: $error.',
+        remedy: 'Run this command again to retry the precache.',
       );
+      logger.err('$exception');
+      throw exception;
     }
     if (result.exitCode != ExitCode.success.code) {
       precacheProgress.fail('Failed to precache Flutter $version');
       final stderr = '${result.stderr}'.trim();
-      throw CacheCorruptedException(
+      final exception = CacheCorruptedException(
         'flutter precache exited with code ${result.exitCode}: $stderr.',
+        remedy: 'Run this command again to retry the precache.',
       );
+      logger.err('$exception');
+      throw exception;
     }
     try {
       precacheStamp.createSync();
     } on FileSystemException catch (error) {
       precacheProgress.fail('Failed to precache Flutter $version');
-      logger.err('$error');
-      throw CacheCorruptedException(
+      final exception = CacheCorruptedException(
         'Failed to record the precache for Flutter $version: $error.',
+        remedy: 'Make sure ${precacheStamp.path} is writable and retry.',
       );
+      logger.err('$exception');
+      throw exception;
     }
     precacheProgress.complete();
   }

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -49,37 +49,76 @@ class ShorebirdFlutter {
   /// presence does not make the checkout look dirty.
   static const precacheStampName = '.shorebird_precache';
 
-  /// Whether [directory] holds a checkout that reached [revision].
+  /// Clones and checks out [revision], publishing it at [targetDirectory]
+  /// only once both have succeeded.
   ///
-  /// `git checkout` moves HEAD last, under a ref lock, so HEAD pointing at
-  /// [revision] means the checkout ran to completion. Anything interrupted
-  /// earlier leaves HEAD on the clone's default branch or on its previous
-  /// value, and a clone that died before writing a valid repository fails
-  /// the lookup outright.
-  Future<bool> _isCheckedOut({
-    required Directory directory,
+  /// The work happens in a directory private to this process, so a run that
+  /// dies partway leaves that behind rather than a half-written
+  /// [targetDirectory]. Nothing infers completeness from the contents of a
+  /// checkout, and no existing install is ever deleted to make room.
+  Future<void> _cloneAndCheckout({
+    required Directory targetDirectory,
     required String revision,
+    required String? version,
   }) async {
-    if (!directory.existsSync()) return false;
+    final installProgress = logger.progress(
+      'Installing Flutter $version (${shortRevisionString(revision)})',
+    );
+
+    final stagingDirectory = Directory('${targetDirectory.path}.$pid.tmp');
     try {
-      final head = await git.revParse(
-        revision: 'HEAD',
-        directory: directory.path,
+      if (stagingDirectory.existsSync()) {
+        stagingDirectory.deleteSync(recursive: true);
+      }
+
+      // Clone the Shorebird Flutter repo into the staging directory.
+      await git.clone(
+        url: flutterGitUrl,
+        outputDirectory: stagingDirectory.path,
+        args: ['--filter=tree:0', '--no-checkout'],
       );
-      return head == revision;
-    } on ProcessException {
-      return false;
+
+      // Checkout the correct revision.
+      await git.checkout(directory: stagingDirectory.path, revision: revision);
+
+      stagingDirectory.renameSync(targetDirectory.path);
+      installProgress.complete();
+    } catch (error) {
+      // Another process publishing the same revision first is not a failure.
+      // Its checkout is as good as ours, so adopt it.
+      if (targetDirectory.existsSync()) {
+        installProgress.complete();
+        _deleteIgnoringErrors(stagingDirectory);
+        return;
+      }
+
+      final short = shortRevisionString(revision);
+      installProgress.fail('Failed to install Flutter $version ($short)');
+      logger.err('$error');
+      _deleteIgnoringErrors(stagingDirectory);
+      rethrow;
+    }
+  }
+
+  void _deleteIgnoringErrors(Directory directory) {
+    try {
+      if (directory.existsSync()) directory.deleteSync(recursive: true);
+    } on FileSystemException catch (error) {
+      logger.detail('Failed to remove ${directory.path}: $error');
     }
   }
 
   /// Install the provided Flutter [revision].
   ///
-  /// Installing is two independent steps, each with its own durable record,
-  /// so an interrupted run resumes instead of leaving a directory that later
-  /// runs mistake for a finished install. Checking out is recorded by git
-  /// itself (see [_isCheckedOut]) and precaching by [precacheStampName]. A
-  /// checkout that did not finish cannot be resumed, so it is discarded and
-  /// redone; precache is idempotent and is simply re-run.
+  /// Installing is two steps, each with its own durable record, so an
+  /// interrupted run resumes instead of leaving state that later runs mistake
+  /// for a finished install.
+  ///
+  /// The checkout records itself by existing: [_cloneAndCheckout] publishes
+  /// [targetDirectory] with a rename, so the directory is either a finished
+  /// checkout or absent. Precaching records itself with [precacheStampName].
+  /// Precache is idempotent, so a missing stamp re-runs it rather than
+  /// re-cloning.
   ///
   /// Precache runs on install as a convenience so the first build is not
   /// unexpectedly slow. A precache failure is treated as a corrupted install:
@@ -88,47 +127,19 @@ class ShorebirdFlutter {
   /// shorebirdtech/shorebird#3783).
   Future<void> installRevision({required String revision}) async {
     final targetDirectory = Directory(_workingDirectory(revision: revision));
-    final precacheStamp = File(
-      p.join(targetDirectory.path, precacheStampName),
-    );
+    final precacheStamp = File(p.join(targetDirectory.path, precacheStampName));
 
-    final isCheckedOut = await _isCheckedOut(
-      directory: targetDirectory,
-      revision: revision,
-    );
+    final isCheckedOut = targetDirectory.existsSync();
     if (isCheckedOut && precacheStamp.existsSync()) return;
 
     final version = await getVersionForRevision(flutterRevision: revision);
 
     if (!isCheckedOut) {
-      if (targetDirectory.existsSync()) {
-        logger.detail(
-          '''${targetDirectory.path} is not a complete checkout of $revision. Reinstalling.''',
-        );
-        targetDirectory.deleteSync(recursive: true);
-      }
-
-      final installProgress = logger.progress(
-        'Installing Flutter $version (${shortRevisionString(revision)})',
+      await _cloneAndCheckout(
+        targetDirectory: targetDirectory,
+        revision: revision,
+        version: version,
       );
-
-      try {
-        // Clone the Shorebird Flutter repo into the target directory.
-        await git.clone(
-          url: flutterGitUrl,
-          outputDirectory: targetDirectory.path,
-          args: ['--filter=tree:0', '--no-checkout'],
-        );
-
-        // Checkout the correct revision.
-        await git.checkout(directory: targetDirectory.path, revision: revision);
-        installProgress.complete();
-      } catch (error) {
-        final short = shortRevisionString(revision);
-        installProgress.fail('Failed to install Flutter $version ($short)');
-        logger.err('$error');
-        rethrow;
-      }
     }
 
     final precacheProgress = logger.progress(
@@ -169,7 +180,15 @@ class ShorebirdFlutter {
         'flutter precache exited with code ${result.exitCode}: $stderr.',
       );
     }
-    precacheStamp.createSync();
+    try {
+      precacheStamp.createSync();
+    } on FileSystemException catch (error) {
+      precacheProgress.fail('Failed to precache Flutter $version');
+      logger.err('$error');
+      throw CacheCorruptedException(
+        'Failed to record the precache for Flutter $version: $error.',
+      );
+    }
     precacheProgress.complete();
   }
 

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -83,12 +83,25 @@ class ShorebirdFlutter {
     );
 
     final precacheArguments = ['precache', ...precacheArgs];
+
+    // Flutter's launcher derives FLUTTER_ROOT from its own script path, so
+    // `workingDirectory` cannot aim precache at [revision]. The vended binary
+    // path is what decides which cache is warmed, and it resolves from the
+    // ambient revision, which is the active one rather than [revision]:
+    // callers install before entering their own override scope.
+    final targetShorebirdEnv = shorebirdEnv.copyWith(
+      flutterRevisionOverride: revision,
+    );
+
     final ShorebirdProcessResult result;
     try {
-      result = await process.run(
-        executable,
-        precacheArguments,
-        workingDirectory: targetDirectory.path,
+      result = await runScoped(
+        () => process.run(
+          executable,
+          precacheArguments,
+          workingDirectory: targetDirectory.path,
+        ),
+        values: {shorebirdEnvRef.overrideWith(() => targetShorebirdEnv)},
       );
     } on Exception catch (error) {
       precacheProgress.fail('Failed to precache Flutter $version');

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -78,7 +78,11 @@ class ShorebirdFlutter {
     );
     try {
       _reclaimStrandedStagingDirectories(targetDirectory);
-      _deleteIgnoringErrors(stagingDirectory);
+      // A normal install has nothing here, and reporting a failure to remove
+      // what was never there would put a spurious error in every run's log.
+      if (stagingDirectory.existsSync()) {
+        _deleteIgnoringErrors(stagingDirectory);
+      }
 
       // Clone the Shorebird Flutter repo into the staging directory.
       await git.clone(

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -42,40 +42,93 @@ class ShorebirdFlutter {
     return p.join(shorebirdEnv.flutterDirectory.parent.path, revision);
   }
 
+  /// Marker written once `flutter precache` has succeeded for an installed
+  /// revision.
+  ///
+  /// Untracked, and [isUnmodified] passes `--untracked-files=no`, so its
+  /// presence does not make the checkout look dirty.
+  static const precacheStampName = '.shorebird_precache';
+
+  /// Whether [directory] holds a checkout that reached [revision].
+  ///
+  /// `git checkout` moves HEAD last, under a ref lock, so HEAD pointing at
+  /// [revision] means the checkout ran to completion. Anything interrupted
+  /// earlier leaves HEAD on the clone's default branch or on its previous
+  /// value, and a clone that died before writing a valid repository fails
+  /// the lookup outright.
+  Future<bool> _isCheckedOut({
+    required Directory directory,
+    required String revision,
+  }) async {
+    if (!directory.existsSync()) return false;
+    try {
+      final head = await git.revParse(
+        revision: 'HEAD',
+        directory: directory.path,
+      );
+      return head == revision;
+    } on ProcessException {
+      return false;
+    }
+  }
+
   /// Install the provided Flutter [revision].
   ///
-  /// Runs `flutter precache` on first install as a convenience so the first
-  /// build is not unexpectedly slow. A precache failure is treated as a
-  /// corrupted install: Flutter's stamp-based cache will otherwise trust a
-  /// partial extraction and surface the missing artifact later as an opaque
-  /// Gradle error (see shorebirdtech/shorebird#3783). The user is directed
-  /// to run `shorebird cache clean` to start over.
+  /// Installing is two independent steps, each with its own durable record,
+  /// so an interrupted run resumes instead of leaving a directory that later
+  /// runs mistake for a finished install. Checking out is recorded by git
+  /// itself (see [_isCheckedOut]) and precaching by [precacheStampName]. A
+  /// checkout that did not finish cannot be resumed, so it is discarded and
+  /// redone; precache is idempotent and is simply re-run.
+  ///
+  /// Precache runs on install as a convenience so the first build is not
+  /// unexpectedly slow. A precache failure is treated as a corrupted install:
+  /// Flutter's stamp-based cache will otherwise trust a partial extraction and
+  /// surface the missing artifact later as an opaque Gradle error (see
+  /// shorebirdtech/shorebird#3783).
   Future<void> installRevision({required String revision}) async {
     final targetDirectory = Directory(_workingDirectory(revision: revision));
-    if (targetDirectory.existsSync()) return;
+    final precacheStamp = File(
+      p.join(targetDirectory.path, precacheStampName),
+    );
+
+    final isCheckedOut = await _isCheckedOut(
+      directory: targetDirectory,
+      revision: revision,
+    );
+    if (isCheckedOut && precacheStamp.existsSync()) return;
 
     final version = await getVersionForRevision(flutterRevision: revision);
 
-    final installProgress = logger.progress(
-      'Installing Flutter $version (${shortRevisionString(revision)})',
-    );
+    if (!isCheckedOut) {
+      if (targetDirectory.existsSync()) {
+        logger.detail(
+          '''${targetDirectory.path} is not a complete checkout of $revision. Reinstalling.''',
+        );
+        targetDirectory.deleteSync(recursive: true);
+      }
 
-    try {
-      // Clone the Shorebird Flutter repo into the target directory.
-      await git.clone(
-        url: flutterGitUrl,
-        outputDirectory: targetDirectory.path,
-        args: ['--filter=tree:0', '--no-checkout'],
+      final installProgress = logger.progress(
+        'Installing Flutter $version (${shortRevisionString(revision)})',
       );
 
-      // Checkout the correct revision.
-      await git.checkout(directory: targetDirectory.path, revision: revision);
-      installProgress.complete();
-    } catch (error) {
-      final short = shortRevisionString(revision);
-      installProgress.fail('Failed to install Flutter $version ($short)');
-      logger.err('$error');
-      rethrow;
+      try {
+        // Clone the Shorebird Flutter repo into the target directory.
+        await git.clone(
+          url: flutterGitUrl,
+          outputDirectory: targetDirectory.path,
+          args: ['--filter=tree:0', '--no-checkout'],
+        );
+
+        // Checkout the correct revision.
+        await git.checkout(directory: targetDirectory.path, revision: revision);
+        installProgress.complete();
+      } catch (error) {
+        final short = shortRevisionString(revision);
+        installProgress.fail('Failed to install Flutter $version ($short)');
+        logger.err('$error');
+        rethrow;
+      }
     }
 
     final precacheProgress = logger.progress(
@@ -116,6 +169,7 @@ class ShorebirdFlutter {
         'flutter precache exited with code ${result.exitCode}: $stderr.',
       );
     }
+    precacheStamp.createSync();
     precacheProgress.complete();
   }
 

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
@@ -49,6 +50,13 @@ class ShorebirdFlutter {
   /// presence does not make the checkout look dirty.
   static const precacheStampName = '.shorebird_precache';
 
+  /// Suffix identifying a directory an install is still writing into.
+  static const _stagingSuffix = '.tmp';
+
+  /// How long a staging directory must sit untouched before another install
+  /// treats it as abandoned rather than as a peer's work in progress.
+  static const _stagingMaxAge = Duration(days: 1);
+
   /// Clones and checks out [revision], publishing it at [targetDirectory]
   /// only once both have succeeded.
   ///
@@ -65,11 +73,12 @@ class ShorebirdFlutter {
       'Installing Flutter $version (${shortRevisionString(revision)})',
     );
 
-    final stagingDirectory = Directory('${targetDirectory.path}.$pid.tmp');
+    final stagingDirectory = Directory(
+      '${targetDirectory.path}.$pid$_stagingSuffix',
+    );
     try {
-      if (stagingDirectory.existsSync()) {
-        stagingDirectory.deleteSync(recursive: true);
-      }
+      _reclaimStrandedStagingDirectories(targetDirectory);
+      _deleteIgnoringErrors(stagingDirectory);
 
       // Clone the Shorebird Flutter repo into the staging directory.
       await git.clone(
@@ -102,9 +111,36 @@ class ShorebirdFlutter {
 
   void _deleteIgnoringErrors(Directory directory) {
     try {
-      if (directory.existsSync()) directory.deleteSync(recursive: true);
+      directory.deleteSync(recursive: true);
     } on FileSystemException catch (error) {
       logger.detail('Failed to remove ${directory.path}: $error');
+    }
+  }
+
+  /// Removes staging directories left by runs that were killed before they
+  /// could publish.
+  ///
+  /// Publishing by rename means an interrupted install strands its staging
+  /// directory instead of poisoning the target, so something has to reclaim
+  /// it. A concurrent install's staging directory looks identical to a
+  /// stranded one, so only entries untouched for [_stagingMaxAge] are
+  /// removed. A clone finishes in minutes.
+  void _reclaimStrandedStagingDirectories(Directory targetDirectory) {
+    final prefix = '${p.basename(targetDirectory.path)}.';
+    final cutoff = clock.now().subtract(_stagingMaxAge);
+
+    final List<FileSystemEntity> siblings;
+    try {
+      siblings = targetDirectory.parent.listSync();
+    } on FileSystemException {
+      return;
+    }
+
+    for (final sibling in siblings.whereType<Directory>()) {
+      final name = p.basename(sibling.path);
+      if (!name.startsWith(prefix) || !name.endsWith(_stagingSuffix)) continue;
+      if (sibling.statSync().modified.isAfter(cutoff)) continue;
+      _deleteIgnoringErrors(sibling);
     }
   }
 

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -1,3 +1,4 @@
+// cspell:words precaching unparseable
 import 'dart:convert';
 import 'dart:io';
 
@@ -60,7 +61,7 @@ class ShorebirdFlutter {
   /// Names a directory the sweep can reclaim once it is old enough.
   ///
   /// The creation time is carried in the name rather than read back from the
-  /// filesystem. A directory's mtime is not ours to depend on: an unrelated
+  /// filesystem. A directory's mtime is not a dependable record: an unrelated
   /// write can bump it, a rename does not touch it at all, and what it means
   /// varies across platforms. This name is written once, by this code, and
   /// never changes afterwards.
@@ -116,7 +117,7 @@ class ShorebirdFlutter {
       installProgress.complete();
     } catch (error) {
       // Another process publishing the same revision first is not a failure.
-      // Its checkout is as good as ours, so adopt it. A directory that is
+      // The winner's checkout is as good, so adopt it. A directory that is
       // demonstrably unusable is not a peer's finished work, so it does not
       // count: the shell bootstrap clones into this path in place, and
       // adopting it mid-clone would precache and stamp a partial checkout.

--- a/packages/shorebird_cli/test/src/shorebird_env_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_env_test.dart
@@ -16,6 +16,34 @@ import 'package:test/test.dart';
 import 'mocks.dart';
 
 void main() {
+  group(CacheCorruptedException, () {
+    test('defaults to advising a full cache wipe', () {
+      const exception = CacheCorruptedException('Could not read a file.');
+
+      expect(
+        exception.toString(),
+        'Could not read a file. Your Shorebird installation may be corrupted. '
+        "Try running 'shorebird cache clean' and retrying.",
+      );
+    });
+
+    test('uses a caller-supplied remedy in place of the wipe', () {
+      const exception = CacheCorruptedException(
+        'Could not move /cache/abc123 aside.',
+        remedy: 'Remove /cache/abc123 and run this command again.',
+      );
+
+      // Wiping the cache takes every other installed revision with it, so a
+      // caller that knows the smaller repair has to be able to say so.
+      expect(
+        exception.toString(),
+        'Could not move /cache/abc123 aside. '
+        'Remove /cache/abc123 and run this command again.',
+      );
+      expect(exception.toString(), isNot(contains('shorebird cache clean')));
+    });
+  });
+
   group(ShorebirdEnv, () {
     const flutterRevision = 'test-flutter-revision';
     late Platform platform;

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -1005,6 +1005,11 @@ origin/flutter_release/3.10.6''';
         ).called(1);
         expect(Directory(cloneDirectory).existsSync(), isFalse);
         expect(targetDirectory.existsSync(), isTrue);
+        // A clean install has no cleanup to report; saying otherwise would
+        // put a failure line in the log support asks users to attach.
+        verifyNever(
+          () => logger.detail(any(that: contains('Failed to remove'))),
+        );
       });
 
       group('when an earlier install was killed before publishing', () {
@@ -1016,6 +1021,19 @@ origin/flutter_release/3.10.6''';
         });
 
         test('reclaims the stranded staging directory', () async {
+          // The sweep runs over every sibling of the target, so the name
+          // filter is all that keeps it off other installs.
+          final otherInstall = Directory(
+            p.join(flutterDirectory.parent.path, 'another-revision'),
+          )..createSync(recursive: true);
+          final notStaging = Directory('${targetDirectory.path}.notstaging')
+            ..createSync(recursive: true);
+          // Another revision's staging directory. Each install reclaims only
+          // its own strays, so this one is not ours to remove.
+          final otherStaging = Directory(
+            p.join(flutterDirectory.parent.path, 'another-revision.9999.tmp'),
+          )..createSync(recursive: true);
+
           // A stranded directory is only distinguishable from a concurrent
           // install's by how long it has sat untouched.
           await withClock(
@@ -1026,6 +1044,9 @@ origin/flutter_release/3.10.6''';
           );
 
           expect(strandedStaging.existsSync(), isFalse);
+          expect(otherInstall.existsSync(), isTrue);
+          expect(notStaging.existsSync(), isTrue);
+          expect(otherStaging.existsSync(), isTrue);
           expect(targetDirectory.existsSync(), isTrue);
         });
 
@@ -1039,6 +1060,29 @@ origin/flutter_release/3.10.6''';
             expect(strandedStaging.existsSync(), isTrue);
           },
         );
+      });
+
+      group('when nothing has been installed yet', () {
+        setUp(() {
+          // No cache directory at all, so there are no siblings to sweep.
+          when(() => shorebirdEnv.flutterDirectory).thenReturn(
+            Directory(p.join(shorebirdRoot.path, 'missing', flutterRevision)),
+          );
+          targetDirectory = Directory(
+            p.join(shorebirdRoot.path, 'missing', revision),
+          );
+        });
+
+        test('installs without tripping over the absent directory', () async {
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ),
+            completes,
+          );
+
+          expect(targetDirectory.existsSync(), isTrue);
+        });
       });
 
       group('when the precache stamp cannot be written', () {

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -915,14 +915,9 @@ origin/flutter_release/3.10.6''';
       late Directory targetDirectory;
       late File precacheStamp;
 
-      /// Puts [targetDirectory] in the state left by a checkout that reached
-      /// [head], without the precache stamp.
-      void createCheckout({String head = revision}) {
-        targetDirectory.createSync(recursive: true);
-        when(
-          () => git.revParse(revision: 'HEAD', directory: targetDirectory.path),
-        ).thenAnswer((_) async => head);
-      }
+      /// Puts [targetDirectory] in the state left by a published checkout,
+      /// without the precache stamp.
+      void createCheckout() => targetDirectory.createSync(recursive: true);
 
       setUp(() {
         targetDirectory = Directory(
@@ -949,7 +944,11 @@ origin/flutter_release/3.10.6''';
           ),
         );
         verifyNever(
-          () => process.run('flutter', any(that: contains('precache'))),
+          () => process.run(
+            'flutter',
+            any(that: contains('precache')),
+            workingDirectory: any(named: 'workingDirectory'),
+          ),
         );
       });
 
@@ -979,63 +978,95 @@ origin/flutter_release/3.10.6''';
         });
       });
 
-      group('when the checkout did not complete', () {
-        // HEAD never reached the requested revision, which is what an
-        // interrupted `git checkout` leaves behind.
-        setUp(() => createCheckout(head: 'some-other-revision'));
+      test('clones and checks out away from the target directory', () async {
+        late String cloneDirectory;
+        when(
+          () => git.clone(
+            url: any(named: 'url'),
+            outputDirectory: any(named: 'outputDirectory'),
+            args: any(named: 'args'),
+          ),
+        ).thenAnswer((invocation) async {
+          cloneDirectory =
+              invocation.namedArguments[#outputDirectory] as String;
+          Directory(cloneDirectory).createSync(recursive: true);
+        });
 
-        test('discards the directory and reinstalls', () async {
-          final leftover = File(p.join(targetDirectory.path, 'leftover'))
-            ..createSync(recursive: true);
+        await runWithOverrides(
+          () => shorebirdFlutter.installRevision(revision: revision),
+        );
 
-          await runWithOverrides(
-            () => shorebirdFlutter.installRevision(revision: revision),
+        // The target directory must never hold an in-progress checkout, so
+        // that its existence is proof of a finished one.
+        expect(cloneDirectory, isNot(targetDirectory.path));
+        verify(
+          () => git.checkout(directory: cloneDirectory, revision: revision),
+        ).called(1);
+        expect(Directory(cloneDirectory).existsSync(), isFalse);
+        expect(targetDirectory.existsSync(), isTrue);
+      });
+
+      group('when the install is interrupted', () {
+        setUp(() {
+          when(
+            () => git.checkout(
+              directory: any(named: 'directory'),
+              revision: any(named: 'revision'),
+            ),
+          ).thenThrow(Exception('interrupted'));
+        });
+
+        test('leaves no target directory and no staging directory', () async {
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ),
+            throwsException,
           );
 
-          expect(leftover.existsSync(), isFalse);
-          verify(
-            () => git.clone(
-              url: ShorebirdFlutter.flutterGitUrl,
-              outputDirectory: targetDirectory.path,
-              args: ['--filter=tree:0', '--no-checkout'],
+          expect(targetDirectory.existsSync(), isFalse);
+          expect(
+            targetDirectory.parent.listSync().where(
+              (e) => p.basename(e.path).startsWith(revision),
             ),
-          ).called(1);
-          verify(
+            isEmpty,
+          );
+        });
+      });
+
+      group('when another process publishes the revision first', () {
+        setUp(() {
+          when(
             () => git.checkout(
-              directory: targetDirectory.path,
-              revision: revision,
+              directory: any(named: 'directory'),
+              revision: any(named: 'revision'),
             ),
-          ).called(1);
+          ).thenAnswer((_) async {
+            // Publishing makes this process's rename onto it fail.
+            File(
+              p.join(targetDirectory.path, 'already-here'),
+            ).createSync(recursive: true);
+          });
+        });
+
+        test('adopts the published checkout instead of failing', () async {
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ),
+            completes,
+          );
+
+          verifyNever(() => progress.fail(any()));
+          expect(
+            File(p.join(targetDirectory.path, 'already-here')).existsSync(),
+            isTrue,
+          );
           verify(
             () => process.run(
               'flutter',
               any(that: contains('precache')),
               workingDirectory: targetDirectory.path,
-            ),
-          ).called(1);
-        });
-      });
-
-      group('when the directory is not a readable git repository', () {
-        // What a clone that died before writing a valid repository leaves.
-        setUp(() {
-          targetDirectory.createSync(recursive: true);
-          when(
-            () =>
-                git.revParse(revision: 'HEAD', directory: targetDirectory.path),
-          ).thenThrow(const ProcessException('git', ['rev-parse']));
-        });
-
-        test('discards the directory and reinstalls', () async {
-          await runWithOverrides(
-            () => shorebirdFlutter.installRevision(revision: revision),
-          );
-
-          verify(
-            () => git.clone(
-              url: ShorebirdFlutter.flutterGitUrl,
-              outputDirectory: targetDirectory.path,
-              args: ['--filter=tree:0', '--no-checkout'],
             ),
           ).called(1);
         });
@@ -1061,12 +1092,16 @@ origin/flutter_release/3.10.6''';
         verify(
           () => git.clone(
             url: ShorebirdFlutter.flutterGitUrl,
-            outputDirectory: p.join(flutterDirectory.parent.path, revision),
+            outputDirectory: any(named: 'outputDirectory'),
             args: ['--filter=tree:0', '--no-checkout'],
           ),
         ).called(1);
         verifyNever(
-          () => process.run('flutter', any(that: contains('precache'))),
+          () => process.run(
+            'flutter',
+            any(that: contains('precache')),
+            workingDirectory: any(named: 'workingDirectory'),
+          ),
         );
       });
 
@@ -1088,13 +1123,13 @@ origin/flutter_release/3.10.6''';
         verify(
           () => git.clone(
             url: ShorebirdFlutter.flutterGitUrl,
-            outputDirectory: p.join(flutterDirectory.parent.path, revision),
+            outputDirectory: any(named: 'outputDirectory'),
             args: ['--filter=tree:0', '--no-checkout'],
           ),
         ).called(1);
         verify(
           () => git.checkout(
-            directory: p.join(flutterDirectory.parent.path, revision),
+            directory: any(named: 'directory'),
             revision: revision,
           ),
         ).called(1);

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -1005,6 +1005,10 @@ origin/flutter_release/3.10.6''';
         // The target directory must never hold an in-progress checkout, so
         // that its existence is proof of a finished one.
         expect(cloneDirectory, isNot(targetDirectory.path));
+        // The sweep finds strays by name alone, so the name the install
+        // writes and the name the sweep matches are one contract.
+        expect(p.basename(cloneDirectory), startsWith('$revision.'));
+        expect(cloneDirectory, endsWith('.tmp'));
         verify(
           () => git.checkout(directory: cloneDirectory, revision: revision),
         ).called(1);
@@ -1041,6 +1045,18 @@ origin/flutter_release/3.10.6''';
             ),
           ).called(1);
           expect(leftover.existsSync(), isFalse);
+          // Moved aside rather than deleted, under a name the sweep reclaims
+          // once nothing can still be writing into it.
+          final debris = targetDirectory.parent.listSync().where(
+            (e) =>
+                p.basename(e.path).startsWith('$revision.') &&
+                e.path.endsWith('.tmp'),
+          );
+          expect(debris, hasLength(1));
+          expect(
+            File(p.join(debris.single.path, 'leftover')).existsSync(),
+            isTrue,
+          );
           // `shorebird cache clean` would have taken this with it.
           expect(otherInstall.existsSync(), isTrue);
           verify(
@@ -1054,10 +1070,10 @@ origin/flutter_release/3.10.6''';
         });
 
         test(
-          'reports when the incomplete install cannot be removed',
+          'reports when the incomplete install cannot be moved aside',
           () async {
-            // Making the parent read-only is the portable way to block the
-            // unlink of a child that is otherwise perfectly deletable.
+            // Making the parent read-only is the portable way to block a
+            // rename of a child that is otherwise perfectly movable.
             final parent = targetDirectory.parent;
             Process.runSync('chmod', ['a-w', parent.path]);
             addTearDown(() => Process.runSync('chmod', ['u+w', parent.path]));
@@ -1068,57 +1084,221 @@ origin/flutter_release/3.10.6''';
               ),
               throwsA(isA<CacheCorruptedException>()),
             );
+
+            // Both callers discard the exception and exit 70, so the reason
+            // has to reach the user from here or not at all, and the advice
+            // has to name this one directory rather than the whole cache.
+            verify(
+              () => logger.err(
+                any(
+                  that: allOf(
+                    contains('Could not move ${targetDirectory.path} aside'),
+                    contains('Remove ${targetDirectory.path}'),
+                    isNot(contains('shorebird cache clean')),
+                  ),
+                ),
+              ),
+            ).called(1);
           },
           testOn: 'linux || mac-os',
         );
-      });
 
-      group('when an earlier install was killed before publishing', () {
-        late Directory strandedStaging;
+        test('quarantines the debris from the moment it moves', () async {
+          Directory debris() => targetDirectory.parent
+              .listSync()
+              .whereType<Directory>()
+              .firstWhere(
+                (e) =>
+                    p.basename(e.path).startsWith('$revision.') &&
+                    e.path.endsWith('.tmp'),
+              );
 
-        setUp(() {
-          strandedStaging = Directory('${targetDirectory.path}.9999.tmp')
-            ..createSync(recursive: true);
-        });
+          await runWithOverrides(
+            () => shorebirdFlutter.installRevision(revision: revision),
+          );
+          final quarantined = debris().path;
 
-        test('reclaims the stranded staging directory', () async {
-          // The sweep runs over every sibling of the target, so the name
-          // filter is all that keeps it off other installs.
-          final otherInstall = Directory(
-            p.join(flutterDirectory.parent.path, 'another-revision'),
-          )..createSync(recursive: true);
-          final notStaging = Directory('${targetDirectory.path}.notstaging')
-            ..createSync(recursive: true);
-          // Another revision's staging directory. Each install reclaims only
-          // its own strays, so this one is not ours to remove.
-          final otherStaging = Directory(
-            p.join(flutterDirectory.parent.path, 'another-revision.9999.tmp'),
-          )..createSync(recursive: true);
+          // The condemned directory can be arbitrarily old, and a rename does
+          // not touch its mtime, so the sweep has to measure from the move
+          // rather than from whenever the directory was last written.
+          await runWithOverrides(
+            () => shorebirdFlutter.installRevision(revision: revision),
+          );
+          expect(Directory(quarantined).existsSync(), isTrue);
 
-          // A stranded directory is only distinguishable from a concurrent
-          // install's by how long it has sat untouched.
           await withClock(
             Clock.fixed(DateTime.now().add(const Duration(days: 2))),
             () => runWithOverrides(
               () => shorebirdFlutter.installRevision(revision: revision),
             ),
           );
+          expect(Directory(quarantined).existsSync(), isFalse);
+        });
+
+        test('carries on when a peer condemns it first', () async {
+          // logger.info runs in the window between deciding the install is
+          // unusable and moving it aside, which is where a peer's rename
+          // lands. Losing that race is not a failure: the directory being
+          // gone is the outcome this process wanted.
+          when(() => logger.info(any())).thenAnswer((_) {
+            targetDirectory.deleteSync(recursive: true);
+          });
+
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ),
+            completes,
+          );
+
+          verifyNever(() => logger.err(any()));
+          expect(targetDirectory.existsSync(), isTrue);
+        });
+
+        test('reads the version before moving the install aside', () async {
+          // getVersionForRevision runs git in the ACTIVE revision's checkout,
+          // which is the directory being condemned when the revision being
+          // installed is the active one.
+          final activeDirectory = Directory(
+            p.join(flutterDirectory.parent.path, flutterRevision),
+          )..createSync(recursive: true);
+          when(
+            () => git.forEachRef(
+              directory: any(named: 'directory'),
+              contains: any(named: 'contains'),
+              format: any(named: 'format'),
+              pattern: any(named: 'pattern'),
+            ),
+          ).thenAnswer((invocation) async {
+            final directory = invocation.namedArguments[#directory] as String;
+            if (!Directory(directory).existsSync()) {
+              throw const ProcessException(
+                'git',
+                ['for-each-ref'],
+                'no such path',
+              );
+            }
+            return 'origin/flutter_release/3.10.6';
+          });
+
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: flutterRevision),
+            ),
+            completes,
+          );
+
+          expect(activeDirectory.existsSync(), isTrue);
+        });
+
+        test(
+          'keeps a Windows install whose launcher is flutter.bat',
+          () async {
+            when(() => platform.isWindows).thenReturn(true);
+            File(
+              p.join(targetDirectory.path, 'bin', 'flutter.bat'),
+            ).createSync(recursive: true);
+
+            await runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            );
+
+            verifyNever(
+              () => logger.info(
+                any(that: contains('is incompletely installed')),
+              ),
+            );
+            verifyNever(
+              () => git.clone(
+                url: any(named: 'url'),
+                outputDirectory: any(named: 'outputDirectory'),
+                args: any(named: 'args'),
+              ),
+            );
+          },
+        );
+      });
+
+      group('when an earlier install was killed before publishing', () {
+        late Directory strandedStaging;
+
+        /// The name an install running [age] ago would have written. The age
+        /// lives in the name, never in the directory's mtime.
+        Directory stray(String path, Duration age) => Directory(
+          '$path.9999.${DateTime.now().subtract(age).millisecondsSinceEpoch}'
+          '.tmp',
+        );
+
+        setUp(() {
+          strandedStaging = stray(targetDirectory.path, const Duration(days: 2))
+            ..createSync(recursive: true);
+        });
+
+        test('reclaims the stranded staging directory', () async {
+          // The sweep runs over every sibling of the target, so the name is
+          // all that keeps it off other installs.
+          final otherInstall = Directory(
+            p.join(flutterDirectory.parent.path, 'another-revision'),
+          )..createSync(recursive: true);
+          final notStaging = Directory('${targetDirectory.path}.notstaging')
+            ..createSync(recursive: true);
+          // Suffixed like a staging directory but carrying no timestamp this
+          // code wrote, so its age is unknown and it is not ours to remove.
+          final unstamped = Directory('${targetDirectory.path}.mystery.tmp')
+            ..createSync(recursive: true);
+          // Another revision's staging directory. Each install reclaims only
+          // its own strays, so this one is not ours either.
+          final otherStaging = stray(
+            p.join(flutterDirectory.parent.path, 'another-revision'),
+            const Duration(days: 2),
+          )..createSync(recursive: true);
+
+          await runWithOverrides(
+            () => shorebirdFlutter.installRevision(revision: revision),
+          );
 
           expect(strandedStaging.existsSync(), isFalse);
           expect(otherInstall.existsSync(), isTrue);
           expect(notStaging.existsSync(), isTrue);
+          expect(unstamped.existsSync(), isTrue);
           expect(otherStaging.existsSync(), isTrue);
           expect(targetDirectory.existsSync(), isTrue);
         });
 
         test(
-          'leaves a concurrent install\'s staging directory alone',
+          "leaves a concurrent install's staging directory alone",
           () async {
+            final live = stray(targetDirectory.path, const Duration(minutes: 5))
+              ..createSync(recursive: true);
+
             await runWithOverrides(
               () => shorebirdFlutter.installRevision(revision: revision),
             );
 
-            expect(strandedStaging.existsSync(), isTrue);
+            expect(live.existsSync(), isTrue);
+          },
+        );
+
+        test(
+          'reclaims it even when the revision is already installed',
+          () async {
+            createCheckout();
+            precacheStamp.createSync();
+
+            // Nothing clones this revision again, so an install that returns
+            // early is the only thing left that can reclaim the stray.
+            await runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            );
+
+            expect(strandedStaging.existsSync(), isFalse);
+            verifyNever(
+              () => git.clone(
+                url: any(named: 'url'),
+                outputDirectory: any(named: 'outputDirectory'),
+                args: any(named: 'args'),
+              ),
+            );
           },
         );
       });
@@ -1206,7 +1386,10 @@ origin/flutter_release/3.10.6''';
               revision: any(named: 'revision'),
             ),
           ).thenAnswer((_) async {
-            // Publishing makes this process's rename onto it fail.
+            // Publishing makes this process's rename onto it fail. The peer
+            // publishes a finished checkout, launcher and all, which is what
+            // separates it from a directory being written in place.
+            createCheckout();
             File(
               p.join(targetDirectory.path, 'already-here'),
             ).createSync(recursive: true);
@@ -1233,6 +1416,45 @@ origin/flutter_release/3.10.6''';
               workingDirectory: targetDirectory.path,
             ),
           ).called(1);
+        });
+      });
+
+      group('when another process is cloning into the target in place', () {
+        setUp(() {
+          when(
+            () => git.checkout(
+              directory: any(named: 'directory'),
+              revision: any(named: 'revision'),
+            ),
+          ).thenAnswer((_) async {
+            // The shell bootstrap clones into this path with --no-checkout,
+            // so the directory exists and blocks the rename long before a
+            // launcher is written to it.
+            File(
+              p.join(targetDirectory.path, '.git', 'config'),
+            ).createSync(recursive: true);
+          });
+        });
+
+        test('fails instead of adopting the half-written checkout', () async {
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ),
+            throwsA(isA<FileSystemException>()),
+          );
+
+          // Adopting it would precache into a directory with no Flutter in
+          // it and then stamp it, so every later run would return early on a
+          // broken install.
+          verifyNever(
+            () => process.run(
+              'flutter',
+              any(that: contains('precache')),
+              workingDirectory: any(named: 'workingDirectory'),
+            ),
+          );
+          expect(precacheStamp.existsSync(), isFalse);
         });
       });
 
@@ -1316,28 +1538,32 @@ origin/flutter_release/3.10.6''';
           ).thenThrow(Exception('oh no!'));
         });
 
-        test(
-          'throws CacheCorruptedException directing to shorebird cache clean',
-          () async {
-            await expectLater(
-              runWithOverrides(
-                () => shorebirdFlutter.installRevision(revision: revision),
-              ),
-              throwsA(
-                isA<CacheCorruptedException>().having(
-                  (e) => e.toString(),
-                  'toString',
-                  contains('shorebird cache clean'),
+        test('reports the reason and says to retry, not to wipe', () async {
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ),
+            throwsA(
+              isA<CacheCorruptedException>().having(
+                (e) => e.toString(),
+                'toString',
+                allOf(
+                  contains('oh no!'),
+                  contains('Run this command again'),
+                  isNot(contains('shorebird cache clean')),
                 ),
               ),
-            );
-            verify(
-              () => progress.fail('Failed to precache Flutter 3.10.6'),
-            ).called(1);
-            // No stamp, so the next run retries precache.
-            expect(precacheStamp.existsSync(), isFalse);
-          },
-        );
+            ),
+          );
+          verify(
+            () => progress.fail('Failed to precache Flutter 3.10.6'),
+          ).called(1);
+          // Both callers discard the exception, so the reason only reaches
+          // the user if it is logged here.
+          verify(() => logger.err(any(that: contains('oh no!')))).called(1);
+          // No stamp, so the next run retries precache.
+          expect(precacheStamp.existsSync(), isFalse);
+        });
       });
 
       group('when precache exits with a non-zero code', () {
@@ -1346,28 +1572,30 @@ origin/flutter_release/3.10.6''';
           when(() => precacheProcessResult.stderr).thenReturn('boom');
         });
 
-        test(
-          'throws CacheCorruptedException directing to shorebird cache clean',
-          () async {
-            await expectLater(
-              runWithOverrides(
-                () => shorebirdFlutter.installRevision(revision: revision),
-              ),
-              throwsA(
-                isA<CacheCorruptedException>().having(
-                  (e) => e.toString(),
-                  'toString',
-                  contains('shorebird cache clean'),
+        test('reports the stderr and says to retry, not to wipe', () async {
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ),
+            throwsA(
+              isA<CacheCorruptedException>().having(
+                (e) => e.toString(),
+                'toString',
+                allOf(
+                  contains('boom'),
+                  contains('Run this command again'),
+                  isNot(contains('shorebird cache clean')),
                 ),
               ),
-            );
-            verify(
-              () => progress.fail('Failed to precache Flutter 3.10.6'),
-            ).called(1);
-            // No stamp, so the next run retries precache.
-            expect(precacheStamp.existsSync(), isFalse);
-          },
-        );
+            ),
+          );
+          verify(
+            () => progress.fail('Failed to precache Flutter 3.10.6'),
+          ).called(1);
+          verify(() => logger.err(any(that: contains('boom')))).called(1);
+          // No stamp, so the next run retries precache.
+          expect(precacheStamp.existsSync(), isFalse);
+        });
       });
 
       test('precaches the target revision, not the active revision', () async {

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -1,6 +1,7 @@
 // cspell:words revis
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
@@ -1004,6 +1005,64 @@ origin/flutter_release/3.10.6''';
         ).called(1);
         expect(Directory(cloneDirectory).existsSync(), isFalse);
         expect(targetDirectory.existsSync(), isTrue);
+      });
+
+      group('when an earlier install was killed before publishing', () {
+        late Directory strandedStaging;
+
+        setUp(() {
+          strandedStaging = Directory('${targetDirectory.path}.9999.tmp')
+            ..createSync(recursive: true);
+        });
+
+        test('reclaims the stranded staging directory', () async {
+          // A stranded directory is only distinguishable from a concurrent
+          // install's by how long it has sat untouched.
+          await withClock(
+            Clock.fixed(DateTime.now().add(const Duration(days: 2))),
+            () => runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ),
+          );
+
+          expect(strandedStaging.existsSync(), isFalse);
+          expect(targetDirectory.existsSync(), isTrue);
+        });
+
+        test(
+          'leaves a concurrent install\'s staging directory alone',
+          () async {
+            await runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            );
+
+            expect(strandedStaging.existsSync(), isTrue);
+          },
+        );
+      });
+
+      group('when the precache stamp cannot be written', () {
+        setUp(() {
+          createCheckout();
+          // Occupying the stamp path with a directory makes createSync throw.
+          Directory(
+            p.join(targetDirectory.path, ShorebirdFlutter.precacheStampName),
+          ).createSync(recursive: true);
+        });
+
+        test('fails loudly instead of exiting silently', () async {
+          await expectLater(
+            runWithOverrides(
+              () => shorebirdFlutter.installRevision(revision: revision),
+            ),
+            throwsA(isA<CacheCorruptedException>()),
+          );
+
+          verify(
+            () => progress.fail('Failed to precache Flutter 3.10.6'),
+          ).called(1);
+          verify(() => logger.err(any())).called(1);
+        });
       });
 
       group('when the install is interrupted', () {

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -67,7 +67,13 @@ void main() {
           outputDirectory: any(named: 'outputDirectory'),
           args: any(named: 'args'),
         ),
-      ).thenAnswer((_) async => {});
+      ).thenAnswer((invocation) async {
+        // Real `git clone` creates the output directory; installRevision
+        // writes into it afterwards.
+        Directory(
+          invocation.namedArguments[#outputDirectory] as String,
+        ).createSync(recursive: true);
+      });
       when(
         () => git.checkout(
           directory: any(named: 'directory'),
@@ -906,11 +912,30 @@ origin/flutter_release/3.10.6''';
 
     group('installRevision', () {
       const revision = 'test-revision';
+      late Directory targetDirectory;
+      late File precacheStamp;
+
+      /// Puts [targetDirectory] in the state left by a checkout that reached
+      /// [head], without the precache stamp.
+      void createCheckout({String head = revision}) {
+        targetDirectory.createSync(recursive: true);
+        when(
+          () => git.revParse(revision: 'HEAD', directory: targetDirectory.path),
+        ).thenAnswer((_) async => head);
+      }
+
+      setUp(() {
+        targetDirectory = Directory(
+          p.join(flutterDirectory.parent.path, revision),
+        );
+        precacheStamp = File(
+          p.join(targetDirectory.path, ShorebirdFlutter.precacheStampName),
+        );
+      });
 
       test('does nothing if the revision is already installed', () async {
-        Directory(
-          p.join(flutterDirectory.parent.path, revision),
-        ).createSync(recursive: true);
+        createCheckout();
+        precacheStamp.createSync();
 
         await runWithOverrides(
           () => shorebirdFlutter.installRevision(revision: revision),
@@ -926,6 +951,94 @@ origin/flutter_release/3.10.6''';
         verifyNever(
           () => process.run('flutter', any(that: contains('precache'))),
         );
+      });
+
+      group('when the checkout completed but precache did not', () {
+        setUp(createCheckout);
+
+        test('precaches without re-cloning', () async {
+          await runWithOverrides(
+            () => shorebirdFlutter.installRevision(revision: revision),
+          );
+
+          verifyNever(
+            () => git.clone(
+              url: any(named: 'url'),
+              outputDirectory: any(named: 'outputDirectory'),
+              args: any(named: 'args'),
+            ),
+          );
+          verify(
+            () => process.run(
+              'flutter',
+              any(that: contains('precache')),
+              workingDirectory: targetDirectory.path,
+            ),
+          ).called(1);
+          expect(precacheStamp.existsSync(), isTrue);
+        });
+      });
+
+      group('when the checkout did not complete', () {
+        // HEAD never reached the requested revision, which is what an
+        // interrupted `git checkout` leaves behind.
+        setUp(() => createCheckout(head: 'some-other-revision'));
+
+        test('discards the directory and reinstalls', () async {
+          final leftover = File(p.join(targetDirectory.path, 'leftover'))
+            ..createSync(recursive: true);
+
+          await runWithOverrides(
+            () => shorebirdFlutter.installRevision(revision: revision),
+          );
+
+          expect(leftover.existsSync(), isFalse);
+          verify(
+            () => git.clone(
+              url: ShorebirdFlutter.flutterGitUrl,
+              outputDirectory: targetDirectory.path,
+              args: ['--filter=tree:0', '--no-checkout'],
+            ),
+          ).called(1);
+          verify(
+            () => git.checkout(
+              directory: targetDirectory.path,
+              revision: revision,
+            ),
+          ).called(1);
+          verify(
+            () => process.run(
+              'flutter',
+              any(that: contains('precache')),
+              workingDirectory: targetDirectory.path,
+            ),
+          ).called(1);
+        });
+      });
+
+      group('when the directory is not a readable git repository', () {
+        // What a clone that died before writing a valid repository leaves.
+        setUp(() {
+          targetDirectory.createSync(recursive: true);
+          when(
+            () =>
+                git.revParse(revision: 'HEAD', directory: targetDirectory.path),
+          ).thenThrow(const ProcessException('git', ['rev-parse']));
+        });
+
+        test('discards the directory and reinstalls', () async {
+          await runWithOverrides(
+            () => shorebirdFlutter.installRevision(revision: revision),
+          );
+
+          verify(
+            () => git.clone(
+              url: ShorebirdFlutter.flutterGitUrl,
+              outputDirectory: targetDirectory.path,
+              args: ['--filter=tree:0', '--no-checkout'],
+            ),
+          ).called(1);
+        });
       });
 
       test('throws exception if unable to clone', () async {
@@ -1022,6 +1135,8 @@ origin/flutter_release/3.10.6''';
             verify(
               () => progress.fail('Failed to precache Flutter 3.10.6'),
             ).called(1);
+            // No stamp, so the next run retries precache.
+            expect(precacheStamp.existsSync(), isFalse);
           },
         );
       });
@@ -1050,6 +1165,8 @@ origin/flutter_release/3.10.6''';
             verify(
               () => progress.fail('Failed to precache Flutter 3.10.6'),
             ).called(1);
+            // No stamp, so the next run retries precache.
+            expect(precacheStamp.existsSync(), isFalse);
           },
         );
       });
@@ -1101,6 +1218,7 @@ origin/flutter_release/3.10.6''';
           ).called(1);
           // Once for the installation and once for the precache.
           verify(progress.complete).called(2);
+          expect(precacheStamp.existsSync(), isTrue);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -106,6 +106,7 @@ void main() {
       ).thenAnswer((_) async => 'origin/flutter_release/3.10.6');
       when(() => logger.progress(any())).thenReturn(progress);
       when(() => platform.isMacOS).thenReturn(false);
+      when(() => platform.isWindows).thenReturn(false);
       when(() => shorebirdEnv.flutterDirectory).thenReturn(flutterDirectory);
       when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
       when(
@@ -918,7 +919,11 @@ origin/flutter_release/3.10.6''';
 
       /// Puts [targetDirectory] in the state left by a published checkout,
       /// without the precache stamp.
-      void createCheckout() => targetDirectory.createSync(recursive: true);
+      void createCheckout() {
+        File(
+          p.join(targetDirectory.path, 'bin', 'flutter'),
+        ).createSync(recursive: true);
+      }
 
       setUp(() {
         targetDirectory = Directory(
@@ -1009,6 +1014,62 @@ origin/flutter_release/3.10.6''';
         // put a failure line in the log support asks users to attach.
         verifyNever(
           () => logger.detail(any(that: contains('Failed to remove'))),
+        );
+      });
+
+      group('when an older version left an incomplete install', () {
+        setUp(() {
+          // Installed in place by a version that did not publish by rename,
+          // so the directory exists without the launcher a checkout writes.
+          targetDirectory.createSync(recursive: true);
+        });
+
+        test('says so and reinstalls that revision alone', () async {
+          final otherInstall = Directory(
+            p.join(flutterDirectory.parent.path, 'another-revision'),
+          )..createSync(recursive: true);
+          final leftover = File(p.join(targetDirectory.path, 'leftover'))
+            ..createSync(recursive: true);
+
+          await runWithOverrides(
+            () => shorebirdFlutter.installRevision(revision: revision),
+          );
+
+          verify(
+            () => logger.info(
+              any(that: contains('is incompletely installed')),
+            ),
+          ).called(1);
+          expect(leftover.existsSync(), isFalse);
+          // `shorebird cache clean` would have taken this with it.
+          expect(otherInstall.existsSync(), isTrue);
+          verify(
+            () => git.clone(
+              url: ShorebirdFlutter.flutterGitUrl,
+              outputDirectory: any(named: 'outputDirectory'),
+              args: any(named: 'args'),
+            ),
+          ).called(1);
+          expect(targetDirectory.existsSync(), isTrue);
+        });
+
+        test(
+          'reports when the incomplete install cannot be removed',
+          () async {
+            // Making the parent read-only is the portable way to block the
+            // unlink of a child that is otherwise perfectly deletable.
+            final parent = targetDirectory.parent;
+            Process.runSync('chmod', ['a-w', parent.path]);
+            addTearDown(() => Process.runSync('chmod', ['u+w', parent.path]));
+
+            await expectLater(
+              runWithOverrides(
+                () => shorebirdFlutter.installRevision(revision: revision),
+              ),
+              throwsA(isA<CacheCorruptedException>()),
+            );
+          },
+          testOn: 'linux || mac-os',
         );
       });
 

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -1,4 +1,4 @@
-// cspell:words revis
+// cspell:words revis precaches
 import 'dart:io';
 
 import 'package:clock/clock.dart';
@@ -1240,14 +1240,14 @@ origin/flutter_release/3.10.6''';
           final otherInstall = Directory(
             p.join(flutterDirectory.parent.path, 'another-revision'),
           )..createSync(recursive: true);
-          final notStaging = Directory('${targetDirectory.path}.notstaging')
+          final notStaging = Directory('${targetDirectory.path}.sibling')
             ..createSync(recursive: true);
-          // Suffixed like a staging directory but carrying no timestamp this
-          // code wrote, so its age is unknown and it is not ours to remove.
+          // Suffixed like a staging directory but carrying no timestamp the
+          // install wrote, so its age is unknown and it is not safe to remove.
           final unstamped = Directory('${targetDirectory.path}.mystery.tmp')
             ..createSync(recursive: true);
           // Another revision's staging directory. Each install reclaims only
-          // its own strays, so this one is not ours either.
+          // its own strays, so this one belongs to a different revision.
           final otherStaging = stray(
             p.join(flutterDirectory.parent.path, 'another-revision'),
             const Duration(days: 2),

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -28,6 +28,7 @@ void main() {
     late Platform platform;
     late Progress progress;
     late ShorebirdEnv shorebirdEnv;
+    late ShorebirdEnv targetShorebirdEnv;
     late ShorebirdProcess process;
     late ShorebirdProcessResult versionProcessResult;
     late ShorebirdProcessResult precacheProcessResult;
@@ -53,6 +54,7 @@ void main() {
       logger = MockShorebirdLogger();
       progress = MockProgress();
       shorebirdEnv = MockShorebirdEnv();
+      targetShorebirdEnv = MockShorebirdEnv();
       platform = MockPlatform();
       process = MockShorebirdProcess();
       versionProcessResult = MockShorebirdProcessResult();
@@ -99,6 +101,16 @@ void main() {
       when(() => platform.isMacOS).thenReturn(false);
       when(() => shorebirdEnv.flutterDirectory).thenReturn(flutterDirectory);
       when(() => shorebirdEnv.flutterRevision).thenReturn(flutterRevision);
+      when(
+        () => shorebirdEnv.copyWith(
+          flutterRevisionOverride: any(named: 'flutterRevisionOverride'),
+        ),
+      ).thenAnswer((invocation) {
+        when(() => targetShorebirdEnv.flutterRevision).thenReturn(
+          invocation.namedArguments[#flutterRevisionOverride] as String,
+        );
+        return targetShorebirdEnv;
+      });
       when(
         () => process.run('flutter', ['--version'], useVendedFlutter: false),
       ).thenAnswer((_) async => versionProcessResult);
@@ -1040,6 +1052,30 @@ origin/flutter_release/3.10.6''';
             ).called(1);
           },
         );
+      });
+
+      test('precaches the target revision, not the active revision', () async {
+        ShorebirdEnv? envDuringPrecache;
+        when(
+          () => process.run(
+            'flutter',
+            any(that: contains('precache')),
+            workingDirectory: any(named: 'workingDirectory'),
+          ),
+        ).thenAnswer((_) async {
+          envDuringPrecache = read(shorebirdEnvRef);
+          return precacheProcessResult;
+        });
+
+        await runWithOverrides(
+          () => shorebirdFlutter.installRevision(revision: revision),
+        );
+
+        // The vended `flutter` binary is resolved from the ambient revision,
+        // so precache only warms [revision] if the scope says so.
+        expect(envDuringPrecache, same(targetShorebirdEnv));
+        expect(envDuringPrecache!.flutterRevision, revision);
+        expect(shorebirdEnv.flutterRevision, isNot(revision));
       });
 
       group('when clone and checkout succeed', () {


### PR DESCRIPTION
## Summary

`installRevision` precached with the active revision's binary rather than the
one it had just cloned, so the new install got no artifacts and the guard from
#3789 only ever covered a revision that was not at risk. It also returned early
on any existing directory, so an interrupted run left a state every later run
read as finished, recoverable only by `shorebird cache clean`, which wipes every
installed revision to repair one.

- Precache runs in a `runScoped` override pinned to the target revision.
  `useVendedFlutter` stays on, so the storage base URL, `--verbose`, and local
  engine arguments are unchanged.
- Clone and checkout stage in a private directory published by rename, w/ an
  untracked `.shorebird_precache` stamp, so an interrupted run resumes rather
  than re-cloning.
- A launcher-less directory is moved aside, not deleted. The shell bootstrap's
  in-place `git clone --no-checkout` looks identical while it runs, and no lock
  this side can take separates them.
- Reclaimable directories carry their creation time in the name, so the sweep
  never reads an mtime that an unrelated write can bump and a rename leaves
  untouched.
- `CacheCorruptedException` takes an optional remedy, so precache failures say
  to retry and only callers w/ nothing narrower still say `cache clean`.

## Testing

- Full `shorebird_cli` suite passes, 2093 tests. Diff coverage 100%, which
  `.github/codecov.yml` requires to merge.
- Every new guard mutation-checked. 10 mutations, all killed.
- Repaired two `verifyNever` calls whose named arguments could never match the
  real call, leaving the already-installed fast path vacuously covered.
