### PR TITLE
fix(ci): turn off the setup-dart problem matcher in composite actions

### DIFF
--- a/.github/actions/dart_package/action.yaml
+++ b/.github/actions/dart_package/action.yaml
@@ -49,6 +49,9 @@ runs:
       uses: dart-lang/setup-dart@v1
       with:
         sdk: ${{inputs.dart_sdk}}
+        # Its matcher path resolves against the calling composite action rather
+        # than setup-dart itself, so the file is never found. setup-dart#198.
+        problem-matcher: false
 
     - name: 📦 Install Dependencies
       working-directory: ${{ inputs.working_directory }}

--- a/.github/actions/license_check/action.yaml
+++ b/.github/actions/license_check/action.yaml
@@ -18,6 +18,9 @@ runs:
       uses: dart-lang/setup-dart@v1
       with:
         sdk: ${{ inputs.dart_sdk }}
+        # Its matcher path resolves against the calling composite action rather
+        # than setup-dart itself, so the file is never found. setup-dart#198.
+        problem-matcher: false
 
     - name: 📦 Install Dependencies
       working-directory: ${{ inputs.working_directory }}

--- a/.github/actions/verify_version/action.yaml
+++ b/.github/actions/verify_version/action.yaml
@@ -16,6 +16,10 @@ runs:
 
     - name: 🎯 Setup Dart
       uses: dart-lang/setup-dart@v1
+      with:
+        # Its matcher path resolves against the calling composite action rather
+        # than setup-dart itself, so the file is never found. setup-dart#198.
+        problem-matcher: false
 
     - name: 📦 Install Dependencies
       shell: ${{ inputs.shell }}


### PR DESCRIPTION
## Summary

Every Dart job on every open PR is failing before it runs a line of Dart:

```
Could not find file '.../.github/actions/license_check/dart-analyzer.json'
```

`setup-dart` registers its analyzer problem matcher with `::add-matcher::` using
a relative path. Inside a composite action GitHub resolves that against the
calling action's folder rather than `setup-dart`'s, so it looks for a file that
has never existed in this repo. The action fails, every step after it skips, and
License Check, Verify, and all three Build jobs go red w/o running. `@v1` is a
floating tag, so this arrived on its own. Upstream is dart-lang/setup-dart#198.

- Opted out of the matcher in the three composite actions that wrap
  `setup-dart`. Workflows calling it as a top-level step resolve the path
  correctly and are untouched.
- The matcher only turns analyzer output into inline annotations in the GitHub
  UI. Warnings still print in the log, and nothing about what CI checks changes.

## Testing

- All three composite actions using `setup-dart` are covered, and each file
  still parses as YAML.
- The real check is this PR's own run: the jobs that died at SDK setup should
  get past it and actually execute.
