### PR TITLE
fix(e2e): use a per-environment API key

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,7 +20,11 @@ on:
     - cron: "0 0 * * *"
 
 env:
-  SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
+  # SHOREBIRD_TOKEN is set per job, next to the SHOREBIRD_HOSTED_URL it has to
+  # match. An API key is a row in one environment's database, so unlike the
+  # Google-refresh-token format it replaced it does not authenticate against
+  # both. A single workflow-level token would silently 401 half the matrix.
+  #
   # Host toolchain for `dart test integration_test`, not the version under test.
   # Must ship a Dart new enough for the SDK constraints in the root pubspec.
   FLUTTER_VERSION: 3.47.1
@@ -72,6 +76,7 @@ jobs:
 
     env:
       SHOREBIRD_HOSTED_URL: https://api-dev.shorebird.dev
+      SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN_DEV }}
 
     steps:
       - name: 📚 Git Checkout
@@ -156,6 +161,7 @@ jobs:
 
     env:
       SHOREBIRD_HOSTED_URL: ${{ matrix.branch == 'stable' && 'https://api.shorebird.dev' || 'https://api-dev.shorebird.dev' }}
+      SHOREBIRD_TOKEN: ${{ matrix.branch == 'stable' && secrets.SHOREBIRD_TOKEN_PROD || secrets.SHOREBIRD_TOKEN_DEV }}
 
     steps:
       - name: 📚 Git Checkout


### PR DESCRIPTION
The e2e matrix spans two environments but drew a single workflow-level `SHOREBIRD_TOKEN`:

| Job | `SHOREBIRD_HOSTED_URL` |
|---|---|
| `patch (*)` | `api-dev.shorebird.dev` |
| `cli (*, main)` | `api-dev.shorebird.dev` |
| `cli (*, stable)` | `api.shorebird.dev` |

That was fine while the secret held a `shorebird login:ci` token. It carries a Google refresh token, so the CLI exchanges it for a Google ID token that either host verifies against Google's JWKS — one value authenticated everywhere.

`login:ci` has since been removed in favor of API keys, and an API key is not portable: it is a row in one environment's database, matched by hash. No single value can satisfy both hosts, so any single token silently 401s whichever half of the matrix it was not minted for.

## Change

`SHOREBIRD_TOKEN` now comes from `SHOREBIRD_TOKEN_DEV` or `SHOREBIRD_TOKEN_PROD`, chosen by the same `matrix.branch == 'stable'` condition that already selects `SHOREBIRD_HOSTED_URL`, and declared on the line below it. Keeping the two adjacent is the point — they have to agree, and a workflow-level token sitting 130 lines from the host it has to match is what allowed them to disagree.

Both secrets are already configured, and each was verified against both hosts before being set (200 against its own environment, 401 against the other).

## Testing

Not yet verified — this needs a run to confirm. The nightly schedule will exercise it, or it can be dispatched manually.

Note the `cli (windows-latest, *)` legs fail for an unrelated reason and are expected to stay red:

```
error: unable to create file engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/
ScenariosUITests/golden_..._simulator.png: Filename too long
```

That is a `core.longpaths` problem on the engine checkout, unaffected by this change.

The old workflow-level `SHOREBIRD_TOKEN` secret is unused once this lands and can be deleted.
