### PR TITLE
fix(shorebird_cli): offer to build missing Gradle wrapper

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/init_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/init_command.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as p;
 import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
@@ -13,6 +14,7 @@ import 'package:shorebird_cli/src/pubspec_editor.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
 import 'package:shorebird_cli/src/shorebird_documentation.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_cli/src/shorebird_process.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 import 'package:yaml_edit/yaml_edit.dart';
@@ -127,6 +129,9 @@ Please make sure you are running "shorebird init" from within your Flutter proje
     Set<String>? macosFlavors;
     var productFlavors = <String>{};
     final projectRoot = shorebirdEnv.getFlutterProjectRoot()!;
+    if (!await _ensureGradleWrapper(projectRoot)) {
+      return ExitCode.software.code;
+    }
     final initializeGradleProgress = logger.progress('Initializing gradlew');
     final bool shouldStartGradleDaemon;
     try {
@@ -345,6 +350,48 @@ For more information about Shorebird, visit ${link(uri: Uri.parse('https://shore
     );
 
     return ExitCode.success.code;
+  }
+
+  Future<bool> _ensureGradleWrapper(Directory projectRoot) async {
+    final androidDirectory = Directory(p.join(projectRoot.path, 'android'));
+    if (!androidDirectory.existsSync() || gradlew.exists(projectRoot.path)) {
+      return true;
+    }
+
+    final executablePath = p.relative(
+      p.join(androidDirectory.path, gradlew.executable),
+    );
+    final missingWrapperException = MissingGradleWrapperException(
+      executablePath,
+    );
+    final canBuild =
+        shorebirdEnv.canAcceptUserInput &&
+        logger.confirm(
+          'Gradle wrapper not found. Would you like to run '
+          '"flutter build apk" now?',
+          defaultValue: true,
+        );
+    if (!canBuild) {
+      logger.err('$missingWrapperException');
+      return false;
+    }
+
+    final int exitCode;
+    try {
+      exitCode = await process.stream(
+        'flutter',
+        ['build', 'apk'],
+        workingDirectory: projectRoot.path,
+      );
+    } on Exception {
+      logger.err('Unable to generate the Gradle wrapper.');
+      return false;
+    }
+    if (exitCode != ExitCode.success.code) {
+      logger.err('Unable to generate the Gradle wrapper.');
+      return false;
+    }
+    return true;
   }
 
   Future<bool> _shouldStartGradleDaemon(String projectPath) async {

--- a/packages/shorebird_cli/test/src/commands/init_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/init_command_test.dart
@@ -49,6 +49,7 @@ environment:
     late ShorebirdLogger logger;
     late Platform platform;
     late Progress progress;
+    late ShorebirdProcess process;
     late PubspecEditor pubspecEditor;
     late ShorebirdEnv shorebirdEnv;
     late ShorebirdValidator shorebirdValidator;
@@ -92,6 +93,7 @@ environment:
       logger = MockShorebirdLogger();
       platform = MockPlatform();
       progress = MockProgress();
+      process = MockShorebirdProcess();
       shorebirdEnv = MockShorebirdEnv();
       shorebirdValidator = MockShorebirdValidator();
 
@@ -116,6 +118,8 @@ environment:
       when(
         () => gradlew.isDaemonAvailable(any()),
       ).thenAnswer((_) async => true);
+      when(() => gradlew.exists(any())).thenReturn(true);
+      when(() => gradlew.executable).thenReturn('gradlew');
       when(
         () => shorebirdEnv.getShorebirdYamlFile(cwd: any(named: 'cwd')),
       ).thenReturn(shorebirdYamlFile);
@@ -314,6 +318,126 @@ Please make sure you are running "shorebird init" from within your Flutter proje
       final exitCode = await runWithOverrides(command.run);
       expect(exitCode, ExitCode.success.code);
       verifyNever(() => gradlew.startDaemon(any()));
+    });
+
+    group('when the Gradle wrapper is missing', () {
+      setUp(() {
+        Directory(
+          p.join(projectRoot.path, 'android'),
+        ).createSync(recursive: true);
+        when(() => gradlew.exists(projectRoot.path)).thenReturn(false);
+      });
+
+      test('offers to build an APK and continues when accepted', () async {
+        when(
+          () => logger.confirm(any(), defaultValue: any(named: 'defaultValue')),
+        ).thenReturn(true);
+        when(
+          () => process.stream(
+            any(),
+            any(),
+            workingDirectory: any(named: 'workingDirectory'),
+          ),
+        ).thenAnswer((_) async => ExitCode.success.code);
+
+        final exitCode = await runWithOverrides(command.run);
+
+        expect(exitCode, ExitCode.success.code);
+        verify(
+          () => logger.confirm(
+            'Gradle wrapper not found. Would you like to run '
+            '"flutter build apk" now?',
+            defaultValue: true,
+          ),
+        ).called(1);
+        verify(
+          () => process.stream('flutter', [
+            'build',
+            'apk',
+          ], workingDirectory: projectRoot.path),
+        ).called(1);
+      });
+
+      test('shows the existing guidance when declined', () async {
+        when(
+          () => logger.confirm(any(), defaultValue: any(named: 'defaultValue')),
+        ).thenReturn(false);
+
+        final exitCode = await runWithOverrides(command.run);
+
+        expect(exitCode, ExitCode.software.code);
+        verify(
+          () => logger.err(any(that: contains('flutter build apk'))),
+        ).called(1);
+        verifyNever(
+          () => process.stream(
+            any(),
+            any(),
+            workingDirectory: any(named: 'workingDirectory'),
+          ),
+        );
+      });
+
+      test('does not prompt when unable to accept user input', () async {
+        when(() => shorebirdEnv.canAcceptUserInput).thenReturn(false);
+
+        final exitCode = await runWithOverrides(command.run);
+
+        expect(exitCode, ExitCode.software.code);
+        verifyNever(
+          () => logger.confirm(
+            any(),
+            defaultValue: any(named: 'defaultValue'),
+          ),
+        );
+        verifyNever(
+          () => process.stream(
+            any(),
+            any(),
+            workingDirectory: any(named: 'workingDirectory'),
+          ),
+        );
+      });
+
+      test('exits when building the APK fails', () async {
+        when(
+          () => logger.confirm(any(), defaultValue: any(named: 'defaultValue')),
+        ).thenReturn(true);
+        when(
+          () => process.stream(
+            any(),
+            any(),
+            workingDirectory: any(named: 'workingDirectory'),
+          ),
+        ).thenAnswer((_) async => ExitCode.software.code);
+
+        final exitCode = await runWithOverrides(command.run);
+
+        expect(exitCode, ExitCode.software.code);
+        verify(
+          () => logger.err('Unable to generate the Gradle wrapper.'),
+        ).called(1);
+      });
+
+      test('exits when starting the APK build fails', () async {
+        when(
+          () => logger.confirm(any(), defaultValue: any(named: 'defaultValue')),
+        ).thenReturn(true);
+        when(
+          () => process.stream(
+            any(),
+            any(),
+            workingDirectory: any(named: 'workingDirectory'),
+          ),
+        ).thenThrow(Exception('oops'));
+
+        final exitCode = await runWithOverrides(command.run);
+
+        expect(exitCode, ExitCode.software.code);
+        verify(
+          () => logger.err('Unable to generate the Gradle wrapper.'),
+        ).called(1);
+      });
     });
 
     test('throws when unable to initialize gradle wrapper', () async {


### PR DESCRIPTION
## Description

When `shorebird init` finds an Android project without a Gradle wrapper, offer to run `flutter build apk` and continue initialization. The prompt defaults to yes; declining or running non-interactively keeps the existing guidance, and build failures exit cleanly.

Adds tests for accepting and declining the prompt, non-interactive use, and build failures.

Fixes #1694.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [x] 🧪 Tests

## Testing

- `dart format --output=none --set-exit-if-changed lib/src/commands/init_command.dart test/src/commands/init_command_test.dart`
- `dart analyze packages/shorebird_cli`
- `dart test -j 4 --reporter failures-only` (2,156 passed, 1 skipped)
