### PR TITLE
fix(shorebird_cli): keep a pubspec comment with its key on init

### DIFF
--- a/packages/shorebird_cli/lib/src/pubspec_editor.dart
+++ b/packages/shorebird_cli/lib/src/pubspec_editor.dart
@@ -77,7 +77,7 @@ class PubspecEditor {
     final lastEntry = flutter.nodes[flutter.keys.last]!;
 
     // A scalar's span stops at the value itself; a nested block's already
-    // includes the newline that closed it. Normalise both to the position just
+    // includes the newline that closed it. Land both on the position just
     // before that newline, or a nested block gains a blank line above the
     // insertion.
     var end = lastEntry.span.end.offset;
@@ -90,11 +90,10 @@ class PubspecEditor {
     }
 
     // Taken from the document rather than assumed, the way `yaml_edit` takes
-    // it, so a pubspec written with a different indent does not come back
-    // reindented in one section only. The keys of `flutter` sit exactly one
-    // step in, which makes that column the step.
-    final step =
-        (flutter.nodes.keys.first as YamlScalar).span.start.column;
+    // it, so a pubspec written with a different indent keeps that indent
+    // here instead of gaining a section in some other one. The keys of
+    // `flutter` sit exactly one step in, which makes that column the step.
+    final step = (flutter.nodes.keys.first as YamlScalar).span.start.column;
     final key = ' ' * step;
     final item = ' ' * (step * 2);
 

--- a/packages/shorebird_cli/lib/src/pubspec_editor.dart
+++ b/packages/shorebird_cli/lib/src/pubspec_editor.dart
@@ -38,17 +38,67 @@ class PubspecEditor {
       );
     } else {
       if (!(yaml['flutter'] as Map).containsKey('assets')) {
-        editor.update(['flutter', 'assets'], ['shorebird.yaml']);
-      } else {
-        final assets = (yaml['flutter'] as Map)['assets'] as List;
-        if (!assets.contains('shorebird.yaml')) {
-          editor.update(['flutter', 'assets'], [...assets, 'shorebird.yaml']);
-        }
+        // Not `editor.update`, which chooses where a new key goes and chooses
+        // wrong when the map has exactly one key: it inserts *before* that
+        // key rather than after it, which separates the key from the comment
+        // block above it. That is the shape `flutter create` emits --
+        // `flutter:` holding only `uses-material-design: true`, with three
+        // lines of comment above describing it -- so almost every first
+        // `shorebird init` rewrote a comment onto the wrong line. With two or
+        // more keys the same call appends correctly, which is why this went
+        // unnoticed: it only misfires on the default project.
+        pubspecFile.writeAsStringSync(
+          _appendAssetsToFlutterSection(pubspecContents, yaml as YamlMap),
+        );
+        return;
+      }
+
+      final assets = (yaml['flutter'] as Map)['assets'] as List;
+      if (!assets.contains('shorebird.yaml')) {
+        editor.update(['flutter', 'assets'], [...assets, 'shorebird.yaml']);
       }
     }
 
     if (editor.edits.isEmpty) return;
 
     pubspecFile.writeAsStringSync(editor.toString());
+  }
+
+  /// Splices an `assets` block in directly after the last entry of an existing
+  /// `flutter` section, which is where `yaml_edit` puts it whenever it has
+  /// more than one entry to reason about.
+  ///
+  /// Placing it by hand rather than by key is what keeps every comment
+  /// attached to the line it documents: a comment is not part of the YAML
+  /// tree, so anything choosing a position from the tree alone is free to land
+  /// between a comment and its key.
+  String _appendAssetsToFlutterSection(String contents, YamlMap yaml) {
+    final flutter = yaml.nodes['flutter']! as YamlMap;
+    final lastEntry = flutter.nodes[flutter.keys.last]!;
+
+    // A scalar's span stops at the value itself; a nested block's already
+    // includes the newline that closed it. Normalise both to the position just
+    // before that newline, or a nested block gains a blank line above the
+    // insertion.
+    var end = lastEntry.span.end.offset;
+    if (end > 0 && contents[end - 1] == '\n') {
+      end -= 1;
+    } else {
+      while (end < contents.length && contents[end] != '\n') {
+        end++;
+      }
+    }
+
+    // Taken from the document rather than assumed, the way `yaml_edit` takes
+    // it, so a pubspec written with a different indent does not come back
+    // reindented in one section only. The keys of `flutter` sit exactly one
+    // step in, which makes that column the step.
+    final step =
+        (flutter.nodes.keys.first as YamlScalar).span.start.column;
+    final key = ' ' * step;
+    final item = ' ' * (step * 2);
+
+    final block = '\n${key}assets:\n$item- shorebird.yaml';
+    return contents.substring(0, end) + block + contents.substring(end);
   }
 }

--- a/packages/shorebird_cli/lib/src/pubspec_editor.dart
+++ b/packages/shorebird_cli/lib/src/pubspec_editor.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:yaml/yaml.dart';
@@ -77,6 +79,29 @@ class PubspecEditor {
     pubspecFile.writeAsStringSync(editor.toString());
   }
 
+  /// The offset just past the deepest scalar under [node].
+  ///
+  /// Recurses rather than reading [node]'s own span because only a scalar's
+  /// span is tight; a collection's extends to whatever comes after it. Keys
+  /// count as well as values, so a mapping whose last entry has an empty
+  /// collection for a value still lands on that key.
+  ///
+  /// A block scalar is a scalar, so text inside one that merely looks like a
+  /// comment stays part of the document rather than being walked over.
+  int _lastLeafEnd(YamlNode node) {
+    if (node is YamlMap && node.nodes.isNotEmpty) {
+      return node.nodes.entries
+          .map(
+            (e) => max(_lastLeafEnd(e.key as YamlNode), _lastLeafEnd(e.value)),
+          )
+          .reduce(max);
+    }
+    if (node is YamlList && node.nodes.isNotEmpty) {
+      return node.nodes.map(_lastLeafEnd).reduce(max);
+    }
+    return node.span.end.offset;
+  }
+
   /// Splices an `assets` block in directly after the last entry of an existing
   /// `flutter` section, which is where `yaml_edit` puts it whenever it has
   /// more than one entry to reason about.
@@ -86,13 +111,13 @@ class PubspecEditor {
   /// tree, so anything choosing a position from the tree alone is free to land
   /// between a comment and its key.
   String _appendAssetsToFlutterSection(String contents, YamlMap flutter) {
-    final lastEntry = flutter.nodes[flutter.keys.last]!;
-
-    // A scalar's span stops at the value itself; a nested block's already
-    // includes the newline that closed it. Land both on the position just
-    // before that newline, or a nested block gains a blank line above the
-    // insertion.
-    var end = lastEntry.span.end.offset;
+    // The last leaf's end, not the last entry's. A scalar's span stops at its
+    // own text, but a block collection's runs on through whatever follows it,
+    // and for the last entry of a mapping that is the rest of the document --
+    // blank lines and any trailing comment included. Appending at the entry's
+    // own end would put `assets:` underneath a comment that has nothing to do
+    // with it, which is the thing this method exists to avoid.
+    var end = _lastLeafEnd(flutter.nodes[flutter.keys.last]!);
     if (end > 0 && contents[end - 1] == '\n') {
       end -= 1;
     } else {

--- a/packages/shorebird_cli/lib/src/pubspec_editor.dart
+++ b/packages/shorebird_cli/lib/src/pubspec_editor.dart
@@ -38,6 +38,7 @@ class PubspecEditor {
       );
     } else {
       if (!(yaml['flutter'] as Map).containsKey('assets')) {
+        final flutter = (yaml as YamlMap).nodes['flutter'];
         // Not `editor.update`, which chooses where a new key goes and chooses
         // wrong when the map has exactly one key: it inserts *before* that
         // key rather than after it, which separates the key from the comment
@@ -47,15 +48,27 @@ class PubspecEditor {
         // `shorebird init` rewrote a comment onto the wrong line. With two or
         // more keys the same call appends correctly, which is why this went
         // unnoticed: it only misfires on the default project.
-        pubspecFile.writeAsStringSync(
-          _appendAssetsToFlutterSection(pubspecContents, yaml as YamlMap),
-        );
-        return;
-      }
-
-      final assets = (yaml['flutter'] as Map)['assets'] as List;
-      if (!assets.contains('shorebird.yaml')) {
-        editor.update(['flutter', 'assets'], [...assets, 'shorebird.yaml']);
+        //
+        // Only for a block map with something in it. An empty one has no last
+        // entry to append after, and a flow one (`flutter: {a: b}`) has no
+        // block layout to match, so appending a block key to it would produce
+        // something that no longer parses. `yaml_edit` handles both of those
+        // correctly, and neither can hit the misplacement above, so they keep
+        // going through it.
+        if (flutter is YamlMap &&
+            flutter.style == CollectionStyle.BLOCK &&
+            flutter.isNotEmpty) {
+          pubspecFile.writeAsStringSync(
+            _appendAssetsToFlutterSection(pubspecContents, flutter),
+          );
+          return;
+        }
+        editor.update(['flutter', 'assets'], ['shorebird.yaml']);
+      } else {
+        final assets = (yaml['flutter'] as Map)['assets'] as List;
+        if (!assets.contains('shorebird.yaml')) {
+          editor.update(['flutter', 'assets'], [...assets, 'shorebird.yaml']);
+        }
       }
     }
 
@@ -72,8 +85,7 @@ class PubspecEditor {
   /// attached to the line it documents: a comment is not part of the YAML
   /// tree, so anything choosing a position from the tree alone is free to land
   /// between a comment and its key.
-  String _appendAssetsToFlutterSection(String contents, YamlMap yaml) {
-    final flutter = yaml.nodes['flutter']! as YamlMap;
+  String _appendAssetsToFlutterSection(String contents, YamlMap flutter) {
     final lastEntry = flutter.nodes[flutter.keys.last]!;
 
     // A scalar's span stops at the value itself; a nested block's already

--- a/packages/shorebird_cli/test/src/pubspec_editor_test.dart
+++ b/packages/shorebird_cli/test/src/pubspec_editor_test.dart
@@ -213,10 +213,48 @@ flutter:
             );
           });
 
+          // A block collection's span runs on past itself to the end of the
+          // document, so appending at the last entry's own end put `assets:`
+          // underneath a comment belonging to nothing.
+          test('appends above a trailing comment, not below it', () {
+            pubspecFile
+              ..createSync()
+              ..writeAsStringSync('''
+$basePubspecContents
+flutter:
+  uses-material-design: true
+  fonts:
+    - family: Foo
+
+# Some unrelated comment
+''');
+            IOOverrides.runZoned(
+              () => runWithOverrides(
+                pubspecEditor.addShorebirdYamlToPubspecAssets,
+              ),
+              getCurrentDirectory: () => tempDir,
+            );
+            expect(
+              pubspecFile.readAsStringSync(),
+              equals('''
+$basePubspecContents
+flutter:
+  uses-material-design: true
+  fonts:
+    - family: Foo
+  assets:
+    - shorebird.yaml
+
+# Some unrelated comment
+'''),
+            );
+          });
+
           // Neither of these can hit the misplacement the append avoids, and
           // neither has a last entry to append after or a block layout to
           // match, so both stay on `yaml_edit`. Appending to them by hand
-          // threw on the first and produced YAML that no longer parses on the second.
+          // threw on the first, and produced YAML that no longer parses on
+          // the second.
           test('handles an empty flutter map', () {
             pubspecFile
               ..createSync()

--- a/packages/shorebird_cli/test/src/pubspec_editor_test.dart
+++ b/packages/shorebird_cli/test/src/pubspec_editor_test.dart
@@ -6,6 +6,7 @@ import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/pubspec_editor.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
 
 import 'mocks.dart';
 
@@ -210,6 +211,51 @@ flutter:
   #   - images/a_dot_burr.jpeg
 '''),
             );
+          });
+
+          // Neither of these can hit the misplacement the append avoids, and
+          // neither has a last entry to append after or a block layout to
+          // match, so both stay on `yaml_edit`. Appending to them by hand
+          // threw on the first and produced YAML that no longer parses on the second.
+          test('handles an empty flutter map', () {
+            pubspecFile
+              ..createSync()
+              ..writeAsStringSync('''
+$basePubspecContents
+flutter: {}
+''');
+            IOOverrides.runZoned(
+              () => runWithOverrides(
+                pubspecEditor.addShorebirdYamlToPubspecAssets,
+              ),
+              getCurrentDirectory: () => tempDir,
+            );
+            final result = pubspecFile.readAsStringSync();
+            expect(result, contains('shorebird.yaml'));
+            final flutter = (loadYaml(result) as YamlMap)['flutter'] as YamlMap;
+            expect(flutter['assets'], equals(['shorebird.yaml']));
+          });
+
+          test('handles a flow-style flutter map', () {
+            pubspecFile
+              ..createSync()
+              ..writeAsStringSync('''
+$basePubspecContents
+flutter: {uses-material-design: true}
+''');
+            IOOverrides.runZoned(
+              () => runWithOverrides(
+                pubspecEditor.addShorebirdYamlToPubspecAssets,
+              ),
+              getCurrentDirectory: () => tempDir,
+            );
+            // Still parses, still has both entries: the point is that the
+            // result is valid YAML rather than any particular formatting.
+            final flutter =
+                (loadYaml(pubspecFile.readAsStringSync()) as YamlMap)['flutter']
+                    as YamlMap;
+            expect(flutter['assets'], equals(['shorebird.yaml']));
+            expect(flutter['uses-material-design'], isTrue);
           });
 
           test('adds shorebird.yaml to assets (existing assets)', () {

--- a/packages/shorebird_cli/test/src/pubspec_editor_test.dart
+++ b/packages/shorebird_cli/test/src/pubspec_editor_test.dart
@@ -158,13 +158,60 @@ flutter:
                 equals('''
 $basePubspecContents
 flutter:
+ uses-material-design: true
  assets:
   - shorebird.yaml
- uses-material-design: true
 '''),
               );
             },
           );
+          // `flutter create` emits a `flutter` section holding exactly one
+          // key with a comment block above it describing that key. Appending
+          // is what keeps the two together: inserting before the only key
+          // leaves the comment sitting on top of `assets:`, describing
+          // something it has nothing to do with.
+          test('keeps a comment attached to the key it documents', () {
+            pubspecFile
+              ..createSync()
+              ..writeAsStringSync('''
+$basePubspecContents
+flutter:
+
+  # The following line ensures that the Material Icons font is
+  # included with your application, so that you can use the icons in
+  # the material Icons class.
+  uses-material-design: true
+
+  # To add assets to your application, add an assets section, like this:
+  # assets:
+  #   - images/a_dot_burr.jpeg
+''');
+            IOOverrides.runZoned(
+              () => runWithOverrides(
+                pubspecEditor.addShorebirdYamlToPubspecAssets,
+              ),
+              getCurrentDirectory: () => tempDir,
+            );
+            expect(
+              pubspecFile.readAsStringSync(),
+              equals('''
+$basePubspecContents
+flutter:
+
+  # The following line ensures that the Material Icons font is
+  # included with your application, so that you can use the icons in
+  # the material Icons class.
+  uses-material-design: true
+  assets:
+    - shorebird.yaml
+
+  # To add assets to your application, add an assets section, like this:
+  # assets:
+  #   - images/a_dot_burr.jpeg
+'''),
+            );
+          });
+
           test('adds shorebird.yaml to assets (existing assets)', () {
             pubspecFile
               ..createSync()


### PR DESCRIPTION
## Description

`shorebird init` moves the comment block above the first key in a project's `flutter:` section onto the `assets:` block it inserts, so the comment ends up describing something it has nothing to do with.

`addShorebirdYamlToPubspecAssets` asks `yaml_edit` to add the `assets` key, and `yaml_edit` inserts a new key at the **front** of a mapping that holds exactly one entry rather than after it. With two or more entries the same call appends correctly — which is why this went unnoticed. It only misfires on a `flutter` section with a single key, and that is exactly what `flutter create` emits:

```yaml
flutter:
  # The following line ensures that the Material Icons font is
  # included with your application, so that you can use the icons in
  # the material Icons class.
  uses-material-design: true
```

becomes

```yaml
flutter:
  # The following line ensures that the Material Icons font is
  # included with your application, so that you can use the icons in
  # the material Icons class.
  assets:
    - shorebird.yaml
  uses-material-design: true
```

So nearly every first `shorebird init` on a default project rewrites a comment onto the wrong line.

### The fix

Splice the block in after the last entry of the `flutter` section, which is where `yaml_edit` puts it once it has more than one entry to reason about. A comment is not part of the YAML tree, so anything choosing a position from the tree alone is free to land between a comment and its key; choosing the position from the source text is what keeps the two together.

Indentation is read from the document rather than assumed, so a pubspec written with a different indent does not come back reindented in one section only.

After:

```yaml
flutter:
  # The following line ensures that the Material Icons font is
  # included with your application, so that you can use the icons in
  # the material Icons class.
  uses-material-design: true
  assets:
    - shorebird.yaml
```

### Tests

The existing `non-empty flutter` test had pinned the old placement, so its expectation is corrected here. A new regression test covers the `flutter create` shape with its comments, including the trailing "To add assets to your application" block.

Verified against a single key with and without a blank line after `flutter:`, two or more keys, a nested block as the last entry, an existing `assets` list, and a file with no trailing newline.

`pubspec_editor` (7), `init_command` and `shorebird_yaml_asset_validator` (52) all pass.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

https://claude.ai/code/session_01ChE18sC3pmpxxvoZxt3jAT