### PR TITLE
feat(shorebird_cli): show plan level in `account whoami`

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -133,6 +133,20 @@ class CodePushClientWrapper {
     return user;
   }
 
+  /// Fetches the plan level for the current user, e.g. `free`, `pro`,
+  /// `business` or `enterprise`. Null when the server does not report one.
+  Future<String?> getPlanLevel() async {
+    final progress = logger.progress('Fetching plan');
+    final String? level;
+    try {
+      level = await codePushClient.getPlanLevel();
+      progress.complete();
+    } catch (error) {
+      _handleErrorAndExit(error, progress: progress);
+    }
+    return level;
+  }
+
   /// Fetches the organization memberships for the current user.
   Future<List<OrganizationMembership>> getOrganizationMemberships() async {
     final progress = logger.progress('Fetching organizations');

--- a/packages/shorebird_cli/lib/src/commands/account/whoami_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/whoami_command.dart
@@ -25,9 +25,12 @@ class WhoamiCommand extends ShorebirdCommand {
       '  ID:             42\n'
       '  Email:          user@example.com\n'
       '  Display name:   Example User\n'
-      '  Plan:           paid\n'
+      '  Plan:           enterprise\n'
+      '  Subscription:   active\n'
       '  Overage limit:  10000\n\n'
-      'Plan is "paid" (active Shorebird subscription) or "free".\n'
+      'Plan is your plan level: "free", "pro", "business" or "enterprise" '
+      '("unknown" if the server does not report one).\n'
+      'Subscription is "active" (paying Shorebird customer) or "none".\n'
       'Overage limit is the max pay-as-you-go patch installs allowed '
       'beyond your plan ("none" if unset).\n\n'
       '${ShorebirdCommand.jsonHint('shorebird account whoami --json')}';
@@ -43,8 +46,10 @@ class WhoamiCommand extends ShorebirdCommand {
     }
 
     final PrivateUser user;
+    final String? planLevel;
     try {
       user = await codePushClientWrapper.getCurrentUser();
+      planLevel = await codePushClientWrapper.getPlanLevel();
     } on ProcessExit catch (e) {
       if (isJsonMode) {
         emitJsonError(
@@ -56,7 +61,8 @@ class WhoamiCommand extends ShorebirdCommand {
       rethrow;
     }
 
-    final plan = (user.hasActiveSubscription ?? false) ? 'paid' : 'free';
+    final isPaying = user.hasActiveSubscription ?? false;
+    final subscription = isPaying ? 'active' : 'none';
 
     if (isJsonMode) {
       emitJsonSuccess({
@@ -64,7 +70,10 @@ class WhoamiCommand extends ShorebirdCommand {
           'id': user.id,
           'email': user.email,
           'display_name': user.displayName,
-          'plan': plan,
+          // `plan` predates plan levels and is kept as-is so existing
+          // scripts keep working; `plan_level` is the finer-grained value.
+          'plan': isPaying ? 'paid' : 'free',
+          'plan_level': planLevel,
           'overage_limit': user.patchOverageLimit,
         },
       });
@@ -78,7 +87,8 @@ class WhoamiCommand extends ShorebirdCommand {
       logger.info('Display name:   ${user.displayName}');
     }
     logger
-      ..info('Plan:           $plan')
+      ..info('Plan:           ${planLevel ?? 'unknown'}')
+      ..info('Subscription:   $subscription')
       ..info('Overage limit:  ${user.patchOverageLimit ?? 'none'}');
 
     return ExitCode.success.code;

--- a/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
+++ b/packages/shorebird_cli/test/src/code_push_client_wrapper_test.dart
@@ -322,6 +322,32 @@ void main() {
         });
       });
 
+      group('getPlanLevel', () {
+        test('exits with code 70 when getting the plan fails', () async {
+          const error = 'something went wrong';
+          when(() => codePushClient.getPlanLevel()).thenThrow(error);
+
+          await expectLater(
+            () async => runWithOverrides(codePushClientWrapper.getPlanLevel),
+            exitsWithCode(ExitCode.software),
+          );
+          verify(() => progress.fail(error)).called(1);
+        });
+
+        test('returns the plan level on success', () async {
+          when(
+            () => codePushClient.getPlanLevel(),
+          ).thenAnswer((_) async => 'enterprise');
+
+          final level = await runWithOverrides(
+            codePushClientWrapper.getPlanLevel,
+          );
+
+          expect(level, equals('enterprise'));
+          verify(() => progress.complete()).called(1);
+        });
+      });
+
       group('getOrganizationMemberships', () {
         test(
           'exits with code 70 when getting organization memberships fails',

--- a/packages/shorebird_cli/test/src/commands/account/whoami_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account/whoami_command_test.dart
@@ -65,6 +65,9 @@ void main() {
       when(
         () => codePushClientWrapper.getCurrentUser(),
       ).thenAnswer((_) async => user);
+      when(
+        () => codePushClientWrapper.getPlanLevel(),
+      ).thenAnswer((_) async => 'enterprise');
     });
 
     test('has correct description', () {
@@ -111,7 +114,10 @@ void main() {
           () => logger.info(any(that: contains('Example User'))),
         ).called(1);
         verify(
-          () => logger.info(any(that: contains('Plan:           paid'))),
+          () => logger.info(any(that: contains('Plan:           enterprise'))),
+        ).called(1);
+        verify(
+          () => logger.info(any(that: contains('Subscription:   active'))),
         ).called(1);
         verify(
           () => logger.info(any(that: contains('Overage limit:  10000'))),
@@ -140,6 +146,22 @@ void main() {
         });
       });
 
+      group('when the server reports no plan level', () {
+        setUp(() {
+          when(
+            () => codePushClientWrapper.getPlanLevel(),
+          ).thenAnswer((_) async => null);
+        });
+
+        test('prints the plan as unknown', () async {
+          final result = await runWithOverrides(command.run);
+          expect(result, equals(ExitCode.success.code));
+          verify(
+            () => logger.info(any(that: contains('Plan:           unknown'))),
+          ).called(1);
+        });
+      });
+
       group('when user is on the free plan', () {
         const userNoSub = PrivateUser(
           id: 3,
@@ -151,13 +173,19 @@ void main() {
           when(
             () => codePushClientWrapper.getCurrentUser(),
           ).thenAnswer((_) async => userNoSub);
+          when(
+            () => codePushClientWrapper.getPlanLevel(),
+          ).thenAnswer((_) async => 'free');
         });
 
-        test('prints plan as free', () async {
+        test('prints plan level and no subscription', () async {
           final result = await runWithOverrides(command.run);
           expect(result, equals(ExitCode.success.code));
           verify(
             () => logger.info(any(that: contains('Plan:           free'))),
+          ).called(1);
+          verify(
+            () => logger.info(any(that: contains('Subscription:   none'))),
           ).called(1);
         });
 
@@ -168,6 +196,21 @@ void main() {
             () => logger.info(any(that: contains('Overage limit:  none'))),
           ).called(1);
         });
+      });
+    });
+
+    group('when the plan fetch fails', () {
+      setUp(() {
+        when(
+          () => codePushClientWrapper.getPlanLevel(),
+        ).thenThrow(ProcessExit(ExitCode.software.code));
+      });
+
+      test('rethrows ProcessExit', () async {
+        await expectLater(
+          () => runWithOverrides(command.run),
+          throwsA(isA<ProcessExit>()),
+        );
       });
     });
 
@@ -237,6 +280,7 @@ void main() {
         expect(userData['email'], 'user@example.com');
         expect(userData['display_name'], 'Example User');
         expect(userData['plan'], 'paid');
+        expect(userData['plan_level'], 'enterprise');
         expect(userData['overage_limit'], 10000);
       });
 

--- a/packages/shorebird_code_push_client/lib/src/code_push_client.dart
+++ b/packages/shorebird_code_push_client/lib/src/code_push_client.dart
@@ -142,6 +142,23 @@ class CodePushClient {
     return PrivateUser.fromJson(json);
   }
 
+  /// Fetches the plan level for the currently logged-in user, e.g. `free`,
+  /// `pro`, `business` or `enterprise`.
+  ///
+  /// The plan itself is a server-local model with billing fields that are
+  /// deliberately not part of this package, so only the level is read here.
+  /// Returns null if the server does not report one.
+  Future<String?> getPlanLevel() async {
+    final response = await _httpClient.get(Uri.parse('$_v1/plan'));
+
+    if (!response.isSuccess) {
+      throw _parseErrorResponse(response.statusCode, response.body);
+    }
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    return json['level'] as String?;
+  }
+
   /// Create a new artifact for a specific [patchId].
   Future<void> createPatchArtifact({
     required String artifactPath,

--- a/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
+++ b/packages/shorebird_code_push_client/test/src/code_push_client_test.dart
@@ -2813,6 +2813,62 @@ void main() {
       });
     });
 
+    group('getPlanLevel', () {
+      group('when request fails', () {
+        setUp(() {
+          when(() => httpClient.send(any())).thenAnswer(
+            (_) async => http.StreamedResponse(
+              const Stream.empty(),
+              HttpStatus.failedDependency,
+            ),
+          );
+        });
+
+        test('throws exception', () async {
+          expect(
+            () async => codePushClient.getPlanLevel(),
+            throwsA(
+              isA<CodePushException>().having(
+                (e) => e.message,
+                'message',
+                CodePushClient.unknownErrorMessage,
+              ),
+            ),
+          );
+        });
+      });
+
+      group('when request succeeds', () {
+        setUp(() {
+          when(() => httpClient.send(any())).thenAnswer(
+            (_) async => http.StreamedResponse(
+              Stream.value(utf8.encode('{"level": "enterprise"}')),
+              HttpStatus.ok,
+            ),
+          );
+        });
+
+        test('returns the level', () async {
+          expect(await codePushClient.getPlanLevel(), equals('enterprise'));
+        });
+      });
+
+      group('when the response has no level', () {
+        setUp(() {
+          when(() => httpClient.send(any())).thenAnswer(
+            (_) async => http.StreamedResponse(
+              Stream.value(utf8.encode('{}')),
+              HttpStatus.ok,
+            ),
+          );
+        });
+
+        test('returns null', () async {
+          expect(await codePushClient.getPlanLevel(), isNull);
+        });
+      });
+    });
+
     group('getGCPUploadSpeedTestUrl', () {
       group('when request fails', () {
         setUp(() {


### PR DESCRIPTION
`shorebird account whoami` reported `Plan: paid` or `Plan: free`, derived from `has_active_subscription`. That is a boolean, so it cannot tell pro from enterprise — and "which plan am I on" is almost always really "can I use this plan-gated capability", like scoped API keys or the `developer` role.

`GET /api/v1/plan` already returns `level`. This reads it.

### Before

```
ID:             42
Email:          user@example.com
Display name:   Example User
Plan:           paid
Overage limit:  10000
```

### After

```
ID:             42
Email:          user@example.com
Display name:   Example User
Plan:           enterprise
Subscription:   active
Overage limit:  10000
```

The paid/free bit moves to its own line rather than being dropped. That is not just for continuity: a subscription whose price carries no `plan_level` metadata resolves to level `free` while still being an active subscription, and seeing `Plan: free` next to `Subscription: active` is how you'd notice.

`Plan` shows `unknown` if the server reports no level.

### Notes

- Only `level` is read, not the whole plan. The plan is a server-local model whose billing fields are deliberately not in the protocol package, so porting it would drag that boundary into the public submodule for one string.
- `--json` keeps `plan` as `paid`/`free` so existing scripts keep working, and adds `plan_level` next to it.

### Testing

New tests cover the client method (success, no `level` in the response, request failure), the wrapper method (success and failure), and the command (plan level in human and `--json` output, `unknown` when null, `Subscription: none` on a free account, and the plan fetch failing).

https://claude.ai/code/session_01JuXTMzbvJ977hMnkZMNfVN
