### PR TITLE
feat(shorebird_cli): manage API keys from `shorebird account api-keys`

### DIFF
--- a/packages/shorebird_cli/lib/src/auth/api_key.dart
+++ b/packages/shorebird_cli/lib/src/auth/api_key.dart
@@ -1,36 +1,16 @@
 import 'package:equatable/equatable.dart';
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 
-/// The permission preset an API key is minted with.
+/// The `--scope` spelling of an [ApiKeyScope].
 ///
-/// These are the only scopes the auth service accepts. Arbitrary permission
-/// combinations are deliberately not offered — a key is one of these two
-/// shapes so that what a key can do is legible from its scope alone.
-enum ApiKeyScope {
-  /// Everything the minting user can do.
-  fullAccess('full-access', wireName: 'full_access'),
-
-  /// Create and publish releases and patches, and read insights. No deletes,
-  /// no member management, no billing.
-  releaseAndPatch('release-and-patch', wireName: 'release_and_patch');
-
-  const ApiKeyScope(this.flagName, {required this.wireName});
-
+/// Command-line spelling is a CLI concern, so it lives here rather than on
+/// the protocol enum, which carries only the wire value.
+extension ApiKeyScopeFlagName on ApiKeyScope {
   /// The value accepted by `--scope` on the command line.
-  final String flagName;
-
-  /// The value the auth service uses for this scope.
-  final String wireName;
-
-  /// The scope whose [wireName] is [value], or null if none matches.
-  ///
-  /// Returns null for a scope this CLI does not know about, which is what a
-  /// newer server introducing a preset looks like from here.
-  static ApiKeyScope? fromWireName(String value) {
-    for (final scope in ApiKeyScope.values) {
-      if (scope.wireName == value) return scope;
-    }
-    return null;
-  }
+  String get flagName => switch (this) {
+    ApiKeyScope.fullAccess => 'full-access',
+    ApiKeyScope.releaseAndPatch => 'release-and-patch',
+  };
 }
 
 /// {@template api_key_metadata}

--- a/packages/shorebird_cli/lib/src/auth/api_key.dart
+++ b/packages/shorebird_cli/lib/src/auth/api_key.dart
@@ -1,0 +1,162 @@
+import 'package:equatable/equatable.dart';
+
+/// The permission preset an API key is minted with.
+///
+/// These are the only scopes the auth service accepts. Arbitrary permission
+/// combinations are deliberately not offered — a key is one of these two
+/// shapes so that what a key can do is legible from its scope alone.
+enum ApiKeyScope {
+  /// Everything the minting user can do.
+  fullAccess('full-access', wireName: 'full_access'),
+
+  /// Create and publish releases and patches, and read insights. No deletes,
+  /// no member management, no billing.
+  releaseAndPatch('release-and-patch', wireName: 'release_and_patch');
+
+  const ApiKeyScope(this.flagName, {required this.wireName});
+
+  /// The value accepted by `--scope` on the command line.
+  final String flagName;
+
+  /// The value the auth service uses for this scope.
+  final String wireName;
+
+  /// The scope whose [wireName] is [value], or null if none matches.
+  ///
+  /// Returns null for a scope this CLI does not know about, which is what a
+  /// newer server introducing a preset looks like from here.
+  static ApiKeyScope? fromWireName(String value) {
+    for (final scope in ApiKeyScope.values) {
+      if (scope.wireName == value) return scope;
+    }
+    return null;
+  }
+}
+
+/// {@template api_key_metadata}
+/// The non-secret half of an API key: everything the auth service will tell
+/// you about a key after it has been created.
+///
+/// The key itself is returned exactly once, at creation, and is never
+/// retrievable afterwards — hence "metadata".
+/// {@endtemplate}
+class ApiKeyMetadata extends Equatable {
+  /// {@macro api_key_metadata}
+  const ApiKeyMetadata({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    this.lastUsedAt,
+    this.expiresAt,
+    this.scope,
+  });
+
+  /// Parses an [ApiKeyMetadata] from the auth service's JSON representation.
+  factory ApiKeyMetadata.fromJson(Map<String, dynamic> json) {
+    final scope = json['scope'];
+    return ApiKeyMetadata(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      lastUsedAt: _parseNullableDate(json['last_used_at']),
+      expiresAt: _parseNullableDate(json['expires_at']),
+      scope: scope is String ? ApiKeyScope.fromWireName(scope) : null,
+    );
+  }
+
+  /// The key's server-side identifier, used to revoke it.
+  final String id;
+
+  /// The name the key was created with.
+  final String name;
+
+  /// When the key was created.
+  final DateTime createdAt;
+
+  /// When the key was last used to authenticate, or null if never used.
+  final DateTime? lastUsedAt;
+
+  /// When the key expires, or null if it never does.
+  final DateTime? expiresAt;
+
+  /// The preset this key's permissions correspond to.
+  ///
+  /// Null when the server reports no scope, or one this CLI does not know:
+  /// a key whose permissions match no preset, or a preset added server-side
+  /// since this CLI shipped. Displayed as "unknown" rather than guessed.
+  final ApiKeyScope? scope;
+
+  @override
+  List<Object?> get props => [
+    id,
+    name,
+    createdAt,
+    lastUsedAt,
+    expiresAt,
+    scope,
+  ];
+}
+
+DateTime? _parseNullableDate(Object? value) =>
+    value is String ? DateTime.parse(value) : null;
+
+/// {@template api_key_request_exception}
+/// Thrown when the auth service rejects or cannot serve an API key request.
+/// {@endtemplate}
+class ApiKeyRequestException implements Exception {
+  /// {@macro api_key_request_exception}
+  const ApiKeyRequestException(this.message);
+
+  /// A description of what went wrong, suitable for showing to the user.
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// {@template api_key_session_required_exception}
+/// Thrown when API key management is attempted without an interactive
+/// session.
+///
+/// Key management authenticates with the session's refresh token, which only
+/// `shorebird login` produces. A `SHOREBIRD_TOKEN` — whether an API key or a
+/// legacy CI token — is not a session and cannot manage keys. That is
+/// deliberate: a leaked CI credential able to mint more credentials would
+/// defeat revocation.
+/// {@endtemplate}
+class ApiKeySessionRequiredException implements Exception {
+  /// {@macro api_key_session_required_exception}
+  const ApiKeySessionRequiredException();
+
+  @override
+  String toString() =>
+      'API key management requires an interactive login. Run `shorebird '
+      'login` on a machine with a browser.';
+}
+
+/// {@template api_key_scope_mismatch_exception}
+/// Thrown when the server minted a key with a different scope than requested.
+///
+/// The failure this guards against is a silent widening: a server that does
+/// not understand scope-by-name ignores the field and defaults to full
+/// access, handing back a broader credential than the caller asked for.
+/// {@endtemplate}
+class ApiKeyScopeMismatchException implements Exception {
+  /// {@macro api_key_scope_mismatch_exception}
+  const ApiKeyScopeMismatchException({
+    required this.requested,
+    required this.granted,
+  });
+
+  /// The scope the caller asked for.
+  final ApiKeyScope requested;
+
+  /// The scope the server actually granted, or null if it reported none.
+  final ApiKeyScope? granted;
+
+  @override
+  String toString() =>
+      'Requested a ${requested.flagName} key but the server granted '
+      '${granted?.flagName ?? 'an unknown scope'}. The key was created — '
+      'revoke it with `shorebird account api-keys revoke`.';
+}

--- a/packages/shorebird_cli/lib/src/auth/auth.dart
+++ b/packages/shorebird_cli/lib/src/auth/auth.dart
@@ -11,6 +11,7 @@ import 'package:jwt/jwt.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_cli/src/auth/api_key.dart';
 import 'package:shorebird_cli/src/auth/ci_token.dart';
 import 'package:shorebird_cli/src/auth/endpoints/endpoints.dart';
 import 'package:shorebird_cli/src/auth/shorebird_oauth.dart' as shorebird_oauth;
@@ -23,6 +24,7 @@ import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/third_party/flutter_tools/lib/flutter_tools.dart';
 import 'package:shorebird_code_push_client/shorebird_code_push_client.dart';
 
+export 'api_key.dart';
 export 'ci_token.dart';
 
 /// A reference to an [Auth] instance.
@@ -334,6 +336,116 @@ class Auth {
       // Best-effort — don't block logout if the server is unreachable.
       logger.detail('Failed to revoke session: $e');
     }
+  }
+
+  /// Lists the current user's API keys, newest first.
+  ///
+  /// Metadata only — the auth service never returns a key's secret after
+  /// creation.
+  Future<List<ApiKeyMetadata>> listApiKeys() async {
+    final response = await _sendApiKeyRequest('GET');
+    final body = json.decode(response.body) as Map<String, dynamic>;
+    final keys = body['api_keys'] as List<dynamic>? ?? <dynamic>[];
+    return keys
+        .map((k) => ApiKeyMetadata.fromJson(k as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Creates an API key named [name] with the permissions of [scope] and
+  /// returns the new key's secret alongside its metadata.
+  ///
+  /// [expiresInDays] must be between 1 and 3650 when supplied; a null value
+  /// creates a key that never expires.
+  ///
+  /// Throws [ApiKeyScopeMismatchException] if the server minted a key whose
+  /// scope differs from the one requested. That happens when this CLI is
+  /// talking to a server predating scope-by-name, which silently defaults to
+  /// full access — a wider key than the caller asked for, so it is surfaced
+  /// as an error rather than accepted.
+  Future<({String secret, ApiKeyMetadata metadata})> createApiKey({
+    required String name,
+    required ApiKeyScope scope,
+    int? expiresInDays,
+  }) async {
+    final response = await _sendApiKeyRequest(
+      'POST',
+      body: {
+        'name': name,
+        'scope': scope.wireName,
+        if (expiresInDays != null) 'expires_in_days': expiresInDays,
+      },
+    );
+    final body = json.decode(response.body) as Map<String, dynamic>;
+    final metadata = ApiKeyMetadata.fromJson(body);
+    if (metadata.scope != scope) {
+      throw ApiKeyScopeMismatchException(
+        requested: scope,
+        granted: metadata.scope,
+      );
+    }
+    return (secret: body['api_key'] as String, metadata: metadata);
+  }
+
+  /// Revokes the API key with the given [id].
+  Future<void> revokeApiKey({required String id}) async {
+    await _sendApiKeyRequest('DELETE', body: {'id': id});
+  }
+
+  /// Sends [method] to the auth service's `api/api-keys` endpoint,
+  /// authenticated with the current session's refresh token.
+  ///
+  /// Key management is deliberately session-only: the auth service looks the
+  /// bearer up in `session_`, which an API key and a legacy CI token are both
+  /// absent from. That is why this reads [_credentials] rather than going
+  /// through [client] — in CI there is no session to use, and pretending
+  /// otherwise would only produce a confusing 401.
+  Future<http.Response> _sendApiKeyRequest(
+    String method, {
+    Map<String, Object?>? body,
+  }) async {
+    final refreshToken = _credentials?.refreshToken;
+    if (refreshToken == null) throw const ApiKeySessionRequiredException();
+
+    final uri = _authServiceUri.replace(
+      path: p.url.join(_authServiceUri.path, 'api/api-keys'),
+    );
+    final request = http.Request(method, uri)
+      ..headers['Authorization'] = 'Bearer $refreshToken';
+    if (body != null) {
+      request
+        ..headers['Content-Type'] = 'application/json'
+        ..body = json.encode(body);
+    }
+
+    final http.Response response;
+    try {
+      response = await http.Response.fromStream(
+        await _httpClient.send(request),
+      );
+    } on Exception catch (error) {
+      throw ApiKeyRequestException('Failed to reach the auth service: $error');
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw ApiKeyRequestException(_describeFailure(response));
+    }
+    return response;
+  }
+
+  /// Turns an auth service error response into something worth printing.
+  ///
+  /// The service answers errors as `{error, error_description}`; fall back to
+  /// the status code when the body is not that shape, so a proxy's HTML error
+  /// page does not get echoed at the user.
+  static String _describeFailure(http.Response response) {
+    try {
+      final body = json.decode(response.body) as Map<String, dynamic>;
+      final description = body['error_description'] ?? body['error'];
+      if (description is String) return description;
+    } on Exception {
+      // Fall through to the status-code message.
+    }
+    return 'The auth service returned ${response.statusCode}.';
   }
 
   oauth2.AccessCredentials? _credentials;

--- a/packages/shorebird_cli/lib/src/commands/account/account.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/account.dart
@@ -1,4 +1,5 @@
 export 'account_command.dart';
+export 'api_keys_command.dart';
 export 'apps_command.dart';
 export 'orgs_command.dart';
 export 'whoami_command.dart';

--- a/packages/shorebird_cli/lib/src/commands/account/account_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/account_command.dart
@@ -8,6 +8,7 @@ class AccountCommand extends ShorebirdCommand {
   /// {@macro account_command}
   AccountCommand() {
     addSubcommand(AccountAppsCommand());
+    addSubcommand(ApiKeysCommand());
     addSubcommand(OrgsCommand());
     addSubcommand(WhoamiCommand());
   }

--- a/packages/shorebird_cli/lib/src/commands/account/api_keys_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/api_keys_command.dart
@@ -5,6 +5,7 @@ import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/json_output.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/shorebird_command.dart';
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 
 /// {@template api_keys_command}
 /// `shorebird account api-keys`

--- a/packages/shorebird_cli/lib/src/commands/account/api_keys_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/api_keys_command.dart
@@ -64,8 +64,11 @@ class ApiKeysListCommand extends ShorebirdCommand {
       return ExitCode.success.code;
     }
 
+    // Diagnostic, not content: `list` emits one line per key, so an empty
+    // account should emit nothing a pipe can count. On stdout this line would
+    // make `list | wc -l` report 1 key where there are none.
     if (keys.isEmpty) {
-      logger.info('No API keys.');
+      io.stderr.writeln('No API keys.');
       return ExitCode.success.code;
     }
 

--- a/packages/shorebird_cli/lib/src/commands/account/api_keys_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/api_keys_command.dart
@@ -1,0 +1,275 @@
+import 'package:mason_logger/mason_logger.dart';
+import 'package:shorebird_cli/src/auth/auth.dart';
+import 'package:shorebird_cli/src/json_output.dart';
+import 'package:shorebird_cli/src/logging/logging.dart';
+import 'package:shorebird_cli/src/shorebird_command.dart';
+
+/// {@template api_keys_command}
+/// `shorebird account api-keys`
+/// Manage the API keys used to authenticate CI and scripts.
+/// {@endtemplate}
+class ApiKeysCommand extends ShorebirdCommand {
+  /// {@macro api_keys_command}
+  ApiKeysCommand() {
+    addSubcommand(ApiKeysListCommand());
+    addSubcommand(ApiKeysCreateCommand());
+    addSubcommand(ApiKeysRevokeCommand());
+  }
+
+  @override
+  String get name => 'api-keys';
+
+  @override
+  String get description =>
+      'Manage API keys for CI and scripts.\n\n'
+      'API keys authenticate non-interactive callers. Set one as the '
+      '${lightCyan.wrap('SHOREBIRD_TOKEN')} environment variable in CI.\n\n'
+      'These commands require an interactive login — an API key cannot '
+      'manage API keys.';
+}
+
+/// {@template api_keys_list_command}
+/// `shorebird account api-keys list`
+/// List the current user's API keys.
+/// {@endtemplate}
+class ApiKeysListCommand extends ShorebirdCommand {
+  /// {@macro api_keys_list_command}
+  ApiKeysListCommand();
+
+  @override
+  String get name => 'list';
+
+  @override
+  String get description =>
+      'List your API keys.\n\n'
+      'Example output (space-separated: id  name  scope  created  last used):\n'
+      '  7  Production CI  release-and-patch  2026-01-04  2026-09-06\n'
+      '  9  Local scripts  full-access        2026-02-11  never\n\n'
+      'Secrets are never listed — a key is shown once, when it is created.\n\n'
+      '${ShorebirdCommand.jsonHint('shorebird account api-keys list --json')}';
+
+  @override
+  Future<int> run() async {
+    final List<ApiKeyMetadata> keys;
+    try {
+      keys = await auth.listApiKeys();
+    } on Exception catch (error) {
+      return _fail(error, 'Failed to list API keys.');
+    }
+
+    if (isJsonMode) {
+      emitJsonSuccess({'api_keys': keys.map(_toJson).toList()});
+      return ExitCode.success.code;
+    }
+
+    if (keys.isEmpty) {
+      logger.info('No API keys.');
+      return ExitCode.success.code;
+    }
+
+    for (final key in keys) {
+      logger.info(
+        '${key.id}  ${key.name}  ${key.scope?.flagName ?? 'unknown'}  '
+        '${_formatDate(key.createdAt)}  '
+        '${key.lastUsedAt == null ? 'never' : _formatDate(key.lastUsedAt!)}',
+      );
+    }
+    return ExitCode.success.code;
+  }
+}
+
+/// {@template api_keys_create_command}
+/// `shorebird account api-keys create`
+/// Create a new API key.
+/// {@endtemplate}
+class ApiKeysCreateCommand extends ShorebirdCommand {
+  /// {@macro api_keys_create_command}
+  ApiKeysCreateCommand() {
+    argParser
+      ..addOption(
+        'name',
+        help: 'A name for the key, so you can tell it apart later.',
+        mandatory: true,
+      )
+      ..addOption(
+        'scope',
+        help: 'What the key is allowed to do.',
+        allowed: ApiKeyScope.values.map((s) => s.flagName),
+        allowedHelp: {
+          ApiKeyScope.releaseAndPatch.flagName:
+              'Create releases and patches, and read insights. No deletes, '
+              'no member management, no billing. Use this for CI.',
+          ApiKeyScope.fullAccess.flagName:
+              'Everything your account can do, in every organization you '
+              'belong to.',
+        },
+        mandatory: true,
+      )
+      ..addOption(
+        'expires-in-days',
+        help:
+            'Days until the key expires (1-3650). Omit for a key that '
+            'never expires.',
+      );
+  }
+
+  @override
+  String get name => 'create';
+
+  @override
+  String get description =>
+      'Create an API key.\n\n'
+      'The key is shown once and cannot be retrieved again.\n\n'
+      '${ShorebirdCommand.jsonHint(_createJsonExample)}';
+
+  @override
+  Future<int> run() async {
+    final scopeFlag = results['scope'] as String;
+    final scope = ApiKeyScope.values.firstWhere(
+      (s) => s.flagName == scopeFlag,
+    );
+
+    final expiresInDaysArg = results['expires-in-days'] as String?;
+    int? expiresInDays;
+    if (expiresInDaysArg != null) {
+      expiresInDays = int.tryParse(expiresInDaysArg);
+      if (expiresInDays == null || expiresInDays < 1 || expiresInDays > 3650) {
+        if (isJsonMode) {
+          emitJsonError(
+            code: JsonErrorCode.usageError,
+            message: _expiresInDaysUsage,
+          );
+        } else {
+          logger.err(_expiresInDaysUsage);
+        }
+        return ExitCode.usage.code;
+      }
+    }
+
+    final ({String secret, ApiKeyMetadata metadata}) created;
+    try {
+      created = await auth.createApiKey(
+        name: results['name'] as String,
+        scope: scope,
+        expiresInDays: expiresInDays,
+      );
+    } on Exception catch (error) {
+      return _fail(error, 'Failed to create the API key.');
+    }
+
+    if (isJsonMode) {
+      emitJsonSuccess({
+        'api_key': created.secret,
+        ..._toJson(created.metadata),
+      });
+      return ExitCode.success.code;
+    }
+
+    logger
+      ..info('')
+      ..info(created.secret)
+      ..info('')
+      ..info(
+        'This is the only time the key will be shown. Store it now — in CI, '
+        'as the ${lightCyan.wrap('SHOREBIRD_TOKEN')} environment variable.',
+      );
+    return ExitCode.success.code;
+  }
+}
+
+/// {@template api_keys_revoke_command}
+/// `shorebird account api-keys revoke`
+/// Revoke an API key.
+/// {@endtemplate}
+class ApiKeysRevokeCommand extends ShorebirdCommand {
+  /// {@macro api_keys_revoke_command}
+  ApiKeysRevokeCommand() {
+    argParser.addOption(
+      'id',
+      help:
+          'The id of the key to revoke, as shown by '
+          '`shorebird account api-keys list`.',
+      mandatory: true,
+    );
+  }
+
+  @override
+  String get name => 'revoke';
+
+  @override
+  String get description =>
+      'Revoke an API key.\n\n'
+      'Takes effect immediately and cannot be undone. Anything using the key '
+      'will start failing.\n\n'
+      '${ShorebirdCommand.jsonHint(_revokeJsonExample)}';
+
+  @override
+  Future<int> run() async {
+    final id = results['id'] as String;
+    try {
+      await auth.revokeApiKey(id: id);
+    } on Exception catch (error) {
+      return _fail(error, 'Failed to revoke the API key.');
+    }
+
+    if (isJsonMode) {
+      emitJsonSuccess({'revoked': id});
+      return ExitCode.success.code;
+    }
+
+    logger.info('Revoked API key $id.');
+    return ExitCode.success.code;
+  }
+}
+
+extension on ShorebirdCommand {
+  /// Reports [error] on whichever output channel is active and returns the
+  /// exit code to use.
+  ///
+  /// [fallback] describes the operation, for exceptions that carry no message
+  /// worth surfacing on their own.
+  int _fail(Exception error, String fallback) {
+    final message = switch (error) {
+      ApiKeySessionRequiredException() => error.toString(),
+      ApiKeyScopeMismatchException() => error.toString(),
+      ApiKeyRequestException() => '$fallback ${error.message}',
+      _ => fallback,
+    };
+    _emitError(message);
+    return ExitCode.software.code;
+  }
+
+  /// Emits [message] as an error on whichever output channel is active.
+  void _emitError(String message) {
+    if (isJsonMode) {
+      emitJsonError(code: JsonErrorCode.fetchFailed, message: message);
+    } else {
+      logger.err(message);
+    }
+  }
+}
+
+/// The `--json` example shown in `api-keys create` help.
+const _createJsonExample = 'shorebird account api-keys create --json';
+
+/// The `--json` example shown in `api-keys revoke` help.
+const _revokeJsonExample = 'shorebird account api-keys revoke --json';
+
+/// The message shown when `--expires-in-days` is outside the range the auth
+/// service accepts.
+const _expiresInDaysUsage =
+    '--expires-in-days must be a whole number from 1 to 3650.';
+
+Map<String, Object?> _toJson(ApiKeyMetadata key) => {
+  'id': key.id,
+  'name': key.name,
+  'scope': key.scope?.wireName,
+  'created_at': key.createdAt.toIso8601String(),
+  'last_used_at': key.lastUsedAt?.toIso8601String(),
+  'expires_at': key.expiresAt?.toIso8601String(),
+};
+
+String _formatDate(DateTime date) =>
+    '${date.year.toString().padLeft(4, '0')}-'
+    '${date.month.toString().padLeft(2, '0')}-'
+    '${date.day.toString().padLeft(2, '0')}';

--- a/packages/shorebird_cli/lib/src/commands/account/api_keys_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/account/api_keys_command.dart
@@ -1,3 +1,5 @@
+import 'dart:io' as io;
+
 import 'package:mason_logger/mason_logger.dart';
 import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/json_output.dart';
@@ -120,6 +122,10 @@ class ApiKeysCreateCommand extends ShorebirdCommand {
   String get description =>
       'Create an API key.\n\n'
       'The key is shown once and cannot be retrieved again.\n\n'
+      'The key is written to stdout on its own; everything else goes to '
+      'stderr, so the command pipes cleanly:\n'
+      '  shorebird account api-keys create --name CI '
+      '--scope release-and-patch | pbcopy\n\n'
       '${ShorebirdCommand.jsonHint(_createJsonExample)}';
 
   @override
@@ -165,13 +171,22 @@ class ApiKeysCreateCommand extends ShorebirdCommand {
       return ExitCode.success.code;
     }
 
-    logger
-      ..info('')
-      ..info(created.secret)
-      ..info('')
-      ..info(
-        'This is the only time the key will be shown. Store it now — in CI, '
-        'as the ${lightCyan.wrap('SHOREBIRD_TOKEN')} environment variable.',
+    // The key is content; everything around it is diagnostic. Content goes to
+    // stdout by itself so the command composes —
+    //
+    //   shorebird account api-keys create … | op item create …
+    //
+    // gets the key and nothing else. The guidance goes to stderr, where a
+    // human still reads it and a pipe never sees it. Same split the logger
+    // already applies to progress ("progress is diagnostic, never content"),
+    // and the same shape as `gh auth token` and `kubectl create token`.
+    io.stdout.writeln(created.secret);
+    io.stderr
+      ..writeln()
+      ..writeln('Created "${created.metadata.name}" (${scope.flagName}).')
+      ..writeln(
+        'This is the only time the key will be shown. In CI, set it as the '
+        'SHOREBIRD_TOKEN environment variable.',
       );
     return ExitCode.success.code;
   }

--- a/packages/shorebird_cli/test/src/auth/api_key_test.dart
+++ b/packages/shorebird_cli/test/src/auth/api_key_test.dart
@@ -1,0 +1,115 @@
+import 'package:shorebird_cli/src/auth/api_key.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(ApiKeyScope, () {
+    test('maps wire names back to scopes', () {
+      expect(
+        ApiKeyScope.fromWireName('release_and_patch'),
+        equals(ApiKeyScope.releaseAndPatch),
+      );
+      expect(
+        ApiKeyScope.fromWireName('full_access'),
+        equals(ApiKeyScope.fullAccess),
+      );
+    });
+
+    test('returns null for a scope this CLI does not know', () {
+      expect(ApiKeyScope.fromWireName('something_new'), isNull);
+    });
+
+    test('flag names are the hyphenated form', () {
+      expect(ApiKeyScope.releaseAndPatch.flagName, equals('release-and-patch'));
+      expect(ApiKeyScope.fullAccess.flagName, equals('full-access'));
+    });
+  });
+
+  group(ApiKeyMetadata, () {
+    test('parses a full response', () {
+      final key = ApiKeyMetadata.fromJson(const {
+        'id': '7',
+        'name': 'Production CI',
+        'created_at': '2026-01-04T00:00:00.000Z',
+        'last_used_at': '2026-09-06T00:00:00.000Z',
+        'expires_at': '2027-01-04T00:00:00.000Z',
+        'scope': 'release_and_patch',
+      });
+
+      expect(key.id, equals('7'));
+      expect(key.name, equals('Production CI'));
+      expect(key.createdAt, equals(DateTime.utc(2026, 1, 4)));
+      expect(key.lastUsedAt, equals(DateTime.utc(2026, 9, 6)));
+      expect(key.expiresAt, equals(DateTime.utc(2027, 1, 4)));
+      expect(key.scope, equals(ApiKeyScope.releaseAndPatch));
+    });
+
+    test('tolerates null timestamps and a missing scope', () {
+      final key = ApiKeyMetadata.fromJson(const {
+        'id': '9',
+        'name': 'Old key',
+        'created_at': '2026-01-04T00:00:00.000Z',
+        'last_used_at': null,
+        'expires_at': null,
+      });
+
+      expect(key.lastUsedAt, isNull);
+      expect(key.expiresAt, isNull);
+      expect(key.scope, isNull);
+    });
+
+    test('reports an unrecognized scope as null rather than guessing', () {
+      final key = ApiKeyMetadata.fromJson(const {
+        'id': '9',
+        'name': 'Future key',
+        'created_at': '2026-01-04T00:00:00.000Z',
+        'scope': 'invented_later',
+      });
+
+      expect(key.scope, isNull);
+    });
+
+    test('compares by value', () {
+      final a = ApiKeyMetadata(
+        id: '1',
+        name: 'k',
+        createdAt: DateTime.utc(2026),
+      );
+      final b = ApiKeyMetadata(
+        id: '1',
+        name: 'k',
+        createdAt: DateTime.utc(2026),
+      );
+      expect(a, equals(b));
+    });
+  });
+
+  group('exceptions', () {
+    test('ApiKeyRequestException prints its message', () {
+      expect(const ApiKeyRequestException('nope').toString(), equals('nope'));
+    });
+
+    test('ApiKeySessionRequiredException points at `shorebird login`', () {
+      expect(
+        const ApiKeySessionRequiredException().toString(),
+        contains('shorebird login'),
+      );
+    });
+
+    test('ApiKeyScopeMismatchException names both scopes', () {
+      const exception = ApiKeyScopeMismatchException(
+        requested: ApiKeyScope.releaseAndPatch,
+        granted: ApiKeyScope.fullAccess,
+      );
+      expect(exception.toString(), contains('release-and-patch'));
+      expect(exception.toString(), contains('full-access'));
+    });
+
+    test('ApiKeyScopeMismatchException handles an absent granted scope', () {
+      const exception = ApiKeyScopeMismatchException(
+        requested: ApiKeyScope.releaseAndPatch,
+        granted: null,
+      );
+      expect(exception.toString(), contains('an unknown scope'));
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/auth/api_key_test.dart
+++ b/packages/shorebird_cli/test/src/auth/api_key_test.dart
@@ -1,4 +1,5 @@
 import 'package:shorebird_cli/src/auth/api_key.dart';
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/shorebird_cli/test/src/auth/auth_api_keys_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_api_keys_test.dart
@@ -1,0 +1,377 @@
+import 'dart:convert';
+import 'dart:io' hide Platform;
+
+import 'package:googleapis_auth/auth_io.dart' as oauth2;
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_cli/src/auth/auth.dart';
+import 'package:shorebird_cli/src/http_client/http_client.dart';
+import 'package:shorebird_cli/src/logging/shorebird_logger.dart';
+import 'package:shorebird_cli/src/platform.dart';
+import 'package:shorebird_cli/src/shorebird_env.dart';
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart'
+    show AuthProvider;
+import 'package:test/test.dart';
+
+import '../fakes.dart';
+import '../mocks.dart';
+
+void main() {
+  group('Auth API key management', () {
+    const refreshToken = 'sb_rt_refresh';
+    final accessToken = oauth2.AccessToken(
+      'Bearer',
+      'accessToken',
+      DateTime.now().add(const Duration(minutes: 10)).toUtc(),
+    );
+
+    late String credentialsDir;
+    late http.Client httpClient;
+    late ShorebirdLogger logger;
+    late Platform platform;
+    late ShorebirdEnv shorebirdEnv;
+    late Map<String, String> environment;
+
+    setUpAll(() {
+      registerFallbackValue(FakeBaseRequest());
+    });
+
+    R runWithOverrides<R>(R Function() body) {
+      return runScoped(
+        body,
+        values: {
+          httpClientRef.overrideWith(() => httpClient),
+          loggerRef.overrideWith(() => logger),
+          platformRef.overrideWith(() => platform),
+          shorebirdEnvRef.overrideWith(() => shorebirdEnv),
+        },
+      );
+    }
+
+    Auth buildAuth() => runWithOverrides(
+      () => Auth(credentialsDir: credentialsDir, httpClient: httpClient),
+    );
+
+    void writeCredentials() {
+      File(p.join(credentialsDir, 'credentials.json')).writeAsStringSync(
+        jsonEncode(
+          oauth2.AccessCredentials(
+            accessToken,
+            refreshToken,
+            const ['openid'],
+          ).toJson(),
+        ),
+      );
+    }
+
+    /// Stubs the next HTTP send with [body] and [statusCode], and returns a
+    /// sink that captures the request that was sent.
+    List<http.BaseRequest> stubSend({
+      required String body,
+      int statusCode = HttpStatus.ok,
+    }) {
+      final requests = <http.BaseRequest>[];
+      when(() => httpClient.send(any())).thenAnswer((invocation) async {
+        final request =
+            invocation.positionalArguments.first as http.BaseRequest;
+        requests.add(request);
+        return http.StreamedResponse(
+          Stream.value(utf8.encode(body)),
+          statusCode,
+        );
+      });
+      return requests;
+    }
+
+    setUp(() {
+      credentialsDir = Directory.systemTemp.createTempSync().path;
+      httpClient = MockHttpClient();
+      logger = MockShorebirdLogger();
+      platform = MockPlatform();
+      shorebirdEnv = MockShorebirdEnv();
+      environment = <String, String>{};
+
+      when(() => platform.environment).thenReturn(environment);
+      when(
+        () => shorebirdEnv.authServiceUri,
+      ).thenReturn(Uri.parse('https://auth.shorebird.dev'));
+      when(() => shorebirdEnv.hostedUri).thenReturn(null);
+    });
+
+    group('without an interactive session', () {
+      test('throws when there are no credentials at all', () async {
+        final auth = buildAuth();
+        await expectLater(
+          auth.listApiKeys(),
+          throwsA(isA<ApiKeySessionRequiredException>()),
+        );
+      });
+
+      test('throws when authenticated with an API key', () async {
+        environment[shorebirdTokenEnvVar] = 'sb_api_something';
+        final auth = buildAuth();
+
+        await expectLater(
+          auth.listApiKeys(),
+          throwsA(isA<ApiKeySessionRequiredException>()),
+        );
+        verifyNever(() => httpClient.send(any()));
+      });
+
+      test('throws when authenticated with a legacy CI token', () async {
+        environment[shorebirdTokenEnvVar] = const CiToken(
+          refreshToken: 'google-refresh-token',
+          authProvider: AuthProvider.google,
+        ).toBase64();
+        final auth = buildAuth();
+
+        await expectLater(
+          auth.listApiKeys(),
+          throwsA(isA<ApiKeySessionRequiredException>()),
+        );
+        verifyNever(() => httpClient.send(any()));
+      });
+    });
+
+    group('listApiKeys', () {
+      setUp(writeCredentials);
+
+      test('sends a GET authenticated with the refresh token', () async {
+        final requests = stubSend(body: jsonEncode({'api_keys': <dynamic>[]}));
+
+        await buildAuth().listApiKeys();
+
+        final request = requests.single;
+        expect(request.method, equals('GET'));
+        expect(
+          request.url,
+          equals(Uri.parse('https://auth.shorebird.dev/api/api-keys')),
+        );
+        expect(
+          request.headers['Authorization'],
+          equals('Bearer $refreshToken'),
+        );
+      });
+
+      test('parses the returned keys', () async {
+        stubSend(
+          body: jsonEncode({
+            'api_keys': [
+              {
+                'id': '7',
+                'name': 'Production CI',
+                'created_at': '2026-01-04T00:00:00.000Z',
+                'last_used_at': null,
+                'expires_at': null,
+                'scope': 'release_and_patch',
+              },
+            ],
+          }),
+        );
+
+        final keys = await buildAuth().listApiKeys();
+
+        expect(keys, hasLength(1));
+        expect(keys.single.id, equals('7'));
+        expect(keys.single.scope, equals(ApiKeyScope.releaseAndPatch));
+      });
+
+      test('treats a missing api_keys field as empty', () async {
+        stubSend(body: jsonEncode(<String, dynamic>{}));
+
+        expect(await buildAuth().listApiKeys(), isEmpty);
+      });
+
+      test('surfaces the error_description from a failure', () async {
+        stubSend(
+          body: jsonEncode({
+            'error': 'unauthorized',
+            'error_description': 'Session expired',
+          }),
+          statusCode: HttpStatus.unauthorized,
+        );
+
+        await expectLater(
+          buildAuth().listApiKeys(),
+          throwsA(
+            isA<ApiKeyRequestException>().having(
+              (e) => e.message,
+              'message',
+              'Session expired',
+            ),
+          ),
+        );
+      });
+
+      test('falls back to the status code for a non-JSON failure', () async {
+        stubSend(body: '<html>gateway</html>', statusCode: 502);
+
+        await expectLater(
+          buildAuth().listApiKeys(),
+          throwsA(
+            isA<ApiKeyRequestException>().having(
+              (e) => e.message,
+              'message',
+              contains('502'),
+            ),
+          ),
+        );
+      });
+
+      test('wraps a transport failure', () async {
+        when(
+          () => httpClient.send(any()),
+        ).thenThrow(const SocketException('offline'));
+
+        await expectLater(
+          buildAuth().listApiKeys(),
+          throwsA(
+            isA<ApiKeyRequestException>().having(
+              (e) => e.message,
+              'message',
+              contains('Failed to reach the auth service'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('createApiKey', () {
+      setUp(writeCredentials);
+
+      test('posts the requested name, scope and expiry', () async {
+        final requests = stubSend(
+          body: jsonEncode({
+            'api_key': 'sb_api_new',
+            'id': '7',
+            'name': 'Production CI',
+            'created_at': '2026-01-04T00:00:00.000Z',
+            'scope': 'release_and_patch',
+          }),
+        );
+
+        final created = await buildAuth().createApiKey(
+          name: 'Production CI',
+          scope: ApiKeyScope.releaseAndPatch,
+          expiresInDays: 90,
+        );
+
+        final request = requests.single as http.Request;
+        expect(request.method, equals('POST'));
+        expect(
+          json.decode(request.body),
+          equals({
+            'name': 'Production CI',
+            'scope': 'release_and_patch',
+            'expires_in_days': 90,
+          }),
+        );
+        expect(created.secret, equals('sb_api_new'));
+        expect(created.metadata.id, equals('7'));
+      });
+
+      test('omits expires_in_days when it was not requested', () async {
+        final requests = stubSend(
+          body: jsonEncode({
+            'api_key': 'sb_api_new',
+            'id': '7',
+            'name': 'Forever',
+            'created_at': '2026-01-04T00:00:00.000Z',
+            'scope': 'full_access',
+          }),
+        );
+
+        await buildAuth().createApiKey(
+          name: 'Forever',
+          scope: ApiKeyScope.fullAccess,
+        );
+
+        final body =
+            json.decode((requests.single as http.Request).body)
+                as Map<String, dynamic>;
+        expect(body.containsKey('expires_in_days'), isFalse);
+      });
+
+      test('throws when the server granted a wider scope', () async {
+        stubSend(
+          body: jsonEncode({
+            'api_key': 'sb_api_new',
+            'id': '7',
+            'name': 'Production CI',
+            'created_at': '2026-01-04T00:00:00.000Z',
+            'scope': 'full_access',
+          }),
+        );
+
+        await expectLater(
+          buildAuth().createApiKey(
+            name: 'Production CI',
+            scope: ApiKeyScope.releaseAndPatch,
+          ),
+          throwsA(
+            isA<ApiKeyScopeMismatchException>()
+                .having(
+                  (e) => e.requested,
+                  'requested',
+                  ApiKeyScope.releaseAndPatch,
+                )
+                .having((e) => e.granted, 'granted', ApiKeyScope.fullAccess),
+          ),
+        );
+      });
+
+      test('throws when the server reports no scope at all', () async {
+        stubSend(
+          body: jsonEncode({
+            'api_key': 'sb_api_new',
+            'id': '7',
+            'name': 'Production CI',
+            'created_at': '2026-01-04T00:00:00.000Z',
+          }),
+        );
+
+        await expectLater(
+          buildAuth().createApiKey(
+            name: 'Production CI',
+            scope: ApiKeyScope.releaseAndPatch,
+          ),
+          throwsA(isA<ApiKeyScopeMismatchException>()),
+        );
+      });
+    });
+
+    group('revokeApiKey', () {
+      setUp(writeCredentials);
+
+      test('sends a DELETE carrying the id', () async {
+        final requests = stubSend(
+          body: jsonEncode({'revoked': true}),
+        );
+
+        await buildAuth().revokeApiKey(id: '7');
+
+        final request = requests.single as http.Request;
+        expect(request.method, equals('DELETE'));
+        expect(json.decode(request.body), equals({'id': '7'}));
+      });
+
+      test('throws when the key does not exist', () async {
+        stubSend(
+          body: jsonEncode({
+            'error': 'not_found',
+            'error_description': 'No such key',
+          }),
+          statusCode: HttpStatus.notFound,
+        );
+
+        await expectLater(
+          buildAuth().revokeApiKey(id: '7'),
+          throwsA(isA<ApiKeyRequestException>()),
+        );
+      });
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/auth/auth_api_keys_test.dart
+++ b/packages/shorebird_cli/test/src/auth/auth_api_keys_test.dart
@@ -13,7 +13,7 @@ import 'package:shorebird_cli/src/logging/shorebird_logger.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart'
-    show AuthProvider;
+    show ApiKeyScope, AuthProvider;
 import 'package:test/test.dart';
 
 import '../fakes.dart';

--- a/packages/shorebird_cli/test/src/commands/account/api_keys_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account/api_keys_command_test.dart
@@ -1,0 +1,369 @@
+import 'dart:convert';
+
+import 'package:args/args.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:scoped_deps/scoped_deps.dart';
+import 'package:shorebird_cli/src/auth/auth.dart';
+import 'package:shorebird_cli/src/commands/account/api_keys_command.dart';
+import 'package:shorebird_cli/src/json_output.dart';
+import 'package:shorebird_cli/src/logging/shorebird_logger.dart';
+import 'package:test/test.dart';
+
+import '../../helpers.dart';
+import '../../mocks.dart';
+
+void main() {
+  final createdAt = DateTime.utc(2026, 1, 4);
+  final lastUsedAt = DateTime.utc(2026, 9, 6);
+
+  final ciKey = ApiKeyMetadata(
+    id: '7',
+    name: 'Production CI',
+    createdAt: createdAt,
+    lastUsedAt: lastUsedAt,
+    scope: ApiKeyScope.releaseAndPatch,
+  );
+  final unusedKey = ApiKeyMetadata(
+    id: '9',
+    name: 'Local scripts',
+    createdAt: createdAt,
+    scope: ApiKeyScope.fullAccess,
+  );
+
+  late Auth auth;
+  late ShorebirdLogger logger;
+  late ArgResults argResults;
+
+  R runWithOverrides<R>(R Function() body, {bool jsonMode = false}) {
+    return runScoped(
+      body,
+      values: {
+        authRef.overrideWith(() => auth),
+        isJsonModeRef.overrideWith(() => jsonMode),
+        loggerRef.overrideWith(() => logger),
+      },
+    );
+  }
+
+  setUpAll(() {
+    registerFallbackValue(ApiKeyScope.fullAccess);
+  });
+
+  setUp(() {
+    auth = MockAuth();
+    logger = MockShorebirdLogger();
+    argResults = MockArgResults();
+  });
+
+  group(ApiKeysCommand, () {
+    test('registers list, create and revoke subcommands', () {
+      final command = runWithOverrides(ApiKeysCommand.new);
+      expect(
+        command.subcommands.keys,
+        containsAll(<String>['list', 'create', 'revoke']),
+      );
+    });
+
+    test('has a name and a description', () {
+      final command = runWithOverrides(ApiKeysCommand.new);
+      expect(command.name, equals('api-keys'));
+      expect(command.description, isNotEmpty);
+    });
+  });
+
+  group(ApiKeysListCommand, () {
+    late ApiKeysListCommand command;
+
+    setUp(() {
+      command = runWithOverrides(ApiKeysListCommand.new)
+        ..testArgResults = argResults;
+    });
+
+    test('lists each key with its scope and dates', () async {
+      when(auth.listApiKeys).thenAnswer((_) async => [ciKey, unusedKey]);
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.success.code));
+      verify(
+        () => logger.info(
+          '7  Production CI  release-and-patch  2026-01-04  2026-09-06',
+        ),
+      ).called(1);
+      verify(
+        () => logger.info(
+          '9  Local scripts  full-access  2026-01-04  never',
+        ),
+      ).called(1);
+    });
+
+    test('reports an unknown scope rather than guessing', () async {
+      when(auth.listApiKeys).thenAnswer(
+        (_) async => [
+          ApiKeyMetadata(id: '1', name: 'Old', createdAt: createdAt),
+        ],
+      );
+
+      await runWithOverrides(command.run);
+
+      verify(
+        () => logger.info('1  Old  unknown  2026-01-04  never'),
+      ).called(1);
+    });
+
+    test('says so when there are no keys', () async {
+      when(auth.listApiKeys).thenAnswer((_) async => []);
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.success.code));
+      verify(() => logger.info('No API keys.')).called(1);
+    });
+
+    test('emits JSON when --json is set', () async {
+      when(auth.listApiKeys).thenAnswer((_) async => [ciKey]);
+
+      final captured = <String>[];
+      await captureStdout(
+        () => runWithOverrides(command.run, jsonMode: true),
+        captured: captured,
+      );
+
+      final output = json.decode(captured.join()) as Map<String, dynamic>;
+      final keys =
+          (output['data'] as Map<String, dynamic>)['api_keys'] as List<dynamic>;
+      final first = keys.single as Map<String, dynamic>;
+      expect(first['id'], equals('7'));
+      expect(first['scope'], equals('release_and_patch'));
+      expect(first['expires_at'], isNull);
+    });
+
+    test('explains that a session is required when there is none', () async {
+      when(auth.listApiKeys).thenThrow(
+        const ApiKeySessionRequiredException(),
+      );
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.software.code));
+      verify(
+        () => logger.err(
+          any(that: contains('requires an interactive login')),
+        ),
+      ).called(1);
+    });
+
+    test('surfaces the auth service message on failure', () async {
+      when(auth.listApiKeys).thenThrow(
+        const ApiKeyRequestException('nope'),
+      );
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.software.code));
+      verify(
+        () => logger.err('Failed to list API keys. nope'),
+      ).called(1);
+    });
+
+    test('falls back to a generic message for other exceptions', () async {
+      when(auth.listApiKeys).thenThrow(Exception('boom'));
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.software.code));
+      verify(() => logger.err('Failed to list API keys.')).called(1);
+    });
+  });
+
+  group(ApiKeysCreateCommand, () {
+    late ApiKeysCreateCommand command;
+
+    setUp(() {
+      command = runWithOverrides(ApiKeysCreateCommand.new)
+        ..testArgResults = argResults;
+      when(() => argResults['name']).thenReturn('Production CI');
+      when(() => argResults['scope']).thenReturn('release-and-patch');
+      when(() => argResults['expires-in-days']).thenReturn(null);
+    });
+
+    test('prints the secret exactly once, with storage guidance', () async {
+      when(
+        () => auth.createApiKey(
+          name: any(named: 'name'),
+          scope: any(named: 'scope'),
+          expiresInDays: any(named: 'expiresInDays'),
+        ),
+      ).thenAnswer((_) async => (secret: 'sb_api_abc', metadata: ciKey));
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.success.code));
+      verify(() => logger.info('sb_api_abc')).called(1);
+      verify(
+        () => logger.info(any(that: contains('SHOREBIRD_TOKEN'))),
+      ).called(1);
+    });
+
+    test('passes the requested scope and expiry through', () async {
+      when(() => argResults['expires-in-days']).thenReturn('90');
+      when(
+        () => auth.createApiKey(
+          name: any(named: 'name'),
+          scope: any(named: 'scope'),
+          expiresInDays: any(named: 'expiresInDays'),
+        ),
+      ).thenAnswer((_) async => (secret: 'sb_api_abc', metadata: ciKey));
+
+      await runWithOverrides(command.run);
+
+      verify(
+        () => auth.createApiKey(
+          name: 'Production CI',
+          scope: ApiKeyScope.releaseAndPatch,
+          expiresInDays: 90,
+        ),
+      ).called(1);
+    });
+
+    test('rejects a non-numeric --expires-in-days', () async {
+      when(() => argResults['expires-in-days']).thenReturn('soon');
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.usage.code));
+      verify(
+        () => logger.err(any(that: contains('whole number from 1 to 3650'))),
+      ).called(1);
+      verifyNever(
+        () => auth.createApiKey(
+          name: any(named: 'name'),
+          scope: any(named: 'scope'),
+          expiresInDays: any(named: 'expiresInDays'),
+        ),
+      );
+    });
+
+    test('rejects an --expires-in-days outside the accepted range', () async {
+      when(() => argResults['expires-in-days']).thenReturn('4000');
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.usage.code));
+    });
+
+    test('reports a usage error as JSON when --json is set', () async {
+      when(() => argResults['expires-in-days']).thenReturn('0');
+
+      final captured = <String>[];
+      await captureStdout(
+        () => runWithOverrides(command.run, jsonMode: true),
+        captured: captured,
+      );
+
+      final output = json.decode(captured.join()) as Map<String, dynamic>;
+      expect(output['status'], equals('error'));
+      expect(
+        (output['error'] as Map<String, dynamic>)['code'],
+        equals('usage_error'),
+      );
+    });
+
+    test('emits the secret as JSON when --json is set', () async {
+      when(
+        () => auth.createApiKey(
+          name: any(named: 'name'),
+          scope: any(named: 'scope'),
+          expiresInDays: any(named: 'expiresInDays'),
+        ),
+      ).thenAnswer((_) async => (secret: 'sb_api_abc', metadata: ciKey));
+
+      final captured = <String>[];
+      await captureStdout(
+        () => runWithOverrides(command.run, jsonMode: true),
+        captured: captured,
+      );
+
+      final output = json.decode(captured.join()) as Map<String, dynamic>;
+      final data = output['data'] as Map<String, dynamic>;
+      expect(data['api_key'], equals('sb_api_abc'));
+      expect(data['scope'], equals('release_and_patch'));
+    });
+
+    test('fails loudly when the server widened the scope', () async {
+      when(
+        () => auth.createApiKey(
+          name: any(named: 'name'),
+          scope: any(named: 'scope'),
+          expiresInDays: any(named: 'expiresInDays'),
+        ),
+      ).thenThrow(
+        const ApiKeyScopeMismatchException(
+          requested: ApiKeyScope.releaseAndPatch,
+          granted: ApiKeyScope.fullAccess,
+        ),
+      );
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.software.code));
+      verify(
+        () => logger.err(any(that: contains('revoke it'))),
+      ).called(1);
+    });
+  });
+
+  group(ApiKeysRevokeCommand, () {
+    late ApiKeysRevokeCommand command;
+
+    setUp(() {
+      command = runWithOverrides(ApiKeysRevokeCommand.new)
+        ..testArgResults = argResults;
+      when(() => argResults['id']).thenReturn('7');
+    });
+
+    test('revokes the requested key', () async {
+      when(() => auth.revokeApiKey(id: any(named: 'id'))).thenAnswer(
+        (_) async {},
+      );
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.success.code));
+      verify(() => auth.revokeApiKey(id: '7')).called(1);
+      verify(() => logger.info('Revoked API key 7.')).called(1);
+    });
+
+    test('emits JSON when --json is set', () async {
+      when(() => auth.revokeApiKey(id: any(named: 'id'))).thenAnswer(
+        (_) async {},
+      );
+
+      final captured = <String>[];
+      await captureStdout(
+        () => runWithOverrides(command.run, jsonMode: true),
+        captured: captured,
+      );
+
+      final output = json.decode(captured.join()) as Map<String, dynamic>;
+      expect(
+        (output['data'] as Map<String, dynamic>)['revoked'],
+        equals('7'),
+      );
+    });
+
+    test('reports failure', () async {
+      when(() => auth.revokeApiKey(id: any(named: 'id'))).thenThrow(
+        const ApiKeyRequestException('not found'),
+      );
+
+      final result = await runWithOverrides(command.run);
+
+      expect(result, equals(ExitCode.software.code));
+      verify(
+        () => logger.err('Failed to revoke the API key. not found'),
+      ).called(1);
+    });
+  });
+}

--- a/packages/shorebird_cli/test/src/commands/account/api_keys_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account/api_keys_command_test.dart
@@ -188,7 +188,7 @@ void main() {
       when(() => argResults['expires-in-days']).thenReturn(null);
     });
 
-    test('prints the secret exactly once, with storage guidance', () async {
+    test('writes the key alone to stdout so it pipes cleanly', () async {
       when(
         () => auth.createApiKey(
           name: any(named: 'name'),
@@ -197,13 +197,42 @@ void main() {
         ),
       ).thenAnswer((_) async => (secret: 'sb_api_abc', metadata: ciKey));
 
-      final result = await runWithOverrides(command.run);
+      final out = <String>[];
+      final err = <String>[];
+      final result = await captureStdout(
+        () => runWithOverrides(command.run),
+        captured: out,
+        stderrCaptured: err,
+      );
 
       expect(result, equals(ExitCode.success.code));
-      verify(() => logger.info('sb_api_abc')).called(1);
-      verify(
-        () => logger.info(any(that: contains('SHOREBIRD_TOKEN'))),
-      ).called(1);
+      // Everything a pipe receives, and nothing else.
+      expect(out.join().trim(), equals('sb_api_abc'));
+    });
+
+    test('keeps the guidance on stderr, out of the pipe', () async {
+      when(
+        () => auth.createApiKey(
+          name: any(named: 'name'),
+          scope: any(named: 'scope'),
+          expiresInDays: any(named: 'expiresInDays'),
+        ),
+      ).thenAnswer((_) async => (secret: 'sb_api_abc', metadata: ciKey));
+
+      final out = <String>[];
+      final err = <String>[];
+      await captureStdout(
+        () => runWithOverrides(command.run),
+        captured: out,
+        stderrCaptured: err,
+      );
+
+      final diagnostics = err.join();
+      expect(diagnostics, contains('SHOREBIRD_TOKEN'));
+      expect(diagnostics, contains('Production CI'));
+      expect(diagnostics, contains('release-and-patch'));
+      // The secret must never appear on the diagnostic channel.
+      expect(diagnostics, isNot(contains('sb_api_abc')));
     });
 
     test('passes the requested scope and expiry through', () async {

--- a/packages/shorebird_cli/test/src/commands/account/api_keys_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account/api_keys_command_test.dart
@@ -112,13 +112,21 @@ void main() {
       ).called(1);
     });
 
-    test('says so when there are no keys', () async {
+    test('says so on stderr when there are no keys', () async {
       when(auth.listApiKeys).thenAnswer((_) async => []);
 
-      final result = await runWithOverrides(command.run);
+      final out = <String>[];
+      final err = <String>[];
+      final result = await captureStdout(
+        () => runWithOverrides(command.run),
+        captured: out,
+        stderrCaptured: err,
+      );
 
       expect(result, equals(ExitCode.success.code));
-      verify(() => logger.info('No API keys.')).called(1);
+      expect(err.join(), contains('No API keys.'));
+      // Nothing on stdout, so `list | wc -l` counts zero keys.
+      expect(out.join().trim(), isEmpty);
     });
 
     test('emits JSON when --json is set', () async {

--- a/packages/shorebird_cli/test/src/commands/account/api_keys_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/account/api_keys_command_test.dart
@@ -8,6 +8,7 @@ import 'package:shorebird_cli/src/auth/auth.dart';
 import 'package:shorebird_cli/src/commands/account/api_keys_command.dart';
 import 'package:shorebird_cli/src/json_output.dart';
 import 'package:shorebird_cli/src/logging/shorebird_logger.dart';
+import 'package:shorebird_code_push_protocol/shorebird_code_push_protocol.dart';
 import 'package:test/test.dart';
 
 import '../../helpers.dart';

--- a/packages/shorebird_cli/test/src/helpers.dart
+++ b/packages/shorebird_cli/test/src/helpers.dart
@@ -13,14 +13,19 @@ File createTempFile(String name) {
 /// If [hasTerminal] is provided, the captured stdout reports that value for
 /// `Stdout.hasTerminal` (otherwise it delegates to the real stdout).
 ///
+/// Pass [stderrCaptured] to capture stderr as well — needed to assert that a
+/// command keeps content on stdout and diagnostics on stderr.
+///
 /// Used to verify JSON output from commands that write to stdout, and to
 /// drive non-interactive code paths in tests.
 Future<T> captureStdout<T>(
   Future<T> Function() body, {
   required List<String> captured,
   bool? hasTerminal,
+  List<String>? stderrCaptured,
 }) async {
   final realStdout = stdout;
+  final realStderr = stderr;
   return IOOverrides.runZoned(
     body,
     stdout: () => CapturingStdout(
@@ -28,6 +33,12 @@ Future<T> captureStdout<T>(
       captured: captured,
       hasTerminalOverride: hasTerminal,
     ),
+    stderr: stderrCaptured == null
+        ? null
+        : () => CapturingStdout(
+            baseStdOut: realStderr,
+            captured: stderrCaptured,
+          ),
   );
 }
 

--- a/packages/shorebird_code_push_protocol/lib/extensions/api_key_scope.dart
+++ b/packages/shorebird_code_push_protocol/lib/extensions/api_key_scope.dart
@@ -1,0 +1,38 @@
+/// The permission preset an API key is minted with.
+///
+/// This enum is hand-written rather than generated: API keys are minted by
+/// the auth service, which is not covered by the CodePush OpenAPI spec. It
+/// lives here rather than in a client because the vocabulary spans both
+/// sides — the auth service mints a key against one of these presets, and
+/// the CodePush server is what enforces the resulting permissions on every
+/// request the key makes.
+///
+/// Arbitrary permission combinations are deliberately not offered. A key is
+/// one of these shapes so that what it can do is legible from its scope
+/// alone, without expanding a permission list to find out.
+enum ApiKeyScope {
+  /// Everything the minting user can do, in every organization they belong to.
+  fullAccess('full_access'),
+
+  /// Create and publish releases and patches, and read insights. No deletes,
+  /// no member management, no billing.
+  releaseAndPatch('release_and_patch');
+
+  const ApiKeyScope(this.wireName);
+
+  /// The value the auth service uses for this scope, on the wire and in the
+  /// `permissions` presets it expands to.
+  final String wireName;
+
+  /// The scope whose [wireName] is [value], or null if none matches.
+  ///
+  /// Returns null rather than throwing for an unrecognized value: a preset
+  /// added server-side is something an older client should report as unknown,
+  /// not crash on and not guess at.
+  static ApiKeyScope? fromWireName(String value) {
+    for (final scope in ApiKeyScope.values) {
+      if (scope.wireName == value) return scope;
+    }
+    return null;
+  }
+}

--- a/packages/shorebird_code_push_protocol/lib/shorebird_code_push_protocol.dart
+++ b/packages/shorebird_code_push_protocol/lib/shorebird_code_push_protocol.dart
@@ -7,6 +7,7 @@
 /// re-exported from here.
 library;
 
+export 'package:shorebird_code_push_protocol/extensions/api_key_scope.dart';
 export 'package:shorebird_code_push_protocol/extensions/auth_provider.dart';
 export 'package:shorebird_code_push_protocol/extensions/release_platform_extensions.dart';
 export 'package:shorebird_code_push_protocol/extensions/test_helpers.dart';


### PR DESCRIPTION
Adds `shorebird account api-keys list | create | revoke`, so setting up CI no longer means leaving the terminal for the console.

```
$ shorebird account api-keys create --name "Production CI" --scope release-and-patch --expires-in-days 365

sb_api_…

This is the only time the key will be shown. Store it now — in CI, as the SHOREBIRD_TOKEN environment variable.

$ shorebird account api-keys list
7  Production CI  release-and-patch  2026-01-04  2026-09-06
9  Local scripts  full-access        2026-02-11  never
```

## Blocked on a server change

**Draft** until the auth service accepts a scope by name. `create` sends `{"scope": "release_and_patch"}`; today's server only understands an expanded `permissions` array and silently defaults to full access when it sees neither.

The CLI does not paper over that. It compares the scope the server reports back against the one requested and fails if they differ, telling you to revoke the key it just made. Better a loud failure than quietly handing someone a full-access credential they asked to be narrow. That check is also what makes this safe to land ahead of the deploy — an old server produces an error, not a wrong key.

The alternative was for the CLI to send the expanded permission list itself, which would have put a third copy of those presets in the tree, to be kept in sync with `api_key_permissions.dart` and `api-key-permissions.ts` forever. Sending a name and letting the server expand it leaves the CLI with no copy at all.

## Session-only, deliberately

None of these commands work in CI, and that is the intent rather than a gap.

The auth service authenticates key management by looking the bearer token up in `session_`. An API key lives in `api_key_` and a legacy CI token is a third-party JWT, so neither hashes to anything in that table — both already get a 401. A leaked CI credential able to mint fresh credentials would defeat revocation entirely: you would revoke the key you knew about while the attacker used the one they had already made.

`_sendApiKeyRequest` therefore reads the stored refresh token directly instead of going through `client`, and raises `ApiKeySessionRequiredException` when there is none, so CI gets

> API key management requires an interactive login. Run `shorebird login` on a machine with a browser.

rather than an unexplained 401. `gh` and `fly` land in the same place; key management is something a person does at a keyboard.

## Notes for review

- `--scope` is **mandatory**. The console defaults to Full access, which is how most existing keys ended up far wider than their job needs. Making the CLI ask seemed better than inheriting that default.
- A scope this CLI doesn't recognize displays as `unknown` rather than being guessed at, so a preset added server-side later degrades to a cosmetic gap instead of a wrong answer.
- `revoke` takes `--id` from `list` and has no confirmation prompt. Worth deciding whether it should have one; it is immediate and irreversible.
- 26 new tests, `dart analyze` clean, full `test/src/auth` and `test/src/commands/account` suites pass (147).

https://claude.ai/code/session_01JuXTMzbvJ977hMnkZMNfVN
