### PR TITLE
fix(shorebird_cli): ignore asset catalog toolchain versions when diffing

### DIFF
--- a/packages/shorebird_cli/lib/src/archive_analysis/apple_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/apple_archive_differ.dart
@@ -169,6 +169,22 @@ class AppleArchiveDiffer extends ArchiveDiffer {
     return _hash(sanitizeCarJson(jsonFile.readAsStringSync()).codeUnits);
   }
 
+  /// Keys in the `assetutil --info` header block that describe the toolchain
+  /// that compiled the asset catalog rather than its contents. Xcode 26.3
+  /// bumped `CoreUIVersion` from 972 to 973, for example, which changes every
+  /// one of these strings without changing a single asset.
+  ///
+  /// `PlatformVersion` and `SchemaVersion` are deliberately not here. They
+  /// describe the catalog a developer asked for, not the tool that built it,
+  /// so a change in either is worth reporting.
+  static const _toolchainVersionKeys = {
+    'AssetStorageVersion',
+    'Authoring Tool',
+    'CoreUIVersion',
+    'DumpToolVersion',
+    'MainVersion',
+  };
+
   static final _uuidRegex = RegExp(
     '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-'
     '[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}',
@@ -187,6 +203,14 @@ class AppleArchiveDiffer extends ArchiveDiffer {
   /// two builds of the same assets hash the same. Currently removes:
   ///
   ///   * `Timestamp`, which records when the .car file was built.
+  ///   * The toolchain version keys in the header block, which record the
+  ///     versions of Xcode and CoreUI that compiled the catalog rather than
+  ///     anything about the assets themselves. They move on every Xcode
+  ///     upgrade, so leaving them in makes an unchanged catalog look changed
+  ///     to any developer who upgrades between a release and its patch. A
+  ///     re-encode that actually alters a rendition still shows up, because
+  ///     `SizeOnDisk`, `Encoding`, `Compression`, both dimensions and
+  ///     `SHA1Digest` are all still compared.
   ///   * The generated suffix in the rendition file names of iOS 18 layered
   ///     icon (.icon) bundles, which `actool` regenerates every build.
   ///   * `SHA1Digest` on those renditions only. Two builds of one unchanged
@@ -226,6 +250,7 @@ class AppleArchiveDiffer extends ArchiveDiffer {
         final keys =
             map.keys
                 .where((key) => key != 'Timestamp')
+                .where((key) => !_toolchainVersionKeys.contains(key))
                 .where((key) => !(isGenerated && key == 'SHA1Digest'))
                 .toList()
               ..sort();

--- a/packages/shorebird_cli/test/src/archive_analysis/apple_archive_differ_test.dart
+++ b/packages/shorebird_cli/test/src/archive_analysis/apple_archive_differ_test.dart
@@ -145,6 +145,47 @@ void main() {
         );
       });
 
+      test('hashes equivalently across an Xcode toolchain bump', () {
+        // The header block assetutil emits for the same unchanged catalog,
+        // built before and after the Xcode 26.3 upgrade that took CoreUI
+        // from 972 to 973.
+        const buildA = '''
+[{"AssetStorageVersion" : "Xcode 26.2 (17B123) via AssetCatalogSimulatorAgent", "Authoring Tool" : "@(#)PROGRAM:CoreThemeDefinition  PROJECT:CoreThemeDefinition-653.3  [IIO-2784.2.5.1.3]", "CoreUIVersion" : 972, "DumpToolVersion" : 918.8, "MainVersion" : "@(#)PROGRAM:CoreUI  PROJECT:CoreUI-972.1", "Platform" : "ios", "PlatformVersion" : "17.0", "SchemaVersion" : 2}]''';
+        const buildB = '''
+[{"AssetStorageVersion" : "Xcode 26.3 (17C529) via AssetCatalogSimulatorAgent", "Authoring Tool" : "@(#)PROGRAM:CoreThemeDefinition  PROJECT:CoreThemeDefinition-653.3  [IIO-2784.3.4]", "CoreUIVersion" : 973, "DumpToolVersion" : 918.8, "MainVersion" : "@(#)PROGRAM:CoreUI  PROJECT:CoreUI-973.1", "Platform" : "ios", "PlatformVersion" : "17.0", "SchemaVersion" : 2}]''';
+        expect(
+          AppleArchiveDiffer.sanitizeCarJson(buildA),
+          AppleArchiveDiffer.sanitizeCarJson(buildB),
+        );
+      });
+
+      test('still detects a rendition edit made under a new toolchain', () {
+        const buildA = '''
+[{"CoreUIVersion" : 972, "RenditionName" : "logo.png", "SizeOnDisk" : 4096}]''';
+        const edited = '''
+[{"CoreUIVersion" : 973, "RenditionName" : "logo.png", "SizeOnDisk" : 8192}]''';
+        expect(
+          AppleArchiveDiffer.sanitizeCarJson(buildA),
+          isNot(AppleArchiveDiffer.sanitizeCarJson(edited)),
+        );
+      });
+
+      test('still detects PlatformVersion and SchemaVersion changes', () {
+        const before = '[{"PlatformVersion" : "17.0", "SchemaVersion" : 2}]';
+        const afterPlatform =
+            '[{"PlatformVersion" : "18.0", "SchemaVersion" : 2}]';
+        const afterSchema =
+            '[{"PlatformVersion" : "17.0", "SchemaVersion" : 3}]';
+        expect(
+          AppleArchiveDiffer.sanitizeCarJson(before),
+          isNot(AppleArchiveDiffer.sanitizeCarJson(afterPlatform)),
+        );
+        expect(
+          AppleArchiveDiffer.sanitizeCarJson(before),
+          isNot(AppleArchiveDiffer.sanitizeCarJson(afterSchema)),
+        );
+      });
+
       test('is insensitive to the order assetutil emits fields in', () {
         const orderA = '[{"Name" : "AppIcon", "Scale" : 1}]';
         const orderB = '[{"Scale" : 1, "Name" : "AppIcon"}]';


### PR DESCRIPTION
Upgrading Xcode between a release and its patch reports every `Assets.car` in the archive as changed, even when no asset was touched.

`assetutil --info` emits the versions of the tools that compiled the catalog in the same JSON we hash to compare two builds. Xcode 26.3 moves `CoreUIVersion` from 972 to 973 and rewrites `Authoring Tool` and `MainVersion` to match, so the hash changes and the differ reports asset changes across the app.

That warning is the only signal a developer gets that patched Dart may reference assets the installed app does not have, and `--allow-asset-diffs` is all-or-nothing. Firing it on an Xcode upgrade costs the warning its credibility for the case where the change is real.

## Change

Drop `AssetStorageVersion`, `Authoring Tool`, `CoreUIVersion`, `DumpToolVersion` and `MainVersion` before hashing, alongside the `Timestamp` and layered-icon exclusions already there.

`PlatformVersion` and `SchemaVersion` are deliberately kept. They describe the catalog that was asked for rather than the tool that built it, so a change in either is worth reporting.

A re-encode that actually alters a rendition is still reported: `SizeOnDisk`, `Encoding`, `Compression`, both dimensions and `SHA1Digest` remain in the hash. The added test covers that case by changing `SizeOnDisk` under a bumped `CoreUIVersion`.

## Tests

Three added to `sanitizeCarJson`:
- an unchanged catalog hashes equal across an Xcode toolchain bump
- a rendition edit made under a new toolchain is still detected
- `PlatformVersion` and `SchemaVersion` changes are still detected

Full file passes (32 tests). The single remaining analyzer info on line 1 is pre-existing on `main`.

https://claude.ai/code/session_019EGM1ZAgHB2ahUiSHq5Hmf