### PR TITLE
feat(shorebird_cli): --json envelopes for release and patch

### DIFF
--- a/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
+++ b/packages/shorebird_cli/lib/src/code_push_client_wrapper.dart
@@ -1146,7 +1146,7 @@ aar artifact already exists, continuing...''');
   /// Publishes a patch to the Shorebird server. This consists of creating a
   /// patch, uploading patch artifacts, and promoting the patch to a specific
   /// channel based on the provided [track].
-  Future<void> publishPatch({
+  Future<Patch> publishPatch({
     required String appId,
     required int releaseId,
     required Json metadata,
@@ -1174,6 +1174,7 @@ aar artifact already exists, continuing...''');
     await promotePatch(appId: appId, patchId: patch.id, channel: channel);
 
     logger.success('\n✅ Published Patch ${patch.number}!');
+    return patch;
   }
 
   /// Returns a GCP download link for measuring download speed.

--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -16,6 +16,7 @@ import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/extensions/string.dart';
 import 'package:shorebird_cli/src/formatters/formatters.dart';
+import 'package:shorebird_cli/src/json_output.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
@@ -231,12 +232,17 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
       return ExitCode.usage.code;
     }
 
-    final patcherFutures = results.releaseTypes
-        .map(_resolvePatcher)
-        .map(createPatch);
+    final published = <PublishedPatch>[];
+    for (final releaseType in results.releaseTypes) {
+      published.add(await createPatch(_resolvePatcher(releaseType)));
+    }
 
-    for (final patcherFuture in patcherFutures) {
-      await patcherFuture;
+    if (isJsonMode) {
+      emitJsonSuccess({
+        'app_id': appId,
+        'track': track.channel,
+        'patches': [for (final p in published) p.toJson()],
+      });
     }
 
     return ExitCode.success.code;
@@ -302,8 +308,11 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
   String? lastBuiltFlutterRevision;
 
   /// Creates a patch using the provided [patcher].
+  ///
+  /// Returns what was published. A dry run does not return: it exits the
+  /// process with success once the patch has been checked.
   @visibleForTesting
-  Future<void> createPatch(Patcher patcher) async {
+  Future<PublishedPatch> createPatch(Patcher patcher) async {
     await patcher.assertPreconditions();
     await patcher.assertArgsAreValid();
     results.assertAbsentOrValidKeyPairOrCommands();
@@ -543,9 +552,20 @@ Building patch with Flutter $flutterVersionString
 
         final dryRun = results['dry-run'] == true;
         if (dryRun) {
-          logger
-            ..info('No issues detected.')
-            ..info('The server may enforce additional checks.');
+          if (isJsonMode) {
+            emitJsonSuccess({
+              'dry_run': true,
+              'app_id': appId,
+              'platform': patcher.releaseType.releasePlatform.name,
+              'release_id': release.id,
+              'release_version': release.version,
+              'link_percentage': patcher.linkPercentage,
+            });
+          } else {
+            logger
+              ..info('No issues detected.')
+              ..info('The server may enforce additional checks.');
+          }
           throw ProcessExit(ExitCode.success.code);
         }
 
@@ -591,12 +611,19 @@ Building patch with Flutter $flutterVersionString
           baseMetadata,
         );
 
-        await patcher.uploadPatchArtifacts(
+        final patch = await patcher.uploadPatchArtifacts(
           appId: appId,
           releaseId: release.id,
           metadata: updateMetadata.toJson(),
           track: track,
           artifacts: patchArtifactBundles,
+        );
+
+        return PublishedPatch(
+          platform: patcher.releaseType.releasePlatform,
+          release: release,
+          patch: patch,
+          linkPercentage: patcher.linkPercentage,
         );
       },
       values: {shorebirdEnvRef.overrideWith(() => releaseFlutterShorebirdEnv)},
@@ -791,4 +818,42 @@ Future<R> _tryBuildingArtifact<R>(Future<R> Function() build) async {
 extension SortReleases on List<Release> {
   /// Sort the list of releases by when they were last updated ascending.
   void sortByUpdatedAt() => sort((a, b) => a.updatedAt.compareTo(b.updatedAt));
+}
+
+/// {@template published_patch}
+/// One platform's outcome of `shorebird patch`: which release it patched,
+/// the patch that resulted, and how much of the release's Dart code the
+/// patch could share with it.
+/// {@endtemplate}
+class PublishedPatch {
+  /// {@macro published_patch}
+  const PublishedPatch({
+    required this.platform,
+    required this.release,
+    required this.patch,
+    required this.linkPercentage,
+  });
+
+  /// The platform the patch was built for.
+  final ReleasePlatform platform;
+
+  /// The release the patch applies to.
+  final Release release;
+
+  /// The patch as the server created it.
+  final Patch patch;
+
+  /// The share of Dart code linked against the release, as a percentage,
+  /// where the platform reports one.
+  final double? linkPercentage;
+
+  /// The shape written into the `--json` envelope.
+  Map<String, dynamic> toJson() => {
+    'platform': platform.name,
+    'release_id': release.id,
+    'release_version': release.version,
+    'patch_id': patch.id,
+    'patch_number': patch.number,
+    'link_percentage': linkPercentage,
+  };
 }

--- a/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patcher.dart
@@ -135,14 +135,14 @@ More info: ${troubleshootingUrl.toLink()}.
   }
 
   /// Uploads the patch artifacts to the CodePush server.
-  Future<void> uploadPatchArtifacts({
+  Future<Patch> uploadPatchArtifacts({
     required String appId,
     required int releaseId,
     required Map<String, dynamic> metadata,
     required Map<Arch, PatchArtifactBundle> artifacts,
     required DeploymentTrack track,
-  }) async {
-    await codePushClientWrapper.publishPatch(
+  }) {
+    return codePushClientWrapper.publishPatch(
       appId: appId,
       releaseId: releaseId,
       metadata: metadata,

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -426,11 +426,23 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
         // this platform still reads draft. A caller reading the envelope
         // should see the release as it is now, which costs one fetch and is
         // only paid when there is an envelope to fill.
+        //
+        // Best-effort, because by this point the release is published: a
+        // refresh that fails must not turn a run that succeeded into a
+        // failed one. getRelease would do exactly that -- it exits the
+        // process, and does it with a message about publishing patches,
+        // which is not what the user just ran. Falling back to the release
+        // in hand costs the envelope a stale status, no more.
         if (!isJsonMode) return release;
-        return codePushClientWrapper.getRelease(
-          appId: appId,
-          releaseVersion: release.version,
-        );
+        try {
+          final refreshed = await codePushClientWrapper.maybeGetRelease(
+            appId: appId,
+            releaseVersion: release.version,
+          );
+          return refreshed ?? release;
+        } on Exception {
+          return release;
+        }
       },
       values: {shorebirdEnvRef.overrideWith(() => releaseFlutterShorebirdEnv)},
     );

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -13,6 +13,7 @@ import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/extensions/string.dart';
+import 'package:shorebird_cli/src/json_output.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/platform.dart';
@@ -193,12 +194,23 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
       return ExitCode.usage.code;
     }
 
-    final releaserFutures = results.releaseTypes
-        .map(_resolveReleaser)
-        .map(createRelease);
+    // One Release can carry several platforms, so releases are collected by
+    // id: each platform's pass refetches the release, and the last fetch is
+    // the one whose platform statuses are complete.
+    final releases = <int, Release>{};
+    for (final releaseType in results.releaseTypes) {
+      final release = await createRelease(_resolveReleaser(releaseType));
+      releases[release.id] = release;
+    }
 
-    for (final future in releaserFutures) {
-      await future;
+    if (isJsonMode) {
+      emitJsonSuccess({
+        'app_id': appId,
+        'platforms': [
+          for (final type in results.releaseTypes) type.releasePlatform.name,
+        ],
+        'releases': [for (final release in releases.values) release.toJson()],
+      });
     }
 
     return ExitCode.success.code;
@@ -270,6 +282,9 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
 
   /// The workflow to create a new release for a Shorebird app.
   ///
+  /// Returns the published [Release]. A dry run does not return: it exits
+  /// the process with success once the build has been checked.
+  ///
   /// Expectations for methods invoked by this command:
   ///  - They perform their own logging. If an error occurs, they are
   ///    responsible for properly logging the error, cleaning up running
@@ -277,7 +292,7 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
   ///  - They handle their own exceptions and exit with a non-zero exit code if
   ///    an error occurs *instead of* throwing an exception.
   @visibleForTesting
-  Future<void> createRelease(Releaser releaser) async {
+  Future<Release> createRelease(Releaser releaser) async {
     await releaser.assertPreconditions();
     await assertArgsAreValid(releaser);
 
@@ -362,9 +377,19 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
 
         final dryRun = results['dry-run'] == true;
         if (dryRun) {
-          logger
-            ..info('No issues detected.')
-            ..info('The server may enforce additional checks.');
+          if (isJsonMode) {
+            emitJsonSuccess({
+              'dry_run': true,
+              'app_id': appId,
+              'platform': releaser.releaseType.releasePlatform.name,
+              'release_version': releaseVersion,
+              'flutter_revision': targetFlutterRevision,
+            });
+          } else {
+            logger
+              ..info('No issues detected.')
+              ..info('The server may enforce additional checks.');
+          }
           throw ProcessExit(ExitCode.success.code);
         }
 
@@ -395,6 +420,16 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
           releaseType: releaser.releaseType,
           flavor: flavor,
           target: target,
+        );
+
+        // The Release in hand predates finalizeRelease, so its status for
+        // this platform still reads draft. A caller reading the envelope
+        // should see the release as it is now, which costs one fetch and is
+        // only paid when there is an envelope to fill.
+        if (!isJsonMode) return release;
+        return codePushClientWrapper.getRelease(
+          appId: appId,
+          releaseVersion: release.version,
         );
       },
       values: {shorebirdEnvRef.overrideWith(() => releaseFlutterShorebirdEnv)},

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -195,7 +195,7 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
     }
 
     // One Release can carry several platforms, so releases are collected by
-    // id: each platform's pass refetches the release, and the last fetch is
+    // id: each platform's pass re-fetches the release, and the last fetch is
     // the one whose platform statuses are complete.
     final releases = <int, Release>{};
     for (final releaseType in results.releaseTypes) {

--- a/packages/shorebird_cli/lib/src/json_output.dart
+++ b/packages/shorebird_cli/lib/src/json_output.dart
@@ -8,8 +8,22 @@ import 'package:shorebird_cli/src/version.dart';
 /// A reference to whether JSON output mode is active.
 final isJsonModeRef = create(() => false);
 
+/// Where a [JsonResult] is written: the process's stdout.
+///
+/// In `--json` mode the runner sends everything else bound for stdout (human
+/// log lines, progress, subprocess output) to stderr, so that stdout carries
+/// the envelope and nothing else. That redirect is an `IOOverrides` zone
+/// inside which `io.stdout` *is* stderr, so the runner binds this ref to the
+/// real stdout from outside the zone. Where nothing has bound it, the
+/// envelope goes to whatever `io.stdout` means in the current zone, which is
+/// what tests capture.
+final jsonSinkRef = create<io.IOSink>(() => io.stdout);
+
 /// Whether JSON output mode is active in the current zone.
-bool get isJsonMode => read(isJsonModeRef);
+///
+/// Off wherever nothing has said otherwise, so code that consults it can
+/// run under a scope that never mentions it.
+bool get isJsonMode => read(isJsonModeRef, orElse: () => false);
 
 /// Builds the subcommand name from [ArgResults] by walking the command chain
 /// (e.g. "doctor" for `shorebird doctor`, "patch ios" for `shorebird patch ios`).
@@ -166,6 +180,6 @@ class JsonResult {
 
   /// Writes this result to stdout as a single JSON line.
   void write() {
-    io.stdout.writeln(jsonEncode(toJson()));
+    read(jsonSinkRef, orElse: () => io.stdout).writeln(jsonEncode(toJson()));
   }
 }

--- a/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
@@ -152,8 +152,12 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
       // In JSON mode stdout carries the envelope and nothing else. Both
       // sinks are bound here, outside the redirect below: the envelope goes
       // to the real stdout, and everything else that would have reached
-      // stdout (human log lines, progress, subprocess output) goes to stderr,
-      // where a caller parsing stdout as JSON will not trip over it.
+      // stdout (human log lines, progress) goes to stderr, where a caller
+      // parsing stdout as JSON will not trip over it. Subprocess output
+      // takes a second path to the same place -- a child started with
+      // `inheritStdio` writes to our real fd 1, past any `IOOverrides`, so
+      // `ShorebirdProcess.stream` pipes instead in JSON mode and forwards
+      // the child's bytes to stderr itself.
       final jsonSink = io.stdout;
       final humanSink = io.stderr;
       // Suppress ANSI escape codes when the user has opted into a

--- a/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' as io;
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
@@ -148,6 +149,13 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
       final shorebirdArtifacts = engineConfig.localEngineSrcPath != null
           ? const ShorebirdLocalEngineArtifacts()
           : const ShorebirdCachedArtifacts();
+      // In JSON mode stdout carries the envelope and nothing else. Both
+      // sinks are bound here, outside the redirect below: the envelope goes
+      // to the real stdout, and everything else that would have reached
+      // stdout (human log lines, progress, subprocess output) goes to stderr,
+      // where a caller parsing stdout as JSON will not trip over it.
+      final jsonSink = io.stdout;
+      final humanSink = io.stderr;
       // Suppress ANSI escape codes when the user has opted into a
       // non-interactive output mode. When stdout/stderr aren't TTYs the io
       // package already disables ANSI automatically.
@@ -156,12 +164,19 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
         values: {
           engineConfigRef.overrideWith(() => engineConfig),
           isJsonModeRef.overrideWith(() => jsonMode),
+          jsonSinkRef.overrideWith(() => jsonSink),
           processRef.overrideWith(() => process),
           shorebirdArtifactsRef.overrideWith(() => shorebirdArtifacts),
         },
       );
       final exitCode = jsonMode
-          ? await overrideAnsiOutput<Future<int?>>(false, runWithRefs)
+          ? await overrideAnsiOutput<Future<int?>>(
+              false,
+              () => io.IOOverrides.runZoned(
+                runWithRefs,
+                stdout: () => humanSink,
+              ),
+            )
           : await runWithRefs();
       return exitCode ?? ExitCode.success.code;
     } on FormatException catch (e, stackTrace) {

--- a/packages/shorebird_cli/lib/src/shorebird_process.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_process.dart
@@ -5,6 +5,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/engine_config.dart';
+import 'package:shorebird_cli/src/json_output.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -43,6 +44,13 @@ class ShorebirdProcess {
   /// on the child side, regressing the interactive UX; a pty or per-fd
   /// shell tee would fix both but costs a dependency / POSIX-only path.
   /// Accepting the logging gap for now.
+  ///
+  /// `--json` mode is the exception. `inheritStdio` hands the child our real
+  /// fd 1, which is exactly where `IOOverrides` cannot follow it, so gradle
+  /// and `flutter build` would write their output into the stream the caller
+  /// is parsing as JSON. There is no interactive terminal UX to protect for
+  /// a caller reading stdout, so pipe there instead and forward both of the
+  /// child's streams to stderr alongside our own human output.
   Future<int> stream(
     String executable,
     List<String> arguments, {
@@ -57,9 +65,22 @@ class ShorebirdProcess {
       environment: environment,
       runInShell: runInShell,
       workingDirectory: workingDirectory,
-      mode: ProcessStartMode.inheritStdio,
+      mode: isJsonMode
+          ? ProcessStartMode.normal
+          : ProcessStartMode.inheritStdio,
     );
     onStart?.call(process);
+    if (!isJsonMode) return process.exitCode;
+
+    // Bytes rather than lines: the child's output is already formatted for a
+    // terminal, and decoding it would only risk throwing on a partial or
+    // invalid UTF-8 sequence. `add` rather than `addStream`, because two
+    // concurrent `addStream` calls on one sink is a StateError.
+    await Future.wait([
+      process.stdout.forEach(stderr.add),
+      process.stderr.forEach(stderr.add),
+    ]);
+    await stderr.flush();
     return process.exitCode;
   }
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -18,6 +19,7 @@ import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
 import 'package:shorebird_cli/src/deployment_track.dart';
 import 'package:shorebird_cli/src/executables/executables.dart';
+import 'package:shorebird_cli/src/json_output.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/patch_diff_checker.dart';
@@ -249,7 +251,7 @@ void main() {
           artifacts: any(named: 'artifacts'),
           metadata: any(named: 'metadata'),
         ),
-      ).thenAnswer((_) async {});
+      ).thenAnswer((_) async => const Patch(id: 3, number: 2));
 
       when(
         () => codePushClientWrapper.getReleaseArtifacts(
@@ -1551,6 +1553,79 @@ void main() {
               ]);
             },
           );
+        });
+      });
+    });
+
+    group('--json', () {
+      Future<T> runJson<T>(Future<T> Function() body) => runScoped(
+        body,
+        values: {isJsonModeRef.overrideWith(() => true)},
+      );
+
+      setUp(() {
+        when(() => patcher.linkPercentage).thenReturn(97.5);
+      });
+
+      test('emits what was published', () async {
+        final captured = <String>[];
+        final exitCode = await captureStdout(
+          () => runJson(() => runWithOverrides(command.run)),
+          captured: captured,
+        );
+
+        expect(exitCode, equals(ExitCode.success.code));
+        expect(captured, hasLength(1));
+        final envelope = jsonDecode(captured.single) as Map<String, dynamic>;
+        expect(envelope['status'], equals('success'));
+        expect(
+          envelope['data'],
+          equals({
+            'app_id': appId,
+            'track': 'stable',
+            'patches': [
+              {
+                'platform': 'android',
+                'release_id': release.id,
+                'release_version': release.version,
+                'patch_id': 3,
+                'patch_number': 2,
+                'link_percentage': 97.5,
+              },
+            ],
+          }),
+        );
+      });
+
+      group('with --dry-run', () {
+        setUp(() {
+          when(() => argResults['dry-run']).thenReturn(true);
+        });
+
+        test('emits what would have been patched', () async {
+          final captured = <String>[];
+          await expectLater(
+            captureStdout(
+              () => runJson(() => runWithOverrides(command.run)),
+              captured: captured,
+            ),
+            exitsWithCode(ExitCode.success),
+          );
+
+          expect(captured, hasLength(1));
+          final envelope = jsonDecode(captured.single) as Map<String, dynamic>;
+          expect(
+            envelope['data'],
+            equals({
+              'dry_run': true,
+              'app_id': appId,
+              'platform': 'android',
+              'release_id': release.id,
+              'release_version': release.version,
+              'link_percentage': 97.5,
+            }),
+          );
+          verifyNever(() => logger.info('No issues detected.'));
         });
       });
     });

--- a/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patcher_test.dart
@@ -216,7 +216,7 @@ void main() {
             track: any(named: 'track'),
             patchArtifactBundles: any(named: 'patchArtifactBundles'),
           ),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => const Patch(id: 1, number: 1));
         await runScoped(
           () async {
             await patcher.uploadPatchArtifacts(

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -404,12 +404,49 @@ void main() {
 
       setUp(() {
         when(
-          () => codePushClientWrapper.getRelease(
+          () => codePushClientWrapper.maybeGetRelease(
             appId: any(named: 'appId'),
             releaseVersion: any(named: 'releaseVersion'),
           ),
         ).thenAnswer((_) async => release);
       });
+
+      // The release is already published by the time the refresh runs, so a
+      // failure there must not turn a successful run into a failed one --
+      // and getRelease, which this used to call, exits the process with a
+      // message about publishing patches.
+      test(
+        'falls back to the release in hand when the refetch fails',
+        () async {
+          var calls = 0;
+          when(
+            () => codePushClientWrapper.maybeGetRelease(
+              appId: any(named: 'appId'),
+              releaseVersion: any(named: 'releaseVersion'),
+            ),
+          ).thenAnswer((_) async {
+            // ensureVersionIsReleasable and getOrCreateRelease each look the
+            // version up before the build; the refresh is the one after it.
+            if (++calls <= 2) return release;
+            throw ProcessExit(ExitCode.software.code);
+          });
+
+          final captured = <String>[];
+          final exitCode = await captureStdout(
+            () => runJson(() => runWithOverrides(command.run)),
+            captured: captured,
+          );
+
+          expect(exitCode, equals(ExitCode.success.code));
+          expect(captured, hasLength(1));
+          final envelope = jsonDecode(captured.single) as Map<String, dynamic>;
+          expect(envelope['status'], equals('success'));
+          expect(
+            (envelope['data'] as Map<String, dynamic>)['releases'],
+            equals([release.toJson()]),
+          );
+        },
+      );
 
       test('emits the published release, re-fetched after finalize', () async {
         final finalized = Release(
@@ -425,7 +462,7 @@ void main() {
           updatedAt: release.updatedAt,
         );
         when(
-          () => codePushClientWrapper.getRelease(
+          () => codePushClientWrapper.maybeGetRelease(
             appId: any(named: 'appId'),
             releaseVersion: any(named: 'releaseVersion'),
           ),

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -411,7 +411,7 @@ void main() {
         ).thenAnswer((_) async => release);
       });
 
-      test('emits the published release, refetched after finalize', () async {
+      test('emits the published release, re-fetched after finalize', () async {
         final finalized = Release(
           id: release.id,
           appId: release.appId,

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -12,6 +13,7 @@ import 'package:shorebird_cli/src/code_push_client_wrapper.dart';
 import 'package:shorebird_cli/src/commands/release/release.dart';
 import 'package:shorebird_cli/src/common_arguments.dart';
 import 'package:shorebird_cli/src/config/config.dart';
+import 'package:shorebird_cli/src/json_output.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/metadata/metadata.dart';
 import 'package:shorebird_cli/src/release_type.dart';
@@ -25,6 +27,7 @@ import 'package:test/test.dart';
 
 import '../../matchers.dart';
 import '../../mocks.dart';
+import '../../helpers.dart';
 
 void main() {
   group(ReleaseCommand, () {
@@ -389,6 +392,108 @@ void main() {
             );
             verify(() => logger.info('fix it')).called(1);
           });
+        });
+      });
+    });
+
+    group('--json', () {
+      Future<T> runJson<T>(Future<T> Function() body) => runScoped(
+        body,
+        values: {isJsonModeRef.overrideWith(() => true)},
+      );
+
+      setUp(() {
+        when(
+          () => codePushClientWrapper.getRelease(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+          ),
+        ).thenAnswer((_) async => release);
+      });
+
+      test('emits the published release, refetched after finalize', () async {
+        final finalized = Release(
+          id: release.id,
+          appId: release.appId,
+          version: release.version,
+          flutterRevision: release.flutterRevision,
+          displayName: release.displayName,
+          platformStatuses: const {
+            ReleasePlatform.android: ReleaseStatus.active,
+          },
+          createdAt: release.createdAt,
+          updatedAt: release.updatedAt,
+        );
+        when(
+          () => codePushClientWrapper.getRelease(
+            appId: any(named: 'appId'),
+            releaseVersion: any(named: 'releaseVersion'),
+          ),
+        ).thenAnswer((_) async => finalized);
+
+        final captured = <String>[];
+        final exitCode = await captureStdout(
+          () => runJson(() => runWithOverrides(command.run)),
+          captured: captured,
+        );
+
+        expect(exitCode, equals(ExitCode.success.code));
+        expect(captured, hasLength(1));
+        final envelope = jsonDecode(captured.single) as Map<String, dynamic>;
+        expect(envelope['status'], equals('success'));
+        expect(
+          envelope['data'],
+          equals({
+            'app_id': appId,
+            'platforms': ['android'],
+            'releases': [finalized.toJson()],
+          }),
+        );
+      });
+
+      test('emits nothing but the envelope on stdout', () async {
+        // Human progress lines are still logged; the runner routes them to
+        // stderr in JSON mode. Here the logger is a mock, so the check is
+        // that the command itself writes only the envelope.
+        final captured = <String>[];
+        await captureStdout(
+          () => runJson(() => runWithOverrides(command.run)),
+          captured: captured,
+        );
+
+        expect(captured, hasLength(1));
+        expect(() => jsonDecode(captured.single), returnsNormally);
+      });
+
+      group('with --dry-run', () {
+        setUp(() {
+          when(() => argResults['dry-run']).thenReturn(true);
+        });
+
+        test('emits what would have been released', () async {
+          final captured = <String>[];
+          await expectLater(
+            captureStdout(
+              () => runJson(() => runWithOverrides(command.run)),
+              captured: captured,
+            ),
+            exitsWithCode(ExitCode.success),
+          );
+
+          expect(captured, hasLength(1));
+          final envelope = jsonDecode(captured.single) as Map<String, dynamic>;
+          expect(envelope['status'], equals('success'));
+          expect(
+            envelope['data'],
+            equals({
+              'dry_run': true,
+              'app_id': appId,
+              'platform': 'android',
+              'release_version': release.version,
+              'flutter_revision': flutterRevision,
+            }),
+          );
+          verifyNever(() => logger.info('No issues detected.'));
         });
       });
     });

--- a/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
@@ -451,6 +451,43 @@ Engine • revision $shorebirdEngineRevision'''),
         return helpers.captureStdout(body, captured: stdoutOutput);
       }
 
+      test('routes everything but the envelope to stderr', () async {
+        // A command that writes a human line straight to stdout and then
+        // emits an envelope. With --json, stdout must carry the envelope
+        // alone; the human line lands on stderr.
+        commandRunner.addCommand(_ChattyCommand());
+        final stderrOutput = <String>[];
+        final realStderr = stderr;
+        final result = await captureStdout(
+          () => IOOverrides.runZoned(
+            () => runWithOverrides(
+              () => commandRunner.run(['--json', 'chatty']),
+            ),
+            stderr: () => helpers.CapturingStdout(
+              baseStdOut: realStderr,
+              captured: stderrOutput,
+            ),
+          ),
+        );
+
+        expect(result, equals(ExitCode.success.code));
+        expect(stdoutOutput, hasLength(1));
+        final json = jsonDecode(stdoutOutput.single) as Map<String, dynamic>;
+        expect(json['status'], equals('success'));
+        expect((json['data'] as Map)['said'], equals('hello'));
+        expect(stderrOutput, contains('hello, human'));
+      });
+
+      test('leaves stdout alone without --json', () async {
+        commandRunner.addCommand(_ChattyCommand());
+        final result = await captureStdout(
+          () => runWithOverrides(() => commandRunner.run(['chatty'])),
+        );
+
+        expect(result, equals(ExitCode.success.code));
+        expect(stdoutOutput, equals(['hello, human']));
+      });
+
       group('on ProcessExit with non-zero exit code', () {
         test('emits JSON error envelope', () async {
           commandRunner.addCommand(_TestCommand(ExitCode.unavailable));
@@ -788,6 +825,22 @@ class _TestCommand extends ShorebirdCommand {
   @override
   Future<int> run() async {
     throw ProcessExit(exitCode.code);
+  }
+}
+
+/// Writes a human line to stdout, then an envelope when in JSON mode.
+class _ChattyCommand extends ShorebirdCommand {
+  @override
+  String get name => 'chatty';
+
+  @override
+  String get description => 'Chatty command';
+
+  @override
+  Future<int> run() async {
+    stdout.writeln('hello, human');
+    if (isJsonMode) emitJsonSuccess({'said': 'hello'});
+    return ExitCode.success.code;
   }
 }
 

--- a/packages/shorebird_cli/test/src/shorebird_process_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_process_test.dart
@@ -1,4 +1,5 @@
 // cspell:ignore asdfasdf
+import 'dart:convert';
 import 'dart:io' hide Platform;
 
 import 'package:mason_logger/mason_logger.dart';
@@ -7,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/engine_config.dart';
+import 'package:shorebird_cli/src/json_output.dart';
 import 'package:shorebird_cli/src/logging/logging.dart';
 import 'package:shorebird_cli/src/platform.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
@@ -468,6 +470,76 @@ void main() {
         expect(exit, ExitCode.success.code);
         expect(identical(received, streamProcess), isTrue);
       });
+
+      group('in json mode', () {
+        late _CapturingIOSink capturedStderr;
+
+        R runInJsonMode<R>(R Function() body) {
+          return runScoped(
+            () => IOOverrides.runZoned(body, stderr: () => capturedStderr),
+            values: {
+              engineConfigRef.overrideWith(() => engineConfig),
+              isJsonModeRef.overrideWith(() => true),
+              loggerRef.overrideWith(() => logger),
+              platformRef.overrideWith(() => platform),
+              shorebirdEnvRef.overrideWith(() => shorebirdEnv),
+            },
+          );
+        }
+
+        setUp(() {
+          capturedStderr = _CapturingIOSink();
+          when(
+            () => processWrapper.start(
+              any(),
+              any(),
+              environment: any(named: 'environment'),
+              mode: ProcessStartMode.normal,
+            ),
+          ).thenAnswer((_) async => streamProcess);
+          when(
+            () => streamProcess.stdout,
+          ).thenAnswer((_) => Stream.value(utf8.encode('built app.aab')));
+          when(
+            () => streamProcess.stderr,
+          ).thenAnswer((_) => Stream.value(utf8.encode('a gradle warning')));
+        });
+
+        // inheritStdio hands the child our real fd 1, where IOOverrides
+        // cannot follow it -- the one stream the caller is parsing as JSON.
+        test('pipes rather than inheriting stdio', () async {
+          await expectLater(
+            runInJsonMode(() => shorebirdProcess.stream('git', ['pull'])),
+            completion(equals(ExitCode.success.code)),
+          );
+
+          verify(
+            () => processWrapper.start(
+              'git',
+              ['pull'],
+              environment: {},
+              mode: ProcessStartMode.normal,
+            ),
+          ).called(1);
+          verifyNever(
+            () => processWrapper.start(
+              any(),
+              any(),
+              environment: any(named: 'environment'),
+              mode: ProcessStartMode.inheritStdio,
+            ),
+          );
+        });
+
+        test("forwards both of the child's streams to stderr", () async {
+          await runInJsonMode(() => shorebirdProcess.stream('git', ['pull']));
+
+          expect(
+            utf8.decode(capturedStderr.bytes),
+            allOf(contains('built app.aab'), contains('a gradle warning')),
+          );
+        });
+      });
     });
 
     group('start', () {
@@ -598,4 +670,19 @@ void main() {
       );
     });
   });
+}
+
+/// A [Stdout] that keeps what was written to it, so a test can read back
+/// what a child process's output was forwarded to.
+class _CapturingIOSink implements Stdout {
+  final bytes = <int>[];
+
+  @override
+  void add(List<int> data) => bytes.addAll(data);
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  void noSuchMethod(Invocation invocation) {}
 }


### PR DESCRIPTION
Twenty commands answer `--json` with a success envelope. The two that do the job did not: `shorebird release` and `shorebird patch` printed their human progress lines and ended, so a caller that asked for JSON got no release id, no patch number, and nothing to branch on short of scraping log text.

## What changed

**`shorebird release --json`**

```json
{"status":"success","data":{"app_id":"…","platforms":["android","ios"],"releases":[{"id":123,"app_id":"…","version":"1.2.3+4","flutter_revision":"…","flutter_version":"3.44.0","platform_statuses":{"android":"active","ios":"active"},…}]},"meta":{"version":"1.6.120","command":"release"}}
```

Releases are collected by id, since one Release carries several platforms. Each is refetched after finalize so its status reads `active` rather than the `draft` the command held in hand; that fetch only happens when there's an envelope to fill.

**`shorebird patch --json`**

```json
{"status":"success","data":{"app_id":"…","track":"stable","patches":[{"platform":"android","release_id":123,"release_version":"1.2.3+4","patch_id":456,"patch_number":7,"link_percentage":97.5}]},"meta":{…}}
```

**`--dry-run --json`** on either emits what would have been published (`dry_run: true` plus the version, platform, and for patch the link percentage) instead of exiting with success and nothing on stdout.

**stdout is the envelope and nothing else.** In JSON mode the runner now redirects everything else bound for stdout (human log lines, `logger.info`/`success`, subprocess output) to stderr for the length of the command, and binds the envelope's sink to the real stdout from outside that redirect. Before this, `--json` on a long command meant a JSON line at the bottom of a page of prose, which is not JSON to anything reading it. Commands that already returned before logging are unaffected.

Smoke test on a real invocation: stdout is exactly one JSON line, the human message is on stderr.

## Plumbing

- `CodePushClientWrapper.publishPatch` and `Patcher.uploadPatchArtifacts` return the `Patch` they create rather than `void`.
- `createRelease` returns the `Release`; `createPatch` returns a `PublishedPatch` (platform, release, patch, link percentage).
- `isJsonMode` reads `false` where nothing has set it, so code that consults it can run under a scope that never mentions it. `JsonResult.write` falls back to the zone's stdout when no sink is bound, which is what tests capture.

## Testing

- `release`: envelope shape with the refetched release; only the envelope reaches stdout; dry-run envelope.
- `patch`: envelope shape; dry-run envelope.
- Runner: a command that writes a human line to stdout then an envelope produces stdout = envelope only, stderr = the human line, under `--json`; stdout untouched without it.
- Full `shorebird_cli` suite passes (2251). Changed lib lines are covered.

https://claude.ai/code/session_01LG6NjeENXsouDyHrt1YPB7
