### PR TITLE
fix(shorebird_cli): parse the positional platform from rest, not the first raw token

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -217,12 +217,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
 
   @override
   Future<int> run() async {
-    if (results.releaseTypes.isEmpty) {
-      logger.err(
-        '''No platforms were provided. Use the --platforms argument to provide one or more platforms''',
-      );
-      return ExitCode.usage.code;
-    }
+    final releaseTypes = releaseTypesOrUsageError(siblingCommand: 'patches');
 
     if (results.wasParsed('staging')) {
       logger.err(
@@ -231,9 +226,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
       return ExitCode.usage.code;
     }
 
-    final patcherFutures = results.releaseTypes
-        .map(_resolvePatcher)
-        .map(createPatch);
+    final patcherFutures = releaseTypes.map(_resolvePatcher).map(createPatch);
 
     for (final patcherFuture in patcherFutures) {
       await patcherFuture;

--- a/packages/shorebird_cli/lib/src/commands/release/release_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/release_command.dart
@@ -186,14 +186,9 @@ of the iOS app that is using this module. (aar and ios-framework only)''',
 
   @override
   Future<int> run() async {
-    if (results.releaseTypes.isEmpty) {
-      logger.err(
-        '''No platforms were provided. Use the --platforms argument to provide one or more platforms''',
-      );
-      return ExitCode.usage.code;
-    }
+    final releaseTypes = releaseTypesOrUsageError(siblingCommand: 'releases');
 
-    final releaserFutures = results.releaseTypes
+    final releaserFutures = releaseTypes
         .map(_resolveReleaser)
         .map(createRelease);
 

--- a/packages/shorebird_cli/lib/src/release_type.dart
+++ b/packages/shorebird_cli/lib/src/release_type.dart
@@ -66,20 +66,72 @@ enum ReleaseType {
   }
 }
 
+/// Thrown when the positional platform arguments cannot be parsed. [message]
+/// is written for the user.
+class PlatformArgumentException implements Exception {
+  /// Creates an exception carrying the user-facing [message].
+  const PlatformArgumentException(this.message);
+
+  /// Why the arguments were rejected, and what to do instead.
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// The platform names accepted on the command line, sorted, for error text.
+String get validPlatformNames =>
+    (ReleaseType.values.map((t) => t.cliName).toList()..sort()).join(', ');
+
 /// Extension on [ArgResults] to get the release types from the CLI arguments.
 extension ReleaseTypeArgs on ArgResults {
+  /// The positional arguments the user typed before any `--` separator.
+  /// [rest] also contains everything after `--`, which is forwarded to
+  /// Flutter and must not be validated here.
+  List<String> get _ownPositionalArgs {
+    final separator = arguments.indexOf('--');
+    if (separator == -1) return rest;
+    final forwardedCount = arguments.length - separator - 1;
+    return rest.sublist(0, rest.length - forwardedCount);
+  }
+
   /// The release types specified in the CLI arguments.
+  ///
+  /// Throws a [PlatformArgumentException] when the positional platform is
+  /// not a valid platform, or when more than one positional argument is
+  /// given.
   Iterable<ReleaseType> get releaseTypes {
     List<String>? releaseTypeCliNames;
     if (wasParsed('platforms')) {
       releaseTypeCliNames = this['platforms'] as List<String>;
     } else {
-      if (arguments.isNotEmpty) {
-        final platformCliName = arguments.first;
+      final positionalArgs = _ownPositionalArgs;
+      if (positionalArgs.isNotEmpty) {
+        final platformCliName = positionalArgs.first;
         if (ReleaseType.values.none(
           (target) => target.cliName == platformCliName,
         )) {
-          throw ArgumentError('Invalid platform: $platformCliName');
+          throw PlatformArgumentException(
+            '''
+Invalid platform: "$platformCliName".
+Valid platforms: $validPlatformNames''',
+          );
+        }
+        if (positionalArgs.length > 1) {
+          final unexpected = positionalArgs[1];
+          final String hint;
+          if (RegExp(r'^\d+\.\d+').hasMatch(unexpected)) {
+            hint = 'Did you mean --release-version=$unexpected?';
+          } else if (ReleaseType.values.any((t) => t.cliName == unexpected)) {
+            hint = 'Did you mean --platforms=$platformCliName,$unexpected?';
+          } else {
+            hint = 'Arguments for Flutter go after --.';
+          }
+          throw PlatformArgumentException(
+            '''
+Unexpected argument: "$unexpected".
+$hint''',
+          );
         }
         releaseTypeCliNames = [platformCliName];
       }

--- a/packages/shorebird_cli/lib/src/shorebird_command.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_command.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+import 'package:collection/collection.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:scoped_deps/scoped_deps.dart';
@@ -10,6 +11,7 @@ import 'package:shorebird_cli/src/config/shorebird_yaml.dart';
 import 'package:shorebird_cli/src/extensions/arg_results.dart';
 import 'package:shorebird_cli/src/interactive_mode.dart' as interactive_mode;
 import 'package:shorebird_cli/src/json_output.dart';
+import 'package:shorebird_cli/src/release_type.dart';
 import 'package:shorebird_cli/src/shorebird_cli_command_runner.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:shorebird_cli/src/shorebird_validator.dart';
@@ -73,6 +75,41 @@ abstract class ShorebirdCommand extends Command<int> {
   /// See [interactive_mode.isInteractive].
   bool get isInteractive => interactive_mode.isInteractive;
   // coverage:ignore-end
+
+  /// The release types named by the positional platform or `--platforms`.
+  ///
+  /// Throws a [UsageException] when no platform was given, the platform is
+  /// not valid, or an extra positional argument was passed. When the invalid
+  /// platform is a subcommand of [siblingCommand] (e.g. `rollback` under
+  /// `patches`), the message points there.
+  Iterable<ReleaseType> releaseTypesOrUsageError({
+    required String siblingCommand,
+  }) {
+    final List<ReleaseType> types;
+    try {
+      types = results.releaseTypes.toList();
+    } on PlatformArgumentException catch (e) {
+      final positional = results.rest.firstOrNull;
+      final sibling = runner!.commands[siblingCommand];
+      if (positional != null &&
+          (sibling?.subcommands.containsKey(positional) ?? false)) {
+        usageException(
+          '''
+${e.message}
+Did you mean "shorebird $siblingCommand $positional"?''',
+        );
+      }
+      usageException(e.message);
+    }
+    if (types.isEmpty) {
+      usageException(
+        '''
+No platform was provided.
+Valid platforms: $validPlatformNames''',
+      );
+    }
+    return types;
+  }
 
   /// The full command name including parent commands (e.g. "releases list").
   String get fullCommandName {

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:mason_logger/mason_logger.dart';
@@ -1781,18 +1782,73 @@ Please re-run the release command for this version or create a new release.'''),
     group('when no platform argument is provided', () {
       setUp(() {
         when(() => argResults['platforms']).thenReturn(const <String>[]);
+        command.testRunner = usageRunner();
       });
 
-      test('fails and log the correct message', () async {
-        final exitCode = await runWithOverrides(command.run);
-
-        expect(exitCode, equals(ExitCode.usage.code));
-
-        verify(
-          () => logger.err(
-            '''No platforms were provided. Use the --platforms argument to provide one or more platforms''',
+      test('throws a usage exception listing the valid platforms', () async {
+        await expectLater(
+          runWithOverrides(command.run),
+          throwsA(
+            isA<UsageException>().having(
+              (e) => e.message,
+              'message',
+              '''
+No platform was provided.
+Valid platforms: aar, android, ios, ios-framework, linux, macos, windows''',
+            ),
           ),
-        ).called(1);
+        );
+      });
+    });
+
+    group('when the platform argument is invalid', () {
+      late MockShorebirdCliCommandRunner runner;
+      late MockCommand patchesCommand;
+
+      setUp(() {
+        runner = usageRunner();
+        patchesCommand = MockCommand();
+        when(() => argResults.wasParsed('platforms')).thenReturn(false);
+        when(() => argResults.arguments).thenReturn(['rollback']);
+        when(() => argResults.rest).thenReturn(['rollback']);
+        when(() => runner.commands).thenReturn({'patches': patchesCommand});
+        when(
+          () => patchesCommand.subcommands,
+        ).thenReturn({'rollback': MockCommand()});
+        command.testRunner = runner;
+      });
+
+      test('points at the patches subcommand of the same name', () async {
+        await expectLater(
+          runWithOverrides(command.run),
+          throwsA(
+            isA<UsageException>().having(
+              (e) => e.message,
+              'message',
+              '''
+Invalid platform: "rollback".
+Valid platforms: aar, android, ios, ios-framework, linux, macos, windows
+Did you mean "shorebird patches rollback"?''',
+            ),
+          ),
+        );
+      });
+
+      test('reports the invalid platform when no subcommand matches', () async {
+        when(() => argResults.arguments).thenReturn(['andriod']);
+        when(() => argResults.rest).thenReturn(['andriod']);
+        await expectLater(
+          runWithOverrides(command.run),
+          throwsA(
+            isA<UsageException>().having(
+              (e) => e.message,
+              'message',
+              '''
+Invalid platform: "andriod".
+Valid platforms: aar, android, ios, ios-framework, linux, macos, windows''',
+            ),
+          ),
+        );
       });
     });
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -1835,8 +1835,8 @@ Did you mean "shorebird patches rollback"?''',
       });
 
       test('reports the invalid platform when no subcommand matches', () async {
-        when(() => argResults.arguments).thenReturn(['andriod']);
-        when(() => argResults.rest).thenReturn(['andriod']);
+        when(() => argResults.arguments).thenReturn(['web']);
+        when(() => argResults.rest).thenReturn(['web']);
         await expectLater(
           runWithOverrides(command.run),
           throwsA(
@@ -1844,7 +1844,7 @@ Did you mean "shorebird patches rollback"?''',
               (e) => e.message,
               'message',
               '''
-Invalid platform: "andriod".
+Invalid platform: "web".
 Valid platforms: aar, android, ios, ios-framework, linux, macos, windows''',
             ),
           ),

--- a/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/release_command_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
@@ -747,18 +748,46 @@ $exception'''),
     group('when no platform argument is provided', () {
       setUp(() {
         when(() => argResults['platforms']).thenReturn(const <String>[]);
+        command.testRunner = usageRunner();
       });
 
-      test('fails and log the correct message', () async {
-        final exitCode = await runWithOverrides(command.run);
-
-        expect(exitCode, equals(ExitCode.usage.code));
-
-        verify(
-          () => logger.err(
-            '''No platforms were provided. Use the --platforms argument to provide one or more platforms''',
+      test('throws a usage exception listing the valid platforms', () async {
+        await expectLater(
+          runWithOverrides(command.run),
+          throwsA(
+            isA<UsageException>().having(
+              (e) => e.message,
+              'message',
+              '''
+No platform was provided.
+Valid platforms: aar, android, ios, ios-framework, linux, macos, windows''',
+            ),
           ),
-        ).called(1);
+        );
+      });
+    });
+
+    group('when the platform argument is invalid', () {
+      setUp(() {
+        when(() => argResults.wasParsed('platforms')).thenReturn(false);
+        when(() => argResults.arguments).thenReturn(['list']);
+        when(() => argResults.rest).thenReturn(['list']);
+        command.testRunner = usageRunner(commands: {});
+      });
+
+      test('throws a usage exception without a subcommand hint', () async {
+        await expectLater(
+          runWithOverrides(command.run),
+          throwsA(
+            isA<UsageException>().having(
+              (e) => e.message,
+              'message',
+              '''
+Invalid platform: "list".
+Valid platforms: aar, android, ios, ios-framework, linux, macos, windows''',
+            ),
+          ),
+        );
       });
     });
 

--- a/packages/shorebird_cli/test/src/mocks.dart
+++ b/packages/shorebird_cli/test/src/mocks.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
 import 'package:googleapis_auth/auth_io.dart';
 import 'package:http/http.dart' as http;
 import 'package:jwt/jwt.dart';
@@ -67,6 +68,19 @@ class MockArchiveDiffer extends Mock implements ArchiveDiffer {}
 class MockArgParser extends Mock implements ArgParser {}
 
 class MockArgResults extends Mock implements ArgResults {}
+
+class MockCommand extends Mock implements Command<int> {}
+
+/// A runner mock stubbed just enough for [Command.usageException] to build
+/// its usage text.
+MockShorebirdCliCommandRunner usageRunner({
+  Map<String, Command<int>> commands = const {},
+}) {
+  final runner = MockShorebirdCliCommandRunner();
+  when(() => runner.executableName).thenReturn('shorebird');
+  when(() => runner.commands).thenReturn(commands);
+  return runner;
+}
 
 class MockArtifactBuildException extends Mock
     implements ArtifactBuildException {}

--- a/packages/shorebird_cli/test/src/release_type_test.dart
+++ b/packages/shorebird_cli/test/src/release_type_test.dart
@@ -59,28 +59,112 @@ void main() {
         });
       });
 
-      group('when the platforms is provided as a raw arg', () {
-        test('throws an ArgumentError if the platform is invalid', () {
+      group('when the platform is provided as a raw arg', () {
+        test('throws if the platform is invalid, listing valid platforms', () {
           expect(
-            () => parser.parse(['foo']).releaseTypes.toList(),
-            throwsArgumentError,
+            () => parser.parse(['rollback']).releaseTypes.toList(),
+            throwsA(
+              isA<PlatformArgumentException>().having(
+                (e) => e.message,
+                'message',
+                '''
+Invalid platform: "rollback".
+Valid platforms: aar, android, ios, ios-framework, linux, macos, windows''',
+              ),
+            ),
           );
         });
 
         test('parses the release types', () {
-          expect(parser.parse(['android', 'foo']).releaseTypes.toList(), [
+          expect(parser.parse(['android']).releaseTypes.toList(), [
             ReleaseType.android,
           ]);
-          expect(parser.parse(['ios', 'foo']).releaseTypes.toList(), [
+          expect(parser.parse(['ios']).releaseTypes.toList(), [
             ReleaseType.ios,
           ]);
-          expect(parser.parse(['ios-framework', 'foo']).releaseTypes.toList(), [
+          expect(parser.parse(['ios-framework']).releaseTypes.toList(), [
             ReleaseType.iosFramework,
           ]);
-          expect(parser.parse(['aar', 'foo']).releaseTypes.toList(), [
+          expect(parser.parse(['aar']).releaseTypes.toList(), [
             ReleaseType.aar,
           ]);
         });
+
+        test('accepts options before the platform', () {
+          parser.addOption('release-version');
+          expect(
+            parser
+                .parse(['--release-version=1.0.0+1', 'android'])
+                .releaseTypes
+                .toList(),
+            [ReleaseType.android],
+          );
+        });
+
+        test('ignores arguments after --', () {
+          expect(
+            parser
+                .parse(['android', '--', '--no-pub', 'lib/main.dart'])
+                .releaseTypes
+                .toList(),
+            [ReleaseType.android],
+          );
+        });
+
+        test('throws on a second positional that looks like a version', () {
+          expect(
+            () => parser.parse(['android', '1.0.0+1']).releaseTypes.toList(),
+            throwsA(
+              isA<PlatformArgumentException>().having(
+                (e) => e.message,
+                'message',
+                '''
+Unexpected argument: "1.0.0+1".
+Did you mean --release-version=1.0.0+1?''',
+              ),
+            ),
+          );
+        });
+
+        test('throws on a second platform, suggesting --platforms', () {
+          expect(
+            () => parser.parse(['android', 'ios']).releaseTypes.toList(),
+            throwsA(
+              isA<PlatformArgumentException>().having(
+                (e) => e.message,
+                'message',
+                '''
+Unexpected argument: "ios".
+Did you mean --platforms=android,ios?''',
+              ),
+            ),
+          );
+        });
+
+        test('throws on any other second positional', () {
+          expect(
+            () => parser
+                .parse(['android', 'lib/main.dart'])
+                .releaseTypes
+                .toList(),
+            throwsA(
+              isA<PlatformArgumentException>().having(
+                (e) => e.message,
+                'message',
+                '''
+Unexpected argument: "lib/main.dart".
+Arguments for Flutter go after --.''',
+              ),
+            ),
+          );
+        });
+      });
+
+      test('PlatformArgumentException.toString is the message', () {
+        expect(
+          const PlatformArgumentException('nope').toString(),
+          equals('nope'),
+        );
       });
     });
   });


### PR DESCRIPTION
\`shorebird patch --release-version=1.0.0+1 android\` failed with \`Invalid argument(s): Invalid platform: --release-version=1.0.0+1\` plus the file-an-issue boilerplate, because \`ReleaseTypeArgs.releaseTypes\` read \`arguments.first\` (the first raw token) instead of the first positional. A stray second positional (\`shorebird patch android 1.0.0+1\`) was silently forwarded to \`flutter build\` as the target file.

Now:

- The platform is taken from \`rest\`, excluding anything after \`--\`.
- Platform errors are \`UsageException\`s (exit 64, command usage printed, \`usage_error\` in \`--json\`) instead of the generic crash path.
- Every message lists the valid platforms.
- When the token is a subcommand of the plural command, the message says so: \`shorebird patch rollback\` -> \`Did you mean "shorebird patches rollback"?\`; same for \`shorebird release list\`.
- A second positional gets a targeted hint: \`1.0.0+1\` -> \`--release-version=1.0.0+1\`; \`ios\` -> \`--platforms=android,ios\`; anything else -> \`Arguments for Flutter go after --.\`

Before/after for \`shorebird patch rollback\`:

\`\`\`
Invalid argument(s): Invalid platform: rollback

If you aren't sure why this command failed, re-run with the --verbose flag ...
\`\`\`

\`\`\`
Invalid platform: "rollback".
Valid platforms: aar, android, ios, ios-framework, linux, macos, windows
Did you mean "shorebird patches rollback"?
Usage: shorebird patch [arguments]
...
\`\`\`

Part of #3917 (the \`patch rollback\` and \`patch android <version>\` forms appear in third-party skill files).

https://claude.ai/code/session_01LG6NjeENXsouDyHrt1YPB7