### PR TITLE
fix(shorebird_cli): name the next step in validator errors

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_validator.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_validator.dart
@@ -71,7 +71,7 @@ class ShorebirdValidator {
     if (supportedOperatingSystems != null &&
         !supportedOperatingSystems.contains(platform.operatingSystem)) {
       logger.err(
-        '''This command is only supported on ${supportedOperatingSystems.join(' ,')}.''',
+        '''This command is only supported on ${supportedOperatingSystems.join(', ')} (this machine is running ${platform.operatingSystem}).''',
       );
       throw UnsupportedOperatingSystemException();
     }

--- a/packages/shorebird_cli/lib/src/validators/flavor_validator.dart
+++ b/packages/shorebird_cli/lib/src/validators/flavor_validator.dart
@@ -29,7 +29,7 @@ class FlavorValidator extends Validator {
       return [
         ValidationIssue.error(
           message:
-              '''The project does not have any flavors defined, but the --flavor argument was provided''',
+              '''The project does not have any flavors defined (no "flavors" in shorebird.yaml), but --flavor was provided. Re-run without --flavor, or run "shorebird init" to detect flavors.''',
         ),
       ];
     }
@@ -39,8 +39,8 @@ class FlavorValidator extends Validator {
         ValidationIssue.warning(
           message:
               '''
-The project has flavors ${projectFlavors.keys}, but no --flavor argument was provided.
-The default app id ${shorebirdYaml.appId} will be used.''',
+The project has flavors ${projectFlavors.keys.join(', ')}, but no --flavor argument was provided.
+The default app id ${shorebirdYaml.appId} will be used. Pass --flavor=<name> to target a flavor.''',
         ),
       ];
     }
@@ -51,7 +51,7 @@ The default app id ${shorebirdYaml.appId} will be used.''',
       return [
         ValidationIssue.error(
           message:
-              '''This project does not have a flavor named "$flavorArg". Available flavors: ${projectFlavors.keys}''',
+              '''This project does not have a flavor named "$flavorArg". Pass one of: ${projectFlavors.keys.join(', ')} (from "flavors" in shorebird.yaml).''',
         ),
       ];
     }

--- a/packages/shorebird_cli/test/src/shorebird_validator_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_validator_test.dart
@@ -71,7 +71,7 @@ void main() {
         );
         verify(
           () => logger.err(
-            '''This command is only supported on ${supportedOperatingSystems.join(' ,')}.''',
+            '''This command is only supported on macos, windows (this machine is running linux).''',
           ),
         ).called(1);
       });
@@ -296,8 +296,8 @@ To fix, update your pubspec.yaml to include the following:
               verify(
                 () => logger.warn(
                   '''
-The project has flavors (flavorA), but no --flavor argument was provided.
-The default app id test will be used.''',
+The project has flavors flavorA, but no --flavor argument was provided.
+The default app id test will be used. Pass --flavor=<name> to target a flavor.''',
                 ),
               ).called(1);
             });

--- a/packages/shorebird_cli/test/src/validators/flavor_validator_test.dart
+++ b/packages/shorebird_cli/test/src/validators/flavor_validator_test.dart
@@ -57,7 +57,7 @@ void main() {
             expect(
               issues.first.message,
               equals(
-                '''The project does not have any flavors defined, but the --flavor argument was provided''',
+                '''The project does not have any flavors defined (no "flavors" in shorebird.yaml), but --flavor was provided. Re-run without --flavor, or run "shorebird init" to detect flavors.''',
               ),
             );
           });
@@ -106,7 +106,7 @@ void main() {
                 equals([
                   ValidationIssue.error(
                     message:
-                        '''This project does not have a flavor named "flavorC". Available flavors: (flavorA, flavorB)''',
+                        '''This project does not have a flavor named "flavorC". Pass one of: flavorA, flavorB (from "flavors" in shorebird.yaml).''',
                   ),
                 ]),
               );
@@ -126,8 +126,8 @@ void main() {
               equals([
                 ValidationIssue.warning(
                   message: '''
-The project has flavors (flavorA, flavorB), but no --flavor argument was provided.
-The default app id $appId will be used.''',
+The project has flavors flavorA, flavorB, but no --flavor argument was provided.
+The default app id $appId will be used. Pass --flavor=<name> to target a flavor.''',
                 ),
               ]),
             );


### PR DESCRIPTION
Part of #3919. Text-only; the other errors in `shorebird_validator.dart` (not logged in, no shorebird.yaml, missing asset entry, flavors unsupported on platform) already name their fix.

| Situation | Before | After |
|---|---|---|
| Command unsupported on host OS | `This command is only supported on macos ,linux.` | `This command is only supported on macos, linux (this machine is running windows).` |
| `--flavor=x` not in shorebird.yaml | `This project does not have a flavor named "x". Available flavors: (a, b)` | `This project does not have a flavor named "x". Pass one of: a, b (from "flavors" in shorebird.yaml).` |
| `--flavor` but no flavors defined | `The project does not have any flavors defined, but the --flavor argument was provided` | `The project does not have any flavors defined (no "flavors" in shorebird.yaml), but --flavor was provided. Re-run without --flavor, or run "shorebird init" to detect flavors.` |
| Flavored project, no `--flavor` (warning) | `The project has flavors (a, b), but no --flavor argument was provided.\nThe default app id X will be used.` | `The project has flavors a, b, ...\nThe default app id X will be used. Pass --flavor=<name> to target a flavor.` |

`dart test` in `packages/shorebird_cli`: 2244 pass.

https://claude.ai/code/session_01LG6NjeENXsouDyHrt1YPB7