### PR TITLE
fix(shorebird_cli): name the next step in patch errors

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/patch_command.dart
@@ -333,10 +333,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
         )
         ..sortByUpdatedAt();
       if (releases.isEmpty) {
-        logger.warn(
-          '''No ${releasePlatform.displayName} releases found for app $appId. You must first create a release before you can create a patch.''',
-        );
-        throw ProcessExit(ExitCode.usage.code);
+        throw _noReleasesToPatch(patcher.releaseType);
       }
       // Use the most recently updated release for the specified platform.
       release = releases.last;
@@ -347,7 +344,7 @@ NOTE: this is ${styleBold.wrap('not')} recommended. Asset changes cannot be incl
         releaseVersion: releaseVersion,
       );
     } else if (shorebirdEnv.canAcceptUserInput) {
-      release = await promptForRelease(releasePlatform);
+      release = await promptForRelease(patcher.releaseType);
     } else {
       final flutterVersionString = await shorebirdFlutter
           .getVersionAndRevision();
@@ -434,12 +431,12 @@ Building with Flutter $flutterVersionString to determine the release version...
     // release, producing a broken patch.
     final userPassedObfuscate = results.flagPresent('obfuscate');
     if (userPassedObfuscate && obfuscationMapFile == null) {
-      logger.err(
-        '--obfuscate was passed, but the release was not built with '
-        'obfuscation. A patch cannot change the obfuscation mode of a '
-        'release.',
+      usageException(
+        '--obfuscate was passed, but release ${release.version} was not '
+        'built with obfuscation. A patch cannot change the obfuscation mode '
+        'of a release: re-run without --obfuscate to patch this release, or '
+        'create a new release with --obfuscate.',
       );
-      throw ProcessExit(ExitCode.software.code);
     }
     if (userPassedObfuscate && obfuscationMapFile != null) {
       logger.info(
@@ -604,7 +601,8 @@ Building patch with Flutter $flutterVersionString
   }
 
   /// Prompts the user for the specific release to patch.
-  Future<Release> promptForRelease(ReleasePlatform platform) async {
+  Future<Release> promptForRelease(ReleaseType releaseType) async {
+    final platform = releaseType.releasePlatform;
     final releases = await codePushClientWrapper.getReleases(appId: appId);
 
     final releasesForPlatform = releases.where(
@@ -612,16 +610,26 @@ Building patch with Flutter $flutterVersionString
     );
 
     if (releasesForPlatform.isEmpty) {
-      logger.warn(
-        '''No ${platform.displayName} releases found for app $appId. You must first create a release before you can create a patch.''',
-      );
-      throw ProcessExit(ExitCode.usage.code);
+      throw _noReleasesToPatch(releaseType);
     }
 
     return chooseRelease(
       releases: releasesForPlatform,
       action: 'patch',
     );
+  }
+
+  /// Logs that there is nothing to patch for [releaseType] and returns the
+  /// [ProcessExit] to throw.
+  ProcessExit _noReleasesToPatch(ReleaseType releaseType) {
+    logger
+      ..err(
+        '''No ${releaseType.releasePlatform.displayName} releases found for app $appId.''',
+      )
+      ..info(
+        '''A patch needs a release to apply to. Create one with ${lightCyan.wrap('shorebird release ${releaseType.cliName}')}, or pass --app-id / --flavor if this is the wrong app.''',
+      );
+    return ProcessExit(ExitCode.usage.code);
   }
 
   /// Asserts that the release contains a platform for the given [patcher].
@@ -673,7 +681,9 @@ Please re-run the release command for this version or create a new release.''');
     } on UserCancelledException {
       throw ProcessExit(ExitCode.success.code);
     } on UnpatchableChangeException {
-      logger.info('Exiting.');
+      // The diff checker has already named the change and the flag that
+      // overrides it.
+      logger.info('Not publishing.');
       throw ProcessExit(ExitCode.software.code);
     }
   }
@@ -711,18 +721,21 @@ Please re-run the release command for this version or create a new release.''');
     if (minLinkPercentage == null ||
         minLinkPercentage < CommonArguments.minLinkPercentageMin ||
         minLinkPercentage > CommonArguments.minLinkPercentageMax) {
-      logger.err(
+      usageException(
         '--min-link-percentage must be an integer between '
         '${CommonArguments.minLinkPercentageMin} and '
         '${CommonArguments.minLinkPercentageMax} '
         '(got $minLinkPercentageRaw).',
       );
-      throw ProcessExit(ExitCode.usage.code);
     }
     if (linkPercentage != null && linkPercentage < minLinkPercentage) {
-      logger.err(
-        '''The link percentage of this patch ($linkPercentage%) is below the minimum threshold ($minLinkPercentage%). Exiting.''',
-      );
+      logger
+        ..err(
+          '''The link percentage of this patch ($linkPercentage%) is below the minimum threshold ($minLinkPercentage%).''',
+        )
+        ..info(
+          '''Not publishing. Lower --min-link-percentage to accept this patch, or see ${Patcher.debugInfoFile.path} for what could not be linked.''',
+        );
       throw ProcessExit(ExitCode.software.code);
     }
 

--- a/packages/shorebird_cli/lib/src/patch_diff_checker.dart
+++ b/packages/shorebird_cli/lib/src/patch_diff_checker.dart
@@ -124,6 +124,9 @@ If you don't know why you're seeing this error, visit our troubleshooting page a
 
       if (!allowNativeChanges) {
         if (!shorebirdEnv.canAcceptUserInput) {
+          // Non-interactive runs never see the confirm prompt's hint, so name
+          // the override here.
+          logger.err(allowNativeDiffsHint);
           throw UnpatchableChangeException();
         }
 
@@ -166,6 +169,7 @@ If you don't know why you're seeing this error, visit our troubleshooting page a
 
       if (!allowAssetChanges) {
         if (!shorebirdEnv.canAcceptUserInput) {
+          logger.err(allowAssetDiffsHint);
           throw UnpatchableChangeException();
         }
 

--- a/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/patch_command_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:mason_logger/mason_logger.dart';
@@ -354,7 +355,8 @@ void main() {
       ).thenAnswer((_) async => {});
 
       command = PatchCommand(resolvePatcher: (_) => patcher)
-        ..testArgResults = argResults;
+        ..testArgResults = argResults
+        ..testRunner = usageRunner();
     });
 
     test('has non-empty description', () {
@@ -668,18 +670,21 @@ void main() {
               when(() => argResults['obfuscate']).thenReturn(true);
             });
 
-            test('logs error and exits', () async {
+            test('throws a usage exception naming both ways out', () async {
               await expectLater(
                 () => runWithOverrides(() => command.createPatch(patcher)),
-                exitsWithCode(ExitCode.software),
-              );
-              verify(
-                () => logger.err(
-                  '--obfuscate was passed, but the release was not built with '
-                  'obfuscation. A patch cannot change the obfuscation mode of '
-                  'a release.',
+                throwsA(
+                  isA<UsageException>().having(
+                    (e) => e.message,
+                    'message',
+                    '--obfuscate was passed, but release $releaseVersion was '
+                        'not built with obfuscation. A patch cannot change the '
+                        'obfuscation mode of a release: re-run without '
+                        '--obfuscate to patch this release, or create a new '
+                        'release with --obfuscate.',
+                  ),
                 ),
-              ).called(1);
+              );
             });
           },
         );
@@ -920,7 +925,15 @@ void main() {
 
               verify(
                 () => logger.err(
-                  '''The link percentage of this patch ($linkPercentage%) is below the minimum threshold (50%). Exiting.''',
+                  '''The link percentage of this patch ($linkPercentage%) is below the minimum threshold (50%).''',
+                ),
+              ).called(1);
+              final debugInfoPath = runWithOverrides(
+                () => Patcher.debugInfoFile.path,
+              );
+              verify(
+                () => logger.info(
+                  '''Not publishing. Lower --min-link-percentage to accept this patch, or see $debugInfoPath for what could not be linked.''',
                 ),
               ).called(1);
             });
@@ -944,14 +957,15 @@ void main() {
                     patchArtifactBundles: patchArtifactBundles,
                   ),
                 ),
-                exitsWithCode(ExitCode.usage),
-              );
-              verify(
-                () => logger.err(
-                  '--min-link-percentage must be an integer between 0 and 100 '
-                  '(got $value).',
+                throwsA(
+                  isA<UsageException>().having(
+                    (e) => e.message,
+                    'message',
+                    '--min-link-percentage must be an integer between 0 and '
+                        '100 (got $value).',
+                  ),
                 ),
-              ).called(1);
+              );
             }
 
             test('above 100 prints error and exits', () async {
@@ -1254,7 +1268,7 @@ void main() {
           );
         });
 
-        test('warns and exits', () async {
+        test('names the release command and exits', () async {
           await expectLater(
             () => runWithOverrides(command.run),
             exitsWithCode(ExitCode.usage),
@@ -1264,8 +1278,13 @@ void main() {
             () => codePushClientWrapper.getReleases(appId: appId),
           ).called(1);
           verify(
-            () => logger.warn(
-              '''No ${releasePlatform.displayName} releases found for app $appId. You must first create a release before you can create a patch.''',
+            () => logger.err(
+              '''No ${releasePlatform.displayName} releases found for app $appId.''',
+            ),
+          ).called(1);
+          verify(
+            () => logger.info(
+              '''A patch needs a release to apply to. Create one with ${lightCyan.wrap('shorebird release android')}, or pass --app-id / --flavor if this is the wrong app.''',
             ),
           ).called(1);
         });
@@ -1403,15 +1422,20 @@ void main() {
           ).thenAnswer((_) async => []);
         });
 
-        test('warns and exits', () async {
+        test('names the release command and exits', () async {
           await expectLater(
             () => runWithOverrides(command.run),
             exitsWithCode(ExitCode.usage),
           );
 
           verify(
-            () => logger.warn(
-              '''No ${releasePlatform.displayName} releases found for app $appId. You must first create a release before you can create a patch.''',
+            () => logger.err(
+              '''No ${releasePlatform.displayName} releases found for app $appId.''',
+            ),
+          ).called(1);
+          verify(
+            () => logger.info(
+              '''A patch needs a release to apply to. Create one with ${lightCyan.wrap('shorebird release android')}, or pass --app-id / --flavor if this is the wrong app.''',
             ),
           ).called(1);
         });
@@ -1750,7 +1774,7 @@ Please re-run the release command for this version or create a new release.'''),
             exitsWithCode(ExitCode.software),
           );
 
-          verify(() => logger.info('Exiting.')).called(1);
+          verify(() => logger.info('Not publishing.')).called(1);
         });
       });
     });

--- a/packages/shorebird_cli/test/src/mocks.dart
+++ b/packages/shorebird_cli/test/src/mocks.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
 import 'package:googleapis_auth/auth_io.dart';
 import 'package:http/http.dart' as http;
 import 'package:jwt/jwt.dart';
@@ -67,6 +68,19 @@ class MockArchiveDiffer extends Mock implements ArchiveDiffer {}
 class MockArgParser extends Mock implements ArgParser {}
 
 class MockArgResults extends Mock implements ArgResults {}
+
+class MockCommand extends Mock implements Command<int> {}
+
+/// A runner mock stubbed just enough for [Command.usageException] to build
+/// its usage text.
+MockShorebirdCliCommandRunner usageRunner({
+  Map<String, Command<int>> commands = const {},
+}) {
+  final runner = MockShorebirdCliCommandRunner();
+  when(() => runner.executableName).thenReturn('shorebird');
+  when(() => runner.commands).thenReturn(commands);
+  return runner;
+}
 
 class MockArtifactBuildException extends Mock
     implements ArtifactBuildException {}

--- a/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
+++ b/packages/shorebird_cli/test/src/patch_diff_checker_test.dart
@@ -212,6 +212,7 @@ void main() {
             throwsA(isA<UnpatchableChangeException>()),
           );
 
+          verify(() => logger.err(allowNativeDiffsHint)).called(1);
           verifyNever(
             () => logger.confirm(any(), hint: any(named: 'hint')),
           );
@@ -328,6 +329,7 @@ void main() {
             throwsA(isA<UnpatchableChangeException>()),
           );
 
+          verify(() => logger.err(allowAssetDiffsHint)).called(1);
           verifyNever(
             () => logger.confirm(any(), hint: any(named: 'hint')),
           );


### PR DESCRIPTION
Part of #3919. Covers `patch_command.dart` plus one change in `patch_diff_checker.dart` that the patch messages depend on.

## Before / after

| Situation | Before | After |
|---|---|---|
| No releases for the platform | warn: `No Android releases found for app X. You must first create a release before you can create a patch.` | err: `No Android releases found for app X.` + `A patch needs a release to apply to. Create one with shorebird release android, or pass --app-id / --flavor if this is the wrong app.` (uses the release type's CLI name: `aar`, `ios-framework`, ...) |
| `--obfuscate` but release not obfuscated | err (exit 70): `--obfuscate was passed, but the release was not built with obfuscation. A patch cannot change the obfuscation mode of a release.` | UsageException: `... of a release: re-run without --obfuscate to patch this release, or create a new release with --obfuscate.` |
| Bad `--min-link-percentage` | err + exit 64 | UsageException (same text) |
| Link % below `--min-link-percentage` | `...is below the minimum threshold (50%). Exiting.` | `...is below the minimum threshold (50%).` + `Not publishing. Lower --min-link-percentage to accept this patch, or see <debug info path> for what could not be linked.` |
| Native/asset diff rejected, **non-interactive** | diff details, troubleshooting link, `Exiting.` (no mention of the override flag) | diff details, troubleshooting link, `Warning: Native changes in a patch are likely to crash your app. Pass --allow-native-diffs to force this patch.`, `Not publishing.` |

## The non-interactive gap

`allowNativeDiffsHint` / `allowAssetDiffsHint` were only passed as the `hint:` of `logger.confirm(...)`. When stdin is not a TTY (CI, agents, `--json`) the checker throws `UnpatchableChangeException` before any prompt, so the one audience that cannot answer the prompt was the one audience that never saw which flag overrides it. The checker now logs the hint before throwing in that branch. This is also the case the third-party skill files in #3917 were written to work around.

## Not in this PR

The `--staging` deprecation site in `patch_command.run` sits next to the `releaseTypes` lines #3918 rewrites; it gets the `UsageException` treatment after that lands (same as `preview` got in #3920).

## Tests

`dart test` in `packages/shorebird_cli`: 2244 pass. Coverage on both files unchanged from main. `mocks.dart` gains the same `usageRunner()` helper as the sibling PRs.

https://claude.ai/code/session_01LG6NjeENXsouDyHrt1YPB7