### PR TITLE
fix(shorebird_cli): point `patch --force` at --allow-native-diffs / --allow-asset-diffs

### DIFF
--- a/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_cli_command_runner.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:cli_completion/cli_completion.dart';
+import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:shorebird_cli/src/commands/commands.dart';
@@ -189,37 +190,23 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
     } on UsageException catch (e) {
       // On usage errors, show the commands usage message and
       // exit with an error code
+      final unknownOption = _unknownOptionName(e.message);
+      final hint = unknownOption == null
+          ? null
+          : _unknownOptionHint(unknownOption, argsList);
+
       if (jsonModeFromArgs) {
         JsonResult.error(
           code: JsonErrorCode.usageError,
           message: e.message,
-          hint: 'Run: shorebird --help',
+          hint: hint ?? 'Run: shorebird --help',
           command: executableName,
         ).write();
         return ExitCode.usage.code;
       }
 
       logger.err(e.message);
-      if (e.message.contains('Could not find an option named')) {
-        final String errorMessage;
-        if (platform.isWindows) {
-          errorMessage = '''
-To proxy an option to the flutter command, use the '--' --<option> syntax.
-
-Example:
-
-${lightCyan.wrap("shorebird release android '--' --no-pub lib/main.dart")}''';
-        } else {
-          errorMessage = '''
-To proxy an option to the flutter command, use the -- --<option> syntax.
-
-Example:
-
-${lightCyan.wrap('shorebird release android -- --no-pub lib/main.dart')}''';
-        }
-
-        logger.err(errorMessage);
-      }
+      if (hint != null) logger.err(hint);
 
       logger
         ..info('')
@@ -360,6 +347,44 @@ ${currentRunLogFile.absolute.path}
     }
 
     return exitCode;
+  }
+
+  /// The option name (without leading dashes) from an args-package
+  /// "Could not find an option named" message, or null for other messages.
+  static String? _unknownOptionName(String message) {
+    final match = RegExp(
+      'Could not find an option named "(?:--)?([^"]+)"',
+    ).firstMatch(message);
+    return match?.group(1);
+  }
+
+  /// Option names people reach for to bypass a safety check.
+  static final _safetyOverridePattern = RegExp(
+    r'^(?:f|y|force|yes|no-confirm)$|allow|skip|ignore',
+  );
+
+  /// The hint to print under an unknown-option error.
+  ///
+  /// `shorebird patch --force` (or any override-shaped option) gets the
+  /// flags that actually bypass the patch safety checks; everything else
+  /// gets the `--` pass-through explanation.
+  String _unknownOptionHint(String option, List<String> args) {
+    final commandName = args.firstWhereOrNull((a) => !a.startsWith('-'));
+    if (commandName == 'patch' && _safetyOverridePattern.hasMatch(option)) {
+      return '''
+shorebird patch has no --$option flag. The patch safety checks are bypassed per check:
+  ${lightCyan.wrap('--allow-native-diffs')}  publish even though native code changed
+  ${lightCyan.wrap('--allow-asset-diffs')}   publish even though assets changed
+The warning that fails the patch names the one that applies.''';
+    }
+
+    final separator = platform.isWindows ? "'--'" : '--';
+    return '''
+To proxy an option to the flutter command, use the $separator --<option> syntax.
+
+Example:
+
+${lightCyan.wrap("shorebird release android $separator --no-pub lib/main.dart")}''';
   }
 
   Future<String?> _tryGetFlutterVersion() async {

--- a/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_cli_command_runner_test.dart
@@ -203,6 +203,71 @@ ${lightCyan.wrap("shorebird release android '--' --no-pub lib/main.dart")}'''),
       verify(() => logger.info('exception usage')).called(1);
     });
 
+    group('unknown option on patch', () {
+      const overrideHint = '''
+shorebird patch has no --force flag. The patch safety checks are bypassed per check:
+  --allow-native-diffs  publish even though native code changed
+  --allow-asset-diffs   publish even though assets changed
+The warning that fails the patch names the one that applies.''';
+
+      test('names --allow-native-diffs / --allow-asset-diffs', () async {
+        final result = await runWithOverrides(
+          () => commandRunner.run(['patch', 'android', '--force']),
+        );
+        expect(result, equals(ExitCode.usage.code));
+        verify(
+          () => logger.err('Could not find an option named "--force".'),
+        ).called(1);
+        verify(() => logger.err(overrideHint)).called(1);
+        verifyNever(
+          () => logger.err(any(that: contains('To proxy an option'))),
+        );
+      });
+
+      test('matches other override-shaped options', () async {
+        await runWithOverrides(
+          () => commandRunner.run(['patch', '--skip-checks']),
+        );
+        verify(
+          () => logger.err(
+            any(that: startsWith('shorebird patch has no --skip-checks flag')),
+          ),
+        ).called(1);
+      });
+
+      test('falls back to the proxy hint for other options', () async {
+        await runWithOverrides(
+          () => commandRunner.run(['patch', 'android', '--no-pub']),
+        );
+        verify(
+          () => logger.err(any(that: contains('To proxy an option'))),
+        ).called(1);
+      });
+
+      test('does not apply to other commands', () async {
+        await runWithOverrides(
+          () => commandRunner.run(['release', 'android', '--force']),
+        );
+        verify(
+          () => logger.err(any(that: contains('To proxy an option'))),
+        ).called(1);
+      });
+
+      test('carries the hint in the --json envelope', () async {
+        final stdoutOutput = <String>[];
+        await helpers.captureStdout<int>(
+          () => runWithOverrides(
+            () => commandRunner.run(['--json', 'patch', 'android', '--force']),
+          ),
+          captured: stdoutOutput,
+        );
+        final json = jsonDecode(stdoutOutput.first) as Map<String, dynamic>;
+        final error = json['error'] as Map<String, dynamic>;
+        expect(error['code'], equals('usage_error'));
+        expect(error['hint'], equals(overrideHint));
+      });
+    });
+
     group('--version', () {
       test('outputs current version info', () async {
         final result = await runWithOverrides(


### PR DESCRIPTION
Part of #3919 (the "also in scope" item).

## Before

```
$ shorebird patch android --force
Could not find an option named "--force".
To proxy an option to the flutter command, use the -- --<option> syntax.

Example:

shorebird release android -- --no-pub lib/main.dart
```

## After

```
$ shorebird patch android --force
Could not find an option named "--force".
shorebird patch has no --force flag. The patch safety checks are bypassed per check:
  --allow-native-diffs  publish even though native code changed
  --allow-asset-diffs   publish even though assets changed
The warning that fails the patch names the one that applies.
```

Applies when the command is `patch` and the option name is `f`, `y`, `force`, `yes`, `no-confirm`, or contains `allow`, `skip`, or `ignore`. Every other unknown option, on any command, still gets the `--` proxy hint. Under `--json` the same text is the envelope's `hint` (previously always `Run: shorebird --help`).

Per the handoff decision, no `--force` flag is added: on `release` it would replace a live release, and on `patch` it would silently suppress both safety prompts.

## Tests

5 new runner tests (parse the real argv, no injected exceptions). `dart test` in `packages/shorebird_cli`: 2249 pass; runner coverage 100%.

https://claude.ai/code/session_01LG6NjeENXsouDyHrt1YPB7