### PR TITLE
fix(shorebird_cli): name the next step in iOS patcher errors

### DIFF
--- a/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
+++ b/packages/shorebird_cli/lib/src/commands/patch/ios_patcher.dart
@@ -108,7 +108,8 @@ class IosPatcher extends Patcher
     if ((flutterVersion ?? minimumSupportedIosFlutterVersion) <
         minimumSupportedIosFlutterVersion) {
       logger.err('''
-iOS patches are not supported with Flutter versions older than $minimumSupportedIosFlutterVersion.
+This release was built with Flutter $flutterVersionAndRevision, but iOS patches need Flutter $minimumSupportedIosFlutterVersion or newer.
+A release cannot change Flutter versions, so create a new release with ${lightCyan.wrap('shorebird release ios --flutter-version=<version>')} and patch that one.
 For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
       throw ProcessExit(ExitCode.software.code);
     }
@@ -158,8 +159,7 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
   }) async {
     // Verify that we have built a patch .xcarchive
     if (artifactManager.getXcarchiveDirectory()?.path == null) {
-      logger.err('Unable to find .xcarchive directory');
-      throw ProcessExit(ExitCode.software.code);
+      _noXcarchiveFound();
     }
 
     final unzipProgress = logger.progress('Extracting release artifact');
@@ -182,7 +182,16 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
       xcarchiveDirectory: Directory(releaseXcarchivePath),
     );
     if (appDirectory == null) {
-      logger.err('Unable to find release artifact .app directory');
+      logger
+        ..err(
+          'The release .xcarchive downloaded from Shorebird has no '
+          'Products/Applications/*.app directory.',
+        )
+        ..info(
+          'Re-run to download it again. If this persists, the release '
+          'artifact is damaged; create a new release with '
+          '${lightCyan.wrap('shorebird release ios')} and patch that one.',
+        );
       throw ProcessExit(ExitCode.software.code);
     }
     final releaseArtifactFile = File(
@@ -274,14 +283,13 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
   @override
   Future<String> extractReleaseVersionFromArtifact(File artifact) async {
     final archivePath = artifactManager.getXcarchiveDirectory()?.path;
-    if (archivePath == null) {
-      logger.err('Unable to find .xcarchive directory');
-      throw ProcessExit(ExitCode.software.code);
-    }
+    if (archivePath == null) _noXcarchiveFound();
 
     final plistFile = File(p.join(archivePath, 'Info.plist'));
     if (!plistFile.existsSync()) {
-      logger.err('No Info.plist file found at ${plistFile.path}.');
+      logger
+        ..err('No Info.plist file found at ${plistFile.path}.')
+        ..info(_passReleaseVersionHint);
       throw ProcessExit(ExitCode.software.code);
     }
 
@@ -289,10 +297,37 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}''');
     try {
       return plist.versionNumber;
     } on Exception catch (error) {
-      logger.err(
-        'Failed to determine release version from ${plistFile.path}: $error',
-      );
+      logger
+        ..err(
+          'Failed to determine release version from ${plistFile.path}: $error',
+        )
+        ..info(_passReleaseVersionHint);
       throw ProcessExit(ExitCode.software.code);
     }
+  }
+
+  /// The release version is only read from the archive when the user did not
+  /// pass one, so passing one is always a way around a broken read.
+  static const _passReleaseVersionHint =
+      'Pass --release-version=<version> (or --release-version=latest) to '
+      'skip reading the version from the archive.';
+
+  /// Logs that `flutter build ipa` left no .xcarchive where Shorebird looks
+  /// for it and throws [ProcessExit].
+  Never _noXcarchiveFound() {
+    final archiveDirectory = p.join(
+      shorebirdEnv.getShorebirdProjectRoot()!.path,
+      'build',
+      'ios',
+      'archive',
+    );
+    logger
+      ..err('No .xcarchive found in $archiveDirectory after the build.')
+      ..info(
+        'Shorebird looks for the archive that '
+        '${lightCyan.wrap('flutter build ipa')} writes there. '
+        'Re-run with --verbose to see the build output.',
+      );
+    throw ProcessExit(ExitCode.software.code);
   }
 }

--- a/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
+++ b/packages/shorebird_cli/test/src/commands/patch/ios_patcher_test.dart
@@ -594,7 +594,8 @@ This may indicate that the patch contains native changes, which cannot be applie
 
           verify(
             () => logger.err('''
-iOS patches are not supported with Flutter versions older than $minimumSupportedIosFlutterVersion.
+This release was built with Flutter $flutterVersionAndRevision, but iOS patches need Flutter $minimumSupportedIosFlutterVersion or newer.
+A release cannot change Flutter versions, so create a new release with ${lightCyan.wrap('shorebird release ios --flutter-version=<version>')} and patch that one.
 For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
           ).called(1);
         });
@@ -1185,11 +1186,13 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
 
               verify(
                 () => logger.err(
-                  any(
-                    that: startsWith(
-                      'Unable to find release artifact .app directory',
-                    ),
-                  ),
+                  'The release .xcarchive downloaded from Shorebird has no '
+                  'Products/Applications/*.app directory.',
+                ),
+              ).called(1);
+              verify(
+                () => logger.info(
+                  any(that: startsWith('Re-run to download it again.')),
                 ),
               ).called(1);
             });
@@ -1538,13 +1541,18 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
           when(() => artifactManager.getXcarchiveDirectory()).thenReturn(null);
         });
 
-        test('exit with code 70', () async {
+        test('names the expected archive path and exits 70', () async {
           await expectLater(
             () => runWithOverrides(
               () => patcher.extractReleaseVersionFromArtifact(File('')),
             ),
             exitsWithCode(ExitCode.software),
           );
+          verify(
+            () => logger.err(
+              '''No .xcarchive found in ${p.join(projectRoot.path, 'build', 'ios', 'archive')} after the build.''',
+            ),
+          ).called(1);
         });
       });
 
@@ -1610,6 +1618,11 @@ For more information see: ${supportedFlutterVersionsUrl.toLink()}'''),
           verify(
             () => logger.err(
               any(that: startsWith('Failed to determine release version')),
+            ),
+          ).called(1);
+          verify(
+            () => logger.info(
+              any(that: startsWith('Pass --release-version=<version>')),
             ),
           ).called(1);
         });


### PR DESCRIPTION
Part of #3919. Text-only; exit codes unchanged. `ios_patcher.dart` (7 sites).

| Situation | Before | After |
|---|---|---|
| Release built with Flutter < 3.22.2 | `iOS patches are not supported with Flutter versions older than 3.22.2.` + docs link | `This release was built with Flutter 3.0.0 (abc123), but iOS patches need Flutter 3.22.2 or newer.` + `A release cannot change Flutter versions, so create a new release with shorebird release ios --flutter-version=<version> and patch that one.` + docs link |
| No `.xcarchive` after `flutter build ipa` (2 sites) | `Unable to find .xcarchive directory` | `No .xcarchive found in <project>/build/ios/archive after the build.` + `Shorebird looks for the archive that flutter build ipa writes there. Re-run with --verbose to see the build output.` |
| Downloaded release archive has no `.app` | `Unable to find release artifact .app directory` | `The release .xcarchive downloaded from Shorebird has no Products/Applications/*.app directory.` + `Re-run to download it again. If this persists, the release artifact is damaged; create a new release with shorebird release ios and patch that one.` |
| `Info.plist` missing / version unreadable | `No Info.plist file found at ...` / `Failed to determine release version from ...: <error>` | same + `Pass --release-version=<version> (or --release-version=latest) to skip reading the version from the archive.` |

The last row holds because `extractReleaseVersionFromArtifact` is only called on the speculative-build path, i.e. when `--release-version` was omitted.

`dart test` in `packages/shorebird_cli`: 2244 pass; `ios_patcher.dart` at 100% coverage.

https://claude.ai/code/session_01LG6NjeENXsouDyHrt1YPB7