### PR TITLE
chore: move unparseable into the global cspell word list

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -151,6 +151,7 @@ words:
   - unmockable
   - unobfuscated
   - unpadded
+  - unparseable
   - Unpatchable
   - unsets
   - unskipped

--- a/packages/shorebird_cli/lib/src/archive_analysis/android_archive_differ.dart
+++ b/packages/shorebird_cli/lib/src/archive_analysis/android_archive_differ.dart
@@ -1,4 +1,3 @@
-// cspell:words unparseable
 import 'dart:typed_data';
 
 import 'package:archive/archive.dart';

--- a/packages/shorebird_cli/lib/src/shorebird_flutter.dart
+++ b/packages/shorebird_cli/lib/src/shorebird_flutter.dart
@@ -1,4 +1,4 @@
-// cspell:words precaching unparseable
+// cspell:words precaching
 import 'dart:convert';
 import 'dart:io';
 


### PR DESCRIPTION
## Description

`unparseable` is currently allowed by two inline `// cspell:words` directives. A third file wants it (`shorebird_code_push_client/lib/src/code_push_client.dart`, in #3907), and CLAUDE.md puts the cutover at two:

> CSpell: use inline `// cspell:words` for 1-2 files; add to global config for more

So this moves it to `cspell.config.yaml`, right next to the `parseable` already in that list, and drops the two directives it makes redundant:

- `packages/shorebird_cli/lib/src/archive_analysis/android_archive_differ.dart` — the directive carried only `unparseable`, so the line goes.
- `packages/shorebird_cli/lib/src/shorebird_flutter.dart` — keeps its directive for `precaching`, which is still single-use.

Splitting this out so #3907 does not have to carry a spell-check change to go green. That PR needs nothing once this lands.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3WoxwqMo1tujgC52zDr4W

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3WoxwqMo1tujgC52zDr4W)_