### PR TITLE
test(shorebird_cli): stop blocking a rename with mode bits

### DIFF
--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -1072,15 +1072,30 @@ origin/flutter_release/3.10.6''';
         test(
           'reports when the incomplete install cannot be moved aside',
           () async {
-            // Making the parent read-only is the portable way to block a
-            // rename of a child that is otherwise perfectly movable.
-            final parent = targetDirectory.parent;
-            Process.runSync('chmod', ['a-w', parent.path]);
-            addTearDown(() => Process.runSync('chmod', ['u+w', parent.path]));
+            // The rename is blocked by occupying the name it moves to, not by
+            // locking the parent's mode bits. `chmod a-w` only stops a process
+            // without CAP_DAC_OVERRIDE, so a mode-based version of this test
+            // passes as an unprivileged CI user and fails as root -- in a
+            // container, a devcontainer, or a root self-hosted runner.
+            // Renaming onto a non-empty directory is ENOTEMPTY for every uid,
+            // and reaches the same FileSystemException on the same line.
+            //
+            // The destination is _reclaimablePath(dir, tag: 'old'), which is
+            // this pid and this instant, so a fixed clock is what makes it
+            // nameable from out here.
+            final now = DateTime.now();
+            final asideDirectory = Directory(
+              '${targetDirectory.path}.$pid.old'
+              '.${now.millisecondsSinceEpoch}.tmp',
+            )..createSync(recursive: true);
+            File(p.join(asideDirectory.path, 'occupied')).createSync();
 
             await expectLater(
-              runWithOverrides(
-                () => shorebirdFlutter.installRevision(revision: revision),
+              withClock(
+                Clock.fixed(now),
+                () => runWithOverrides(
+                  () => shorebirdFlutter.installRevision(revision: revision),
+                ),
               ),
               throwsA(isA<CacheCorruptedException>()),
             );

--- a/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
+++ b/packages/shorebird_cli/test/src/shorebird_flutter_test.dart
@@ -1,4 +1,4 @@
-// cspell:words revis precaches
+// cspell:words revis precaches ENOTEMPTY
 import 'dart:io';
 
 import 'package:clock/clock.dart';


### PR DESCRIPTION
## Description

`ShorebirdFlutter installRevision › reports when the incomplete install cannot be moved aside` fails when the suite runs as root.

It blocked the rename with `chmod a-w` on the parent directory. That only stops a process without `CAP_DAC_OVERRIDE`, so as root the rename simply succeeds, `_discardUnusableInstall` never throws, and the test reports:

```
Expected: throws <Instance of 'CacheCorruptedException'>
  Actual: <Instance of 'Future<void>'>
```

It passes on CI because CI runs unprivileged, and fails in a container, a devcontainer, or a root self-hosted runner. This is the only test in the repo that depended on a permission denial — the other `chmod` references are `verify` calls on a mocked `ShorebirdProcess`.

## Fix

Block the rename by **occupying the name it moves to** rather than by locking mode bits.

`_discardUnusableInstall` renames onto `_reclaimablePath(dir, tag: 'old')`, so the test pre-creates that path as a non-empty directory. Renaming onto a non-empty directory is `ENOTEMPTY` for every uid, and reaches the same `FileSystemException` on the same line — the test keeps its teeth instead of being skipped.

The destination embeds the pid and the current instant, so a fixed clock is what makes it nameable from the test. `withClock(Clock.fixed(...))` is the pattern this file already uses a few tests further down.

This mirrors the reasoning already recorded on `analyze_snapshot_stager_test.dart` in `_shorebird`, which made the same move for the same reason.

## Testing

Run as root (uid 0):

| | before | after |
|---|---|---|
| `shorebird_flutter_test.dart` | 63 passed, **1 failed** | **64 passed** |
| full `shorebird_cli` suite | 1 failed | **2017 passed, 0 failed** |

Mutation-checked rather than assumed: making `_discardUnusableInstall` `return` instead of `throw` turns this test red again, so it still detects the bug it was written for.

`dart analyze --fatal-warnings` and `dart format` clean.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [x] 🧪 Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3WoxwqMo1tujgC52zDr4W

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3WoxwqMo1tujgC52zDr4W)_