### PR TITLE
ci: run required checks on the merge queue

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -254,7 +254,11 @@ jobs:
         build_redis,
         verify_packages,
       ]
-    if: ${{ always() }}
+    # Not always(): that keeps this job alive through a run cancellation,
+    # so a superseded push would report ci red on the stale commit. A
+    # skipped required check reports success, which is the right answer
+    # for a run nothing is waiting on.
+    if: ${{ !cancelled() }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -246,6 +246,7 @@ jobs:
   ci:
     needs:
       [
+        changes,
         license_check,
         semantic_pull_request,
         build_cross_platform_dart_packages,
@@ -258,6 +259,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: ⛔️ exit(1) on failure
-        if: ${{ contains(join(needs.*.result, ','), 'failure') }}
+      - name: ⛔️ exit(1) on failure or cancellation
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,11 @@ concurrency:
 
 on:
   pull_request:
+  # Checks run on the queue's own temp branch, not the PR. Without this
+  # trigger the required contexts never report there and the queue
+  # ejects every PR at the timeout.
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - main

--- a/.github/workflows/shorebird_ci.yaml
+++ b/.github/workflows/shorebird_ci.yaml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches:
       - main
+  # Checks run on the queue's own temp branch, not the PR. Without this
+  # trigger the required contexts never report there and the queue
+  # ejects every PR at the timeout.
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - main

--- a/packages/shorebird_ci/CHANGELOG.md
+++ b/packages/shorebird_ci/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- cspell:words toplevel -->
 
+# 0.2.5
+
+- Generated workflows now trigger on `merge_group`, in both `--style static` and `--style dynamic`. Without it, a repo that turns on GitHub's merge queue produces no check runs on the queue's temp branch, the `required` context never reports, and the queue ejects every PR at the timeout.
+- Static action pin bumped to `dorny/paths-filter@v4`. v3 has no `merge_group` case and falls back to diffing the default branch by merge-base rather than the queue's base commit; merge-queue support landed in v4.0.1. Only reachable via `--no-update-actions`, since `generate` resolves pins at write time by default.
+
 # 0.2.4
 
 - `verify` now enforces the `--required` aggregator's `needs:` list. Name-based detection: if a workflow has a top-level job named `required`, every other top-level job must appear in its `needs:`, and every entry in `needs:` must match a real top-level job in the same file. A `required:` key w/ no map body is also reported as malformed. Closes three silent-failure modes: a hand-edited workflow could leave a job out of `required.needs` and have its status silently ignored by the merge gate, a typo'd `needs:` entry could go unnoticed until GHA rejected it at runtime, or a bodiless `required:` could pass verify while doing nothing at runtime.

--- a/packages/shorebird_ci/CHANGELOG.md
+++ b/packages/shorebird_ci/CHANGELOG.md
@@ -3,7 +3,7 @@
 # 0.2.5
 
 - Generated workflows now trigger on `merge_group`, in both `--style static` and `--style dynamic`. Without it, a repo that turns on GitHub's merge queue produces no check runs on the queue's temp branch, the `required` context never reports, and the queue ejects every PR at the timeout.
-- Static action pin bumped to `dorny/paths-filter@v4`. v3 has no `merge_group` case and falls back to diffing the default branch by merge-base rather than the queue's base commit; merge-queue support landed in v4.0.1. Only reachable via `--no-update-actions`, since `generate` resolves pins at write time by default.
+- Static action pin bumped to `dorny/paths-filter@v4`. v3 has no `merge_group` case and falls back to diffing the default branch by merge-base rather than the queue's base commit. Merge-queue support landed in v4.0.1. Only reachable via `--no-update-actions`, since `generate` resolves pins at write time by default.
 
 # 0.2.4
 

--- a/packages/shorebird_ci/lib/src/commands/generate_command.dart
+++ b/packages/shorebird_ci/lib/src/commands/generate_command.dart
@@ -346,7 +346,7 @@ jobs:
       - run: dart pub global activate shorebird_ci
       - name: Verify CI coverage
         run: shorebird_ci verify
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/packages/shorebird_ci/lib/src/commands/generate_command.dart
+++ b/packages/shorebird_ci/lib/src/commands/generate_command.dart
@@ -313,6 +313,11 @@ on:
   pull_request:
     branches:
       - main
+  # Checks run on the queue's own temp branch, not the PR. Without this
+  # trigger the required contexts never report there and the queue
+  # ejects every PR at the timeout.
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - main
@@ -623,6 +628,11 @@ on:
   pull_request:
     branches:
       - main
+  # Checks run on the queue's own temp branch, not the PR. Without this
+  # trigger the required contexts never report there and the queue
+  # ejects every PR at the timeout.
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - main

--- a/packages/shorebird_ci/pubspec.yaml
+++ b/packages/shorebird_ci/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   CI tooling for Dart and Flutter monorepos. Generates GitHub Actions
   workflows, resolves affected packages via dependency graphs, and
   verifies path filters stay in sync.
-version: 0.2.4
+version: 0.2.5
 homepage: https://shorebird.dev
 repository: https://github.com/shorebirdtech/shorebird/tree/main/packages/shorebird_ci
 topics: [ci, github-actions, monorepo, shorebird]

--- a/packages/shorebird_ci/test/generate_command_test.dart
+++ b/packages/shorebird_ci/test/generate_command_test.dart
@@ -279,6 +279,18 @@ void main() {
       );
     });
 
+    test('static workflow triggers on merge_group', () async {
+      // Branch protection's required contexts only gate a merge if they
+      // report on the queue's temp branch too.
+      createPackage(tempDir, 'packages/foo', 'foo');
+      initGitRepo(tempDir);
+
+      await runGenerate(tempDir, extra: ['--style', 'static']);
+
+      final yaml = _readMain(tempDir);
+      expect(yaml, contains('  merge_group:\n    types: [checks_requested]'));
+    });
+
     test('emits main + both reusables for mixed repo', () async {
       createPackage(tempDir, 'packages/dart_pkg', 'dart_pkg');
       createPackage(
@@ -731,6 +743,16 @@ void main() {
   });
 
   group('setup-job runner ergonomics', () {
+    test('dynamic workflow triggers on merge_group', () async {
+      // Branch protection's required contexts only gate a merge if they
+      // report on the queue's temp branch too.
+      createPackage(tempDir, 'packages/foo', 'foo');
+      initGitRepo(tempDir);
+      await runGenerate(tempDir);
+      final yaml = _readMain(tempDir);
+      expect(yaml, contains('  merge_group:\n    types: [checks_requested]'));
+    });
+
     test('dynamic workflow has workflow_dispatch trigger', () async {
       createPackage(tempDir, 'packages/foo', 'foo');
       initGitRepo(tempDir);


### PR DESCRIPTION
## Summary

Merge queue cannot be turned on today. Branch protection requires the `ci` and `required` contexts, neither workflow triggers on `merge_group`, so a queued PR produces no check runs and gets ejected at the queue timeout. Turning the queue on also changes what a green `ci` means, from something a human reads before clicking merge into the thing that authorizes an automated one, and `ci` had two ways to report success over work that never ran. I passed on scoping the cancellation check to queue runs only, since `!cancelled()` is GitHub's documented alternative to `always()` and closes it on every event instead.

- `merge_group` trigger on both workflows and on both templates `shorebird_ci generate` emits, so a regenerate does not silently drop it
- `ci` fails when a job ends `cancelled`, matching the `required` job it sits beside
- `ci` depends on `changes`, so a detection failure fails the gate instead of skipping every build into a green result
- `ci` guards on `!cancelled()` rather than `always()`, so a push that supersedes a run does not report red on the stale commit
- `dorny/paths-filter` pinned to v4 in the static template, released as `shorebird_ci` 0.2.5 so other repos actually receive it

## Testing

- The `merge_group` path cannot be exercised before the queue is enabled, so the event-specific behavior was verified against upstream sources rather than a run
- `dorny/paths-filter` v4 takes its base from `merge_group.base_sha` and fetches that SHA itself, so the shallow checkout in `main.yaml`'s `changes` job still diffs correctly. v3 has no `merge_group` case, which is why the template pin moved
- `cspell-action` falls back to a full scan on an unsupported event and the VGV semantic-pull-request workflow already guards its step on `github.event_name`, so neither turns red in the queue
- `shorebird_ci verify` passes, 184 package tests pass

## Risk

`ci` can now fail where it previously passed, on a cancelled job or a failed `changes` step. That is the intent, and it means a cancellation that used to slide through now blocks a merge. Rollback is the two workflow files.
