### PR TITLE
fix(shorebird_cli): summarize macOS xcode stats and side-by-side assemble correctly

### DIFF
--- a/packages/shorebird_cli/lib/src/artifact_builder/build_trace_summary.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/build_trace_summary.dart
@@ -38,8 +38,10 @@ class BuildTraceSummary {
   /// Build a summary from the raw list of trace events written by Flutter
   /// (and merged with Shorebird-side events).
   ///
-  /// [platform] is `android` or `ios`. Platform-specific stats ([android] /
-  /// [ios]) are only populated for the matching platform.
+  /// [platform] is the release platform name (`android`, `ios`, `macos`,
+  /// `linux`, `windows`). Platform-specific stats are only populated
+  /// where the build system produces them: [android] for `android`,
+  /// [ios] for every xcodebuild-driven platform (`ios`, `macos`).
   /// [shorebirdOverhead] captures Shorebird's own wall-clock time around
   /// `flutter build` — null when the caller can't compute it.
   factory BuildTraceSummary.fromEvents(
@@ -73,6 +75,7 @@ class BuildTraceSummary {
     final name = (e['name'] as String?) ?? '';
     final args =
         (e['args'] as Map<Object?, Object?>?) ?? const <Object?, Object?>{};
+    final ts = (e['ts'] as num?)?.toInt();
     switch (TraceCategory.parse(e['cat'] as String?)) {
       case TraceCategory.flutter:
         _processFlutterEvent(acc, name: name, dur: dur);
@@ -81,10 +84,12 @@ class BuildTraceSummary {
       case TraceCategory.gradle:
       case TraceCategory.xcode:
         acc.nativeBuild += dur;
+        if (ts != null) acc.nativeSpans.add(_Interval(ts, dur));
       case TraceCategory.assemble:
         acc.assembleCount++;
         if (args['skipped'] == true) acc.skippedAssembleCount++;
         acc.assembleCategory.add(_categorize(name), dur);
+        acc.assembleSpans.add(_Interval(ts, dur));
       case TraceCategory.gradleTask:
         _processGradleTaskEvent(acc, dur: dur, args: args);
       case TraceCategory.xcodeSubsection:
@@ -174,7 +179,7 @@ class BuildTraceSummary {
       native: _nativeStats(acc),
       flutterTool: acc.flutterTool,
       android: platform == 'android' ? _androidStats(acc) : null,
-      ios: platform == 'ios' ? _iosStats(acc) : null,
+      ios: xcodePlatforms.contains(platform) ? _iosStats(acc) : null,
       environment: environment,
     );
   }
@@ -201,14 +206,19 @@ class BuildTraceSummary {
   }
 
   static NativeBuildStats _nativeStats(_Accumulator acc) {
-    // "Native compile only" = native outer minus everything flutter
-    // assemble reported running inside it. Clamped at 0 because the
-    // sum can exceed nativeBuild in edge cases.
-    final assembleTotal = acc.assembleCategory.values.fold(
+    // "Native compile only" = native outer minus the flutter assemble
+    // time that actually ran inside it. On apk/appbundle/ios/macos,
+    // assemble is a child of gradle/xcodebuild so that's all of it; on
+    // ios-framework the App.framework targets are built in-process
+    // beside the plugin xcodebuilds, so only their overlap (typically
+    // none) is subtracted. Overlap is measured from timestamps; an
+    // assemble event with no `ts` is assumed nested, matching the
+    // pre-timestamp behavior. Clamped at 0 for edge cases.
+    final nestedAssemble = acc.assembleSpans.fold(
       Duration.zero,
-      (a, b) => a + b,
+      (sum, span) => sum + span.overlapWith(acc.nativeSpans),
     );
-    final rawNativeCompile = acc.nativeBuild - assembleTotal;
+    final rawNativeCompile = acc.nativeBuild - nestedAssemble;
     final nativeCompile = rawNativeCompile < Duration.zero
         ? Duration.zero
         : rawNativeCompile;
@@ -331,7 +341,8 @@ class BuildTraceSummary {
     return _AssembleCategory.other;
   }
 
-  /// `android` or `ios`.
+  /// The release platform name this trace came from (`android`, `ios`,
+  /// `macos`, `linux`, `windows`).
   final String platform;
 
   /// Total command wall-clock (Flutter build + Shorebird overhead).
@@ -368,8 +379,16 @@ class BuildTraceSummary {
   /// Android-specific stats. Only non-null when `platform == 'android'`.
   final AndroidStats? android;
 
-  /// iOS-specific stats. Only non-null when `platform == 'ios'`.
+  /// Xcode-driven build stats (pod install phases, xcodebuild target
+  /// timings). Only non-null for a platform in [xcodePlatforms]; the JSON
+  /// key stays `ios` for compatibility with existing consumers.
   final IosStats? ios;
+
+  /// Platforms whose native build runs through xcodebuild and CocoaPods,
+  /// so their traces carry the events [IosStats] is built from. Note
+  /// `ios` covers `ios-framework` releases too — the CLI reports
+  /// `ReleasePlatform.name`, which maps both to `ios`.
+  static const xcodePlatforms = {'ios', 'macos'};
 
   /// Build-environment snapshot — caching configuration, CI provider,
   /// etc. Lets us tell apart "slow because nothing's configured" from
@@ -644,7 +663,7 @@ class GradleStats {
   };
 }
 
-/// Platform-specific iOS stats.
+/// Stats specific to xcodebuild-driven platforms (iOS and macOS).
 class IosStats {
   /// Creates an [IosStats].
   IosStats({required this.podInstall, required this.xcode});
@@ -760,6 +779,47 @@ class _Accumulator {
   // "Archive target <name>", etc.) so the summary keeps aggregates and
   // a histogram rather than name-keyed totals.
   final xcodeSubsectionDurations = <Duration>[];
+
+  /// Outer native-build spans (gradle / xcodebuild) and assemble spans,
+  /// kept with timestamps so [BuildTraceSummary._nativeStats] can tell
+  /// which assemble work ran inside the native build.
+  final nativeSpans = <_Interval>[];
+  final assembleSpans = <_Interval>[];
+}
+
+/// A `[start, start + dur)` window in trace microseconds. [start] is
+/// null when the event carried no `ts`.
+class _Interval {
+  const _Interval(this.start, this.dur);
+
+  final int? start;
+  final Duration dur;
+
+  int? get end {
+    final s = start;
+    return s == null ? null : s + dur.inMicroseconds;
+  }
+
+  /// How much of this window falls inside any of [others]. A window with
+  /// no timestamp is treated as fully inside — the producer predates
+  /// timestamps, and every producer that old nested assemble in the
+  /// native build. [others] are assumed non-overlapping (sequential
+  /// gradle / xcodebuild invocations), so their overlaps simply sum.
+  Duration overlapWith(List<_Interval> others) {
+    final s = start;
+    final e = end;
+    if (s == null || e == null) return dur;
+    var total = 0;
+    for (final o in others) {
+      final os = o.start;
+      final oe = o.end;
+      if (os == null || oe == null) continue;
+      final lo = s > os ? s : os;
+      final hi = e < oe ? e : oe;
+      if (hi > lo) total += hi - lo;
+    }
+    return Duration(microseconds: total);
+  }
 }
 
 extension on Map<dynamic, Duration> {

--- a/packages/shorebird_cli/lib/src/artifact_builder/build_trace_summary.dart
+++ b/packages/shorebird_cli/lib/src/artifact_builder/build_trace_summary.dart
@@ -210,7 +210,7 @@ class BuildTraceSummary {
     // time that actually ran inside it. On apk/appbundle/ios/macos,
     // assemble is a child of gradle/xcodebuild so that's all of it; on
     // ios-framework the App.framework targets are built in-process
-    // beside the plugin xcodebuilds, so only their overlap (typically
+    // beside the plugin xcodebuild runs, so only their overlap (typically
     // none) is subtracted. Overlap is measured from timestamps; an
     // assemble event with no `ts` is assumed nested, matching the
     // pre-timestamp behavior. Clamped at 0 for edge cases.

--- a/packages/shorebird_cli/test/src/artifact_builder/build_trace_summary_test.dart
+++ b/packages/shorebird_cli/test/src/artifact_builder/build_trace_summary_test.dart
@@ -291,6 +291,164 @@ void main() {
       );
     });
 
+    test('macos trace → xcode stats populated under the ios key', () {
+      final events = [
+        _event(
+          name: 'pod install',
+          cat: 'subprocess',
+          ts: 0,
+          dur: 4_000_000,
+          tid: 1,
+        ),
+        _event(
+          name: 'Build target Runner',
+          cat: 'xcode_subsection',
+          ts: 5_000_000,
+          dur: 20_000_000,
+          tid: 1,
+        ),
+        _event(
+          name: 'xcode build',
+          cat: 'xcode',
+          ts: 4_000_000,
+          dur: 30_000_000,
+          tid: 2,
+        ),
+        _event(
+          name: 'flutter build macos',
+          cat: 'flutter',
+          ts: 0,
+          dur: 40_000_000,
+          tid: 1,
+        ),
+      ];
+      final s = BuildTraceSummary.fromEvents(events, platform: 'macos');
+
+      expect(s.platform, 'macos');
+      expect(s.android, isNull);
+      expect(s.ios, isNotNull);
+      expect(s.ios!.podInstall.duration, const Duration(seconds: 4));
+      expect(s.ios!.xcode.subsectionDistribution.count, 1);
+      expect(s.native.build, const Duration(seconds: 30));
+      expect(s.toJson()['ios'], isNotNull);
+    });
+
+    test('linux trace → no platform-specific stats', () {
+      final s = BuildTraceSummary.fromEvents([], platform: 'linux');
+      expect(s.android, isNull);
+      expect(s.ios, isNull);
+    });
+
+    group('native.compile', () {
+      // gen_snapshot inside gradle: [10s, 13s) within [5s, 35s).
+      final nested = _event(
+        name: 'aot_android_asset_bundle',
+        cat: 'assemble',
+        ts: 10_000_000,
+        dur: 3_000_000,
+        tid: 1,
+      );
+      final gradle = _event(
+        name: 'gradle bundleRelease',
+        cat: 'gradle',
+        ts: 5_000_000,
+        dur: 30_000_000,
+        tid: 2,
+      );
+
+      test('subtracts assemble time that ran inside the native build', () {
+        final s = BuildTraceSummary.fromEvents([
+          nested,
+          gradle,
+        ], platform: 'android');
+        expect(s.native.build, const Duration(seconds: 30));
+        expect(s.native.compile, const Duration(seconds: 27));
+      });
+
+      test('does not subtract assemble time that ran beside it', () {
+        // ios-framework builds App.framework in-process ([0s, 8s)), then
+        // runs xcodebuild for plugins ([10s, 20s)). None of the assemble
+        // work is inside xcodebuild, so native compile is the full span.
+        final s = BuildTraceSummary.fromEvents([
+          _event(
+            name: 'kernel_snapshot',
+            cat: 'assemble',
+            ts: 0,
+            dur: 8_000_000,
+            tid: 3,
+          ),
+          _event(
+            name: 'xcode build plugins (iphoneos)',
+            cat: 'xcode',
+            ts: 10_000_000,
+            dur: 10_000_000,
+            tid: 2,
+          ),
+        ], platform: 'ios');
+        expect(s.native.build, const Duration(seconds: 10));
+        expect(s.native.compile, const Duration(seconds: 10));
+      });
+
+      test('subtracts only the overlapping portion', () {
+        // assemble [0s, 8s) straddles the start of xcode [6s, 16s).
+        final s = BuildTraceSummary.fromEvents([
+          _event(
+            name: 'kernel_snapshot',
+            cat: 'assemble',
+            ts: 0,
+            dur: 8_000_000,
+            tid: 3,
+          ),
+          _event(
+            name: 'xcode build',
+            cat: 'xcode',
+            ts: 6_000_000,
+            dur: 10_000_000,
+            tid: 2,
+          ),
+        ], platform: 'ios');
+        expect(s.native.compile, const Duration(seconds: 8));
+      });
+
+      test('treats an assemble event without ts as nested', () {
+        // Older producers emitted no timestamps; they all nested
+        // assemble inside the native build, so keep subtracting.
+        final s = BuildTraceSummary.fromEvents([
+          {
+            'ph': 'X',
+            'name': 'kernel_snapshot',
+            'cat': 'assemble',
+            'dur': 3_000_000,
+            'pid': 1,
+            'tid': 1,
+          },
+          gradle,
+        ], platform: 'android');
+        expect(s.native.compile, const Duration(seconds: 27));
+      });
+
+      test('clamps at zero', () {
+        final s = BuildTraceSummary.fromEvents([
+          _event(
+            name: 'kernel_snapshot',
+            cat: 'assemble',
+            ts: 5_000_000,
+            dur: 30_000_000,
+            tid: 1,
+          ),
+          _event(
+            name: 'kernel_snapshot',
+            cat: 'assemble',
+            ts: 5_000_000,
+            dur: 30_000_000,
+            tid: 1,
+          ),
+          gradle,
+        ], platform: 'android');
+        expect(s.native.compile, Duration.zero);
+      });
+    });
+
     test('toJson shape is nested and omits the other platform', () {
       final events = [
         _event(


### PR DESCRIPTION
Consumer-side follow-up to shorebirdtech/flutter#162 (traces `flutter build macos`) and shorebirdtech/flutter#163 (traces `flutter build ios-framework`). Independent of #3709 and safe to land before the pin bump — it only changes how a trace is summarized once one exists.

## Two fixes in `BuildTraceSummary`

**1. macOS gets Xcode stats.** Pod-install phases and xcodebuild target timings were only computed when `platform == 'ios'`. macOS runs the identical xcodebuild + CocoaPods pipeline and, with flutter#162, emits the identical events — so they're now filled for any platform in `BuildTraceSummary.xcodePlatforms` (`ios`, `macos`). The JSON key stays `ios` so the existing admin parser and the `version: 8` schema are untouched. Documented on the field.

**2. `native.compile` measures overlap instead of assuming nesting.** It was `nativeBuild − Σ assemble`, which assumes `flutter assemble` always runs *inside* gradle/xcodebuild. True for apk/appbundle/ios/macos; false for ios-framework, where App.framework is built in-process *beside* the plugin xcodebuilds. That subtraction under-reported (clamped to zero). Now only the assemble time that overlaps a native span, by timestamp, is subtracted. An assemble event with no `ts` is treated as nested — every producer old enough to omit timestamps nested it — so android/ios summaries from existing pins are unchanged.

## Test plan

- [x] `dart test test/src/artifact_builder/build_trace_summary_test.dart test/src/artifact_builder/artifact_builder_test.dart` — 124 pass. New tests: macOS trace populates `ios` stats; linux gets neither; five `native.compile` cases (fully nested, fully beside, partial overlap, no-`ts` fallback, clamp).
- [x] `dart analyze` — no new diagnostics (four pre-existing infos in this file).

## Not in this PR

The admin build-timing dashboard is typed `'android' | 'ios'` (`web/apps/admin/app/models/code_push/build_timing.ts`, `code_push_db.server.ts`); macOS rows won't display until that's widened. Separate PR in the private repo.

https://claude.ai/code/session_01X2aY3kQvT2tgM1mYbN9c7W
