### PR TITLE
fix(shorebird_cli): warn when app extension versions do not match the app

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -15,6 +15,7 @@ words:
   - apigee
   - Apks
   - appbundle
+  - appex # Apple app extension bundle
   - archs
   - armeabi
   - Azul
@@ -59,6 +60,7 @@ words:
   - iokit
   - iphoneos
   - isatty
+  - ITMS # App Store Connect error code prefix, e.g. ITMS-90473
   - keyalg # From .github/workflows/e2e.yaml
   - keypass # From .github/workflows/e2e.yaml
   - keysize # From .github/workflows/e2e.yaml

--- a/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
+++ b/packages/shorebird_cli/lib/src/commands/release/ios_releaser.dart
@@ -129,6 +129,16 @@ If left checked, Xcode will rewrite the build number in the uploaded IPA, so the
       throw ProcessExit(ExitCode.software.code);
     }
 
+    // Surface mismatched app extension versions here rather than letting the
+    // user discover them via an App Store Connect rejection days later.
+    // See https://github.com/shorebirdtech/shorebird/issues/1956.
+    final versionMismatches = findAppExtensionVersionMismatches(
+      appDirectory: appDirectory,
+    );
+    if (versionMismatches.isNotEmpty) {
+      logger.warn(appExtensionVersionMismatchWarning(versionMismatches));
+    }
+
     // When code signing is requested (the default), `flutter build ipa` is
     // expected to export a signed .ipa. Flutter treats the export step as
     // optional and exits 0 even when it fails (e.g. no signing certificate),

--- a/packages/shorebird_cli/lib/src/platform/apple/app_extension_versions.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple/app_extension_versions.dart
@@ -34,18 +34,16 @@ class AppExtensionVersionMismatch {
 /// the app extensions it embeds.
 ///
 /// Apple rejects uploads whose extensions disagree with their containing app
-/// about `CFBundleShortVersionString` or `CFBundleVersion` (ITMS-90473). Xcode
-/// normally papers over this by rewriting every embedded bundle's version at
-/// export time, but that behavior is driven by
-/// `manageAppVersionAndBuildNumber`, which Shorebird requires to be off so that
-/// the version it records for a release is the version that actually ships.
-/// The consequence is that extension versions are left as their targets built
-/// them, and a mismatch surfaces as an App Store Connect rejection rather than
-/// as a build failure.
+/// about `CFBundleShortVersionString` or `CFBundleVersion` (ITMS-90473).
+///
+/// Xcode rewrites embedded bundle versions at export time when
+/// `manageAppVersionAndBuildNumber` is set. Shorebird requires it off so the
+/// version it records for a release is the version that ships, so extension
+/// versions stay as their targets built them and a mismatch surfaces as an App
+/// Store Connect rejection.
 ///
 /// An extension is skipped if its Info.plist is missing, cannot be parsed, or
-/// does not declare the version keys. This is a diagnostic aid, and a
-/// malformed extension plist is not something to fail or warn a release over.
+/// does not declare the version keys.
 List<AppExtensionVersionMismatch> findAppExtensionVersionMismatches({
   required Directory appDirectory,
 }) {
@@ -113,22 +111,20 @@ String appExtensionVersionMismatchWarning(
       .map(
         (m) =>
             '  ${m.extensionName}: ${m.key} is "${m.extensionValue}", '
-            'but the app is "${m.appValue}"',
+            'the app is "${m.appValue}"',
       )
       .join('\n');
 
   return '''
-Your app embeds app extensions whose versions do not match the app:
+These app extensions have versions that do not match the app:
 
 $details
 
 App Store Connect rejects uploads with mismatched extension versions
-(ITMS-90473), so this will likely fail at upload time rather than now.
+(ITMS-90473).
 
-Shorebird builds with Xcode's "Manage Version and Build Number" disabled so
-that the version recorded for this release is the version that ships, which
-means Xcode will not update your extension versions for you. Set each
-extension target's MARKETING_VERSION and CURRENT_PROJECT_VERSION to match the
-app, or set them to \$(MARKETING_VERSION) and \$(CURRENT_PROJECT_VERSION) so
-they follow it automatically.''';
+Shorebird builds with Xcode's "Manage Version and Build Number" disabled, so
+Xcode does not update extension versions for you. Set each extension target's
+MARKETING_VERSION and CURRENT_PROJECT_VERSION to match the app, or to
+\$(MARKETING_VERSION) and \$(CURRENT_PROJECT_VERSION).''';
 }

--- a/packages/shorebird_cli/lib/src/platform/apple/app_extension_versions.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple/app_extension_versions.dart
@@ -1,0 +1,134 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/platform/apple/plist.dart';
+
+/// {@template app_extension_version_mismatch}
+/// A version key whose value in an app extension does not match the value in
+/// the extension's containing app.
+/// {@endtemplate}
+class AppExtensionVersionMismatch {
+  /// {@macro app_extension_version_mismatch}
+  const AppExtensionVersionMismatch({
+    required this.extensionName,
+    required this.key,
+    required this.appValue,
+    required this.extensionValue,
+  });
+
+  /// The file name of the .appex bundle, e.g. `NotificationService.appex`.
+  final String extensionName;
+
+  /// The Info.plist key that differs, either [Plist.releaseVersionKey] or
+  /// [Plist.buildNumberKey].
+  final String key;
+
+  /// The value of [key] in the containing app's Info.plist.
+  final String appValue;
+
+  /// The value of [key] in the extension's Info.plist.
+  final String extensionValue;
+}
+
+/// Returns the version mismatches between the app bundle at [appDirectory] and
+/// the app extensions it embeds.
+///
+/// Apple rejects uploads whose extensions disagree with their containing app
+/// about `CFBundleShortVersionString` or `CFBundleVersion` (ITMS-90473). Xcode
+/// normally papers over this by rewriting every embedded bundle's version at
+/// export time, but that behavior is driven by
+/// `manageAppVersionAndBuildNumber`, which Shorebird requires to be off so that
+/// the version it records for a release is the version that actually ships.
+/// The consequence is that extension versions are left as their targets built
+/// them, and a mismatch surfaces as an App Store Connect rejection rather than
+/// as a build failure.
+///
+/// An extension is skipped if its Info.plist is missing, cannot be parsed, or
+/// does not declare the version keys. This is a diagnostic aid, and a
+/// malformed extension plist is not something to fail or warn a release over.
+List<AppExtensionVersionMismatch> findAppExtensionVersionMismatches({
+  required Directory appDirectory,
+}) {
+  final appPlistFile = File(p.join(appDirectory.path, 'Info.plist'));
+  if (!appPlistFile.existsSync()) return [];
+
+  final Plist appPlist;
+  try {
+    appPlist = Plist(file: appPlistFile);
+  } on Exception {
+    return [];
+  }
+
+  final pluginsDirectory = Directory(p.join(appDirectory.path, 'PlugIns'));
+  if (!pluginsDirectory.existsSync()) return [];
+
+  final mismatches = <AppExtensionVersionMismatch>[];
+  final extensionDirectories =
+      pluginsDirectory
+          .listSync()
+          .whereType<Directory>()
+          .where((d) => p.extension(d.path) == '.appex')
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+  for (final extensionDirectory in extensionDirectories) {
+    final extensionPlistFile = File(
+      p.join(extensionDirectory.path, 'Info.plist'),
+    );
+    if (!extensionPlistFile.existsSync()) continue;
+
+    final Plist extensionPlist;
+    try {
+      extensionPlist = Plist(file: extensionPlistFile);
+    } on Exception {
+      continue;
+    }
+
+    for (final key in [Plist.releaseVersionKey, Plist.buildNumberKey]) {
+      final appValue = appPlist.properties[key];
+      final extensionValue = extensionPlist.properties[key];
+      if (appValue is! String || extensionValue is! String) continue;
+      if (appValue == extensionValue) continue;
+
+      mismatches.add(
+        AppExtensionVersionMismatch(
+          extensionName: p.basename(extensionDirectory.path),
+          key: key,
+          appValue: appValue,
+          extensionValue: extensionValue,
+        ),
+      );
+    }
+  }
+
+  return mismatches;
+}
+
+/// The warning shown when [findAppExtensionVersionMismatches] finds a
+/// mismatch.
+String appExtensionVersionMismatchWarning(
+  List<AppExtensionVersionMismatch> mismatches,
+) {
+  final details = mismatches
+      .map(
+        (m) =>
+            '  ${m.extensionName}: ${m.key} is "${m.extensionValue}", '
+            'but the app is "${m.appValue}"',
+      )
+      .join('\n');
+
+  return '''
+Your app embeds app extensions whose versions do not match the app:
+
+$details
+
+App Store Connect rejects uploads with mismatched extension versions
+(ITMS-90473), so this will likely fail at upload time rather than now.
+
+Shorebird builds with Xcode's "Manage Version and Build Number" disabled so
+that the version recorded for this release is the version that ships, which
+means Xcode will not update your extension versions for you. Set each
+extension target's MARKETING_VERSION and CURRENT_PROJECT_VERSION to match the
+app, or set them to \$(MARKETING_VERSION) and \$(CURRENT_PROJECT_VERSION) so
+they follow it automatically.''';
+}

--- a/packages/shorebird_cli/lib/src/platform/apple/apple.dart
+++ b/packages/shorebird_cli/lib/src/platform/apple/apple.dart
@@ -15,6 +15,7 @@ import 'package:shorebird_cli/src/shorebird_artifacts.dart';
 import 'package:shorebird_cli/src/shorebird_env.dart';
 import 'package:xml/xml.dart';
 
+export 'app_extension_versions.dart';
 export 'apple_platform.dart';
 export 'export_method.dart';
 export 'invalid_export_options_plist_exception.dart';

--- a/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
+++ b/packages/shorebird_cli/test/src/commands/release/ios_releaser_test.dart
@@ -663,6 +663,56 @@ $body
         });
       });
 
+      group('when an app extension version does not match the app', () {
+        setUp(() {
+          String plist(String shortVersion, String version) =>
+              '''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleShortVersionString</key>
+	<string>$shortVersion</string>
+	<key>CFBundleVersion</key>
+	<string>$version</string>
+</dict>
+</plist>
+''';
+
+          File(
+            p.join(iosAppDirectory.path, 'Info.plist'),
+          ).writeAsStringSync(plist('1.15.67', '250'));
+          final extensionDirectory = Directory(
+            p.join(
+              iosAppDirectory.path,
+              'PlugIns',
+              'NotificationService.appex',
+            ),
+          )..createSync(recursive: true);
+          File(
+            p.join(extensionDirectory.path, 'Info.plist'),
+          ).writeAsStringSync(plist('1.15.32', '250'));
+        });
+
+        test('warns but does not fail the release', () async {
+          expect(
+            await runWithOverrides(iosReleaser.buildReleaseArtifacts),
+            equals(xcarchiveDirectory),
+          );
+
+          verify(
+            () => logger.warn(
+              any(
+                that: allOf(
+                  contains('NotificationService.appex'),
+                  contains('ITMS-90473'),
+                ),
+              ),
+            ),
+          ).called(1);
+        });
+      });
+
       group('when codesigning and ipa not found after build', () {
         setUp(() {
           when(() => argResults['codesign']).thenReturn(true);

--- a/packages/shorebird_cli/test/src/platform/apple/app_extension_versions_test.dart
+++ b/packages/shorebird_cli/test/src/platform/apple/app_extension_versions_test.dart
@@ -1,0 +1,250 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:shorebird_cli/src/platform/apple/app_extension_versions.dart';
+import 'package:shorebird_cli/src/platform/apple/plist.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('findAppExtensionVersionMismatches', () {
+    late Directory tempDir;
+    late Directory appDirectory;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('app_extension_versions_');
+      appDirectory = Directory(p.join(tempDir.path, 'Runner.app'))
+        ..createSync(recursive: true);
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    String plistContents({String? shortVersion, String? version}) {
+      final entries = [
+        if (shortVersion != null)
+          '''
+	<key>CFBundleShortVersionString</key>
+	<string>$shortVersion</string>''',
+        if (version != null)
+          '''
+	<key>CFBundleVersion</key>
+	<string>$version</string>''',
+      ].join('\n');
+
+      return '''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+$entries
+</dict>
+</plist>
+''';
+    }
+
+    void writeAppPlist({
+      String? shortVersion = '1.0.0',
+      String? version = '1',
+    }) {
+      File(p.join(appDirectory.path, 'Info.plist')).writeAsStringSync(
+        plistContents(shortVersion: shortVersion, version: version),
+      );
+    }
+
+    void writeExtension(
+      String name, {
+      String? shortVersion,
+      String? version,
+      String? rawContents,
+      bool writePlist = true,
+    }) {
+      final extensionDirectory = Directory(
+        p.join(appDirectory.path, 'PlugIns', name),
+      )..createSync(recursive: true);
+      if (!writePlist) return;
+      File(p.join(extensionDirectory.path, 'Info.plist')).writeAsStringSync(
+        rawContents ??
+            plistContents(shortVersion: shortVersion, version: version),
+      );
+    }
+
+    test('returns empty when the app has no Info.plist', () {
+      writeExtension('Service.appex', shortVersion: '9.9.9', version: '99');
+
+      expect(
+        findAppExtensionVersionMismatches(appDirectory: appDirectory),
+        isEmpty,
+      );
+    });
+
+    test('returns empty when the app Info.plist is malformed', () {
+      File(
+        p.join(appDirectory.path, 'Info.plist'),
+      ).writeAsStringSync('not a plist');
+      writeExtension('Service.appex', shortVersion: '9.9.9', version: '99');
+
+      expect(
+        findAppExtensionVersionMismatches(appDirectory: appDirectory),
+        isEmpty,
+      );
+    });
+
+    test('returns empty when there is no PlugIns directory', () {
+      writeAppPlist();
+
+      expect(
+        findAppExtensionVersionMismatches(appDirectory: appDirectory),
+        isEmpty,
+      );
+    });
+
+    test('returns empty when extension versions match', () {
+      writeAppPlist();
+      writeExtension('Service.appex', shortVersion: '1.0.0', version: '1');
+
+      expect(
+        findAppExtensionVersionMismatches(appDirectory: appDirectory),
+        isEmpty,
+      );
+    });
+
+    test('ignores non-.appex entries in PlugIns', () {
+      writeAppPlist();
+      final other = Directory(
+        p.join(appDirectory.path, 'PlugIns', 'NotAnExtension.bundle'),
+      )..createSync(recursive: true);
+      File(
+        p.join(other.path, 'Info.plist'),
+      ).writeAsStringSync(plistContents(shortVersion: '9.9.9', version: '99'));
+
+      expect(
+        findAppExtensionVersionMismatches(appDirectory: appDirectory),
+        isEmpty,
+      );
+    });
+
+    test('skips extensions with no Info.plist', () {
+      writeAppPlist();
+      writeExtension('Service.appex', writePlist: false);
+
+      expect(
+        findAppExtensionVersionMismatches(appDirectory: appDirectory),
+        isEmpty,
+      );
+    });
+
+    test('skips extensions with a malformed Info.plist', () {
+      writeAppPlist();
+      writeExtension('Service.appex', rawContents: 'not a plist');
+
+      expect(
+        findAppExtensionVersionMismatches(appDirectory: appDirectory),
+        isEmpty,
+      );
+    });
+
+    test('skips keys the extension does not declare', () {
+      writeAppPlist();
+      // Declares a matching CFBundleVersion but no CFBundleShortVersionString.
+      writeExtension('Service.appex', version: '1');
+
+      expect(
+        findAppExtensionVersionMismatches(appDirectory: appDirectory),
+        isEmpty,
+      );
+    });
+
+    test('reports a CFBundleShortVersionString mismatch', () {
+      writeAppPlist(shortVersion: '1.15.67', version: '250');
+      writeExtension(
+        'NotificationService.appex',
+        shortVersion: '1.15.32',
+        version: '250',
+      );
+
+      final mismatches = findAppExtensionVersionMismatches(
+        appDirectory: appDirectory,
+      );
+
+      expect(mismatches, hasLength(1));
+      expect(mismatches.single.extensionName, 'NotificationService.appex');
+      expect(mismatches.single.key, Plist.releaseVersionKey);
+      expect(mismatches.single.appValue, '1.15.67');
+      expect(mismatches.single.extensionValue, '1.15.32');
+    });
+
+    test('reports a CFBundleVersion mismatch', () {
+      writeAppPlist(shortVersion: '1.15.67', version: '250');
+      writeExtension(
+        'NotificationService.appex',
+        shortVersion: '1.15.67',
+        version: '2142',
+      );
+
+      final mismatches = findAppExtensionVersionMismatches(
+        appDirectory: appDirectory,
+      );
+
+      expect(mismatches, hasLength(1));
+      expect(mismatches.single.key, Plist.buildNumberKey);
+      expect(mismatches.single.appValue, '250');
+      expect(mismatches.single.extensionValue, '2142');
+    });
+
+    test('reports both keys and multiple extensions, sorted by path', () {
+      writeAppPlist(shortVersion: '3.50.0', version: '1719410970');
+      writeExtension(
+        'OneSignalNotificationService.appex',
+        shortVersion: '1.0',
+        version: '7',
+      );
+      writeExtension(
+        'CleverTapNotificationService.appex',
+        shortVersion: '1.0',
+        version: '1',
+      );
+
+      final mismatches = findAppExtensionVersionMismatches(
+        appDirectory: appDirectory,
+      );
+
+      expect(mismatches, hasLength(4));
+      expect(
+        mismatches.map((m) => '${m.extensionName}:${m.key}'),
+        [
+          'CleverTapNotificationService.appex:${Plist.releaseVersionKey}',
+          'CleverTapNotificationService.appex:${Plist.buildNumberKey}',
+          'OneSignalNotificationService.appex:${Plist.releaseVersionKey}',
+          'OneSignalNotificationService.appex:${Plist.buildNumberKey}',
+        ],
+      );
+    });
+  });
+
+  group('appExtensionVersionMismatchWarning', () {
+    test('names each mismatch and how to fix it', () {
+      final warning = appExtensionVersionMismatchWarning(const [
+        AppExtensionVersionMismatch(
+          extensionName: 'NotificationService.appex',
+          key: Plist.releaseVersionKey,
+          appValue: '1.15.67',
+          extensionValue: '1.15.32',
+        ),
+      ]);
+
+      expect(
+        warning,
+        allOf(
+          contains('NotificationService.appex'),
+          contains(Plist.releaseVersionKey),
+          contains('1.15.67'),
+          contains('1.15.32'),
+          contains('ITMS-90473'),
+          contains('MARKETING_VERSION'),
+          contains('CURRENT_PROJECT_VERSION'),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

Refs #1956. This warns about the mismatch. It does not sync the versions, and does not close the issue.

### Why it does not sync them

#2620 removed our generated `ExportOptions.plist` and closed this. That fixed plain `shorebird release ios`, since Flutter's own export options let Xcode harmonize embedded bundle versions. It was reopened in July 2025 by users on fastlane-plugin-shorebird, users supplying their own `ExportOptions.plist`, and users archiving in Xcode by hand.

Those remaining cases are structural. `assertValidExportOptionsPlist` rejects `manageAppVersionAndBuildNumber: true`, and `ios_releaser.dart` tells `--no-codesign` users to uncheck "Manage Version and Build Number". We need Xcode's version management off so the version we record is the version that ships, and that setting is what would otherwise rewrite extension versions.

Syncing them requires one of:

1. Rewriting `Info.plist` inside each `.appex` after export. Extensions are signed individually, so this invalidates their signatures.
2. Setting the extension targets' build settings before the build, which means mutating the user's Xcode project from a release command.
3. @eseidel's option 3 from the thread: teach `flutter build ipa` to set extension versions the way it already sets the app's. Still the right long-term answer, and upstream.

### What this does

After `flutter build ipa`, reads the exported `Runner.app/Info.plist` and each `PlugIns/*.appex/Info.plist`, and warns on any `CFBundleShortVersionString` / `CFBundleVersion` disagreement:

```
These app extensions have versions that do not match the app:

  NotificationService.appex: CFBundleShortVersionString is "1.15.32", the app is "1.15.67"

App Store Connect rejects uploads with mismatched extension versions
(ITMS-90473).

Shorebird builds with Xcode's "Manage Version and Build Number" disabled, so
Xcode does not update extension versions for you. Set each extension target's
MARKETING_VERSION and CURRENT_PROJECT_VERSION to match the app, or to
$(MARKETING_VERSION) and $(CURRENT_PROJECT_VERSION).
```

Today the failure arrives as an Apple email hours or days after a release that appeared to succeed, with nothing pointing back at Shorebird. Five people in the thread each rediscovered the cause over two years. Every reporter's extension (`NotificationService.appex`, `CleverTapNotificationServiceExtension.appex`, `OneSignalNotificationService.appex`) would have produced this warning at build time.

It warns and continues, and never fails the release. A missing or malformed extension plist is skipped.

Scoped to `shorebird release ios`. Not covered: macOS bundles (`Contents/PlugIns`), extensions nested inside a bundled watchOS app, and any ExtensionKit `Extensions/` directory. Worth follow-ups if this approach is wanted.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Verification

Installed a Dart SDK in the session container and ran:

- `dart analyze` on the package: 90 issues, identical to the pre-change baseline, none in the new files.
- `dart format --set-exit-if-changed`: clean across all touched files.
- `dart test test/src/platform/apple/app_extension_versions_test.dart`: 12/12. Covers both keys, multiple extensions, non-`.appex` entries in `PlugIns`, missing and malformed app and extension plists, and extensions that do not declare a key.
- `ios_releaser_test.dart` is `testOn: 'mac-os'`. Ran it on Linux with the guard temporarily lifted: 36/36 pass, including the new case. Guard restored; that change is not committed.
- Mutation tests. Removing the `logger.warn` call fails the releaser test. Returning `[]` from the detector fails 3 unit tests. Dropping the `.appex` filter fails 1. Checking only `CFBundleShortVersionString` fails 2.
- `cspell --config cspell.config.yaml`: clean. `appex` and `ITMS` went into the global config rather than inline, since three files need them.
- CI green on macos-latest, ubuntu-latest and windows-latest.

Not tested: a real iOS build. The `.app` layouts in the tests are constructed, since verifying against an actual `.xcarchive` needs macOS and Xcode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fnEF9Ch8k5VQnwmBGD1nn